### PR TITLE
docs: add last-updated comment to VERSION_HISTORY

### DIFF
--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -513,3 +513,4 @@ The bump scripts automatically:
 - Run `task build:backend` after Go changes
 - Run `task dev` for development with hot reload
 - Run `task package` only for final release builds
+


### PR DESCRIPTION
Test PR to verify ReAgent webhook is firing correctly for agentmuxhq org after migration from a5af.