### PR TITLE
fix: add missing auth key to /wave/file requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.31.27"
+version = "0.31.28"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.31.27"
+version = "0.31.28"
 dependencies = [
  "async-stream",
  "axum",
@@ -6831,7 +6831,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.31.27"
+version = "0.31.28"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.31.27"
+version = "0.31.28"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -532,6 +532,12 @@ async function fetchWaveFile(
     if (offset != null) {
         usp.set("offset", offset.toString());
     }
+    if (globalThis.window != null) {
+        const authKey = getApi()?.getAuthKey?.();
+        if (authKey) {
+            usp.set("authkey", authKey);
+        }
+    }
     const resp = await fetch(getWebServerEndpoint() + "/wave/file?" + usp.toString());
     if (!resp.ok) {
         if (resp.status === 404) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agentmux",
-    "version": "0.31.27",
+    "version": "0.31.28",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "agentmux",
-            "version": "0.31.27",
+            "version": "0.31.28",
             "license": "Apache-2.0",
             "workspaces": [
                 "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "productName": "AgentMux",
     "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
     "license": "Apache-2.0",
-    "version": "0.31.27",
+    "version": "0.31.28",
     "homepage": "https://github.com/agentmuxhq/agentmux",
     "build": {
         "appId": "com.agentmuxhq.agentmux"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.31.27"
+version = "0.31.28"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.31.27",
+  "version": "0.31.28",
   "identifier": "com.agentmuxhq.agentmux",
   "build": {
     "devUrl": "http://localhost:5173",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.31.27"
+version = "0.31.28"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary
- `fetchWaveFile` in `frontend/app/store/global.ts` was missing the `authkey` query parameter
- This caused `401 Unauthorized` on `GET /wave/file?zoneid=...&name=cache:term:full` during terminal initialization
- New terminals would get stuck in `loadInitialTerminalData` because the file fetch was rejected by auth middleware
- Added the same auth key pattern already used by `/wave/service`, WebSocket, and schema endpoints

## Root Cause
The `fetchWaveFile` function built its URL without including the auth key:
```typescript
// Before (missing auth)
const resp = await fetch(getWebServerEndpoint() + "/wave/file?" + usp.toString());

// After (auth key added)
if (globalThis.window != null) {
    const authKey = getApi()?.getAuthKey?.();
    if (authKey) {
        usp.set("authkey", authKey);
    }
}
const resp = await fetch(getWebServerEndpoint() + "/wave/file?" + usp.toString());
```

## Test plan
- [ ] Open new terminal — should load without 401 errors in console
- [ ] Open multiple terminals rapidly — none should get stuck
- [ ] Verify no `401 (Unauthorized)` on `/wave/file` in browser dev console

🤖 Generated with [Claude Code](https://claude.com/claude-code)