### PR TITLE
fix: remove automatic tag trigger from CI workflow

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -2,9 +2,6 @@ name: Build Tauri
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
 
 jobs:
   build-tauri:


### PR DESCRIPTION
## Summary
- Remove `push: tags: v*` trigger from tauri-build workflow
- Keep `workflow_dispatch` only so builds are intentional
- The tag trigger was causing unintended builds on every `bump-version.sh` tag push

## Test plan
- [x] Verify workflow only has `workflow_dispatch` trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)