### PR TITLE
fix: prevent double-click maximize on widget bar buttons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.31.47"
+version = "0.31.48"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.31.47"
+version = "0.31.48"
 dependencies = [
  "async-stream",
  "axum",
@@ -6835,7 +6835,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.31.47"
+version = "0.31.48"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.31.47"
+version = "0.31.48"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/frontend/app/window/action-widgets.scss
+++ b/frontend/app/window/action-widgets.scss
@@ -8,4 +8,5 @@
     gap: 4px;
     height: 100%;
     user-select: none;
+    -webkit-app-region: no-drag;
 }

--- a/frontend/app/window/system-status.scss
+++ b/frontend/app/window/system-status.scss
@@ -9,6 +9,7 @@
     align-items: center;
     justify-content: flex-end;
     margin-right: 6px;
+    -webkit-app-region: no-drag;
 
     .config-error-button {
         color: black;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "agentmux",
-  "version": "0.31.47",
+  "version": "0.31.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.31.47",
+  "version": "0.31.48",
   "homepage": "https://github.com/agentmuxhq/agentmux",
   "build": {
     "appId": "com.agentmuxhq.agentmux"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.31.47"
+version = "0.31.48"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.31.47",
-  "identifier": "com.agentmuxhq.agentmux.v0-31-47",
+  "version": "0.31.48",
+  "identifier": "com.agentmuxhq.agentmux.v0-31-48",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.31.47"
+version = "0.31.48"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary
- Add `-webkit-app-region: no-drag` to `.action-widgets` and `.system-status` SCSS to prevent Chromium from treating widget bar buttons as part of the window drag region
- Double-clicking terminal/help/devtools widgets no longer triggers window maximize
- Double-click on empty header space still maximizes as expected
- Bumps version to 0.31.48

## Root Cause
The parent `.window-header` has `data-tauri-drag-region` which makes the entire header a native drag region. While child elements had `data-tauri-drag-region="false"`, this only affects Tauri's JS-level handling — Chromium's native window manager still sees the area as draggable because the CSS `-webkit-app-region: drag` propagates from the parent. Adding `-webkit-app-region: no-drag` on the widget containers overrides this at the Chromium level, before native WM events are generated.

## Test plan
- [ ] Double-click on terminal/help/devtools widget buttons — should NOT maximize window
- [ ] Double-click on empty header bar space — SHOULD maximize window
- [ ] Single-click on widgets still works (opens terminal, help, devtools)
- [ ] Window dragging from header still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)