### PR TITLE
chore: add .bump.json for bump-cli version management

### DIFF
--- a/.bump.json
+++ b/.bump.json
@@ -1,0 +1,66 @@
+{
+  "sourceOfTruth": "package.json",
+  "targets": [
+    {
+      "file": "package.json",
+      "type": "json",
+      "path": "version"
+    },
+    {
+      "file": "src-tauri/Cargo.toml",
+      "type": "toml",
+      "path": "package.version"
+    },
+    {
+      "file": "agentmuxsrv-rs/Cargo.toml",
+      "type": "toml",
+      "path": "package.version"
+    },
+    {
+      "file": "wsh-rs/Cargo.toml",
+      "type": "toml",
+      "path": "package.version"
+    },
+    {
+      "file": "src-tauri/tauri.conf.json",
+      "type": "json",
+      "path": "version"
+    },
+    {
+      "file": "src-tauri/tauri.conf.json",
+      "type": "json",
+      "path": "identifier",
+      "transform": "template",
+      "template": "com.agentmuxhq.agentmux.v{{version | replace('.', '-')}}"
+    }
+  ],
+  "lockfiles": [
+    {
+      "type": "npm",
+      "command": "npm install --package-lock-only",
+      "allowFailure": true
+    },
+    {
+      "type": "cargo",
+      "command": "cargo generate-lockfile"
+    }
+  ],
+  "history": {
+    "file": "VERSION_HISTORY.md",
+    "format": "table",
+    "template": "| {{version}}-fork | v0.12.0 | {{date}} | {{agent}} | {{message}} |"
+  },
+  "git": {
+    "add": [
+      "package.json",
+      "package-lock.json",
+      "Cargo.lock",
+      "VERSION_HISTORY.md",
+      "src-tauri/Cargo.toml",
+      "src-tauri/tauri.conf.json",
+      "agentmuxsrv-rs/Cargo.toml",
+      "wsh-rs/Cargo.toml"
+    ],
+    "commitMessage": "chore: bump version to {{version}}"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.bump.json` configuration file for use with `@a5af/bump-cli` (dev-tools PR #305)
- Defines all 6 version targets: `package.json`, 3x `Cargo.toml`, `tauri.conf.json` (version + identifier with template transform)
- Configures lockfile regeneration (npm + cargo) and VERSION_HISTORY.md updates
- Replaces `bump-version.sh` which fails on Windows (interactive prompts, perl dependency)

### Before (bump-version.sh)
- Bash script with `read -p` interactive prompt
- Uses `perl -i` for TOML/JSON edits
- Fails silently on Windows/Git Bash

### After (bump-cli)
```bash
bump patch -m "Add feature" --commit    # Non-interactive, cross-platform
bump verify                              # Check consistency
bump patch --dry-run                     # Preview changes
```

## Test plan
- [x] `bump verify` — all 6 targets read correctly
- [x] `bump patch --dry-run` — correct transforms including tauri identifier
- [x] `bump show` — displays all targets with annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)