### PR TITLE
fix: remove .transparent(true) build error, fix CI release permissions

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -2,6 +2,12 @@ name: Build Tauri
 
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
 
 jobs:
   build-tauri:

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -37,7 +37,6 @@ pub async fn open_new_window<R: Runtime>(app: tauri::AppHandle<R>) -> Result<Str
     .inner_size(1200.0, 800.0)
     .min_inner_size(400.0, 300.0)
     .decorations(false)
-    .transparent(true)
     .visible(false);
 
     #[cfg(target_os = "linux")]
@@ -50,7 +49,6 @@ pub async fn open_new_window<R: Runtime>(app: tauri::AppHandle<R>) -> Result<Str
     .inner_size(1200.0, 800.0)
     .min_inner_size(400.0, 300.0)
     .decorations(false)
-    .transparent(true)
     .visible(false)
     .center();
 


### PR DESCRIPTION
## Summary

- **Remove `.transparent(true)` from `WebviewWindowBuilder`** — This method doesn't exist in Tauri v2.10's runtime API (it's config-only via `tauri.conf.json`). This caused macOS CI builds to fail with `error[E0599]: no method named 'transparent'`. Was fixed on the release branch but not on main.
- **Add `permissions: contents: write`** to `tauri-build.yml` — The `create-release` job was hitting 403 on `workflow_dispatch` triggers because `GITHUB_TOKEN` lacked write permissions.
- **Add `push: tags: v*` trigger** — So tag pushes automatically trigger builds and create releases.

## Test plan

- [ ] CI builds succeed on all 4 platforms (Linux, macOS arm64, macOS x64, Windows)
- [ ] Tag push (`v*`) triggers workflow and creates release automatically
- [ ] `workflow_dispatch` still works for manual builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)