### PR TITLE
docs: link AgentMux Corp to agentmux.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A rich monitoring and orchestration UI for AI agents. See every tool call, catch
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Website](https://img.shields.io/badge/Website-agentmux.ai-blue)](https://agentmux.ai)
 
-> Developed by **[AgentMux Corp.](./LEGAL.md)** - Delaware corporation, California registered.
+> Developed by **[AgentMux Corp.](https://agentmux.ai)** - Delaware corporation, California registered.
 
 ## The Problem
 


### PR DESCRIPTION
## Summary
- Change "AgentMux Corp." link in README from `./LEGAL.md` to `https://agentmux.ai`

## Test plan
- [ ] Verify link renders correctly on GitHub README

🤖 Generated with [Claude Code](https://claude.com/claude-code)