### PR TITLE
fix: rename GitHub org agentmuxhq to agentmuxai

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: true
 contact_links:
     - name: General Question
-      url: https://github.com/agentmuxhq/agentmux/discussions
+      url: https://github.com/agentmuxai/agentmux/discussions
       about: Have a question on something? Start a new discussion thread.
     - name: Engage with us directly on Discord
       url: https://discord.gg/XfvZ334gwU
       about: Join our Discord server to get updates on new features, bug fixes, and more.
     - name: Review open issues
-      url: https://github.com/agentmuxhq/agentmux/issues
+      url: https://github.com/agentmuxai/agentmux/issues
       about: Please check if your issue isn't already there.

--- a/BUILD.md
+++ b/BUILD.md
@@ -82,7 +82,7 @@ See full instructions: https://taskfile.dev/installation/
 ## Clone the Repository
 
 ```bash
-git clone https://github.com/agentmuxhq/agentmux.git
+git clone https://github.com/agentmuxai/agentmux.git
 cd agentmux
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Repository
 
 - **Name:** AgentMux
-- **GitHub:** https://github.com/agentmuxhq/agentmux
+- **GitHub:** https://github.com/agentmuxai/agentmux
 - **Type:** Tauri v2 terminal application
 - **Build System:** Task (Taskfile.yml)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 We welcome contributions to AgentMux! There are several ways to get involved:
 
-- Report bugs or request features via [GitHub Issues](https://github.com/agentmuxhq/agentmux/issues)
-- Fix outstanding [issues](https://github.com/agentmuxhq/agentmux/issues) in the existing code
+- Report bugs or request features via [GitHub Issues](https://github.com/agentmuxai/agentmux/issues)
+- Fix outstanding [issues](https://github.com/agentmuxai/agentmux/issues) in the existing code
 - Improve [documentation](./docs)
 - Star the repository to show your appreciation
 
@@ -27,7 +27,7 @@ Contributions must be accompanied by a Contributor License Agreement (CLA). You 
 ## How to Contribute
 
 - For minor changes, open a pull request directly.
-- For major changes, [create an issue](https://github.com/agentmuxhq/agentmux/issues/new) first to discuss the approach.
+- For major changes, [create an issue](https://github.com/agentmuxai/agentmux/issues/new) first to discuss the approach.
 - Branch naming: `agenta/feature-name` (e.g., `agenta/fix-terminal-scroll`)
 
 ### Development Environment

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -472,7 +472,7 @@ Feature branches follow the pattern: `feature/description` or `agent/feature-nam
 
 - **Upstream repository:** https://github.com/wavetermdev/waveterm
 - **Base Upstream Version:** v0.12.0
-- **Fork repository:** https://github.com/agentmuxhq/agentmux
+- **Fork repository:** https://github.com/agentmuxai/agentmux
 - **Latest Fork:** v0.31.4
 - **Commits Ahead of Upstream:** 100+ commits with custom features
 

--- a/frontend/app/modals/about.tsx
+++ b/frontend/app/modals/about.tsx
@@ -36,7 +36,7 @@ const AboutModal = ({}: AboutModalProps) => {
                 </div>
                 <div className="flex items-start gap-[10px] self-stretch w-full text-center">
                     <a
-                        href="https://github.com/agentmuxhq/agentmux?ref=about"
+                        href="https://github.com/agentmuxai/agentmux?ref=about"
                         target="_blank"
                         rel="noopener"
                         className="inline-flex items-center px-4 py-2 rounded border border-border hover:bg-hoverbg transition-colors duration-200"
@@ -44,7 +44,7 @@ const AboutModal = ({}: AboutModalProps) => {
                         <i className="fa-brands fa-github mr-2"></i>Github
                     </a>
                     <a
-                        href="https://github.com/agentmuxhq/agentmux?ref=about"
+                        href="https://github.com/agentmuxai/agentmux?ref=about"
                         target="_blank"
                         rel="noopener"
                         className="inline-flex items-center px-4 py-2 rounded border border-border hover:bg-hoverbg transition-colors duration-200"
@@ -52,7 +52,7 @@ const AboutModal = ({}: AboutModalProps) => {
                         <i className="fa-sharp fa-light fa-globe mr-2"></i>Website
                     </a>
                     <a
-                        href="https://github.com/agentmuxhq/agentmux/blob/main/ACKNOWLEDGEMENTS.md"
+                        href="https://github.com/agentmuxai/agentmux/blob/main/ACKNOWLEDGEMENTS.md"
                         target="_blank"
                         rel="noopener"
                         className="inline-flex items-center px-4 py-2 rounded border border-border hover:bg-hoverbg transition-colors duration-200"

--- a/frontend/app/onboarding/onboarding-upgrade.tsx
+++ b/frontend/app/onboarding/onboarding-upgrade.tsx
@@ -60,7 +60,7 @@ const UpgradeOnboardingModal = () => {
             oref: WOS.makeORef("client", clientId),
             meta: { "onboarding:githubstar": true },
         });
-        window.open("https://github.com/agentmuxhq/agentmux?ref=upgrade", "_blank");
+        window.open("https://github.com/agentmuxai/agentmux?ref=upgrade", "_blank");
         setPageName("features");
     };
 

--- a/frontend/app/onboarding/onboarding.tsx
+++ b/frontend/app/onboarding/onboarding.tsx
@@ -74,7 +74,7 @@ const InitPage = ({ isCompact }: { isCompact: boolean }) => {
                         <div>
                             <a
                                 target="_blank"
-                                href="https://github.com/agentmuxhq/agentmux?ref=install"
+                                href="https://github.com/agentmuxai/agentmux?ref=install"
                                 rel={"noopener"}
                             >
                                 <i className="text-[32px] text-white/50 fa-brands fa-github"></i>
@@ -87,10 +87,10 @@ const InitPage = ({ isCompact }: { isCompact: boolean }) => {
                                 users. Please show your support by giving us a star on{" "}
                                 <a
                                     target="_blank"
-                                    href="https://github.com/agentmuxhq/agentmux?ref=install"
+                                    href="https://github.com/agentmuxai/agentmux?ref=install"
                                     rel={"noopener"}
                                 >
-                                    Github&nbsp;(agentmuxhq/agentmux)
+                                    Github&nbsp;(agentmuxai/agentmux)
                                 </a>
                             </div>
                         </div>
@@ -147,7 +147,7 @@ const NoTelemetryStarPage = ({ isCompact }: { isCompact: boolean }) => {
             oref: WOS.makeORef("client", clientId),
             meta: { "onboarding:githubstar": true },
         });
-        window.open("https://github.com/agentmuxhq/agentmux?ref=not", "_blank");
+        window.open("https://github.com/agentmuxai/agentmux?ref=not", "_blank");
         setPageName("features");
     };
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -295,7 +295,7 @@ aws dynamodb query \
 
 ## Support
 
-- **Issues:** https://github.com/agentmuxhq/agentmux/issues
+- **Issues:** https://github.com/agentmuxai/agentmux/issues
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
   "version": "0.31.64",
-  "homepage": "https://github.com/agentmuxhq/agentmux",
+  "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"
   },

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/agentmuxhq/agentmux/pkg/wconfig/settings-type",
+  "$id": "https://github.com/agentmuxai/agentmux/pkg/wconfig/settings-type",
   "$ref": "#/$defs/SettingsType",
   "$defs": {
     "SettingsType": {

--- a/specs/RELEASE_v0.31.20.md
+++ b/specs/RELEASE_v0.31.20.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-03
 **Version:** 0.31.20
-**Goal:** Produce Windows, macOS, and Linux installers + portables from the fresh `agentmuxhq/agentmux` repo.
+**Goal:** Produce Windows, macOS, and Linux installers + portables from the fresh `agentmuxai/agentmux` repo.
 
 ---
 
@@ -196,7 +196,7 @@ Alternatively, keep `"targets": ["nsis"]` and override per-platform in CI:
 
 ### Step 4: GitHub Secrets Required
 
-The following secrets must be configured on `agentmuxhq/agentmux`:
+The following secrets must be configured on `agentmuxai/agentmux`:
 
 | Secret | Purpose | Required? |
 |--------|---------|-----------|
@@ -224,7 +224,7 @@ For macOS code signing (optional but recommended):
 # Go to Actions > Build Tauri > Run workflow
 
 # Option B: Via gh CLI
-gh workflow run tauri-build.yml --repo agentmuxhq/agentmux
+gh workflow run tauri-build.yml --repo agentmuxai/agentmux
 
 # Option C: Tag-triggered (if workflow is updated to trigger on tags)
 git tag v0.31.20
@@ -488,7 +488,7 @@ jobs:
 
 - [ ] Rewrite `.github/workflows/tauri-build.yml` (remove Go, add Rust)
 - [ ] Update `src-tauri/tauri.conf.json` bundle targets if needed
-- [ ] Install GitHub App permissions for Actions on `agentmuxhq/agentmux`
+- [ ] Install GitHub App permissions for Actions on `agentmuxai/agentmux`
 - [ ] Configure secrets (TAURI_SIGNING keys - optional for first release)
 - [ ] Push workflow to main (requires branch protection bypass or PR)
 - [ ] Trigger workflow via Actions UI or `gh workflow run`

--- a/tools/sandbox/README.md
+++ b/tools/sandbox/README.md
@@ -1,4 +1,4 @@
-# @agentmuxhq/sandbox - AgentMux Development Tools
+# @agentmuxai/sandbox - AgentMux Development Tools
 
 AgentMux development sandbox setup and management tools.
 

--- a/tools/sandbox/package.json
+++ b/tools/sandbox/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentmuxhq/sandbox",
+  "name": "@agentmuxai/sandbox",
   "version": "1.0.0",
   "description": "AgentMux development sandbox setup and management tools",
   "private": true,


### PR DESCRIPTION
## Summary
- Replace all `agentmuxhq` references with `agentmuxai` across app code, docs, and config
- **App code (user-facing):** about modal, onboarding screens, visible "agentmuxhq/agentmux" text
- **Config:** package.json homepage, settings.json schema $id, issue templates
- **Docs:** BUILD.md, CLAUDE.md, CONTRIBUTING.md, VERSION_HISTORY.md, infra/README.md, tools/sandbox, release spec
- Archive specs (`specs/archive/`, `specs/identifier-rename.md`) left unchanged as historical records
- 25 replacements across 14 files

## Test plan
- [ ] Verify about modal links open correct GitHub org
- [ ] Verify onboarding links resolve
- [ ] Check issue template links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)