### PR TITLE
fix: agent pane command not executing (\r vs \n)

### DIFF
--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -74,8 +74,8 @@ export class AgentViewModel implements ViewModel {
             setTimeout(async () => {
                 const cmdText =
                     provider.defaultArgs.length > 0
-                        ? `${cliPath} ${provider.defaultArgs.join(" ")}\n`
-                        : `${cliPath}\n`;
+                        ? `${cliPath} ${provider.defaultArgs.join(" ")}\r`
+                        : `${cliPath}\r`;
                 const b64data = stringToBase64(cmdText);
                 await RpcApi.ControllerInputCommand(TabRpcClient, {
                     blockid: blockId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.31.69",
+  "version": "0.31.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.31.69",
+      "version": "0.31.71",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.31.70",
+  "version": "0.31.71",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Injected CLI command appeared in terminal but didn't execute — user had to press Enter manually
- PTY input expects `\r` (carriage return) for Enter, not `\n` (line feed)
- Changed the injected command suffix from `\n` to `\r`

## Test plan

- [ ] Click Claude Code button → command executes automatically
- [ ] Click Codex/Gemini buttons → same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)