### PR TITLE
fix: unset nested-session env vars before CLI launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.31.70"
+version = "0.31.72"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.31.70"
+version = "0.31.72"
 dependencies = [
  "async-stream",
  "axum",
@@ -50,6 +50,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 5.0.1",
+ "json_comments",
  "libc",
  "parking_lot",
  "portable-pty",
@@ -2286,6 +2287,12 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "json_comments"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "jsonptr"
@@ -6756,7 +6763,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.31.70"
+version = "0.31.72"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.31.70"
+version = "0.31.72"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.31.71",
+  "version": "0.31.72",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.31.70"
+version = "0.31.72"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.31.70",
-  "identifier": "ai.agentmux.app.v0-31-70",
+  "version": "0.31.72",
+  "identifier": "ai.agentmux.app.v0-31-72",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.31.70"
+version = "0.31.72"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

- Claude Code sets `CLAUDECODE` env var to detect nested sessions and refuses to launch inside another instance
- AgentMux's shell inherits this env var from the parent process, blocking `claude` from starting
- Added `unsetEnv` field to `ProviderDefinition` — lists env vars to clear before launching the CLI
- `connectWithProvider` now builds a platform-aware prefix (`$env:VAR=$null` on Windows, `unset VAR` on Unix) before injecting the CLI command

## Test plan

- [ ] Launch AgentMux from a Claude Code terminal → click Claude Code → `claude` starts without nested-session error
- [ ] Launch AgentMux standalone → click Claude Code → still works normally
- [ ] Codex/Gemini buttons unaffected (no `unsetEnv` configured)