### PR TITLE
fix: unset CLAUDECODE env var before CLI launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.31.72"
+version = "0.31.73"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.31.72"
+version = "0.31.73"
 dependencies = [
  "async-stream",
  "axum",
@@ -6763,7 +6763,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.31.72"
+version = "0.31.73"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.31.72"
+version = "0.31.73"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -4,7 +4,7 @@
 import { BlockNodeModel } from "@/app/block/blocktypes";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
-import { atoms, globalStore, WOS } from "@/app/store/global";
+import { atoms, getApi, globalStore, WOS } from "@/app/store/global";
 import { atom, Atom, PrimitiveAtom } from "jotai";
 import React from "react";
 import { AgentViewWrapper } from "./agent-view";
@@ -72,10 +72,22 @@ export class AgentViewModel implements ViewModel {
 
             // Inject the CLI command after a short delay for the shell to initialize
             setTimeout(async () => {
-                const cmdText =
-                    provider.defaultArgs.length > 0
-                        ? `${cliPath} ${provider.defaultArgs.join(" ")}\r`
-                        : `${cliPath}\r`;
+                // Build env cleanup prefix (e.g. CLAUDECODE nested-session guard)
+                let envPrefix = "";
+                if (provider.unsetEnv?.length) {
+                    const isWindows = getApi().getPlatform() === "win32";
+                    if (isWindows) {
+                        // PowerShell: $env:VAR=$null; ...
+                        envPrefix = provider.unsetEnv.map((v) => `$env:${v}=$null`).join("; ") + "; ";
+                    } else {
+                        // bash/zsh: unset VAR; ...
+                        envPrefix = provider.unsetEnv.map((v) => `unset ${v}`).join("; ") + "; ";
+                    }
+                }
+                const cliCmd = provider.defaultArgs.length > 0
+                    ? `${cliPath} ${provider.defaultArgs.join(" ")}`
+                    : cliPath;
+                const cmdText = `${envPrefix}${cliCmd}\r`;
                 const b64data = stringToBase64(cmdText);
                 await RpcApi.ControllerInputCommand(TabRpcClient, {
                     blockid: blockId,

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -14,6 +14,7 @@ export interface ProviderDefinition {
     pinnedVersion: string;       // version to install ("latest" or specific)
     docsUrl: string;
     icon: string;
+    unsetEnv?: string[];         // env vars to unset before launching (e.g. nested-session guards)
 }
 
 export const PROVIDERS: Record<string, ProviderDefinition> = {
@@ -30,6 +31,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         pinnedVersion: "latest",
         docsUrl: "https://docs.anthropic.com/claude-code",
         icon: "sparkles",
+        unsetEnv: ["CLAUDECODE"],
     },
     codex: {
         id: "codex",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.31.71",
+  "version": "0.31.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.31.71",
+      "version": "0.31.72",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.31.72",
+  "version": "0.31.73",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.31.72"
+version = "0.31.73"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.31.72",
-  "identifier": "ai.agentmux.app.v0-31-72",
+  "version": "0.31.73",
+  "identifier": "ai.agentmux.app.v0-31-73",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.31.72"
+version = "0.31.73"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

- Claude Code refuses to launch inside AgentMux because the `CLAUDECODE` env var is inherited from the parent process
- Added `unsetEnv` field to `ProviderDefinition` for per-provider env cleanup
- `connectWithProvider` now injects `$env:CLAUDECODE=$null;` (Windows) or `unset CLAUDECODE;` (Unix) before the CLI command

## Test plan

- [ ] Launch AgentMux from Claude Code terminal → click Claude Code → starts without nested-session error
- [ ] Launch AgentMux standalone → click Claude Code → still works