### PR TITLE
fix: add copy:schema to dev build tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,9 +180,8 @@ ls -lh dist/bin/wsh-*       # Verify
 Ensure `frontend/wave.ts` uses `getApi().getAboutModalDetails().version`
 
 ### Build Fails After Clean
-`dist/schema/` is wiped by `task clean` but not recreated.
-Workaround: `cp -r schema dist/schema` before `npx tauri build`
-Permanent fix: `copy:schema` task in Taskfile.yml
+`dist/schema/` is wiped by `task clean` but automatically recreated by the
+`copy:schema` dependency in `dev`, `start`, `quickdev`, and `package` tasks.
 
 ### Port Conflicts
 - Dev server port: 1420 (Vite) + backend port (varies)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -29,6 +29,7 @@ tasks:
             - npm:install
             - build:backend
             - sync:dev:binaries
+            - copy:schema
         env:
             AGENTMUX_ENVFILE: "{{.ROOT_DIR}}/.env"
             WCLOUD_ENDPOINT: "https://api-dev.agentmux.ai/central"
@@ -77,6 +78,7 @@ tasks:
         deps:
             - npm:install
             - build:backend
+            - copy:schema
         env:
             AGENTMUX_ENVFILE: "{{.ROOT_DIR}}/.env"
             WCLOUD_ENDPOINT: "https://api-dev.agentmux.ai/central"
@@ -88,6 +90,7 @@ tasks:
         deps:
             - npm:install
             - build:backend:rust
+            - copy:schema
         env:
             AGENTMUX_ENVFILE: "{{.ROOT_DIR}}/.env"
             WCLOUD_ENDPOINT: "https://api-dev.agentmux.ai/central"
@@ -508,6 +511,7 @@ tasks:
         cmds:
             - task: build:backend
             - task: tauri:copy-sidecars
+            - task: copy:schema
             - npm run tauri:dev
         deps:
             - npm:install


### PR DESCRIPTION
## Summary
- Adds `copy:schema` as a dependency to `dev`, `start`, `quickdev`, and `tauri:dev` tasks
- Fixes build failure after `task clean` or fresh clone where `dist/schema/` doesn't exist
- The `copy:schema` task already existed but was only wired to `package` tasks
- Updates CLAUDE.md to reflect the fix

## Test plan
- [ ] `task clean && task dev` succeeds without manual `cp -r schema dist/schema`
- [ ] `task start` succeeds from clean state
- [ ] `task quickdev` succeeds from clean state

🤖 Generated with [Claude Code](https://claude.com/claude-code)