### PR TITLE
fix: strip bundled system libs from AppImage (86MB → 16MB)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -177,6 +177,11 @@ tasks:
                   echo "❌ AppDir not found — Tauri build failed before linuxdeploy stage"
                   exit 1
                 fi
+                # Remove bundled system libraries — WebKitGTK, GTK3, glib, etc. are
+                # system dependencies on Linux and should not be shipped in the AppImage.
+                # Bundling them bloats the image from ~15MB to ~90MB.
+                rm -rf "$APPDIR/usr/lib"
+                echo "✓ Stripped bundled system libraries from AppDir"
                 # Ensure lowercase icon exists (desktop file references 'agentmux')
                 [ -f "$APPDIR/agentmux.png" ] || cp "$APPDIR/AgentMux.png" "$APPDIR/agentmux.png"
                 VERSION=$(node version.cjs)


### PR DESCRIPTION
## Summary
- Strips `usr/lib/` from the AppDir before running `appimagetool`
- `linuxdeploy` bundles 183 system libraries (WebKitGTK 87MB, GTK3, glib, etc.) that are standard Linux system dependencies
- Reduces AppImage from **86MB → 16MB**
- Change is inside `package:portable:linux` task (`platforms: [linux]`) — does not affect Windows or macOS builds

## Test plan
- [ ] `task package:portable:linux` produces ~15-16MB AppImage
- [ ] AppImage launches correctly on Ubuntu/Fedora/Arch
- [ ] Windows `task package` unaffected
- [ ] macOS `task package:macos` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)