### PR TITLE
fix(ci): sign macOS resource binaries before notarization

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -128,6 +128,33 @@ jobs:
           mkdir -p dist/schema
           cp -r schema/* dist/schema/
 
+      - name: Sign macOS resource binaries
+        if: matrix.platform == 'darwin'
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          # Import certificate into a temporary keychain
+          echo "$APPLE_CERTIFICATE" | base64 --decode > /tmp/certificate.p12
+          security create-keychain -p ci-keychain /tmp/build.keychain
+          security default-keychain -s /tmp/build.keychain
+          security unlock-keychain -p ci-keychain /tmp/build.keychain
+          security import /tmp/certificate.p12 -k /tmp/build.keychain \
+            -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k ci-keychain /tmp/build.keychain
+
+          # Sign resource binaries in binaries/bin/ — Tauri signs sidecars
+          # automatically but not resources, and notarization requires all
+          # binaries to be signed with hardened runtime + secure timestamp
+          for bin in src-tauri/binaries/bin/*; do
+            echo "Signing $bin"
+            codesign --force --sign "$APPLE_SIGNING_IDENTITY" \
+              --options runtime --timestamp "$bin"
+          done
+
       - name: Build Tauri application
         uses: tauri-apps/tauri-action@v0
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.31.97"
+version = "0.31.99"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.31.97"
+version = "0.31.99"
 dependencies = [
  "async-stream",
  "axum",
@@ -7069,7 +7069,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.31.97"
+version = "0.31.99"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.31.97"
+version = "0.31.99"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.31.91",
+  "version": "0.31.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.31.91",
+      "version": "0.31.100",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.31.97",
+  "version": "0.31.99",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.31.97"
+version = "0.31.99"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.31.97",
-  "identifier": "ai.agentmux.app.v0-31-97",
+  "version": "0.31.99",
+  "identifier": "ai.agentmux.app.v0-31-99",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.31.97"
+version = "0.31.99"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
Apple's notarizer rejected the DMG because `wsh-*-darwin.arm64` (bundled as a resource in `binaries/bin/`) was unsigned. Tauri signs registered sidecar binaries automatically but not resource files.

**Fix:** Add a pre-build step on macOS that imports the Developer ID cert into a temp keychain and runs `codesign --options runtime --timestamp` on all binaries in `src-tauri/binaries/bin/`.

**Root cause from notarization log:**
```
path: binaries/bin/wsh-0.31.97-darwin.arm64
- The binary is not signed with a valid Developer ID certificate.
- The signature does not include a secure timestamp.
- The executable does not have the hardened runtime enabled.
```