### PR TITLE
fix(ci): comprehensive release workflow fixes

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -23,10 +23,6 @@ jobs:
             target: aarch64-apple-darwin
             platform: darwin
             arch: arm64
-          - os: macos-14
-            target: x86_64-apple-darwin
-            platform: darwin
-            arch: x64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             platform: windows
@@ -97,7 +93,13 @@ jobs:
 
       - name: Verify version consistency
         shell: bash
-        run: bash scripts/verify-version.sh
+        env:
+          A5AF_PACKAGES_TOKEN: ${{ secrets.A5AF_PACKAGES_TOKEN }}
+        run: |
+          npm config set @a5af:registry https://npm.pkg.github.com
+          npm config set //npm.pkg.github.com/:_authToken "${A5AF_PACKAGES_TOKEN}"
+          npm install -g @a5af/bump-cli
+          bump verify
 
       - name: Copy sidecar binaries to Tauri
         shell: bash
@@ -126,12 +128,45 @@ jobs:
           mkdir -p dist/schema
           cp -r schema/* dist/schema/
 
+      - name: Sign macOS resource binaries
+        if: matrix.platform == 'darwin'
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          # Import certificate into a temporary keychain
+          echo "$APPLE_CERTIFICATE" | base64 --decode > /tmp/certificate.p12
+          security create-keychain -p ci-keychain /tmp/build.keychain
+          security default-keychain -s /tmp/build.keychain
+          security unlock-keychain -p ci-keychain /tmp/build.keychain
+          security import /tmp/certificate.p12 -k /tmp/build.keychain \
+            -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s \
+            -k ci-keychain /tmp/build.keychain
+
+          # Sign resource binaries in binaries/bin/ — Tauri signs sidecars
+          # automatically but not resources, and notarization requires all
+          # binaries to be signed with hardened runtime + secure timestamp
+          for bin in src-tauri/binaries/bin/*; do
+            echo "Signing $bin"
+            codesign --force --sign "$APPLE_SIGNING_IDENTITY" \
+              --options runtime --timestamp "$bin"
+          done
+
       - name: Build Tauri application
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           tauriScript: npx tauri
           args: --target ${{ matrix.target }}
@@ -140,35 +175,11 @@ jobs:
         if: matrix.platform == 'windows'
         shell: powershell
         run: |
-          $version = (node -p "require('./package.json').version")
-          $bundleDir = "target/${{ matrix.target }}/release"
-          $zipName = "AgentMux_${version}_${{ matrix.arch }}-portable.zip"
-          $outDir = "$bundleDir/bundle/portable"
-          New-Item -ItemType Directory -Force -Path $outDir
-
-          # Stage the main exe and its dependencies
-          $staging = "$outDir/AgentMux-portable"
-          New-Item -ItemType Directory -Force -Path $staging
-          Copy-Item "$bundleDir/agentmux.exe" "$staging/"
-
-          # Copy sidecar binaries
-          if (Test-Path "src-tauri/binaries") {
-            Copy-Item "src-tauri/binaries/*" "$staging/" -Recurse
-          }
-
-          # Copy schema resources
-          if (Test-Path "dist/schema") {
-            New-Item -ItemType Directory -Force -Path "$staging/schema"
-            Copy-Item "dist/schema/*" "$staging/schema/" -Recurse
-          }
-
-          # Copy WebView2Loader if present
-          Get-ChildItem "$bundleDir" -Filter "WebView2Loader.dll" -ErrorAction SilentlyContinue |
-            Copy-Item -Destination "$staging/"
-
-          Compress-Archive -Path "$staging/*" -DestinationPath "$outDir/$zipName"
-          Write-Host "Created portable ZIP: $outDir/$zipName"
-          Get-ChildItem "$outDir"
+          $buildDir = "target\${{ matrix.target }}\release"
+          $outDir = "$buildDir\bundle\portable"
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+          & scripts\package-portable.ps1 -BuildDir $buildDir -OutputDir $outDir
+          Get-ChildItem $outDir
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -198,15 +209,26 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            artifacts/**/*.exe
-            artifacts/**/*.zip
-            artifacts/**/*.deb
-            artifacts/**/*.AppImage
-            artifacts/**/*.dmg
-            artifacts/**/*.tar.gz
-            artifacts/**/*.sig
+            artifacts/**/AgentMux_*.dmg
+            artifacts/**/AgentMux_*-setup.exe
+            artifacts/**/agentmux-*-portable.zip
+            artifacts/**/AgentMux_*.AppImage
+            artifacts/**/AgentMux_*.deb
           draft: false
           prerelease: false
-          generate_release_notes: true
+          generate_release_notes: false
+          body: |
+            ## AgentMux ${{ github.ref_name }}
+
+            ### Downloads
+            | Platform | File |
+            |----------|------|
+            | Windows x64 (installer) | `AgentMux_${{ github.ref_name }}_x64-setup.exe` |
+            | Windows x64 (portable) | `agentmux-${{ github.ref_name }}-x64-portable.zip` |
+            | macOS Apple Silicon | `AgentMux_${{ github.ref_name }}_aarch64.dmg` |
+            | Linux x64 (AppImage) | `AgentMux_${{ github.ref_name }}_amd64.AppImage` |
+            | Linux x64 (deb) | `AgentMux_${{ github.ref_name }}_amd64.deb` |
+
+            **Full changelog:** https://github.com/agentmuxai/agentmux/commits/${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

All CI/release workflow fixes in one clean diff against the pre-CI baseline.

- **Drop Intel Mac** from matrix — only Apple Silicon DMG
- **Replace missing \`scripts/verify-version.sh\`** with \`bump verify\` via \`A5AF_PACKAGES_TOKEN\`
- **Sign macOS resource binaries** before Tauri build — imports Developer ID cert, runs \`codesign --options runtime --timestamp\` on \`src-tauri/binaries/bin/*\` (notarization requires all binaries signed with hardened runtime; Tauri auto-signs sidecars but not resources)
- **Apple signing secrets** wired into Build Tauri step (6 secrets)
- **Windows portable ZIP** delegates to \`scripts/package-portable.ps1\` — correct binary names matching portable mode detection in \`sidecar.rs\`
- **Tighten release asset globs** — only named artifacts, no junk files
- **Explicit release body** with download table

## Test plan

- [ ] Push a \`v*\` tag — 3 jobs complete (Linux x64, macOS arm64, Windows x64)
- [ ] macOS DMG signed + notarized (no Gatekeeper "damaged" warning)
- [ ] Windows portable ZIP: \`agentmux.exe\`, \`agentmuxsrv-rs.x64.exe\`, \`bin/wsh-*-windows.x64.exe\`, \`README.txt\`
- [ ] Release page shows only the 5 expected artifact types

🤖 Generated with [Claude Code](https://claude.com/claude-code)