### PR TITLE
fix: stale uiContext tab ID causing CreateBlock not-found errors

### DIFF
--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.31.105"
+version = "0.31.106"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.31.105",
+  "version": "0.31.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.31.105",
+      "version": "0.31.106",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.31.105",
+  "version": "0.31.106",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.31.105"
+version = "0.31.106"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.31.105",
-  "identifier": "ai.agentmux.app.v0-31-105",
+  "version": "0.31.106",
+  "identifier": "ai.agentmux.app.v0-31-106",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.31.105"
+version = "0.31.106"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

- **Bug:** After closing the initial tab and switching to a new tab, all `CreateBlock` calls fail with `"not found"`, spamming unhandled promise rejections until the app becomes unusable.
- **Root cause:** `uiContextAtom` in `global.ts` hardcoded `activetabid` to `initOpts.tabId` (the tab ID at window startup). It never updated when the user switched or closed tabs. Every `callBackendService` call sent this stale tab ID to the backend, which tried `store.must_get::<Tab>(tab_id)` on a deleted tab → `StoreError::NotFound`.
- **Fix:** Changed `uiContextAtom` from a static value to a derived atom that reads `activeTabIdAtom` (which reactively tracks `workspace.activetabid`). Now `uiContext.activetabid` always reflects the current active tab.

Closes #107 (Phase 0 — related bug found during investigation)

## Test plan

- [ ] Open app, create multiple tabs
- [ ] Close the first/initial tab
- [ ] Create a new pane (split, new terminal, etc.) — should succeed without errors
- [ ] Switch between tabs and create panes in each — all should work
- [ ] Check dev console for absence of `CreateBlock error: not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)