### PR TITLE
fix: unify jekt paths — bus:inject now writes to PTY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.31.118"
+version = "0.31.119"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.31.118"
+version = "0.31.119"
 dependencies = [
  "async-stream",
  "axum",
@@ -7069,7 +7069,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.31.118"
+version = "0.31.119"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.31.118"
+version = "0.31.119"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/agentmuxsrv-rs/src/backend/reactive/handler.rs
+++ b/agentmuxsrv-rs/src/backend/reactive/handler.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use super::sanitize::{format_injected_message, sanitize_message, validate_agent_id};
 use super::types::*;
-use super::{now_unix_millis, sha256_hex, AUDIT_LOG_MAX, INJECT_ENTER_DELAY_MS, RATE_LIMIT_MAX};
+use super::{now_unix_millis, sha256_hex, AUDIT_LOG_MAX, RATE_LIMIT_MAX};
 
 // ---- Rate Limiter ----
 
@@ -260,30 +260,10 @@ impl Handler {
             }
         };
 
-        // Step 1: Send message
-        if let Err(e) = sender(&block_id, final_msg.as_bytes()) {
-            self.log_audit(
-                req.source_agent.as_deref(),
-                &req.target_agent,
-                &block_id,
-                &sanitized,
-                false,
-                Some(&e),
-                &request_id,
-            );
-            return InjectionResponse {
-                success: false,
-                request_id,
-                block_id: Some(block_id),
-                error: Some(e),
-                timestamp: now,
-            };
-        }
-
-        // Step 2: Wait 150ms then send Enter
-        std::thread::sleep(Duration::from_millis(INJECT_ENTER_DELAY_MS));
-
-        if let Err(e) = sender(&block_id, b"\r") {
+        // Send message + Enter as a single payload. PTY handles it correctly
+        // without needing a delay between them.
+        let payload = format!("{}\r", final_msg);
+        if let Err(e) = sender(&block_id, payload.as_bytes()) {
             self.log_audit(
                 req.source_agent.as_deref(),
                 &req.target_agent,

--- a/agentmuxsrv-rs/src/backend/reactive/mod.rs
+++ b/agentmuxsrv-rs/src/backend/reactive/mod.rs
@@ -31,9 +31,6 @@ const AUDIT_LOG_MAX: usize = 100;
 /// Rate limit: max tokens (requests per second).
 const RATE_LIMIT_MAX: u32 = 10;
 
-/// Delay between message injection and Enter key (milliseconds).
-const INJECT_ENTER_DELAY_MS: u64 = 150;
-
 /// Default poll interval for AgentMux poller (seconds).
 pub const DEFAULT_POLL_INTERVAL_SECS: u64 = 30;
 

--- a/agentmuxsrv-rs/src/server/messagebus.rs
+++ b/agentmuxsrv-rs/src/server/messagebus.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::backend::messagebus::{BusMessage, MessageType, Priority};
+use crate::backend::reactive::InjectionRequest;
 use super::AppState;
 
 // ---- Request types ----
@@ -118,15 +119,47 @@ pub(super) async fn handle_send(
 }
 
 /// POST /api/bus/inject
+///
+/// Tries ReactiveHandler first (direct PTY write via blockcontroller).
+/// Falls back to MessageBus WebSocket push if agent has no block_id registered.
 pub(super) async fn handle_inject(
     State(state): State<AppState>,
     Json(req): Json<InjectRequest>,
 ) -> Json<Value> {
-    let priority = parse_priority(&req.priority);
+    // Try direct PTY injection via ReactiveHandler (agent has registered block_id)
+    let reactive_req = InjectionRequest {
+        target_agent: req.target.clone(),
+        message: req.message.clone(),
+        source_agent: Some(req.from.clone()),
+        request_id: None,
+        priority: req.priority.clone(),
+        wait_for_idle: false,
+    };
+    let resp = state.reactive_handler.inject_message(reactive_req);
+    if resp.success {
+        return Json(json!({
+            "status": "injected",
+            "via": "pty",
+            "block_id": resp.block_id,
+            "target": req.target,
+        }));
+    }
 
+    // Agent not registered with a block_id — fall back to MessageBus WS push
+    // (only fall back on "agent not found", propagate other errors)
+    let is_not_found = resp.error.as_deref().map(|e| e.contains("not found")).unwrap_or(false);
+    if !is_not_found {
+        return Json(json!({
+            "status": "error",
+            "error": resp.error,
+        }));
+    }
+
+    let priority = parse_priority(&req.priority);
     match state.messagebus.inject(&req.from, &req.target, &req.message, priority) {
         Ok(msg_id) => Json(json!({
             "status": "injected",
+            "via": "messagebus",
             "message_id": msg_id,
             "target": req.target,
         })),

--- a/agentmuxsrv-rs/src/server/websocket.rs
+++ b/agentmuxsrv-rs/src/server/websocket.rs
@@ -303,6 +303,37 @@ async fn handle_incoming_text(
                 if let (Some(ref target), Some(ref message)) =
                     (&incoming.target, &incoming.bus_message_text)
                 {
+                    // Try direct PTY injection via ReactiveHandler first
+                    let reactive_req = crate::backend::reactive::InjectionRequest {
+                        target_agent: target.clone(),
+                        message: message.clone(),
+                        source_agent: Some(from.to_string()),
+                        request_id: None,
+                        priority: incoming.priority.clone(),
+                        wait_for_idle: false,
+                    };
+                    let resp = state.reactive_handler.inject_message(reactive_req);
+                    if resp.success {
+                        let ack = json!({ "type": "bus:injected", "via": "pty", "block_id": resp.block_id });
+                        let msg = serde_json::to_string(&ack).unwrap_or_default();
+                        if socket.send(Message::Text(msg.into())).await.is_err() {
+                            return Err(true);
+                        }
+                        return Ok(None);
+                    }
+
+                    // Non-"agent not found" error — report it
+                    let is_not_found = resp.error.as_deref().map(|e| e.contains("not found")).unwrap_or(false);
+                    if !is_not_found {
+                        let err = json!({ "type": "bus:error", "error": resp.error });
+                        let msg = serde_json::to_string(&err).unwrap_or_default();
+                        if socket.send(Message::Text(msg.into())).await.is_err() {
+                            return Err(true);
+                        }
+                        return Ok(None);
+                    }
+
+                    // Fall back to MessageBus WebSocket push
                     let priority = match incoming.priority.as_deref() {
                         Some("high") => crate::backend::messagebus::Priority::High,
                         Some("urgent") => crate::backend::messagebus::Priority::Urgent,
@@ -310,7 +341,7 @@ async fn handle_incoming_text(
                     };
                     match state.messagebus.inject(from, target, message, priority) {
                         Ok(msg_id) => {
-                            let ack = json!({ "type": "bus:injected", "message_id": msg_id });
+                            let ack = json!({ "type": "bus:injected", "via": "messagebus", "message_id": msg_id });
                             let msg = serde_json::to_string(&ack).unwrap_or_default();
                             if socket.send(Message::Text(msg.into())).await.is_err() {
                                 return Err(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.31.116",
+  "version": "0.31.118",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.31.116",
+      "version": "0.31.118",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.31.118",
+  "version": "0.31.119",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.31.118"
+version = "0.31.119"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.31.118",
-  "identifier": "ai.agentmux.app.v0-31-118",
+  "version": "0.31.119",
+  "identifier": "ai.agentmux.app.v0-31-119",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.31.118"
+version = "0.31.119"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Problem

Two bugs in the jekt (terminal injection) paths:

**Bug 1: `std::thread::sleep(150ms)` in reactive handler**
`inject_message()` held the Mutex while sleeping 150ms between sending message bytes and Enter. Blocked concurrent injections. Also unnecessary — PTY handles `message\r` as a single write correctly.

**Bug 2: `bus:inject` never wrote to PTY**
Both `POST /api/bus/inject` and WebSocket `bus:inject` routed through `MessageBus::inject()` which pushes via WebSocket as a `bus:message` event. Frontend received it as a notification — nothing wrote bytes to the terminal PTY. Jekt via the messagebus path was silently broken.

## Fix

### `reactive/handler.rs`
- Remove `std::thread::sleep(150ms)`
- Send `format!("{}\r", message)` as a single payload

### `server/messagebus.rs` + `server/websocket.rs`
Both `bus:inject` entry points now:
1. Try `ReactiveHandler.inject_message()` first → direct PTY write via `blockcontroller::send_input()`
2. Fall back to MessageBus WS push only when agent has no registered `block_id`
3. Return `"via": "pty"` or `"via": "messagebus"` so callers know which path fired

## Test

```bash
# Register agent with block_id
curl -X POST http://localhost:<port>/wave/reactive/register   -H 'Content-Type: application/json'   -d '{"agent_id": "test-agent", "block_id": "<block-id>"}'

# Inject via bus — now writes to PTY
curl -X POST http://localhost:<port>/api/bus/inject   -H 'Content-Type: application/json'   -d '{"from": "agentx", "target": "test-agent", "message": "echo hello"}'
# {"status":"injected","via":"pty","block_id":"...","target":"test-agent"}
```