### PR TITLE
feat: jekt system — auto-registration, cross-instance routing, inject timing

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Static CRT linking for Windows MSVC targets.
+# Embeds VCRUNTIME140.dll into the binary so it runs on bare Windows
+# installs without the Visual C++ Redistributable package.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.31.120"
+version = "0.31.127"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.31.120"
+version = "0.31.127"
 dependencies = [
  "async-stream",
  "axum",
@@ -7069,7 +7069,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.31.120"
+version = "0.31.127"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.31.120"
+version = "0.31.127"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 
@@ -35,6 +35,7 @@ portable-pty = "0.9"
 sysinfo = "0.34"
 parking_lot = "0.12"
 notify = "7"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking", "json"] }

--- a/agentmuxsrv-rs/src/backend/blockcontroller/shell.rs
+++ b/agentmuxsrv-rs/src/backend/blockcontroller/shell.rs
@@ -369,6 +369,22 @@ impl Controller for ShellController {
         let cmd_args = Self::get_cmd_args(&block_meta);
         let interactive = Self::is_interactive(&block_meta);
 
+        // Resolve effective AGENTMUX_AGENT_ID for jekt auto-registration.
+        // Priority: block metadata > global settings > WAVEMUX_AGENT_ID env compat.
+        let agent_id_for_jekt: Option<String> = block_meta
+            .get(META_KEY_CMD_ENV)
+            .and_then(|m| m.as_object())
+            .and_then(|obj| obj.get("AGENTMUX_AGENT_ID"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                let cfg = crate::backend::wconfig::ConfigWatcher::with_config(
+                    crate::backend::wconfig::build_default_config(),
+                );
+                cfg.get_settings().cmd_env.get("AGENTMUX_AGENT_ID").cloned()
+            })
+            .or_else(|| std::env::var("WAVEMUX_AGENT_ID").ok());
+
         let mut cmd = if !cmd_str.is_empty() && (!cmd_args.is_empty() || interactive) {
             // Direct spawn: cmd:args provided or cmd:interactive set.
             // Spawn the CLI directly (no sh -c wrapper) so args are passed correctly.
@@ -430,6 +446,12 @@ impl Controller for ShellController {
             c.env("AGENTMUX_BLOCKID", &self.block_id);
             c.env("AGENTMUX_TABID", &self.tab_id);
             c.env("AGENTMUX_VERSION", env!("CARGO_PKG_VERSION"));
+
+            // Propagate local backend URL so agentbus-client prefers local PTY delivery.
+            // Set by main.rs after binding; absent in test/mock contexts (graceful no-op).
+            if let Ok(local_url) = std::env::var("AGENTMUX_LOCAL_URL") {
+                c.env("AGENTMUX_LOCAL_URL", &local_url);
+            }
 
             // Set AGENTMUX to the wsh binary path for portable mode detection in scripts
             if let Some(wsh_path) = crate::backend::shellintegration::find_wsh_binary() {
@@ -499,6 +521,39 @@ impl Controller for ShellController {
             format!("failed to spawn command: {e}")
         })?;
         tracing::info!(block_id = %self.block_id, "process spawned successfully");
+
+        // Auto-register with jekt if AGENTMUX_AGENT_ID was set in the block env.
+        // This maps agent_id → block_id in the ReactiveHandler so jekt can deliver
+        // messages directly to this PTY without a separate /wave/reactive/register call.
+        if let Some(ref agent_id) = agent_id_for_jekt {
+            match crate::backend::reactive::get_global_handler()
+                .register_agent(agent_id, &self.block_id, Some(&self.tab_id))
+            {
+                Ok(()) => {
+                    tracing::info!(
+                        block_id = %self.block_id,
+                        agent_id = %agent_id,
+                        "jekt: auto-registered"
+                    );
+                    // Also write to cross-instance file registry.
+                    if let Ok(local_url) = std::env::var("AGENTMUX_LOCAL_URL") {
+                        let data_dir = crate::backend::wavebase::get_wave_data_dir();
+                        crate::backend::reactive::registry::write(
+                            &data_dir,
+                            agent_id,
+                            &local_url,
+                            &self.block_id,
+                        );
+                    }
+                }
+                Err(e) => tracing::warn!(
+                    block_id = %self.block_id,
+                    agent_id = %agent_id,
+                    error = %e,
+                    "jekt: auto-register failed"
+                ),
+            }
+        }
         tracing::info!(
             block_id = %self.block_id,
             wstore_present = self.wstore.is_some(),
@@ -650,6 +705,7 @@ impl Controller for ShellController {
         // Spawn wait task (monitors process exit)
         let inner_wait = Arc::clone(&self.inner);
         let block_id_wait = self.block_id.clone();
+        let agent_id_wait = agent_id_for_jekt.clone();
         let broker_wait = self.broker.clone();
         let run_lock = Arc::clone(&self.run_lock);
         tokio::task::spawn_blocking(move || {
@@ -673,6 +729,16 @@ impl Controller for ShellController {
             };
 
             tracing::info!(block_id = %block_id_wait, exit_code = exit_code, "process exited");
+
+            // Deregister from jekt — removes the agent_id → block_id mapping so
+            // subsequent jekt attempts fall back to MessageBus rather than a dead PTY.
+            crate::backend::reactive::get_global_handler().unregister_block(&block_id_wait);
+
+            // Also remove from cross-instance file registry.
+            if let Some(ref agent_id) = agent_id_wait {
+                let data_dir = crate::backend::wavebase::get_wave_data_dir();
+                crate::backend::reactive::registry::remove(&data_dir, agent_id);
+            }
 
             // Update inner state
             {

--- a/agentmuxsrv-rs/src/backend/reactive/handler.rs
+++ b/agentmuxsrv-rs/src/backend/reactive/handler.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use super::sanitize::{format_injected_message, sanitize_message, validate_agent_id};
 use super::types::*;
-use super::{now_unix_millis, sha256_hex, AUDIT_LOG_MAX, INJECT_ENTER_DELAY_MS, RATE_LIMIT_MAX};
+use super::{now_unix_millis, sha256_hex, AUDIT_LOG_MAX, RATE_LIMIT_MAX};
 
 // ---- Rate Limiter ----
 
@@ -168,9 +168,9 @@ impl Handler {
 
     /// Inject a message into an agent's terminal.
     ///
-    /// CRITICAL: Message and Enter are sent separately with a 150ms delay.
-    /// This is required because the PTY needs to see the message first,
-    /// then Enter as a distinct event.
+    /// Sends `message\r` as a single payload (required for text display),
+    /// then spawns 3 delayed `\r` sends at 200ms intervals as separate
+    /// PTY writes to ensure submission. See `specs/jekt-inject-timing.md`.
     pub fn inject_message(&mut self, mut req: InjectionRequest) -> InjectionResponse {
         let now = now_unix_millis();
 
@@ -260,8 +260,25 @@ impl Handler {
             }
         };
 
-        // Step 1: Send message
-        if let Err(e) = sender(&block_id, final_msg.as_bytes()) {
+        // Jekt inject sequence (see specs/jekt-inject-timing.md):
+        // 1. \r to clear any partial input on the line
+        // 2. message\r as single payload (proven to display text — v0.31.122/125)
+        // 3. Three delayed \r at 200ms intervals as separate PTY writes to submit
+        let _ = sender(&block_id, b"\r");
+        let payload = format!("{}\r", final_msg);
+        tracing::info!(
+            target_agent = %req.target_agent,
+            block_id = %block_id,
+            msg_len = payload.len(),
+            "inject: sending payload to PTY"
+        );
+        if let Err(e) = sender(&block_id, payload.as_bytes()) {
+            tracing::error!(
+                target_agent = %req.target_agent,
+                block_id = %block_id,
+                error = %e,
+                "inject: sender failed"
+            );
             self.log_audit(
                 req.source_agent.as_deref(),
                 &req.target_agent,
@@ -280,27 +297,17 @@ impl Handler {
             };
         }
 
-        // Step 2: Wait 150ms then send Enter
-        std::thread::sleep(Duration::from_millis(INJECT_ENTER_DELAY_MS));
-
-        if let Err(e) = sender(&block_id, b"\r") {
-            self.log_audit(
-                req.source_agent.as_deref(),
-                &req.target_agent,
-                &block_id,
-                &sanitized,
-                false,
-                Some(&e),
-                &request_id,
-            );
-            return InjectionResponse {
-                success: false,
-                request_id,
-                block_id: Some(block_id),
-                error: Some(e),
-                timestamp: now,
-            };
-        }
+        // Spawn 3 delayed \r sends as separate PTY events to ensure submission.
+        let sender_enter = sender.clone();
+        let block_id_enter = block_id.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            let _ = sender_enter(&block_id_enter, b"\r");
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            let _ = sender_enter(&block_id_enter, b"\r");
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            let _ = sender_enter(&block_id_enter, b"\r");
+        });
 
         // Success
         self.log_audit(

--- a/agentmuxsrv-rs/src/backend/reactive/mod.rs
+++ b/agentmuxsrv-rs/src/backend/reactive/mod.rs
@@ -10,6 +10,7 @@
 
 pub mod handler;
 pub mod poller;
+pub mod registry;
 pub mod sanitize;
 pub mod types;
 #[cfg(test)]
@@ -30,9 +31,6 @@ const AUDIT_LOG_MAX: usize = 100;
 
 /// Rate limit: max tokens (requests per second).
 const RATE_LIMIT_MAX: u32 = 10;
-
-/// Delay between message injection and Enter key (milliseconds).
-const INJECT_ENTER_DELAY_MS: u64 = 150;
 
 /// Default poll interval for AgentMux poller (seconds).
 pub const DEFAULT_POLL_INTERVAL_SECS: u64 = 30;

--- a/agentmuxsrv-rs/src/backend/reactive/registry.rs
+++ b/agentmuxsrv-rs/src/backend/reactive/registry.rs
@@ -1,0 +1,99 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! File-based cross-instance agent registry.
+//!
+//! Each AgentMux instance writes agent registrations to
+//! `{data_dir}/agents/{agent_id}.json`. When a local inject fails with
+//! "agent not found", the inject handler looks up this registry and
+//! HTTP-forwards the request to the owning instance.
+//!
+//! Lifecycle:
+//! - Register: write file (on HTTP register endpoint + shell auto-register)
+//! - Unregister: delete file (on HTTP unregister endpoint + process exit)
+//! - Cleanup: TTL-based removal of stale files at startup
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+use super::now_unix_millis;
+
+/// One entry per registered agent in the shared data dir.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentEntry {
+    pub agent_id: String,
+    /// Local HTTP URL of the owning AgentMux instance (e.g. http://127.0.0.1:PORT).
+    pub local_url: String,
+    pub block_id: String,
+    /// OS PID of the owning agentmuxsrv-rs process.
+    pub pid: u32,
+    /// Unix milliseconds of last update.
+    pub updated_at: u64,
+}
+
+fn agents_dir(data_dir: &Path) -> PathBuf {
+    data_dir.join("agents")
+}
+
+fn agent_path(data_dir: &Path, agent_id: &str) -> PathBuf {
+    // Sanitize: only allow alphanumeric, dash, underscore to prevent path traversal.
+    let safe: String = agent_id
+        .chars()
+        .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .collect();
+    agents_dir(data_dir).join(format!("{}.json", safe))
+}
+
+/// Write (create or update) an agent entry in the shared registry.
+pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
+    let dir = agents_dir(data_dir);
+    let _ = std::fs::create_dir_all(&dir);
+    let entry = AgentEntry {
+        agent_id: agent_id.to_string(),
+        local_url: local_url.to_string(),
+        block_id: block_id.to_string(),
+        pid: std::process::id(),
+        updated_at: now_unix_millis(),
+    };
+    if let Ok(json) = serde_json::to_string(&entry) {
+        let _ = std::fs::write(agent_path(data_dir, agent_id), json);
+    }
+}
+
+/// Remove an agent entry from the shared registry.
+pub fn remove(data_dir: &Path, agent_id: &str) {
+    let _ = std::fs::remove_file(agent_path(data_dir, agent_id));
+}
+
+/// Look up an agent entry. Returns None if not found or file is malformed.
+pub fn lookup(data_dir: &Path, agent_id: &str) -> Option<AgentEntry> {
+    let content = std::fs::read_to_string(agent_path(data_dir, agent_id)).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Remove stale entries at startup.
+///
+/// An entry is considered stale if `updated_at` is older than `max_age_ms`.
+/// The default is 4 hours — well beyond any reasonable agent session.
+/// Entries are also removed if their JSON is malformed.
+pub fn cleanup_stale(data_dir: &Path, max_age_ms: u64) {
+    let dir = agents_dir(data_dir);
+    let Ok(entries) = std::fs::read_dir(&dir) else { return };
+    let cutoff = now_unix_millis().saturating_sub(max_age_ms);
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            let _ = std::fs::remove_file(&path);
+            continue;
+        };
+        match serde_json::from_str::<AgentEntry>(&content) {
+            Ok(agent) if agent.updated_at >= cutoff => {} // still fresh
+            _ => {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+    }
+}

--- a/agentmuxsrv-rs/src/main.rs
+++ b/agentmuxsrv-rs/src/main.rs
@@ -172,6 +172,29 @@ async fn main() {
     // Local MessageBus for inter-agent communication
     let messagebus = Arc::new(backend::messagebus::MessageBus::new());
 
+    // 5. Bind 2 TCP listeners on 127.0.0.1:0 (web + ws — separate ports matching Go)
+    let web_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("failed to bind web listener");
+    let ws_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("failed to bind ws listener");
+
+    let web_addr = web_listener.local_addr().unwrap();
+    let ws_addr = ws_listener.local_addr().unwrap();
+    let local_web_url = format!("http://{}", web_addr);
+
+    // Make local backend URL available to child processes (PTY shells).
+    // agentbus-client reads AGENTMUX_LOCAL_URL and uses it for local PTY delivery
+    // instead of routing through the cloud agentbus.
+    std::env::set_var("AGENTMUX_LOCAL_URL", &local_web_url);
+
+    // Clean up stale cross-instance agent registry entries (entries older than 4h).
+    backend::reactive::registry::cleanup_stale(
+        &wavebase::get_wave_data_dir(),
+        4 * 60 * 60 * 1000,
+    );
+
     let state = AppState {
         auth_key: config.auth_key.clone(),
         version: version.clone(),
@@ -184,18 +207,9 @@ async fn main() {
         poller,
         config_watcher,
         messagebus,
+        local_web_url: local_web_url.clone(),
+        http_client: reqwest::Client::new(),
     };
-
-    // 5. Bind 2 TCP listeners on 127.0.0.1:0 (web + ws — separate ports matching Go)
-    let web_listener = TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("failed to bind web listener");
-    let ws_listener = TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("failed to bind ws listener");
-
-    let web_addr = web_listener.local_addr().unwrap();
-    let ws_addr = ws_listener.local_addr().unwrap();
 
     // 6. Emit WAVESRV-ESTART on stderr (exact format from cmd/server/main-server.go:617)
     eprintln!(

--- a/agentmuxsrv-rs/src/server/messagebus.rs
+++ b/agentmuxsrv-rs/src/server/messagebus.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::backend::messagebus::{BusMessage, MessageType, Priority};
+use crate::backend::reactive::InjectionRequest;
 use super::AppState;
 
 // ---- Request types ----
@@ -118,15 +119,47 @@ pub(super) async fn handle_send(
 }
 
 /// POST /api/bus/inject
+///
+/// Tries ReactiveHandler first (direct PTY write via blockcontroller).
+/// Falls back to MessageBus WebSocket push if agent has no block_id registered.
 pub(super) async fn handle_inject(
     State(state): State<AppState>,
     Json(req): Json<InjectRequest>,
 ) -> Json<Value> {
-    let priority = parse_priority(&req.priority);
+    // Try direct PTY injection via ReactiveHandler (agent has registered block_id)
+    let reactive_req = InjectionRequest {
+        target_agent: req.target.clone(),
+        message: req.message.clone(),
+        source_agent: Some(req.from.clone()),
+        request_id: None,
+        priority: req.priority.clone(),
+        wait_for_idle: false,
+    };
+    let resp = state.reactive_handler.inject_message(reactive_req);
+    if resp.success {
+        return Json(json!({
+            "status": "injected",
+            "via": "pty",
+            "block_id": resp.block_id,
+            "target": req.target,
+        }));
+    }
 
+    // Agent not registered with a block_id — fall back to MessageBus WS push
+    // (only fall back on "agent not found", propagate other errors)
+    let is_not_found = resp.error.as_deref().map(|e| e.contains("not found")).unwrap_or(false);
+    if !is_not_found {
+        return Json(json!({
+            "status": "error",
+            "error": resp.error,
+        }));
+    }
+
+    let priority = parse_priority(&req.priority);
     match state.messagebus.inject(&req.from, &req.target, &req.message, priority) {
         Ok(msg_id) => Json(json!({
             "status": "injected",
+            "via": "messagebus",
             "message_id": msg_id,
             "target": req.target,
         })),

--- a/agentmuxsrv-rs/src/server/mod.rs
+++ b/agentmuxsrv-rs/src/server/mod.rs
@@ -45,6 +45,11 @@ pub struct AppState {
     pub poller: Arc<Poller>,
     pub config_watcher: Arc<wconfig::ConfigWatcher>,
     pub messagebus: Arc<MessageBus>,
+    /// Local HTTP URL of this instance (e.g. "http://127.0.0.1:PORT").
+    /// Used for cross-instance inject forwarding and file registry entries.
+    pub local_web_url: String,
+    /// Shared HTTP client for cross-instance inject forwarding.
+    pub http_client: reqwest::Client,
 }
 
 /// Build the Axum router with all routes, auth middleware, and CORS.

--- a/agentmuxsrv-rs/src/server/reactive.rs
+++ b/agentmuxsrv-rs/src/server/reactive.rs
@@ -6,6 +6,8 @@ use axum::{
 use serde_json::json;
 
 use crate::backend::reactive::InjectionRequest;
+use crate::backend::reactive::registry as agent_registry;
+use crate::backend::wavebase;
 
 use super::AppState;
 
@@ -13,7 +15,67 @@ pub(super) async fn handle_reactive_inject(
     State(state): State<AppState>,
     Json(req): Json<InjectionRequest>,
 ) -> Json<serde_json::Value> {
-    let resp = state.reactive_handler.inject_message(req);
+    tracing::info!(
+        target_agent = %req.target_agent,
+        source_agent = ?req.source_agent,
+        msg_len = req.message.len(),
+        "reactive inject request received"
+    );
+
+    // 1. Try local ReactiveHandler first (fast path — same instance).
+    let resp = state.reactive_handler.inject_message(req.clone());
+    if resp.success {
+        return Json(serde_json::to_value(&resp).unwrap_or_default());
+    }
+
+    // 2. On "agent not found", check cross-instance file registry and forward.
+    let is_not_found = resp
+        .error
+        .as_deref()
+        .map(|e| e.starts_with("agent not found"))
+        .unwrap_or(false);
+
+    if is_not_found {
+        let data_dir = wavebase::get_wave_data_dir();
+        if let Some(entry) = agent_registry::lookup(&data_dir, &req.target_agent) {
+            // Guard against self-forwarding loops.
+            if entry.local_url != state.local_web_url {
+                let forward_url = format!("{}/wave/reactive/inject", entry.local_url);
+                tracing::debug!(
+                    target = %req.target_agent,
+                    url = %forward_url,
+                    "cross-instance inject forward"
+                );
+                match state.http_client.post(&forward_url).json(&req).send().await {
+                    Ok(r) if r.status().is_success() => {
+                        if let Ok(body) = r.json::<serde_json::Value>().await {
+                            return Json(body);
+                        }
+                    }
+                    Ok(r) => {
+                        tracing::warn!(
+                            target = %req.target_agent,
+                            status = %r.status(),
+                            url = %forward_url,
+                            "cross-instance forward: non-success status"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target = %req.target_agent,
+                            error = %e,
+                            url = %forward_url,
+                            "cross-instance forward failed — removing stale registry entry"
+                        );
+                        // Remove stale entry so next call doesn't retry a dead instance.
+                        agent_registry::remove(&data_dir, &req.target_agent);
+                    }
+                }
+            }
+        }
+    }
+
+    // 3. Return original error (agentbus-client will fall back to cloud).
     Json(serde_json::to_value(&resp).unwrap_or_default())
 }
 
@@ -81,11 +143,22 @@ pub(super) async fn handle_reactive_register(
     State(state): State<AppState>,
     Json(req): Json<RegisterRequest>,
 ) -> Response {
+    tracing::info!(
+        agent_id = %req.agent_id,
+        block_id = %req.block_id,
+        "reactive register request"
+    );
     match state
         .reactive_handler
         .register_agent(&req.agent_id, &req.block_id, req.tab_id.as_deref())
     {
-        Ok(()) => Json(json!({"success": true})).into_response(),
+        Ok(()) => {
+            // Also write to cross-instance file registry so other AgentMux
+            // instances can forward inject requests to this one.
+            let data_dir = wavebase::get_wave_data_dir();
+            agent_registry::write(&data_dir, &req.agent_id, &state.local_web_url, &req.block_id);
+            Json(json!({"success": true})).into_response()
+        }
         Err(e) => (
             StatusCode::BAD_REQUEST,
             Json(json!({"error": e})),
@@ -104,6 +177,9 @@ pub(super) async fn handle_reactive_unregister(
     Json(req): Json<UnregisterRequest>,
 ) -> Json<serde_json::Value> {
     state.reactive_handler.unregister_agent(&req.agent_id);
+    // Also remove from cross-instance file registry.
+    let data_dir = wavebase::get_wave_data_dir();
+    agent_registry::remove(&data_dir, &req.agent_id);
     Json(json!({"success": true}))
 }
 

--- a/agentmuxsrv-rs/src/server/websocket.rs
+++ b/agentmuxsrv-rs/src/server/websocket.rs
@@ -303,6 +303,37 @@ async fn handle_incoming_text(
                 if let (Some(ref target), Some(ref message)) =
                     (&incoming.target, &incoming.bus_message_text)
                 {
+                    // Try direct PTY injection via ReactiveHandler first
+                    let reactive_req = crate::backend::reactive::InjectionRequest {
+                        target_agent: target.clone(),
+                        message: message.clone(),
+                        source_agent: Some(from.to_string()),
+                        request_id: None,
+                        priority: incoming.priority.clone(),
+                        wait_for_idle: false,
+                    };
+                    let resp = state.reactive_handler.inject_message(reactive_req);
+                    if resp.success {
+                        let ack = json!({ "type": "bus:injected", "via": "pty", "block_id": resp.block_id });
+                        let msg = serde_json::to_string(&ack).unwrap_or_default();
+                        if socket.send(Message::Text(msg.into())).await.is_err() {
+                            return Err(true);
+                        }
+                        return Ok(None);
+                    }
+
+                    // Non-"agent not found" error — report it
+                    let is_not_found = resp.error.as_deref().map(|e| e.contains("not found")).unwrap_or(false);
+                    if !is_not_found {
+                        let err = json!({ "type": "bus:error", "error": resp.error });
+                        let msg = serde_json::to_string(&err).unwrap_or_default();
+                        if socket.send(Message::Text(msg.into())).await.is_err() {
+                            return Err(true);
+                        }
+                        return Ok(None);
+                    }
+
+                    // Fall back to MessageBus WebSocket push
                     let priority = match incoming.priority.as_deref() {
                         Some("high") => crate::backend::messagebus::Priority::High,
                         Some("urgent") => crate::backend::messagebus::Priority::Urgent,
@@ -310,7 +341,7 @@ async fn handle_incoming_text(
                     };
                     match state.messagebus.inject(from, target, message, priority) {
                         Ok(msg_id) => {
-                            let ack = json!({ "type": "bus:injected", "message_id": msg_id });
+                            let ack = json!({ "type": "bus:injected", "via": "messagebus", "message_id": msg_id });
                             let msg = serde_json::to_string(&ack).unwrap_or_default();
                             if socket.send(Message::Text(msg.into())).await.is_err() {
                                 return Err(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.31.116",
+  "version": "0.31.126",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.31.116",
+      "version": "0.31.126",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.31.120",
+  "version": "0.31.127",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/jekt-auto-registration.md
+++ b/specs/jekt-auto-registration.md
@@ -1,0 +1,189 @@
+# Jekt Auto-Registration via AGENTMUX_AGENT_ID
+
+**Author:** AgentX
+**Date:** 2026-03-12
+**Status:** Draft
+**Branch:** agentx/jekt-auto-register
+
+---
+
+## Problem
+
+Jekt (terminal injection) currently requires a **manual registration call** before it works:
+
+```bash
+POST /wave/reactive/register
+{ "agent_id": "AgentX", "block_id": "<block-id>" }
+```
+
+But the backend already has all the information it needs at spawn time:
+- `block_id` — the block's own identifier, set in `ShellController`
+- `tab_id` — known at spawn time
+- `AGENTMUX_AGENT_ID` — set in the block's env via `cmd:env` metadata or global settings
+
+The explicit registration call is friction that shouldn't exist. If a pane is launched
+with `AGENTMUX_AGENT_ID` set, jekt should work immediately — no extra step.
+
+---
+
+## Current Flow (broken without manual step)
+
+```
+1. User/Forge sets cmd:env["AGENTMUX_AGENT_ID"] = "Agent1" on block
+2. Block spawns — AGENTMUX_AGENT_ID + AGENTMUX_BLOCKID are set in PTY env
+3. ← Manual step required: POST /wave/reactive/register {agent_id, block_id}
+4. Jekt via POST /api/bus/inject → ReactiveHandler → blockcontroller::send_input → PTY ✓
+```
+
+Without step 3, jekt returns "agent not found" and falls back to MessageBus WS push
+(which pushes a bus:message event but never writes to PTY).
+
+---
+
+## Proposed Flow (automatic)
+
+```
+1. User/Forge sets cmd:env["AGENTMUX_AGENT_ID"] = "Agent1" on block
+2. Block spawns → ShellController detects AGENTMUX_AGENT_ID in env
+3. ShellController auto-calls reactive::get_global_handler().register_agent(agent_id, block_id, tab_id)
+4. Jekt via POST /api/bus/inject → ReactiveHandler → blockcontroller::send_input → PTY ✓
+5. Process exits → ShellController auto-calls reactive_handler.unregister_block(block_id)
+```
+
+---
+
+## Implementation
+
+### File: `agentmuxsrv-rs/src/backend/blockcontroller/shell.rs`
+
+#### 1. Capture effective agent_id during env construction
+
+**Change** `has_agent_id: bool` → `agent_id_for_jekt: Option<String>` to capture
+the actual value rather than just presence.
+
+Priority order (highest wins, matches existing env injection priority):
+1. Block metadata `cmd:env["AGENTMUX_AGENT_ID"]` (highest)
+2. Global settings `cmd_env["AGENTMUX_AGENT_ID"]`
+3. `WAVEMUX_AGENT_ID` env var (backward compat bridge, lowest)
+
+```rust
+// Before (current)
+let mut has_agent_id = false;
+// ...
+if k == "AGENTMUX_AGENT_ID" { has_agent_id = true; }
+// ...
+if !has_agent_id { c.env("AGENTMUX_AGENT_ID", &wavemux_val); }
+
+// After
+let mut agent_id_for_jekt: Option<String> = None;
+// ...
+if k == "AGENTMUX_AGENT_ID" { agent_id_for_jekt = Some(v.clone()); }
+// ...
+if agent_id_for_jekt.is_none() {
+    if let Ok(val) = std::env::var("WAVEMUX_AGENT_ID") {
+        agent_id_for_jekt = Some(val.clone());
+        c.env("AGENTMUX_AGENT_ID", &val);
+    }
+}
+```
+
+#### 2. Auto-register after successful spawn
+
+Immediately after `pair.slave.spawn_command(cmd)` succeeds:
+
+```rust
+if let Some(ref agent_id) = agent_id_for_jekt {
+    match crate::backend::reactive::get_global_handler()
+        .register_agent(agent_id, &self.block_id, Some(&self.tab_id))
+    {
+        Ok(()) => tracing::info!(
+            block_id = %self.block_id,
+            agent_id = %agent_id,
+            "jekt: auto-registered"
+        ),
+        Err(e) => tracing::warn!(
+            block_id = %self.block_id,
+            agent_id = %agent_id,
+            error = %e,
+            "jekt: auto-register failed"
+        ),
+    }
+}
+```
+
+#### 3. Auto-unregister on process exit
+
+In the `spawn_blocking` wait task, after `child.wait()` returns:
+
+```rust
+tracing::info!(block_id = %block_id_wait, exit_code = exit_code, "process exited");
+crate::backend::reactive::get_global_handler().unregister_block(&block_id_wait);
+```
+
+`unregister_block` looks up by block_id and removes the agent_id → block_id mapping.
+Already exists on `ReactiveHandler`.
+
+---
+
+## Scope
+
+### What changes
+- `shell.rs`: ~15 lines changed/added
+
+### What does NOT change
+- `/wave/reactive/register` endpoint — still works for manual registration (backward compat,
+  useful for non-shell blocks or external processes)
+- MessageBus registration — unchanged; agents can still call `bus:register` separately
+- Any frontend code
+- Any other Rust files
+
+---
+
+## Edge Cases
+
+### Agent ID re-use (same agent_id, different block)
+`register_agent()` already handles this — it removes the old block mapping and installs
+the new one. If Agent1 is restarted in a new block, the new block wins.
+
+### Multiple blocks with same agent_id
+Same as above — last-write wins. This is consistent with existing manual registration behavior.
+
+### Process restart (run_on_start / resync)
+If the same block is restarted (e.g. resync command), it re-spawns and hits the same
+auto-register path. The mapping is refreshed with the same block_id. No issue.
+
+### Blocks without AGENTMUX_AGENT_ID
+`agent_id_for_jekt` stays `None` → no registration attempt. Pure shell panes, code editor
+panes, etc. are unaffected.
+
+---
+
+## Testing
+
+```bash
+# 1. Open AgentMux, create a terminal pane with cmd:env["AGENTMUX_AGENT_ID"] = "test-agent"
+# 2. Immediately jekt it — no /wave/reactive/register call needed:
+curl -X POST http://localhost:<port>/api/bus/inject \
+  -H 'Content-Type: application/json' \
+  -d '{"from": "agentx", "target": "test-agent", "message": "echo hello"}'
+# Expected: {"status":"injected","via":"pty","block_id":"...","target":"test-agent"}
+
+# 3. Close the pane, retry jekt:
+# Expected: {"status":"injected","via":"messagebus",...} (falls back, agent deregistered)
+
+# 4. Verify agents list:
+curl http://localhost:<port>/wave/reactive/agents
+# Expected: [] after close, ["test-agent"] while running
+```
+
+---
+
+## Open Questions
+
+1. **Shell panes (no cmd:env agent_id)** — should the block's own `AGENTMUX_BLOCKID`
+   be jekt-addressable by block_id directly? Currently no — jekt targets are always
+   agent_ids. Leave for later.
+
+2. **wsh binary** — should `wsh` support a `register` subcommand so non-shell processes
+   (e.g. a Python script) can self-register? Out of scope here; manual HTTP endpoint
+   still available.

--- a/specs/jekt-inject-timing.md
+++ b/specs/jekt-inject-timing.md
@@ -1,0 +1,41 @@
+# Jekt Inject Timing Spec
+
+## Problem
+Text injected into Claude Code's PTY via `handler.rs` appears but doesn't submit.
+Claude Code's readline requires Enter (`\r`) as a **separate PTY write** after the
+text is in the input buffer.
+
+## Working Baseline (v0.31.125)
+Single payload `message\r` — text appears but Enter doesn't submit.
+
+## Target Sequence
+
+```
+t=0ms     sender(block_id, "\r")              // clear any partial input
+t=0ms     sender(block_id, message_text)       // inject message text
+t=200ms   sender(block_id, "\r")              // submit attempt 1
+t=400ms   sender(block_id, "\r")              // submit attempt 2
+t=600ms   sender(block_id, "\r")              // submit attempt 3
+```
+
+## Implementation
+
+In `handler.rs` `Handler::inject_message()`:
+
+1. **Sync (immediate, under Mutex):**
+   - Send `\r` to clear line
+   - Send `message\r` (message + trailing \r as single payload — preserves text display)
+
+2. **Async (tokio::spawn, after Mutex released):**
+   - Clone `sender` (Arc) and `block_id` (String) before spawn
+   - Sleep 200ms → send `\r`
+   - Sleep 200ms → send `\r`
+   - Sleep 200ms → send `\r`
+
+The initial `message\r` is the proven working payload from v0.31.122/125.
+The spawned delayed `\r`s are backup submits that arrive as separate PTY events.
+
+## Constraints
+- Must NOT break text display (the `message\r` single payload handles that)
+- `tokio::spawn` is safe from within `std::sync::Mutex` scope (doesn't hold the guard)
+- If spawn fails for any reason, text still appears (fail-safe)

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.31.120"
+version = "0.31.127"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.31.120",
-  "identifier": "ai.agentmux.app.v0-31-120",
+  "version": "0.31.127",
+  "identifier": "ai.agentmux.app.v0-31-127",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.31.120"
+version = "0.31.127"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

Complete jekt (terminal injection) system overhaul:

- **Auto-registration**: Agents with `AGENTMUX_AGENT_ID` env var auto-register with ReactiveHandler at PTY spawn, auto-unregister on exit
- **Cross-instance routing**: File-based agent registry (`~/.agentmux/agents/`) enables jekt forwarding between AgentMux instances with stale entry cleanup
- **AGENTMUX_LOCAL_URL**: Set in PTY env after server binds, so agentbus-client routes to local backend instead of cloud
- **Inject timing**: Send `message\r` as proven payload for text display, then spawn 3 delayed `\r` at 200ms intervals as separate PTY writes to ensure submission (see `specs/jekt-inject-timing.md`)
- **PTY-first injection**: Both HTTP (`/api/bus/inject`) and WebSocket (`bus:inject`) paths try ReactiveHandler first, fall back to MessageBus
- **Static CRT linking**: Eliminate VCRUNTIME140.dll dependency on Windows
- **Tracing**: Structured logging for inject and register handlers

## Changed files

| File | Change |
|------|--------|
| `shell.rs` | Auto-register/unregister agents at PTY spawn/exit |
| `handler.rs` | Inject timing: message\r + 3 delayed \r sends |
| `registry.rs` | **New** - Cross-instance file-based agent registry |
| `main.rs` | Set AGENTMUX_LOCAL_URL, cleanup stale registry |
| `messagebus.rs` | PTY-first injection with MessageBus fallback |
| `reactive.rs` | Tracing, cross-instance forwarding, poller endpoints |
| `websocket.rs` | PTY-first injection for WS bus:inject path |
| `.cargo/config.toml` | Static CRT linking for Windows |

## Test plan

- [x] Agent with AGENTMUX_AGENT_ID env auto-registers at spawn
- [x] Jekt inject shows text in target terminal
- [x] Jekt inject submits (Enter processed via delayed \r sends)
- [ ] Cross-instance jekt: two AgentMux windows can jekt each other
- [ ] Agent unregisters on terminal close

Version: 0.31.127