### PR TITLE
feat: forge context management phases 2-4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.31.128"
+version = "0.31.129"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.31.128"
+version = "0.31.129"
 dependencies = [
  "async-stream",
  "axum",
@@ -7068,7 +7068,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.31.128"
+version = "0.31.129"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.31.128"
+version = "0.31.129"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/agentmuxsrv-rs/src/backend/rpc_types.rs
+++ b/agentmuxsrv-rs/src/backend/rpc_types.rs
@@ -263,6 +263,20 @@ pub const COMMAND_GET_FORGE_CONTENT: &str = "getforgecontent";
 pub const COMMAND_SET_FORGE_CONTENT: &str = "setforgecontent";
 pub const COMMAND_GET_ALL_FORGE_CONTENT: &str = "getallforgecontent";
 
+// Forge Skills
+pub const COMMAND_LIST_FORGE_SKILLS: &str = "listforgeskills";
+pub const COMMAND_CREATE_FORGE_SKILL: &str = "createforgeskill";
+pub const COMMAND_UPDATE_FORGE_SKILL: &str = "updateforgeskill";
+pub const COMMAND_DELETE_FORGE_SKILL: &str = "deleteforgeskill";
+
+// Forge History
+pub const COMMAND_APPEND_FORGE_HISTORY: &str = "appendforgehistory";
+pub const COMMAND_LIST_FORGE_HISTORY: &str = "listforgehistory";
+pub const COMMAND_SEARCH_FORGE_HISTORY: &str = "searchforgehistory";
+
+// Forge Import
+pub const COMMAND_IMPORT_FORGE_FROM_CLAW: &str = "importforgefromclaw";
+
 // ---- Client type constants ----
 
 pub const CLIENT_TYPE_CONN_SERVER: &str = "connserver";
@@ -694,6 +708,97 @@ pub struct CommandSetForgeContentData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandGetAllForgeContentData {
     pub agent_id: String,
+}
+
+// ---- Forge Skills command data types ----
+
+/// Input for listforgeskills
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandListForgeSkillsData {
+    pub agent_id: String,
+}
+
+/// Input for createforgeskill
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandCreateForgeSkillData {
+    pub agent_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub trigger: String,
+    #[serde(default = "default_skill_type")]
+    pub skill_type: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub content: String,
+}
+
+fn default_skill_type() -> String {
+    "prompt".to_string()
+}
+
+/// Input for updateforgeskill
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandUpdateForgeSkillData {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub trigger: String,
+    #[serde(default)]
+    pub skill_type: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub content: String,
+}
+
+/// Input for deleteforgeskill
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandDeleteForgeSkillData {
+    pub id: String,
+}
+
+// ---- Forge History command data types ----
+
+/// Input for appendforgehistory
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandAppendForgeHistoryData {
+    pub agent_id: String,
+    pub entry: String,
+}
+
+/// Input for listforgehistory
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandListForgeHistoryData {
+    pub agent_id: String,
+    #[serde(default)]
+    pub session_date: Option<String>,
+    #[serde(default = "default_history_limit")]
+    pub limit: i64,
+    #[serde(default)]
+    pub offset: i64,
+}
+
+fn default_history_limit() -> i64 {
+    50
+}
+
+/// Input for searchforgehistory
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandSearchForgeHistoryData {
+    pub agent_id: String,
+    pub query: String,
+    #[serde(default = "default_history_limit")]
+    pub limit: i64,
+}
+
+// ---- Forge Import command data types ----
+
+/// Input for importforgefromclaw
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandImportForgeFromClawData {
+    pub workspace_path: String,
+    pub agent_name: String,
 }
 
 // ====================================================================

--- a/agentmuxsrv-rs/src/backend/storage/migrations.rs
+++ b/agentmuxsrv-rs/src/backend/storage/migrations.rs
@@ -125,6 +125,35 @@ pub fn run_forge_v2_migrations(conn: &Connection) -> Result<(), StoreError> {
         );",
     )?;
 
+    // Create db_forge_skills table for reusable agent skills
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS db_forge_skills (
+            id TEXT PRIMARY KEY,
+            agent_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            trigger TEXT NOT NULL DEFAULT '',
+            skill_type TEXT NOT NULL DEFAULT 'prompt',
+            description TEXT NOT NULL DEFAULT '',
+            content TEXT NOT NULL DEFAULT '',
+            created_at INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY (agent_id) REFERENCES db_forge_agents(id) ON DELETE CASCADE
+        );",
+    )?;
+
+    // Create db_forge_history table for append-only session logs
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS db_forge_history (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id TEXT NOT NULL,
+            session_date TEXT NOT NULL,
+            entry TEXT NOT NULL,
+            timestamp INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY (agent_id) REFERENCES db_forge_agents(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_forge_history_agent_date
+            ON db_forge_history(agent_id, session_date);",
+    )?;
+
     Ok(())
 }
 

--- a/agentmuxsrv-rs/src/backend/storage/mod.rs
+++ b/agentmuxsrv-rs/src/backend/storage/mod.rs
@@ -12,3 +12,6 @@ pub mod wstore;
 pub use error::StoreError;
 pub use wstore::ForgeAgent;
 pub use wstore::ForgeContent;
+#[allow(unused_imports)]
+pub use wstore::ForgeHistory;
+pub use wstore::ForgeSkill;

--- a/agentmuxsrv-rs/src/backend/storage/wstore.rs
+++ b/agentmuxsrv-rs/src/backend/storage/wstore.rs
@@ -423,6 +423,29 @@ pub struct ForgeContent {
     pub updated_at: i64,
 }
 
+/// A reusable skill/capability attached to a forge agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeSkill {
+    pub id: String,
+    pub agent_id: String,
+    pub name: String,
+    pub trigger: String,
+    pub skill_type: String,
+    pub description: String,
+    pub content: String,
+    pub created_at: i64,
+}
+
+/// An append-only session history entry for a forge agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeHistory {
+    pub id: i64,
+    pub agent_id: String,
+    pub session_date: String,
+    pub entry: String,
+    pub timestamp: i64,
+}
+
 impl WaveStore {
     /// List all forge agents, ordered by created_at ascending.
     pub fn forge_list(&self) -> Result<Vec<ForgeAgent>, StoreError> {
@@ -588,6 +611,233 @@ impl WaveStore {
         )?;
         Ok(rows > 0)
     }
+
+    // ---- ForgeSkill CRUD ----
+
+    /// List all skills for an agent, ordered by created_at ascending.
+    pub fn forge_list_skills(&self, agent_id: &str) -> Result<Vec<ForgeSkill>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, agent_id, name, trigger, skill_type, description, content, created_at
+             FROM db_forge_skills WHERE agent_id=?1 ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![agent_id], |row| {
+            Ok(ForgeSkill {
+                id: row.get(0)?,
+                agent_id: row.get(1)?,
+                name: row.get(2)?,
+                trigger: row.get(3)?,
+                skill_type: row.get(4)?,
+                description: row.get(5)?,
+                content: row.get(6)?,
+                created_at: row.get(7)?,
+            })
+        })?;
+        let mut skills = Vec::new();
+        for row in rows {
+            skills.push(row?);
+        }
+        Ok(skills)
+    }
+
+    /// Get a single skill by id.
+    pub fn forge_get_skill(&self, id: &str) -> Result<Option<ForgeSkill>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, agent_id, name, trigger, skill_type, description, content, created_at
+             FROM db_forge_skills WHERE id=?1",
+        )?;
+        let result = stmt.query_row(params![id], |row| {
+            Ok(ForgeSkill {
+                id: row.get(0)?,
+                agent_id: row.get(1)?,
+                name: row.get(2)?,
+                trigger: row.get(3)?,
+                skill_type: row.get(4)?,
+                description: row.get(5)?,
+                content: row.get(6)?,
+                created_at: row.get(7)?,
+            })
+        });
+        match result {
+            Ok(skill) => Ok(Some(skill)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(StoreError::Sqlite(e)),
+        }
+    }
+
+    /// Insert a new skill.
+    pub fn forge_insert_skill(&self, skill: &ForgeSkill) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_forge_skills (id, agent_id, name, trigger, skill_type, description, content, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            params![
+                skill.id,
+                skill.agent_id,
+                skill.name,
+                skill.trigger,
+                skill.skill_type,
+                skill.description,
+                skill.content,
+                skill.created_at
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Update an existing skill (all fields except id, agent_id, created_at).
+    pub fn forge_update_skill(&self, skill: &ForgeSkill) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "UPDATE db_forge_skills SET name=?1, trigger=?2, skill_type=?3, description=?4, content=?5
+             WHERE id=?6",
+            params![
+                skill.name,
+                skill.trigger,
+                skill.skill_type,
+                skill.description,
+                skill.content,
+                skill.id
+            ],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// Delete a skill by id. Returns true if a row was deleted.
+    pub fn forge_delete_skill(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "DELETE FROM db_forge_skills WHERE id=?1",
+            params![id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    // ---- ForgeHistory methods ----
+
+    /// Append a history entry for an agent. Auto-sets session_date (today) and timestamp.
+    pub fn forge_append_history(&self, agent_id: &str, entry: &str) -> Result<ForgeHistory, StoreError> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        // session_date as YYYY-MM-DD
+        let secs = (now / 1000) as u64;
+        let days = secs / 86400;
+        // Simple date calculation (no chrono dependency needed)
+        let session_date = format_epoch_date(days);
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_forge_history (agent_id, session_date, entry, timestamp) VALUES (?1, ?2, ?3, ?4)",
+            params![agent_id, session_date, entry, now],
+        )?;
+        let id = conn.last_insert_rowid();
+        Ok(ForgeHistory {
+            id,
+            agent_id: agent_id.to_string(),
+            session_date,
+            entry: entry.to_string(),
+            timestamp: now,
+        })
+    }
+
+    /// List history entries for an agent, with optional date filter and pagination.
+    pub fn forge_list_history(
+        &self,
+        agent_id: &str,
+        session_date: Option<&str>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ForgeHistory>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let (sql, params_vec): (String, Vec<Box<dyn rusqlite::types::ToSql>>) = match session_date {
+            Some(date) => (
+                "SELECT id, agent_id, session_date, entry, timestamp
+                 FROM db_forge_history WHERE agent_id=?1 AND session_date=?2
+                 ORDER BY timestamp DESC LIMIT ?3 OFFSET ?4".to_string(),
+                vec![
+                    Box::new(agent_id.to_string()),
+                    Box::new(date.to_string()),
+                    Box::new(limit),
+                    Box::new(offset),
+                ],
+            ),
+            None => (
+                "SELECT id, agent_id, session_date, entry, timestamp
+                 FROM db_forge_history WHERE agent_id=?1
+                 ORDER BY timestamp DESC LIMIT ?2 OFFSET ?3".to_string(),
+                vec![
+                    Box::new(agent_id.to_string()),
+                    Box::new(limit),
+                    Box::new(offset),
+                ],
+            ),
+        };
+        let params_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|b| b.as_ref()).collect();
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params_refs.as_slice(), |row| {
+            Ok(ForgeHistory {
+                id: row.get(0)?,
+                agent_id: row.get(1)?,
+                session_date: row.get(2)?,
+                entry: row.get(3)?,
+                timestamp: row.get(4)?,
+            })
+        })?;
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row?);
+        }
+        Ok(entries)
+    }
+
+    /// Search history entries for an agent using LIKE-based matching.
+    pub fn forge_search_history(
+        &self,
+        agent_id: &str,
+        query: &str,
+        limit: i64,
+    ) -> Result<Vec<ForgeHistory>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let pattern = format!("%{}%", query);
+        let mut stmt = conn.prepare(
+            "SELECT id, agent_id, session_date, entry, timestamp
+             FROM db_forge_history WHERE agent_id=?1 AND entry LIKE ?2
+             ORDER BY timestamp DESC LIMIT ?3",
+        )?;
+        let rows = stmt.query_map(params![agent_id, pattern, limit], |row| {
+            Ok(ForgeHistory {
+                id: row.get(0)?,
+                agent_id: row.get(1)?,
+                session_date: row.get(2)?,
+                entry: row.get(3)?,
+                timestamp: row.get(4)?,
+            })
+        })?;
+        let mut entries = Vec::new();
+        for row in rows {
+            entries.push(row?);
+        }
+        Ok(entries)
+    }
+}
+
+/// Format days-since-epoch as YYYY-MM-DD string.
+/// Simple implementation without chrono dependency.
+fn format_epoch_date(days_since_epoch: u64) -> String {
+    // Algorithm from https://howardhinnant.github.io/date_algorithms.html
+    let z = days_since_epoch + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{:04}-{:02}-{:02}", y, m, d)
 }
 
 // ====================================================================

--- a/agentmuxsrv-rs/src/server/websocket.rs
+++ b/agentmuxsrv-rs/src/server/websocket.rs
@@ -25,10 +25,18 @@ use crate::backend::rpc_types::{
     COMMAND_LIST_FORGE_AGENTS, COMMAND_CREATE_FORGE_AGENT, COMMAND_UPDATE_FORGE_AGENT,
     COMMAND_DELETE_FORGE_AGENT, COMMAND_GET_FORGE_CONTENT, COMMAND_SET_FORGE_CONTENT,
     COMMAND_GET_ALL_FORGE_CONTENT,
+    COMMAND_LIST_FORGE_SKILLS, COMMAND_CREATE_FORGE_SKILL, COMMAND_UPDATE_FORGE_SKILL,
+    COMMAND_DELETE_FORGE_SKILL,
+    COMMAND_APPEND_FORGE_HISTORY, COMMAND_LIST_FORGE_HISTORY, COMMAND_SEARCH_FORGE_HISTORY,
+    COMMAND_IMPORT_FORGE_FROM_CLAW,
     CommandCreateForgeAgentData, CommandUpdateForgeAgentData, CommandDeleteForgeAgentData,
     CommandGetForgeContentData, CommandSetForgeContentData, CommandGetAllForgeContentData,
+    CommandListForgeSkillsData, CommandCreateForgeSkillData, CommandUpdateForgeSkillData,
+    CommandDeleteForgeSkillData,
+    CommandAppendForgeHistoryData, CommandListForgeHistoryData, CommandSearchForgeHistoryData,
+    CommandImportForgeFromClawData,
 };
-use crate::backend::storage::{ForgeAgent, ForgeContent};
+use crate::backend::storage::{ForgeAgent, ForgeContent, ForgeSkill};
 use crate::backend::waveobj::{Block, TermSize, WaveObjUpdate, wave_obj_to_value};
 use super::service::update_object_meta;
 
@@ -919,6 +927,283 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let contents = wstore.forge_get_all_content(&cmd.agent_id)
                     .map_err(|e| format!("getallforgecontent: {e}"))?;
                 Ok(Some(serde_json::to_value(&contents).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // ── Forge Skills handlers ──────────────────────────────────────────────
+
+    // listforgeskills → return all skills for an agent
+    let wstore_lfs = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_FORGE_SKILLS,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_lfs.clone();
+            Box::pin(async move {
+                let cmd: CommandListForgeSkillsData = serde_json::from_value(data)
+                    .map_err(|e| format!("listforgeskills: {e}"))?;
+                let skills = wstore.forge_list_skills(&cmd.agent_id)
+                    .map_err(|e| format!("listforgeskills: {e}"))?;
+                Ok(Some(serde_json::to_value(&skills).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // createforgeskill → insert new skill, broadcast forgeskills:changed
+    let wstore_cfs = state.wstore.clone();
+    let broker_cfs = state.broker.clone();
+    engine.register_handler(
+        COMMAND_CREATE_FORGE_SKILL,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_cfs.clone();
+            let broker = broker_cfs.clone();
+            Box::pin(async move {
+                let cmd: CommandCreateForgeSkillData = serde_json::from_value(data)
+                    .map_err(|e| format!("createforgeskill: {e}"))?;
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as i64;
+                let skill = ForgeSkill {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    agent_id: cmd.agent_id,
+                    name: cmd.name,
+                    trigger: cmd.trigger,
+                    skill_type: cmd.skill_type,
+                    description: cmd.description,
+                    content: cmd.content,
+                    created_at: now,
+                };
+                wstore.forge_insert_skill(&skill).map_err(|e| format!("createforgeskill: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "forgeskills:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&skill).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // updateforgeskill → update existing skill, broadcast forgeskills:changed
+    let wstore_ufs = state.wstore.clone();
+    let broker_ufs = state.broker.clone();
+    engine.register_handler(
+        COMMAND_UPDATE_FORGE_SKILL,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_ufs.clone();
+            let broker = broker_ufs.clone();
+            Box::pin(async move {
+                let cmd: CommandUpdateForgeSkillData = serde_json::from_value(data)
+                    .map_err(|e| format!("updateforgeskill: {e}"))?;
+                let existing = wstore.forge_get_skill(&cmd.id)
+                    .map_err(|e| format!("updateforgeskill: {e}"))?
+                    .ok_or_else(|| format!("updateforgeskill: skill {} not found", cmd.id))?;
+                let skill = ForgeSkill {
+                    id: cmd.id,
+                    agent_id: existing.agent_id,
+                    name: cmd.name,
+                    trigger: cmd.trigger,
+                    skill_type: cmd.skill_type,
+                    description: cmd.description,
+                    content: cmd.content,
+                    created_at: existing.created_at,
+                };
+                let found = wstore.forge_update_skill(&skill).map_err(|e| format!("updateforgeskill: {e}"))?;
+                if !found {
+                    return Err(format!("updateforgeskill: skill {} not found", skill.id));
+                }
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "forgeskills:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&skill).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // deleteforgeskill → delete skill by id, broadcast forgeskills:changed
+    let wstore_dfs = state.wstore.clone();
+    let broker_dfs = state.broker.clone();
+    engine.register_handler(
+        COMMAND_DELETE_FORGE_SKILL,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_dfs.clone();
+            let broker = broker_dfs.clone();
+            Box::pin(async move {
+                let cmd: CommandDeleteForgeSkillData = serde_json::from_value(data)
+                    .map_err(|e| format!("deleteforgeskill: {e}"))?;
+                wstore.forge_delete_skill(&cmd.id).map_err(|e| format!("deleteforgeskill: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "forgeskills:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(None)
+            })
+        }),
+    );
+
+    // ── Forge History handlers ─────────────────────────────────────────────
+
+    // appendforgehistory → append a history entry, broadcast forgehistory:changed
+    let wstore_afh = state.wstore.clone();
+    let broker_afh = state.broker.clone();
+    engine.register_handler(
+        COMMAND_APPEND_FORGE_HISTORY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_afh.clone();
+            let broker = broker_afh.clone();
+            Box::pin(async move {
+                let cmd: CommandAppendForgeHistoryData = serde_json::from_value(data)
+                    .map_err(|e| format!("appendforgehistory: {e}"))?;
+                let entry = wstore.forge_append_history(&cmd.agent_id, &cmd.entry)
+                    .map_err(|e| format!("appendforgehistory: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "forgehistory:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&entry).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // listforgehistory → return history entries with pagination
+    let wstore_lfh = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_FORGE_HISTORY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_lfh.clone();
+            Box::pin(async move {
+                let cmd: CommandListForgeHistoryData = serde_json::from_value(data)
+                    .map_err(|e| format!("listforgehistory: {e}"))?;
+                let entries = wstore.forge_list_history(
+                    &cmd.agent_id,
+                    cmd.session_date.as_deref(),
+                    cmd.limit,
+                    cmd.offset,
+                ).map_err(|e| format!("listforgehistory: {e}"))?;
+                Ok(Some(serde_json::to_value(&entries).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // searchforgehistory → search history entries by query
+    let wstore_sfh = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_SEARCH_FORGE_HISTORY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_sfh.clone();
+            Box::pin(async move {
+                let cmd: CommandSearchForgeHistoryData = serde_json::from_value(data)
+                    .map_err(|e| format!("searchforgehistory: {e}"))?;
+                let entries = wstore.forge_search_history(&cmd.agent_id, &cmd.query, cmd.limit)
+                    .map_err(|e| format!("searchforgehistory: {e}"))?;
+                Ok(Some(serde_json::to_value(&entries).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // ── Forge Import handler ───────────────────────────────────────────────
+
+    // importforgefromclaw → read claw workspace, create agent + content
+    let wstore_ifc = state.wstore.clone();
+    let broker_ifc = state.broker.clone();
+    engine.register_handler(
+        COMMAND_IMPORT_FORGE_FROM_CLAW,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_ifc.clone();
+            let broker = broker_ifc.clone();
+            Box::pin(async move {
+                let cmd: CommandImportForgeFromClawData = serde_json::from_value(data)
+                    .map_err(|e| format!("importforgefromclaw: {e}"))?;
+
+                let workspace_path = std::path::Path::new(&cmd.workspace_path);
+                if !workspace_path.exists() {
+                    return Err(format!("importforgefromclaw: path does not exist: {}", cmd.workspace_path));
+                }
+
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as i64;
+
+                // Detect provider from .claude/settings.json if present
+                let mut provider = "claude".to_string();
+                let settings_path = workspace_path.join(".claude").join("settings.json");
+                if settings_path.exists() {
+                    if let Ok(settings_str) = std::fs::read_to_string(&settings_path) {
+                        if let Ok(settings) = serde_json::from_str::<serde_json::Value>(&settings_str) {
+                            if let Some(p) = settings.get("provider").and_then(|v| v.as_str()) {
+                                provider = p.to_string();
+                            }
+                        }
+                    }
+                }
+
+                // Create the agent
+                let agent = ForgeAgent {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    name: cmd.agent_name.clone(),
+                    icon: "\u{2726}".to_string(),
+                    provider,
+                    description: format!("Imported from {}", cmd.workspace_path),
+                    working_directory: cmd.workspace_path.clone(),
+                    shell: String::new(),
+                    provider_flags: String::new(),
+                    auto_start: 0,
+                    restart_on_crash: 0,
+                    idle_timeout_minutes: 0,
+                    created_at: now,
+                };
+                wstore.forge_insert(&agent).map_err(|e| format!("importforgefromclaw: {e}"))?;
+
+                // Read CLAUDE.md → agentmd content
+                let claude_md_path = workspace_path.join("CLAUDE.md");
+                if claude_md_path.exists() {
+                    if let Ok(content) = std::fs::read_to_string(&claude_md_path) {
+                        let fc = ForgeContent {
+                            agent_id: agent.id.clone(),
+                            content_type: "agentmd".to_string(),
+                            content,
+                            updated_at: now,
+                        };
+                        let _ = wstore.forge_set_content(&fc);
+                    }
+                }
+
+                // Read .mcp.json → mcp content
+                let mcp_path = workspace_path.join(".mcp.json");
+                if mcp_path.exists() {
+                    if let Ok(content) = std::fs::read_to_string(&mcp_path) {
+                        let fc = ForgeContent {
+                            agent_id: agent.id.clone(),
+                            content_type: "mcp".to_string(),
+                            content,
+                            updated_at: now,
+                        };
+                        let _ = wstore.forge_set_content(&fc);
+                    }
+                }
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "forgeagents:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&agent).unwrap_or_default()))
             })
         }),
     );

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -543,6 +543,46 @@ class RpcApiType {
         return client.wshRpcCall("getallforgecontent", data, opts);
     }
 
+    // command "listforgeskills" [call]
+    ListForgeSkillsCommand(client: WshClient, data: CommandListForgeSkillsData, opts?: RpcOpts): Promise<ForgeSkill[]> {
+        return client.wshRpcCall("listforgeskills", data, opts);
+    }
+
+    // command "createforgeskill" [call]
+    CreateForgeSkillCommand(client: WshClient, data: CommandCreateForgeSkillData, opts?: RpcOpts): Promise<ForgeSkill> {
+        return client.wshRpcCall("createforgeskill", data, opts);
+    }
+
+    // command "updateforgeskill" [call]
+    UpdateForgeSkillCommand(client: WshClient, data: CommandUpdateForgeSkillData, opts?: RpcOpts): Promise<ForgeSkill> {
+        return client.wshRpcCall("updateforgeskill", data, opts);
+    }
+
+    // command "deleteforgeskill" [call]
+    DeleteForgeSkillCommand(client: WshClient, data: CommandDeleteForgeSkillData, opts?: RpcOpts): Promise<void> {
+        return client.wshRpcCall("deleteforgeskill", data, opts);
+    }
+
+    // command "appendforgehistory" [call]
+    AppendForgeHistoryCommand(client: WshClient, data: CommandAppendForgeHistoryData, opts?: RpcOpts): Promise<ForgeHistory> {
+        return client.wshRpcCall("appendforgehistory", data, opts);
+    }
+
+    // command "listforgehistory" [call]
+    ListForgeHistoryCommand(client: WshClient, data: CommandListForgeHistoryData, opts?: RpcOpts): Promise<ForgeHistory[]> {
+        return client.wshRpcCall("listforgehistory", data, opts);
+    }
+
+    // command "searchforgehistory" [call]
+    SearchForgeHistoryCommand(client: WshClient, data: CommandSearchForgeHistoryData, opts?: RpcOpts): Promise<ForgeHistory[]> {
+        return client.wshRpcCall("searchforgehistory", data, opts);
+    }
+
+    // command "importforgefromclaw" [call]
+    ImportForgeFromClawCommand(client: WshClient, data: CommandImportForgeFromClawData, opts?: RpcOpts): Promise<ForgeAgent> {
+        return client.wshRpcCall("importforgefromclaw", data, opts);
+    }
+
 }
 
 export const RpcApi = new RpcApiType();

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -127,6 +127,14 @@ export class AgentViewModel implements ViewModel {
             contentMap[c.content_type] = c.content;
         }
 
+        // Load skills for this agent (lazy-loading: only names/descriptions injected)
+        let skills: ForgeSkill[] = [];
+        try {
+            skills = await RpcApi.ListForgeSkillsCommand(TabRpcClient, { agent_id: agent.id }) ?? [];
+        } catch (e: any) {
+            Logger.error("agent", "Failed to load forge skills", { error: String(e) });
+        }
+
         // Determine working directory
         const workDir = agent.working_directory || `~/.agentmux/agents/${agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-")}`;
 
@@ -153,7 +161,7 @@ export class AgentViewModel implements ViewModel {
 
             setTimeout(async () => {
                 // Build config-writing preamble
-                const preamble = buildConfigPreamble(contentMap, workDir, agent);
+                const preamble = buildConfigPreamble(contentMap, workDir, agent, skills);
 
                 const script = buildBootstrapScript({
                     version,
@@ -190,14 +198,15 @@ export class AgentViewModel implements ViewModel {
 function buildConfigPreamble(
     contentMap: Record<string, string>,
     workDir: string,
-    agent: ForgeAgent
+    agent: ForgeAgent,
+    skills: ForgeSkill[] = []
 ): string {
     const lines: string[] = [];
 
     // Create working directory
     lines.push(`mkdir -p ${shellEscape(workDir)}`);
 
-    // Build CLAUDE.md content: Soul + AgentMD + Memory
+    // Build CLAUDE.md content: Soul + AgentMD + Memory + Skills Index
     const claudeMdParts: string[] = [];
     if (contentMap["soul"]) {
         claudeMdParts.push(contentMap["soul"]);
@@ -209,6 +218,16 @@ function buildConfigPreamble(
     if (contentMap["memory"]) {
         claudeMdParts.push("\n# Memory\n");
         claudeMdParts.push(contentMap["memory"]);
+    }
+
+    // Append skill index (lazy-loading: only names/descriptions, not full content)
+    if (skills.length > 0) {
+        claudeMdParts.push("\n# Available Skills\n\n");
+        for (const skill of skills) {
+            const triggerPart = skill.trigger ? ` (trigger: /${skill.trigger})` : "";
+            const descPart = skill.description ? ` \u2014 ${skill.description}` : "";
+            claudeMdParts.push(`- **${skill.name}**${triggerPart}${descPart}\n`);
+        }
     }
 
     if (claudeMdParts.length > 0) {

--- a/frontend/app/view/forge/forge-model.ts
+++ b/frontend/app/view/forge/forge-model.ts
@@ -12,12 +12,17 @@ export type ForgeView = "list" | "create" | "edit" | "detail";
 export const CONTENT_TABS = ["soul", "agentmd", "mcp", "env"] as const;
 export type ContentTabId = (typeof CONTENT_TABS)[number];
 
+export type DetailSection = "content" | "skills" | "history";
+
 export const CONTENT_TAB_LABELS: Record<ContentTabId, string> = {
     soul: "Soul",
     agentmd: "Instructions",
     mcp: "MCP",
     env: "Env",
 };
+
+export const SKILL_TYPES = ["prompt", "command", "workflow", "mcp-tool"] as const;
+export type SkillType = (typeof SKILL_TYPES)[number];
 
 export class ForgeViewModel implements ViewModel {
     viewType = "forge";
@@ -44,11 +49,27 @@ export class ForgeViewModel implements ViewModel {
     detailAgentAtom: PrimitiveAtom<ForgeAgent | null> = atom<ForgeAgent | null>(null);
     contentAtom: PrimitiveAtom<Record<string, ForgeContent>> = atom<Record<string, ForgeContent>>({});
     activeTabAtom: PrimitiveAtom<ContentTabId> = atom<ContentTabId>("soul");
+    activeSectionAtom: PrimitiveAtom<DetailSection> = atom<DetailSection>("content");
     contentLoadingAtom: PrimitiveAtom<boolean> = atom(false);
     contentSavingAtom: PrimitiveAtom<boolean> = atom(false);
 
+    // Skills state
+    skillsAtom: PrimitiveAtom<ForgeSkill[]> = atom<ForgeSkill[]>([]);
+    editingSkillAtom: PrimitiveAtom<ForgeSkill | null> = atom<ForgeSkill | null>(null);
+    skillsLoadingAtom: PrimitiveAtom<boolean> = atom(false);
+
+    // History state
+    historyAtom: PrimitiveAtom<ForgeHistory[]> = atom<ForgeHistory[]>([]);
+    historyLoadingAtom: PrimitiveAtom<boolean> = atom(false);
+    historySearchAtom: PrimitiveAtom<string> = atom("");
+
+    // Import state
+    importingAtom: PrimitiveAtom<boolean> = atom(false);
+
     private unsubForgeChanged: (() => void) | null = null;
     private unsubContentChanged: (() => void) | null = null;
+    private unsubSkillsChanged: (() => void) | null = null;
+    private unsubHistoryChanged: (() => void) | null = null;
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
@@ -61,6 +82,14 @@ export class ForgeViewModel implements ViewModel {
         this.unsubContentChanged = waveEventSubscribe({
             eventType: "forgecontent:changed",
             handler: () => this.reloadContentIfDetail(),
+        });
+        this.unsubSkillsChanged = waveEventSubscribe({
+            eventType: "forgeskills:changed",
+            handler: () => this.reloadSkillsIfDetail(),
+        });
+        this.unsubHistoryChanged = waveEventSubscribe({
+            eventType: "forgehistory:changed",
+            handler: () => this.reloadHistoryIfDetail(),
         });
     }
 
@@ -139,7 +168,10 @@ export class ForgeViewModel implements ViewModel {
         const { globalStore } = await import("@/app/store/global");
         globalStore.set(this.detailAgentAtom, agent);
         globalStore.set(this.activeTabAtom, "soul");
+        globalStore.set(this.activeSectionAtom, "content");
         globalStore.set(this.contentAtom, {});
+        globalStore.set(this.skillsAtom, []);
+        globalStore.set(this.historyAtom, []);
         globalStore.set(this.viewAtom, "detail");
         await this.loadContent(agent.id);
     };
@@ -148,6 +180,8 @@ export class ForgeViewModel implements ViewModel {
         const { globalStore } = await import("@/app/store/global");
         globalStore.set(this.detailAgentAtom, null);
         globalStore.set(this.contentAtom, {});
+        globalStore.set(this.skillsAtom, []);
+        globalStore.set(this.historyAtom, []);
         globalStore.set(this.viewAtom, "list");
     };
 
@@ -199,6 +233,124 @@ export class ForgeViewModel implements ViewModel {
         }
     };
 
+    // ── Skills methods ──────────────────────────────────────────────────
+
+    loadSkills = async (agentId: string): Promise<void> => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(this.skillsLoadingAtom, true);
+        try {
+            const skills = await RpcApi.ListForgeSkillsCommand(TabRpcClient, { agent_id: agentId });
+            globalStore.set(this.skillsAtom, skills ?? []);
+        } catch {
+            // silently ignore
+        } finally {
+            globalStore.set(this.skillsLoadingAtom, false);
+        }
+    };
+
+    createSkill = async (data: CommandCreateForgeSkillData): Promise<void> => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(this.errorAtom, null);
+        try {
+            await RpcApi.CreateForgeSkillCommand(TabRpcClient, data);
+            globalStore.set(this.editingSkillAtom, null);
+        } catch (e: any) {
+            globalStore.set(this.errorAtom, String(e?.message ?? e));
+        }
+    };
+
+    updateSkill = async (data: CommandUpdateForgeSkillData): Promise<void> => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(this.errorAtom, null);
+        try {
+            await RpcApi.UpdateForgeSkillCommand(TabRpcClient, data);
+            globalStore.set(this.editingSkillAtom, null);
+        } catch (e: any) {
+            globalStore.set(this.errorAtom, String(e?.message ?? e));
+        }
+    };
+
+    deleteSkill = async (id: string): Promise<void> => {
+        try {
+            await RpcApi.DeleteForgeSkillCommand(TabRpcClient, { id });
+        } catch {
+            // silently ignore
+        }
+    };
+
+    private reloadSkillsIfDetail = async (): Promise<void> => {
+        const { globalStore } = await import("@/app/store/global");
+        const view = globalStore.get(this.viewAtom);
+        const agent = globalStore.get(this.detailAgentAtom);
+        if (view === "detail" && agent) {
+            await this.loadSkills(agent.id);
+        }
+    };
+
+    // ── History methods ──────────────────────────────────────────────────
+
+    loadHistory = async (agentId: string, sessionDate?: string): Promise<void> => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(this.historyLoadingAtom, true);
+        try {
+            const entries = await RpcApi.ListForgeHistoryCommand(TabRpcClient, {
+                agent_id: agentId,
+                session_date: sessionDate,
+                limit: 100,
+            });
+            globalStore.set(this.historyAtom, entries ?? []);
+        } catch {
+            // silently ignore
+        } finally {
+            globalStore.set(this.historyLoadingAtom, false);
+        }
+    };
+
+    searchHistory = async (agentId: string, query: string): Promise<void> => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(this.historyLoadingAtom, true);
+        try {
+            const entries = await RpcApi.SearchForgeHistoryCommand(TabRpcClient, {
+                agent_id: agentId,
+                query,
+                limit: 100,
+            });
+            globalStore.set(this.historyAtom, entries ?? []);
+        } catch {
+            // silently ignore
+        } finally {
+            globalStore.set(this.historyLoadingAtom, false);
+        }
+    };
+
+    private reloadHistoryIfDetail = async (): Promise<void> => {
+        const { globalStore } = await import("@/app/store/global");
+        const view = globalStore.get(this.viewAtom);
+        const agent = globalStore.get(this.detailAgentAtom);
+        const section = globalStore.get(this.activeSectionAtom);
+        if (view === "detail" && agent && section === "history") {
+            await this.loadHistory(agent.id);
+        }
+    };
+
+    // ── Import from Claw ──────────────────────────────────────────────────
+
+    importFromClaw = async (workspacePath: string, agentName: string): Promise<void> => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(this.importingAtom, true);
+        globalStore.set(this.errorAtom, null);
+        try {
+            await RpcApi.ImportForgeFromClawCommand(TabRpcClient, {
+                workspace_path: workspacePath,
+                agent_name: agentName,
+            });
+        } catch (e: any) {
+            globalStore.set(this.errorAtom, String(e?.message ?? e));
+        } finally {
+            globalStore.set(this.importingAtom, false);
+        }
+    };
+
     // ── Edit from detail ──────────────────────────────────────────────────
 
     startEditFromDetail = async (): Promise<void> => {
@@ -218,5 +370,7 @@ export class ForgeViewModel implements ViewModel {
     dispose(): void {
         this.unsubForgeChanged?.();
         this.unsubContentChanged?.();
+        this.unsubSkillsChanged?.();
+        this.unsubHistoryChanged?.();
     }
 }

--- a/frontend/app/view/forge/forge-view.scss
+++ b/frontend/app/view/forge/forge-view.scss
@@ -514,3 +514,232 @@
         accent-color: var(--accent-color, #a78bfa);
     }
 }
+
+// ── Section tabs (Content / Skills / History) ──────────────────────────────
+
+.forge-section-tabs {
+    display: flex;
+    gap: 2px;
+    margin-bottom: 8px;
+}
+
+.forge-section-tab {
+    padding: 5px 14px;
+    background: transparent;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--secondary-text-color);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+
+    &:hover {
+        background: var(--highlight-bg-color);
+        color: var(--main-text-color);
+    }
+
+    &.active {
+        background: var(--accent-color, #a78bfa);
+        border-color: var(--accent-color, #a78bfa);
+        color: #fff;
+    }
+}
+
+.forge-section-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+// ── Skills panel ─────────────────────────────────────────────────────────────
+
+.forge-skills-panel {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+}
+
+.forge-skills-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1;
+    overflow-y: auto;
+}
+
+.forge-skills-footer {
+    margin-top: 10px;
+    display: flex;
+    justify-content: flex-start;
+}
+
+// ── Skill card ──────────────────────────────────────────────────────────────
+
+.forge-skill-card {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 10px;
+    background: var(--block-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+}
+
+.forge-skill-card-info {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+    gap: 2px;
+}
+
+.forge-skill-card-top {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.forge-skill-card-name {
+    font-weight: 500;
+    color: var(--main-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.forge-skill-type-badge {
+    font-size: 10px;
+    padding: 1px 6px;
+    background: var(--highlight-bg-color);
+    border-radius: 3px;
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+}
+
+.forge-skill-card-trigger {
+    font-size: 11px;
+    color: var(--accent-color, #a78bfa);
+    font-family: var(--termfontfamily, monospace);
+}
+
+.forge-skill-card-desc {
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+// ── Skill form ──────────────────────────────────────────────────────────────
+
+.forge-skill-form {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex: 1;
+    overflow-y: auto;
+
+    form {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+}
+
+.forge-skill-form-header {
+    margin-bottom: 4px;
+}
+
+.forge-skill-content {
+    min-height: 100px;
+    max-height: 200px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+// ── History panel ─────────────────────────────────────────────────────────────
+
+.forge-history-panel {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    overflow: hidden;
+}
+
+.forge-history-search {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.forge-history-list {
+    flex: 1;
+    overflow-y: auto;
+}
+
+.forge-history-group {
+    margin-bottom: 12px;
+}
+
+.forge-history-date {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--accent-color, #a78bfa);
+    margin-bottom: 4px;
+    padding: 2px 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.forge-history-entry {
+    display: flex;
+    gap: 8px;
+    padding: 4px 0;
+    font-size: 12px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.forge-history-time {
+    flex-shrink: 0;
+    color: var(--secondary-text-color);
+    font-family: var(--termfontfamily, monospace);
+    font-size: 11px;
+    min-width: 70px;
+}
+
+.forge-history-text {
+    color: var(--main-text-color);
+    word-break: break-word;
+}
+
+// ── Import overlay ──────────────────────────────────────────────────────────
+
+.forge-import-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+}
+
+.forge-import-dialog {
+    background: var(--block-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 16px;
+    min-width: 400px;
+    max-width: 500px;
+
+    form {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+    }
+}
+
+.forge-import-btn {
+    margin-left: 6px;
+}

--- a/frontend/app/view/forge/forge-view.tsx
+++ b/frontend/app/view/forge/forge-view.tsx
@@ -1,10 +1,10 @@
 // Copyright 2025, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import React, { memo, useCallback, useState } from "react";
+import React, { memo, useCallback, useEffect, useState } from "react";
 import { useAtomValue } from "jotai";
-import type { ForgeViewModel, ContentTabId } from "./forge-model";
-import { CONTENT_TABS, CONTENT_TAB_LABELS } from "./forge-model";
+import type { ForgeViewModel, ContentTabId, DetailSection } from "./forge-model";
+import { CONTENT_TABS, CONTENT_TAB_LABELS, SKILL_TYPES } from "./forge-model";
 import "./forge-view.scss";
 
 const PROVIDERS = [
@@ -35,6 +35,7 @@ ForgeView.displayName = "ForgeView";
 
 const ForgeList: React.FC<{ model: ForgeViewModel }> = memo(({ model }) => {
     const agents = useAtomValue(model.agentsAtom);
+    const [showImport, setShowImport] = useState(false);
 
     return (
         <div className="forge-pane">
@@ -50,6 +51,9 @@ const ForgeList: React.FC<{ model: ForgeViewModel }> = memo(({ model }) => {
                     <button className="forge-new-btn" onClick={() => model.startCreate()}>
                         + New Agent
                     </button>
+                    <button className="forge-new-btn forge-import-btn" onClick={() => setShowImport(true)}>
+                        Import from Claw
+                    </button>
                 </div>
             ) : (
                 <>
@@ -62,9 +66,13 @@ const ForgeList: React.FC<{ model: ForgeViewModel }> = memo(({ model }) => {
                         <button className="forge-new-btn" onClick={() => model.startCreate()}>
                             + New Agent
                         </button>
+                        <button className="forge-new-btn forge-import-btn" onClick={() => setShowImport(true)}>
+                            Import from Claw
+                        </button>
                     </div>
                 </>
             )}
+            {showImport && <ForgeImportForm model={model} onClose={() => setShowImport(false)} />}
         </div>
     );
 });
@@ -130,11 +138,15 @@ ForgeAgentCard.displayName = "ForgeAgentCard";
 
 // ── Detail View ───────────────────────────────────────────────────────────────
 
+const DETAIL_SECTIONS: { id: DetailSection; label: string }[] = [
+    { id: "content", label: "Content" },
+    { id: "skills", label: "Skills" },
+    { id: "history", label: "History" },
+];
+
 const ForgeDetail: React.FC<{ model: ForgeViewModel }> = memo(({ model }) => {
     const agent = useAtomValue(model.detailAgentAtom);
-    const contentMap = useAtomValue(model.contentAtom);
-    const activeTab = useAtomValue(model.activeTabAtom);
-    const contentLoading = useAtomValue(model.contentLoadingAtom);
+    const activeSection = useAtomValue(model.activeSectionAtom);
 
     if (!agent) return null;
 
@@ -159,6 +171,61 @@ const ForgeDetail: React.FC<{ model: ForgeViewModel }> = memo(({ model }) => {
                 </button>
             </div>
             <div className="forge-divider" />
+            <div className="forge-section-tabs">
+                {DETAIL_SECTIONS.map((s) => (
+                    <DetailSectionButton key={s.id} section={s} activeSection={activeSection} model={model} agentId={agent.id} />
+                ))}
+            </div>
+            <div className="forge-section-body">
+                {activeSection === "content" && <ForgeContentSection model={model} agentId={agent.id} />}
+                {activeSection === "skills" && <ForgeSkillsPanel model={model} agentId={agent.id} />}
+                {activeSection === "history" && <ForgeHistoryPanel model={model} agentId={agent.id} />}
+            </div>
+        </div>
+    );
+});
+
+ForgeDetail.displayName = "ForgeDetail";
+
+// ── Detail Section Button ────────────────────────────────────────────────────
+
+const DetailSectionButton: React.FC<{
+    section: { id: DetailSection; label: string };
+    activeSection: DetailSection;
+    model: ForgeViewModel;
+    agentId: string;
+}> = memo(({ section, activeSection, model, agentId }) => {
+    const handleClick = useCallback(async () => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(model.activeSectionAtom, section.id);
+        if (section.id === "skills") {
+            await model.loadSkills(agentId);
+        } else if (section.id === "history") {
+            await model.loadHistory(agentId);
+        }
+    }, [model, section.id, agentId]);
+
+    return (
+        <button
+            className={`forge-section-tab${activeSection === section.id ? " active" : ""}`}
+            onClick={handleClick}
+        >
+            {section.label}
+        </button>
+    );
+});
+
+DetailSectionButton.displayName = "DetailSectionButton";
+
+// ── Content Section (existing tabs) ──────────────────────────────────────────
+
+const ForgeContentSection: React.FC<{ model: ForgeViewModel; agentId: string }> = memo(({ model, agentId }) => {
+    const contentMap = useAtomValue(model.contentAtom);
+    const activeTab = useAtomValue(model.activeTabAtom);
+    const contentLoading = useAtomValue(model.contentLoadingAtom);
+
+    return (
+        <>
             <div className="forge-content-tabs">
                 {CONTENT_TABS.map((tab) => (
                     <ContentTabButton key={tab} tab={tab} activeTab={activeTab} model={model} />
@@ -169,18 +236,18 @@ const ForgeDetail: React.FC<{ model: ForgeViewModel }> = memo(({ model }) => {
                     <div className="forge-content-loading">Loading...</div>
                 ) : (
                     <ContentEditor
-                        agentId={agent.id}
+                        agentId={agentId}
                         contentType={activeTab}
                         content={contentMap[activeTab]}
                         model={model}
                     />
                 )}
             </div>
-        </div>
+        </>
     );
 });
 
-ForgeDetail.displayName = "ForgeDetail";
+ForgeContentSection.displayName = "ForgeContentSection";
 
 // ── Content Tab Button ────────────────────────────────────────────────────────
 
@@ -282,6 +349,381 @@ const ContentEditor: React.FC<{
 });
 
 ContentEditor.displayName = "ContentEditor";
+
+// ── Skills Panel ──────────────────────────────────────────────────────────────
+
+const ForgeSkillsPanel: React.FC<{ model: ForgeViewModel; agentId: string }> = memo(({ model, agentId }) => {
+    const skills = useAtomValue(model.skillsAtom);
+    const loading = useAtomValue(model.skillsLoadingAtom);
+    const editingSkill = useAtomValue(model.editingSkillAtom);
+    const [showForm, setShowForm] = useState(false);
+
+    const handleNewSkill = useCallback(async () => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(model.editingSkillAtom, null);
+        setShowForm(true);
+    }, [model]);
+
+    const handleEditSkill = useCallback(async (skill: ForgeSkill) => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(model.editingSkillAtom, skill);
+        setShowForm(true);
+    }, [model]);
+
+    const handleCloseForm = useCallback(async () => {
+        const { globalStore } = await import("@/app/store/global");
+        globalStore.set(model.editingSkillAtom, null);
+        setShowForm(false);
+    }, [model]);
+
+    if (loading) {
+        return <div className="forge-content-loading">Loading skills...</div>;
+    }
+
+    if (showForm) {
+        return (
+            <ForgeSkillForm
+                model={model}
+                agentId={agentId}
+                skill={editingSkill}
+                onClose={handleCloseForm}
+            />
+        );
+    }
+
+    return (
+        <div className="forge-skills-panel">
+            {skills.length === 0 ? (
+                <div className="forge-content-empty">No skills yet</div>
+            ) : (
+                <div className="forge-skills-list">
+                    {skills.map((skill) => (
+                        <ForgeSkillCard
+                            key={skill.id}
+                            skill={skill}
+                            model={model}
+                            onEdit={handleEditSkill}
+                        />
+                    ))}
+                </div>
+            )}
+            <div className="forge-skills-footer">
+                <button className="forge-btn-primary" onClick={handleNewSkill}>
+                    + Add Skill
+                </button>
+            </div>
+        </div>
+    );
+});
+
+ForgeSkillsPanel.displayName = "ForgeSkillsPanel";
+
+// ── Skill Card ────────────────────────────────────────────────────────────────
+
+const ForgeSkillCard: React.FC<{
+    skill: ForgeSkill;
+    model: ForgeViewModel;
+    onEdit: (skill: ForgeSkill) => void;
+}> = memo(({ skill, model, onEdit }) => {
+    const [confirming, setConfirming] = useState(false);
+
+    const handleDelete = useCallback(async () => {
+        if (!confirming) {
+            setConfirming(true);
+            return;
+        }
+        setConfirming(false);
+        await model.deleteSkill(skill.id);
+    }, [confirming, model, skill.id]);
+
+    return (
+        <div className="forge-skill-card">
+            <div className="forge-skill-card-info">
+                <div className="forge-skill-card-top">
+                    <span className="forge-skill-card-name">{skill.name}</span>
+                    <span className="forge-skill-type-badge">{skill.skill_type}</span>
+                </div>
+                {skill.trigger && (
+                    <span className="forge-skill-card-trigger">/{skill.trigger}</span>
+                )}
+                {skill.description && (
+                    <span className="forge-skill-card-desc">{skill.description}</span>
+                )}
+            </div>
+            <div className="forge-card-actions">
+                <button className="forge-card-btn" onClick={() => onEdit(skill)} title="Edit">
+                    Edit
+                </button>
+                <button
+                    className={`forge-card-btn forge-card-btn-delete${confirming ? " confirming" : ""}`}
+                    onClick={handleDelete}
+                    onBlur={() => setConfirming(false)}
+                    title={confirming ? "Click again to confirm" : "Delete"}
+                >
+                    {confirming ? "Sure?" : "\u2715"}
+                </button>
+            </div>
+        </div>
+    );
+});
+
+ForgeSkillCard.displayName = "ForgeSkillCard";
+
+// ── Skill Form ────────────────────────────────────────────────────────────────
+
+const ForgeSkillForm: React.FC<{
+    model: ForgeViewModel;
+    agentId: string;
+    skill: ForgeSkill | null;
+    onClose: () => void;
+}> = memo(({ model, agentId, skill, onClose }) => {
+    const error = useAtomValue(model.errorAtom);
+    const isEdit = skill != null;
+
+    const [name, setName] = useState(skill?.name ?? "");
+    const [trigger, setTrigger] = useState(skill?.trigger ?? "");
+    const [skillType, setSkillType] = useState(skill?.skill_type ?? "prompt");
+    const [description, setDescription] = useState(skill?.description ?? "");
+    const [content, setContent] = useState(skill?.content ?? "");
+
+    const handleSubmit = useCallback(async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!name.trim()) return;
+        if (isEdit) {
+            await model.updateSkill({
+                id: skill!.id,
+                name: name.trim(),
+                trigger,
+                skill_type: skillType,
+                description,
+                content,
+            });
+        } else {
+            await model.createSkill({
+                agent_id: agentId,
+                name: name.trim(),
+                trigger,
+                skill_type: skillType,
+                description,
+                content,
+            });
+        }
+        onClose();
+    }, [isEdit, model, skill, agentId, name, trigger, skillType, description, content, onClose]);
+
+    return (
+        <div className="forge-skill-form">
+            <div className="forge-skill-form-header">
+                <span className="forge-title-sub">{isEdit ? "Edit Skill" : "New Skill"}</span>
+            </div>
+            <form onSubmit={handleSubmit}>
+                <div className="forge-form-row">
+                    <label className="forge-form-label">Name</label>
+                    <input
+                        className="forge-form-input"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        placeholder="Skill name"
+                        autoFocus
+                        required
+                    />
+                </div>
+                <div className="forge-form-row">
+                    <label className="forge-form-label">Trigger</label>
+                    <input
+                        className="forge-form-input"
+                        value={trigger}
+                        onChange={(e) => setTrigger(e.target.value)}
+                        placeholder="/command-name"
+                    />
+                </div>
+                <div className="forge-form-row">
+                    <label className="forge-form-label">Type</label>
+                    <select
+                        className="forge-form-input forge-form-select"
+                        value={skillType}
+                        onChange={(e) => setSkillType(e.target.value)}
+                    >
+                        {SKILL_TYPES.map((t) => (
+                            <option key={t} value={t}>{t}</option>
+                        ))}
+                    </select>
+                </div>
+                <div className="forge-form-row">
+                    <label className="forge-form-label">Description</label>
+                    <input
+                        className="forge-form-input"
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        placeholder="Brief description"
+                    />
+                </div>
+                <div className="forge-form-row forge-form-row-col">
+                    <label className="forge-form-label">Content</label>
+                    <textarea
+                        className="forge-content-textarea forge-skill-content"
+                        value={content}
+                        onChange={(e) => setContent(e.target.value)}
+                        placeholder="Skill content (prompt, command, etc.)"
+                        spellCheck={false}
+                    />
+                </div>
+                {error && <div className="forge-form-error">{error}</div>}
+                <div className="forge-form-actions">
+                    <button type="submit" className="forge-btn-primary" disabled={!name.trim()}>
+                        {isEdit ? "Update" : "Create"}
+                    </button>
+                    <button type="button" className="forge-btn-secondary" onClick={onClose}>
+                        Cancel
+                    </button>
+                </div>
+            </form>
+        </div>
+    );
+});
+
+ForgeSkillForm.displayName = "ForgeSkillForm";
+
+// ── History Panel ─────────────────────────────────────────────────────────────
+
+const ForgeHistoryPanel: React.FC<{ model: ForgeViewModel; agentId: string }> = memo(({ model, agentId }) => {
+    const entries = useAtomValue(model.historyAtom);
+    const loading = useAtomValue(model.historyLoadingAtom);
+    const [searchQuery, setSearchQuery] = useState("");
+
+    const handleSearch = useCallback(async () => {
+        if (searchQuery.trim()) {
+            await model.searchHistory(agentId, searchQuery.trim());
+        } else {
+            await model.loadHistory(agentId);
+        }
+    }, [model, agentId, searchQuery]);
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === "Enter") {
+            handleSearch();
+        }
+    }, [handleSearch]);
+
+    // Group entries by session_date
+    const groupedEntries = entries.reduce<Record<string, ForgeHistory[]>>((acc, entry) => {
+        const date = entry.session_date;
+        if (!acc[date]) acc[date] = [];
+        acc[date].push(entry);
+        return acc;
+    }, {});
+    const sortedDates = Object.keys(groupedEntries).sort().reverse();
+
+    return (
+        <div className="forge-history-panel">
+            <div className="forge-history-search">
+                <input
+                    className="forge-form-input"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder="Search history..."
+                />
+                <button className="forge-card-btn" onClick={handleSearch}>
+                    Search
+                </button>
+            </div>
+            <div className="forge-history-list">
+                {loading ? (
+                    <div className="forge-content-loading">Loading history...</div>
+                ) : entries.length === 0 ? (
+                    <div className="forge-content-empty">No history entries</div>
+                ) : (
+                    sortedDates.map((date) => (
+                        <div key={date} className="forge-history-group">
+                            <div className="forge-history-date">{date}</div>
+                            {groupedEntries[date].map((entry) => (
+                                <div key={entry.id} className="forge-history-entry">
+                                    <span className="forge-history-time">
+                                        {new Date(entry.timestamp).toLocaleTimeString()}
+                                    </span>
+                                    <span className="forge-history-text">{entry.entry}</span>
+                                </div>
+                            ))}
+                        </div>
+                    ))
+                )}
+            </div>
+        </div>
+    );
+});
+
+ForgeHistoryPanel.displayName = "ForgeHistoryPanel";
+
+// ── Import Form ───────────────────────────────────────────────────────────────
+
+const ForgeImportForm: React.FC<{ model: ForgeViewModel; onClose: () => void }> = memo(({ model, onClose }) => {
+    const importing = useAtomValue(model.importingAtom);
+    const error = useAtomValue(model.errorAtom);
+    const [workspacePath, setWorkspacePath] = useState("");
+    const [agentName, setAgentName] = useState("");
+
+    // Auto-fill agent name from path
+    useEffect(() => {
+        if (workspacePath && !agentName) {
+            const parts = workspacePath.replace(/\\/g, "/").split("/").filter(Boolean);
+            if (parts.length > 0) {
+                setAgentName(parts[parts.length - 1]);
+            }
+        }
+    }, [workspacePath, agentName]);
+
+    const handleSubmit = useCallback(async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!workspacePath.trim() || !agentName.trim()) return;
+        await model.importFromClaw(workspacePath.trim(), agentName.trim());
+        onClose();
+    }, [model, workspacePath, agentName, onClose]);
+
+    return (
+        <div className="forge-import-overlay">
+            <div className="forge-import-dialog">
+                <div className="forge-skill-form-header">
+                    <span className="forge-title-sub">Import from Claw</span>
+                </div>
+                <form onSubmit={handleSubmit}>
+                    <div className="forge-form-row">
+                        <label className="forge-form-label">Workspace Path</label>
+                        <input
+                            className="forge-form-input"
+                            value={workspacePath}
+                            onChange={(e) => setWorkspacePath(e.target.value)}
+                            placeholder="~/.claw/workspaces/agent1"
+                            autoFocus
+                            required
+                        />
+                    </div>
+                    <div className="forge-form-row">
+                        <label className="forge-form-label">Agent Name</label>
+                        <input
+                            className="forge-form-input"
+                            value={agentName}
+                            onChange={(e) => setAgentName(e.target.value)}
+                            placeholder="Agent name"
+                            required
+                        />
+                    </div>
+                    {error && <div className="forge-form-error">{error}</div>}
+                    <div className="forge-form-actions">
+                        <button type="submit" className="forge-btn-primary" disabled={importing || !workspacePath.trim() || !agentName.trim()}>
+                            {importing ? "Importing..." : "Import"}
+                        </button>
+                        <button type="button" className="forge-btn-secondary" onClick={onClose} disabled={importing}>
+                            Cancel
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+});
+
+ForgeImportForm.displayName = "ForgeImportForm";
 
 // ── Create / Edit Form ────────────────────────────────────────────────────────
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -270,6 +270,84 @@ declare global {
         agent_id: string;
     };
 
+    // ForgeSkill
+    type ForgeSkill = {
+        id: string;
+        agent_id: string;
+        name: string;
+        trigger: string;
+        skill_type: string;
+        description: string;
+        content: string;
+        created_at: number;
+    };
+
+    // CommandListForgeSkillsData
+    type CommandListForgeSkillsData = {
+        agent_id: string;
+    };
+
+    // CommandCreateForgeSkillData
+    type CommandCreateForgeSkillData = {
+        agent_id: string;
+        name: string;
+        trigger?: string;
+        skill_type?: string;
+        description?: string;
+        content?: string;
+    };
+
+    // CommandUpdateForgeSkillData
+    type CommandUpdateForgeSkillData = {
+        id: string;
+        name: string;
+        trigger?: string;
+        skill_type?: string;
+        description?: string;
+        content?: string;
+    };
+
+    // CommandDeleteForgeSkillData
+    type CommandDeleteForgeSkillData = {
+        id: string;
+    };
+
+    // ForgeHistory
+    type ForgeHistory = {
+        id: number;
+        agent_id: string;
+        session_date: string;
+        entry: string;
+        timestamp: number;
+    };
+
+    // CommandAppendForgeHistoryData
+    type CommandAppendForgeHistoryData = {
+        agent_id: string;
+        entry: string;
+    };
+
+    // CommandListForgeHistoryData
+    type CommandListForgeHistoryData = {
+        agent_id: string;
+        session_date?: string;
+        limit?: number;
+        offset?: number;
+    };
+
+    // CommandSearchForgeHistoryData
+    type CommandSearchForgeHistoryData = {
+        agent_id: string;
+        query: string;
+        limit?: number;
+    };
+
+    // CommandImportForgeFromClawData
+    type CommandImportForgeFromClawData = {
+        workspace_path: string;
+        agent_name: string;
+    };
+
     // wshrpc.CommandDeleteBlockData
     type CommandDeleteBlockData = {
         blockid: string;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.31.128",
+  "version": "0.31.129",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.31.128"
+version = "0.31.129"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.31.128",
-  "identifier": "ai.agentmux.app.v0-31-128",
+  "version": "0.31.129",
+  "identifier": "ai.agentmux.app.v0-31-129",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.31.128"
+version = "0.31.129"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

Implements the remaining phases of the Forge Context Management spec (`specs/forge-context-management.md`), building on Phase 1 (PR #122):

- **Phase 2 - Skills system:** `db_forge_skills` table, CRUD operations, 4 WebSocket handlers, Skills tab in detail view with add/edit/delete UI, and skill index injection into CLAUDE.md at launch (lazy-loading pattern: only names/descriptions in context, full content loaded on-demand)
- **Phase 3 - Session history:** `db_forge_history` table with date index, append/list/search methods, 3 WebSocket handlers, History section with date-grouped entries and search
- **Phase 4 - Import from Claw:** `importforgefromclaw` handler that reads workspace CLAUDE.md + .mcp.json, creates ForgeAgent + content entries, Import button + dialog in forge list view

### Files changed (11 source files + 6 version files)

| File | Changes |
|------|---------|
| `migrations.rs` | Added `db_forge_skills` + `db_forge_history` tables |
| `wstore.rs` | `ForgeSkill` + `ForgeHistory` structs with CRUD/query methods |
| `mod.rs` | Re-export new types |
| `rpc_types.rs` | 12 new command constants + data types |
| `websocket.rs` | 8 new handlers (4 skills, 3 history, 1 import) |
| `gotypes.d.ts` | Frontend types for skills, history, import |
| `wshclientapi.ts` | 8 new RPC methods |
| `forge-model.ts` | Skills/history/import atoms + methods, event subscriptions |
| `forge-view.tsx` | Skills panel, history panel, import dialog, section tabs |
| `forge-view.scss` | Styles for skills, history, import, section tabs |
| `agent-model.ts` | Skill index injection in `launchForgeAgent` |

## Test plan

- [ ] `cargo check` on backend compiles cleanly (verified)
- [ ] Create agent → add skills with different types → verify they appear in Skills tab
- [ ] Launch agent → verify CLAUDE.md contains `# Available Skills` section with skill index
- [ ] Append history entries via RPC → verify they appear in History section
- [ ] Search history → verify results filter correctly
- [ ] Import from Claw → point at existing claw workspace → verify agent + content created
- [ ] Event subscriptions: changes broadcast via `forgeskills:changed` / `forgehistory:changed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)