### PR TITLE
fix: restore macOS window resize handles

### DIFF
--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -302,6 +302,8 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
             data-role="block-header"
             data-testid="block-header"
             ref={dragHandleRef ? (el) => { dragHandleRef.current = el; } : undefined}
+            onPointerDown={dragHandleRef ? () => { props.nodeModel.dragReady._set(true); } : undefined}
+            onPointerUp={dragHandleRef ? () => { props.nodeModel.dragReady._set(false); } : undefined}
             onContextMenu={onContextMenu}
             style={headerStyle()}
         >

--- a/frontend/layout/lib/TileLayout.tsx
+++ b/frontend/layout/lib/TileLayout.tsx
@@ -262,6 +262,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
         globalDragLayoutModel = null;
         props.layoutModel.activeDrag._set(false);
         setIsDragging(false);
+        nodeModel.dragReady._set(false);
     };
 
     // Attach drag handle ref to the drag handle element
@@ -298,7 +299,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
             ref={tileNodeRef}
             id={props.node.id}
             style={addlProps()?.transform as JSX.CSSProperties}
-            draggable={!isEphemeral() && !isMagnified()}
+            draggable={nodeModel.dragReady() && !isEphemeral() && !isMagnified()}
             onDragStart={onDragStart}
             onDragEnd={onDragEnd}
             onPointerEnter={generatePreviewImage}

--- a/frontend/layout/lib/layoutNodeModels.ts
+++ b/frontend/layout/lib/layoutNodeModels.ts
@@ -1,7 +1,7 @@
 // Copyright 2025, Command Line Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createSignalAtom, fireAndForget } from "@/util/util";
+import { createSignalAtom, fireAndForget, type SignalAtom } from "@/util/util";
 import type { Properties as CSSProperties } from "csstype";
 import { createMemo } from "solid-js";
 import { LayoutNode, LayoutNodeAdditionalProps, NodeModel } from "./types";
@@ -62,6 +62,7 @@ export function getNodeModel(model: LayoutModel, node: LayoutNode): NodeModel {
                 },
                 toggleMagnify: () => model.magnifyNodeToggle(nodeid),
                 focusNode: () => model.focusNode(nodeid),
+                dragReady: createSignalAtom(false),
                 dragHandleRef: { current: null as HTMLDivElement | null },
                 displayContainerRef: model.displayContainerRef,
             });

--- a/frontend/layout/lib/types.ts
+++ b/frontend/layout/lib/types.ts
@@ -258,6 +258,7 @@ export interface NodeModel {
     toggleMagnify: () => void;
     focusNode: () => void;
     onClose: () => void;
+    dragReady: import("@/util/util").SignalAtom<boolean>;
     // DOM refs in SolidJS are plain { current: T | null } objects
     dragHandleRef?: { current: HTMLDivElement | null };
     displayContainerRef: { current: HTMLDivElement | null };

--- a/specs/fix-macos-resize-handles.md
+++ b/specs/fix-macos-resize-handles.md
@@ -1,0 +1,42 @@
+# Fix: macOS Window Resize Handles Missing After SolidJS Migration
+
+## Problem
+
+Window border resize handles work on Windows but not macOS. Broke after the SolidJS migration (PR #120).
+
+## Root Cause
+
+After the SolidJS migration, every `DisplayNode` tile div has `draggable={true}` at all times (line 301 of `TileLayout.tsx`). On macOS with `decorations: false` + `transparent: true`, the WebView's `draggable` elements near window edges intercept pointer events before they reach the native NSWindow resize hit-test area.
+
+**React (worked):** `react-dnd`'s HTML5Backend only set elements as draggable during active drag operations. At rest, no tile had `draggable=true`, so pointer events at window edges fell through to NSWindow resize handling.
+
+**SolidJS (broken):** Native HTML5 drag puts `draggable={true}` on all tile nodes unconditionally. WebKit's drag initiation takes priority over NSWindow resize hit-testing.
+
+Windows is unaffected — Win32's `WM_NCHITTEST` provides resize zones below the WebView layer regardless of `draggable` attributes.
+
+## Fix
+
+Make `draggable` conditional on drag intent, matching react-dnd's implicit behavior.
+
+### Changes
+
+| File | Change |
+|------|--------|
+| `frontend/layout/lib/types.ts` | Add `dragReady: SignalAtom<boolean>` to `NodeModel` interface |
+| `frontend/layout/lib/layoutNodeModels.ts` | Create `dragReady` signal (default `false`) for each node model |
+| `frontend/app/block/blockframe.tsx` | Set `dragReady` true on `pointerdown` on block header (drag handle), false on `pointerup` |
+| `frontend/layout/lib/TileLayout.tsx` | Gate `draggable` on `nodeModel.dragReady()` instead of always-on; clear on drag end |
+
+### How it works
+
+1. At rest: no tile node has `draggable=true` — macOS NSWindow edge resize works
+2. User presses on block header (drag handle): `dragReady` becomes `true`, enabling HTML5 drag
+3. Drag ends or pointer released: `dragReady` resets to `false`
+4. Windows/Linux: unaffected — they don't depend on WebView pointer events for window resize
+
+### Platform impact
+
+- **macOS:** Restores resize handles at window edges
+- **Windows:** No change — `WM_NCHITTEST` handles resize independently
+- **Linux:** No change — X11/Wayland resize handling is independent of WebView drag state
+- **Drag-and-drop:** Works identically — user always initiates drag from the header bar

--- a/specs/macos-window-resize-handles.md
+++ b/specs/macos-window-resize-handles.md
@@ -1,0 +1,121 @@
+# Spec: macOS Window Resize Handles Missing After SolidJS Migration
+
+## Problem
+
+Window border resize handles work on Windows but not macOS. Worked on macOS before the SolidJS migration (PR #120), broke after.
+
+## What Changed
+
+The Tauri config, Rust code, CSS, and HTML structure are **identical** between React and SolidJS builds. The only relevant changes are in the JS layer:
+
+### 1. react-dnd removed, replaced with native HTML5 drag
+
+React version:
+```tsx
+import { useDrag, useDrop, useDragLayer } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
+
+<DndProvider backend={HTML5Backend}>
+    <Workspace />
+    <CrossWindowDragMonitor />
+</DndProvider>
+```
+
+SolidJS version:
+```tsx
+// No DnD provider. Native HTML5 drag via draggable attribute + dataTransfer.
+<Workspace />
+<CrossWindowDragMonitor />
+```
+
+`react-dnd-html5-backend` registers **global document-level event listeners** for `dragstart`, `dragover`, `dragend`, `drop`, etc. These listeners use `addEventListener` with specific options and call `preventDefault()` / `stopPropagation()` in various cases. Removing this layer changes how pointer and drag events propagate through the DOM.
+
+### 2. `<Suspense>` wrapper removed from TileLayout
+
+React version wrapped the tile layout in `<Suspense>`, SolidJS does not. This changes the initial render timing — React defers rendering until all lazy children resolve, potentially allowing native window chrome to handle early pointer events. Without Suspense, SolidJS renders immediately, and the full-bleed content captures all events from the start.
+
+### 3. DisplayNode now has `draggable={true}` on the tile div itself
+
+React version used `react-dnd`'s `useDrag` hook which attaches drag behavior to a separate drag handle ref. SolidJS puts `draggable={true}` directly on the tile node div:
+
+```tsx
+<div
+    ref={tileNodeRef}
+    id={props.node.id}
+    draggable={!isEphemeral() && !isMagnified()}
+    onDragStart={onDragStart}
+    onDragEnd={onDragEnd}
+    ...
+>
+```
+
+When every display node div is natively `draggable`, the browser may handle pointer events at window edges differently — especially on macOS WebKit where native drag initiation competes with NSWindow resize hit-testing.
+
+## Root Cause Analysis
+
+On macOS with `decorations: false` + `transparent: true`, window edge resize relies on NSWindow providing resize hit-test areas that the WebView doesn't intercept. This is fragile — it depends on how the WebView handles events near the edges.
+
+**Why it worked with React:** `react-dnd-html5-backend` managed drag state through its own event layer, and individual tile nodes were NOT natively `draggable`. The HTML5Backend only made elements draggable when a drag actually started (via `connectDragSource`). At rest, no elements had `draggable=true`, so pointer events at window edges could fall through to the native NSWindow resize handler.
+
+**Why it broke with SolidJS:** Every display node div now has `draggable={true}` at all times. On macOS WebKit, a `draggable` element near the window edge intercepts the pointer event before it reaches the NSWindow resize hit-test area. The browser's drag initiation logic takes priority over the window manager's resize logic.
+
+## Solution
+
+### Option A: Only set `draggable` during active drag intent (recommended)
+
+Match React-DnD's behavior — don't set `draggable={true}` on tile nodes by default. Only make them draggable when the user starts a drag gesture (e.g., on long-press of the drag handle, or when pointer-down on the header bar):
+
+```tsx
+// In DisplayNode:
+const [isDragReady, setIsDragReady] = createSignal(false);
+
+<div
+    ref={tileNodeRef}
+    draggable={isDragReady()}
+    ...
+>
+    <div
+        class="drag-handle"
+        onPointerDown={() => setIsDragReady(true)}
+        onPointerUp={() => setIsDragReady(false)}
+    />
+    ...
+</div>
+```
+
+This restores the React-era behavior where tile nodes are not natively draggable at rest, allowing macOS NSWindow edge resize to work.
+
+### Option B: CSS `pointer-events: none` border zone
+
+Add an invisible border zone (4-6px) around the window content that has `pointer-events: none`, allowing native resize events to pass through to the NSWindow:
+
+```scss
+// In app.scss
+#main {
+    // Inset content slightly so native resize areas at edges are reachable
+    padding: 4px;
+}
+```
+
+Simple but loses 4px of usable space on all edges.
+
+### Option C: Native NSWindow style mask fix (fallback)
+
+If the above don't work, explicitly set `NSWindowStyleMaskResizable` on the NSWindow after creation in Rust code. This is a deeper fix but may not help if the WebView is still consuming the events.
+
+## Implementation Plan
+
+1. **Try Option A first** — conditionally set `draggable` only on drag-handle interaction, not on the entire tile node. This is the most targeted fix and matches what react-dnd did.
+2. **Verify on macOS** — resize cursor appears at window edges, drag to resize works.
+3. **Verify drag-and-drop still works** — pane reorder, cross-window drag, file drop all still function.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `frontend/layout/lib/TileLayout.tsx` | Conditionally set `draggable` on DisplayNode — only during active drag intent |
+
+## Notes
+
+- Windows is unaffected because Win32's `WM_NCHITTEST` provides resize zones below the WebView layer regardless of `draggable` attributes.
+- This is a WebKit-specific behavior on macOS — `draggable` elements near window edges compete with native resize hit-testing for frameless windows.


### PR DESCRIPTION
## Summary

- Gate tile node `draggable` attribute on active drag intent instead of always-on
- After the SolidJS migration (PR #120), all tile nodes had `draggable={true}` unconditionally, which intercepted pointer events at window edges on macOS before they reached NSWindow resize hit-testing
- Now `draggable` is only true when the user presses on the block header (drag handle), matching react-dnd's implicit behavior
- Windows/Linux unaffected — their resize handling is independent of WebView drag state

## Files changed

| File | Change |
|------|--------|
| `frontend/layout/lib/types.ts` | Add `dragReady: SignalAtom<boolean>` to `NodeModel` |
| `frontend/layout/lib/layoutNodeModels.ts` | Create `dragReady` signal for each node model |
| `frontend/app/block/blockframe.tsx` | Set `dragReady` on pointerdown/pointerup on block header |
| `frontend/layout/lib/TileLayout.tsx` | Gate `draggable` on `dragReady()`, clear on drag end |
| `specs/` | Investigation spec + fix plan |

## Test plan

- [ ] macOS: resize cursor appears at window edges, drag-to-resize works
- [ ] macOS: drag pane by header still works (reorder, cross-window)
- [ ] Windows: drag-and-drop unaffected
- [ ] Linux: drag-and-drop unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)