### PR TITLE
feat: auto-seed Forge with claw agents on first launch

### DIFF
--- a/agentmuxsrv-rs/forge-seed.json
+++ b/agentmuxsrv-rs/forge-seed.json
@@ -1,0 +1,233 @@
+{
+  "version": 1,
+  "agents": [
+    {
+      "id": "agentx",
+      "name": "AgentX",
+      "icon": "\ud83d\udd34",
+      "agent_type": "host",
+      "environment": "windows",
+      "provider": "claude-code",
+      "description": "Primary host agent \u2014 claw deployment, container orchestration, host operations",
+      "working_directory": "~/.claw/agentx-workspace",
+      "shell": "pwsh",
+      "agent_bus_id": "agentx",
+      "auto_start": false,
+      "restart_on_crash": false,
+      "content": {
+        "env": "AGENT_NAME=agentx\nAWS_PROFILE=AgentX\nAGENTBUS_URL=https://agentbus.asaf.cc\nAGENTBUS_AGENT_ID=agentx"
+      },
+      "skills": [
+        { "name": "Startup", "trigger": "/startup", "skill_type": "prompt", "description": "Full context reload and verification" },
+        { "name": "Reinforce", "trigger": "/reinforce", "skill_type": "prompt", "description": "Quick critical rules reminder" },
+        { "name": "Git Workflow", "trigger": "/git-workflow", "skill_type": "prompt", "description": "Branch and PR rules" },
+        { "name": "Versioning", "trigger": "/versioning", "skill_type": "prompt", "description": "npm version bump rules" },
+        { "name": "GitHub Layers", "trigger": "/github-layers", "skill_type": "prompt", "description": "3-layer GitHub access system" },
+        { "name": "Dev Tools", "trigger": "/dev-tools", "skill_type": "prompt", "description": "@a5af package reference" },
+        { "name": "Deployment", "trigger": "/deployment", "skill_type": "prompt", "description": "Deploy CLI and CDK" },
+        { "name": "AWS Secrets", "trigger": "/aws-secrets", "skill_type": "prompt", "description": "Secrets Manager access" },
+        { "name": "AWS Setup", "trigger": "/aws-setup", "skill_type": "prompt", "description": "AWS identity and profiles" },
+        { "name": "MCP Servers", "trigger": "/mcp-servers", "skill_type": "prompt", "description": "MCP configuration reference" },
+        { "name": "ReAgent", "trigger": "/reagent", "skill_type": "prompt", "description": "PR review workflow" },
+        { "name": "E2E Testing", "trigger": "/e2e-testing", "skill_type": "prompt", "description": "HTTP Auth and Playwright" },
+        { "name": "VS Code Bridge", "trigger": "/vscode-bridge", "skill_type": "prompt", "description": "VS Code integration" },
+        { "name": "Container Mgmt", "trigger": "/container-mgmt", "skill_type": "prompt", "description": "Docker container operations (host only)" },
+        { "name": "PowerShell 7", "trigger": "/pwsh", "skill_type": "prompt", "description": "PowerShell 7 guidelines (host only)" }
+      ]
+    },
+    {
+      "id": "agenty",
+      "name": "AgentY",
+      "icon": "\ud83d\udfe1",
+      "agent_type": "host",
+      "environment": "windows",
+      "provider": "claude-code",
+      "description": "Secondary host agent",
+      "working_directory": "~/.claw/agenty-workspace",
+      "shell": "pwsh",
+      "agent_bus_id": "agenty",
+      "auto_start": false,
+      "restart_on_crash": false,
+      "content": {
+        "env": "AGENT_NAME=agenty\nAWS_PROFILE=AgentY\nAGENTBUS_URL=https://agentbus.asaf.cc\nAGENTBUS_AGENT_ID=agenty"
+      },
+      "skills": [
+        { "name": "Startup", "trigger": "/startup", "skill_type": "prompt", "description": "Full context reload and verification" },
+        { "name": "Reinforce", "trigger": "/reinforce", "skill_type": "prompt", "description": "Quick critical rules reminder" },
+        { "name": "Git Workflow", "trigger": "/git-workflow", "skill_type": "prompt", "description": "Branch and PR rules" },
+        { "name": "Versioning", "trigger": "/versioning", "skill_type": "prompt", "description": "npm version bump rules" },
+        { "name": "GitHub Layers", "trigger": "/github-layers", "skill_type": "prompt", "description": "3-layer GitHub access system" },
+        { "name": "Dev Tools", "trigger": "/dev-tools", "skill_type": "prompt", "description": "@a5af package reference" },
+        { "name": "Deployment", "trigger": "/deployment", "skill_type": "prompt", "description": "Deploy CLI and CDK" },
+        { "name": "AWS Secrets", "trigger": "/aws-secrets", "skill_type": "prompt", "description": "Secrets Manager access" },
+        { "name": "AWS Setup", "trigger": "/aws-setup", "skill_type": "prompt", "description": "AWS identity and profiles" },
+        { "name": "MCP Servers", "trigger": "/mcp-servers", "skill_type": "prompt", "description": "MCP configuration reference" },
+        { "name": "ReAgent", "trigger": "/reagent", "skill_type": "prompt", "description": "PR review workflow" },
+        { "name": "E2E Testing", "trigger": "/e2e-testing", "skill_type": "prompt", "description": "HTTP Auth and Playwright" },
+        { "name": "VS Code Bridge", "trigger": "/vscode-bridge", "skill_type": "prompt", "description": "VS Code integration" },
+        { "name": "Container Mgmt", "trigger": "/container-mgmt", "skill_type": "prompt", "description": "Docker container operations (host only)" },
+        { "name": "PowerShell 7", "trigger": "/pwsh", "skill_type": "prompt", "description": "PowerShell 7 guidelines (host only)" }
+      ]
+    },
+    {
+      "id": "agent1",
+      "name": "Agent1",
+      "icon": "\ud83d\udfe2",
+      "agent_type": "container",
+      "environment": "linux",
+      "provider": "claude-code",
+      "description": "Container code agent \u2014 isolated Docker workspace for code, PRs, reviews",
+      "working_directory": "/workspace",
+      "shell": "bash",
+      "agent_bus_id": "agent1",
+      "auto_start": false,
+      "restart_on_crash": true,
+      "content": {
+        "env": "AGENT_NAME=agent1\nAWS_PROFILE=Agent1\nAGENTBUS_URL=https://agentbus.asaf.cc\nAGENTBUS_AGENT_ID=agent1\nPLAYWRIGHT_BROWSERS_SERVER=ws://playwright-browsers:3000\nCHOKIDAR_USEPOLLING=true"
+      },
+      "skills": [
+        { "name": "Startup", "trigger": "/startup", "skill_type": "prompt", "description": "Full context reload and verification" },
+        { "name": "Reinforce", "trigger": "/reinforce", "skill_type": "prompt", "description": "Quick critical rules reminder" },
+        { "name": "Git Workflow", "trigger": "/git-workflow", "skill_type": "prompt", "description": "Branch and PR rules" },
+        { "name": "Versioning", "trigger": "/versioning", "skill_type": "prompt", "description": "npm version bump rules" },
+        { "name": "GitHub Layers", "trigger": "/github-layers", "skill_type": "prompt", "description": "3-layer GitHub access system" },
+        { "name": "Dev Tools", "trigger": "/dev-tools", "skill_type": "prompt", "description": "@a5af package reference" },
+        { "name": "Deployment", "trigger": "/deployment", "skill_type": "prompt", "description": "Deploy CLI and CDK" },
+        { "name": "AWS Secrets", "trigger": "/aws-secrets", "skill_type": "prompt", "description": "Secrets Manager access" },
+        { "name": "AWS Setup", "trigger": "/aws-setup", "skill_type": "prompt", "description": "AWS identity and profiles" },
+        { "name": "MCP Servers", "trigger": "/mcp-servers", "skill_type": "prompt", "description": "MCP configuration reference" },
+        { "name": "ReAgent", "trigger": "/reagent", "skill_type": "prompt", "description": "PR review workflow" },
+        { "name": "E2E Testing", "trigger": "/e2e-testing", "skill_type": "prompt", "description": "HTTP Auth and Playwright" },
+        { "name": "VS Code Bridge", "trigger": "/vscode-bridge", "skill_type": "prompt", "description": "VS Code integration" }
+      ]
+    },
+    {
+      "id": "agent2",
+      "name": "Agent2",
+      "icon": "\ud83d\udfe0",
+      "agent_type": "container",
+      "environment": "linux",
+      "provider": "claude-code",
+      "description": "Container code agent \u2014 isolated Docker workspace for code, PRs, reviews",
+      "working_directory": "/workspace",
+      "shell": "bash",
+      "agent_bus_id": "agent2",
+      "auto_start": false,
+      "restart_on_crash": true,
+      "content": {
+        "env": "AGENT_NAME=agent2\nAWS_PROFILE=Agent2\nAGENTBUS_URL=https://agentbus.asaf.cc\nAGENTBUS_AGENT_ID=agent2\nPLAYWRIGHT_BROWSERS_SERVER=ws://playwright-browsers:3000\nCHOKIDAR_USEPOLLING=true"
+      },
+      "skills": [
+        { "name": "Startup", "trigger": "/startup", "skill_type": "prompt", "description": "Full context reload and verification" },
+        { "name": "Reinforce", "trigger": "/reinforce", "skill_type": "prompt", "description": "Quick critical rules reminder" },
+        { "name": "Git Workflow", "trigger": "/git-workflow", "skill_type": "prompt", "description": "Branch and PR rules" },
+        { "name": "Versioning", "trigger": "/versioning", "skill_type": "prompt", "description": "npm version bump rules" },
+        { "name": "GitHub Layers", "trigger": "/github-layers", "skill_type": "prompt", "description": "3-layer GitHub access system" },
+        { "name": "Dev Tools", "trigger": "/dev-tools", "skill_type": "prompt", "description": "@a5af package reference" },
+        { "name": "Deployment", "trigger": "/deployment", "skill_type": "prompt", "description": "Deploy CLI and CDK" },
+        { "name": "AWS Secrets", "trigger": "/aws-secrets", "skill_type": "prompt", "description": "Secrets Manager access" },
+        { "name": "AWS Setup", "trigger": "/aws-setup", "skill_type": "prompt", "description": "AWS identity and profiles" },
+        { "name": "MCP Servers", "trigger": "/mcp-servers", "skill_type": "prompt", "description": "MCP configuration reference" },
+        { "name": "ReAgent", "trigger": "/reagent", "skill_type": "prompt", "description": "PR review workflow" },
+        { "name": "E2E Testing", "trigger": "/e2e-testing", "skill_type": "prompt", "description": "HTTP Auth and Playwright" },
+        { "name": "VS Code Bridge", "trigger": "/vscode-bridge", "skill_type": "prompt", "description": "VS Code integration" }
+      ]
+    },
+    {
+      "id": "agent3",
+      "name": "Agent3",
+      "icon": "\ud83d\udfe3",
+      "agent_type": "container",
+      "environment": "linux",
+      "provider": "claude-code",
+      "description": "Container code agent \u2014 isolated Docker workspace for code, PRs, reviews",
+      "working_directory": "/workspace",
+      "shell": "bash",
+      "agent_bus_id": "agent3",
+      "auto_start": false,
+      "restart_on_crash": true,
+      "content": {
+        "env": "AGENT_NAME=agent3\nAWS_PROFILE=Agent3\nAGENTBUS_URL=https://agentbus.asaf.cc\nAGENTBUS_AGENT_ID=agent3\nPLAYWRIGHT_BROWSERS_SERVER=ws://playwright-browsers:3000\nCHOKIDAR_USEPOLLING=true"
+      },
+      "skills": [
+        { "name": "Startup", "trigger": "/startup", "skill_type": "prompt", "description": "Full context reload and verification" },
+        { "name": "Reinforce", "trigger": "/reinforce", "skill_type": "prompt", "description": "Quick critical rules reminder" },
+        { "name": "Git Workflow", "trigger": "/git-workflow", "skill_type": "prompt", "description": "Branch and PR rules" },
+        { "name": "Versioning", "trigger": "/versioning", "skill_type": "prompt", "description": "npm version bump rules" },
+        { "name": "GitHub Layers", "trigger": "/github-layers", "skill_type": "prompt", "description": "3-layer GitHub access system" },
+        { "name": "Dev Tools", "trigger": "/dev-tools", "skill_type": "prompt", "description": "@a5af package reference" },
+        { "name": "Deployment", "trigger": "/deployment", "skill_type": "prompt", "description": "Deploy CLI and CDK" },
+        { "name": "AWS Secrets", "trigger": "/aws-secrets", "skill_type": "prompt", "description": "Secrets Manager access" },
+        { "name": "AWS Setup", "trigger": "/aws-setup", "skill_type": "prompt", "description": "AWS identity and profiles" },
+        { "name": "MCP Servers", "trigger": "/mcp-servers", "skill_type": "prompt", "description": "MCP configuration reference" },
+        { "name": "ReAgent", "trigger": "/reagent", "skill_type": "prompt", "description": "PR review workflow" },
+        { "name": "E2E Testing", "trigger": "/e2e-testing", "skill_type": "prompt", "description": "HTTP Auth and Playwright" },
+        { "name": "VS Code Bridge", "trigger": "/vscode-bridge", "skill_type": "prompt", "description": "VS Code integration" }
+      ]
+    },
+    {
+      "id": "agent4",
+      "name": "Agent4",
+      "icon": "\ud83d\udfe0",
+      "agent_type": "container",
+      "environment": "linux",
+      "provider": "claude-code",
+      "description": "Container code agent \u2014 isolated Docker workspace for code, PRs, reviews",
+      "working_directory": "/workspace",
+      "shell": "bash",
+      "agent_bus_id": "agent4",
+      "auto_start": false,
+      "restart_on_crash": true,
+      "content": {
+        "env": "AGENT_NAME=agent4\nAWS_PROFILE=Agent4\nAGENTBUS_URL=https://agentbus.asaf.cc\nAGENTBUS_AGENT_ID=agent4\nPLAYWRIGHT_BROWSERS_SERVER=ws://playwright-browsers:3000\nCHOKIDAR_USEPOLLING=true"
+      },
+      "skills": [
+        { "name": "Startup", "trigger": "/startup", "skill_type": "prompt", "description": "Full context reload and verification" },
+        { "name": "Reinforce", "trigger": "/reinforce", "skill_type": "prompt", "description": "Quick critical rules reminder" },
+        { "name": "Git Workflow", "trigger": "/git-workflow", "skill_type": "prompt", "description": "Branch and PR rules" },
+        { "name": "Versioning", "trigger": "/versioning", "skill_type": "prompt", "description": "npm version bump rules" },
+        { "name": "GitHub Layers", "trigger": "/github-layers", "skill_type": "prompt", "description": "3-layer GitHub access system" },
+        { "name": "Dev Tools", "trigger": "/dev-tools", "skill_type": "prompt", "description": "@a5af package reference" },
+        { "name": "Deployment", "trigger": "/deployment", "skill_type": "prompt", "description": "Deploy CLI and CDK" },
+        { "name": "AWS Secrets", "trigger": "/aws-secrets", "skill_type": "prompt", "description": "Secrets Manager access" },
+        { "name": "AWS Setup", "trigger": "/aws-setup", "skill_type": "prompt", "description": "AWS identity and profiles" },
+        { "name": "MCP Servers", "trigger": "/mcp-servers", "skill_type": "prompt", "description": "MCP configuration reference" },
+        { "name": "ReAgent", "trigger": "/reagent", "skill_type": "prompt", "description": "PR review workflow" },
+        { "name": "E2E Testing", "trigger": "/e2e-testing", "skill_type": "prompt", "description": "HTTP Auth and Playwright" },
+        { "name": "VS Code Bridge", "trigger": "/vscode-bridge", "skill_type": "prompt", "description": "VS Code integration" }
+      ]
+    },
+    {
+      "id": "agent5",
+      "name": "Agent5",
+      "icon": "\u26aa",
+      "agent_type": "container",
+      "environment": "linux",
+      "provider": "claude-code",
+      "description": "Container code agent \u2014 isolated Docker workspace for code, PRs, reviews",
+      "working_directory": "/workspace",
+      "shell": "bash",
+      "agent_bus_id": "agent5",
+      "auto_start": false,
+      "restart_on_crash": true,
+      "content": {
+        "env": "AGENT_NAME=agent5\nAWS_PROFILE=Agent5\nAGENTBUS_URL=https://agentbus.asaf.cc\nAGENTBUS_AGENT_ID=agent5\nPLAYWRIGHT_BROWSERS_SERVER=ws://playwright-browsers:3000\nCHOKIDAR_USEPOLLING=true"
+      },
+      "skills": [
+        { "name": "Startup", "trigger": "/startup", "skill_type": "prompt", "description": "Full context reload and verification" },
+        { "name": "Reinforce", "trigger": "/reinforce", "skill_type": "prompt", "description": "Quick critical rules reminder" },
+        { "name": "Git Workflow", "trigger": "/git-workflow", "skill_type": "prompt", "description": "Branch and PR rules" },
+        { "name": "Versioning", "trigger": "/versioning", "skill_type": "prompt", "description": "npm version bump rules" },
+        { "name": "GitHub Layers", "trigger": "/github-layers", "skill_type": "prompt", "description": "3-layer GitHub access system" },
+        { "name": "Dev Tools", "trigger": "/dev-tools", "skill_type": "prompt", "description": "@a5af package reference" },
+        { "name": "Deployment", "trigger": "/deployment", "skill_type": "prompt", "description": "Deploy CLI and CDK" },
+        { "name": "AWS Secrets", "trigger": "/aws-secrets", "skill_type": "prompt", "description": "Secrets Manager access" },
+        { "name": "AWS Setup", "trigger": "/aws-setup", "skill_type": "prompt", "description": "AWS identity and profiles" },
+        { "name": "MCP Servers", "trigger": "/mcp-servers", "skill_type": "prompt", "description": "MCP configuration reference" },
+        { "name": "ReAgent", "trigger": "/reagent", "skill_type": "prompt", "description": "PR review workflow" },
+        { "name": "E2E Testing", "trigger": "/e2e-testing", "skill_type": "prompt", "description": "HTTP Auth and Playwright" },
+        { "name": "VS Code Bridge", "trigger": "/vscode-bridge", "skill_type": "prompt", "description": "VS Code integration" }
+      ]
+    }
+  ]
+}

--- a/agentmuxsrv-rs/src/backend/forge_seed.rs
+++ b/agentmuxsrv-rs/src/backend/forge_seed.rs
@@ -1,0 +1,207 @@
+// Copyright 2025, Command Line Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Forge seed engine: preloads agents from an embedded manifest on first launch.
+//! Seeds host agents (AgentX, AgentY) and container agents (Agent1-5) with their
+//! full configuration including content blobs (CLAUDE.md, MCP, env) and skills.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Deserialize;
+
+use super::storage::wstore::{ForgeAgent, ForgeContent, ForgeSkill, WaveStore};
+use super::storage::StoreError;
+
+/// Report returned after seeding.
+pub struct SeedReport {
+    pub created: usize,
+    pub skipped: usize,
+}
+
+/// Top-level seed manifest structure.
+#[derive(Debug, Deserialize)]
+struct SeedManifest {
+    #[allow(dead_code)]
+    version: u32,
+    agents: Vec<SeedAgent>,
+}
+
+/// An agent definition in the seed manifest.
+#[derive(Debug, Deserialize)]
+struct SeedAgent {
+    id: String,
+    name: String,
+    #[serde(default = "default_icon")]
+    icon: String,
+    agent_type: String,
+    environment: String,
+    provider: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    working_directory: String,
+    #[serde(default)]
+    shell: String,
+    #[serde(default)]
+    agent_bus_id: String,
+    #[serde(default)]
+    auto_start: bool,
+    #[serde(default)]
+    restart_on_crash: bool,
+    #[serde(default)]
+    content: SeedContent,
+    #[serde(default)]
+    skills: Vec<SeedSkill>,
+}
+
+fn default_icon() -> String {
+    "\u{2726}".to_string()
+}
+
+/// Content blobs to seed for an agent.
+#[derive(Debug, Default, Deserialize)]
+struct SeedContent {
+    #[serde(default)]
+    agentmd: Option<String>,
+    #[serde(default)]
+    mcp: Option<String>,
+    #[serde(default)]
+    env: Option<String>,
+    #[serde(default)]
+    soul: Option<String>,
+}
+
+/// A skill definition in the seed manifest.
+#[derive(Debug, Deserialize)]
+struct SeedSkill {
+    name: String,
+    #[serde(default)]
+    trigger: String,
+    #[serde(default = "default_skill_type")]
+    skill_type: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    content: String,
+}
+
+fn default_skill_type() -> String {
+    "prompt".to_string()
+}
+
+/// The embedded seed manifest JSON.
+const SEED_MANIFEST: &str = include_str!("../../forge-seed.json");
+
+/// Seed forge agents from the embedded manifest.
+/// Skips agents whose ID already exists in the database.
+pub fn seed_forge_agents(wstore: &Arc<WaveStore>) -> Result<SeedReport, StoreError> {
+    let manifest: SeedManifest = serde_json::from_str(SEED_MANIFEST)
+        .map_err(|e| StoreError::Other(format!("forge seed: parse manifest: {e}")))?;
+
+    let existing = wstore.forge_list()?;
+    let existing_ids: std::collections::HashSet<String> =
+        existing.iter().map(|a| a.id.clone()).collect();
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    let mut created = 0usize;
+    let mut skipped = 0usize;
+
+    for agent_def in &manifest.agents {
+        if existing_ids.contains(&agent_def.id) {
+            skipped += 1;
+            continue;
+        }
+
+        // Insert agent
+        let agent = ForgeAgent {
+            id: agent_def.id.clone(),
+            name: agent_def.name.clone(),
+            icon: agent_def.icon.clone(),
+            provider: agent_def.provider.clone(),
+            description: agent_def.description.clone(),
+            working_directory: agent_def.working_directory.clone(),
+            shell: agent_def.shell.clone(),
+            provider_flags: String::new(),
+            auto_start: if agent_def.auto_start { 1 } else { 0 },
+            restart_on_crash: if agent_def.restart_on_crash { 1 } else { 0 },
+            idle_timeout_minutes: 0,
+            created_at: now,
+            agent_type: agent_def.agent_type.clone(),
+            environment: agent_def.environment.clone(),
+            agent_bus_id: agent_def.agent_bus_id.clone(),
+            is_seeded: 1,
+        };
+        wstore.forge_insert(&agent)?;
+
+        // Insert content blobs
+        let content_pairs = [
+            ("agentmd", &agent_def.content.agentmd),
+            ("mcp", &agent_def.content.mcp),
+            ("env", &agent_def.content.env),
+            ("soul", &agent_def.content.soul),
+        ];
+        for (content_type, maybe_content) in &content_pairs {
+            if let Some(content) = maybe_content {
+                if !content.is_empty() {
+                    wstore.forge_set_content(&ForgeContent {
+                        agent_id: agent_def.id.clone(),
+                        content_type: content_type.to_string(),
+                        content: content.clone(),
+                        updated_at: now,
+                    })?;
+                }
+            }
+        }
+
+        // Insert skills
+        for skill_def in &agent_def.skills {
+            let skill = ForgeSkill {
+                id: uuid::Uuid::new_v4().to_string(),
+                agent_id: agent_def.id.clone(),
+                name: skill_def.name.clone(),
+                trigger: skill_def.trigger.clone(),
+                skill_type: skill_def.skill_type.clone(),
+                description: skill_def.description.clone(),
+                content: skill_def.content.clone(),
+                created_at: now,
+            };
+            wstore.forge_insert_skill(&skill)?;
+        }
+
+        created += 1;
+    }
+
+    Ok(SeedReport { created, skipped })
+}
+
+/// Run auto-seed on startup: only seeds if the forge agents table is empty.
+pub fn auto_seed_on_startup(wstore: &Arc<WaveStore>) {
+    match wstore.forge_count() {
+        Ok(count) if count == 0 => {
+            tracing::info!("forge: no agents found, seeding from manifest...");
+            match seed_forge_agents(wstore) {
+                Ok(report) => {
+                    tracing::info!(
+                        "forge: seeded {} agents ({} skipped)",
+                        report.created,
+                        report.skipped
+                    );
+                }
+                Err(e) => {
+                    tracing::error!("forge: seed failed: {e}");
+                }
+            }
+        }
+        Ok(count) => {
+            tracing::info!("forge: {} agents exist, skipping auto-seed", count);
+        }
+        Err(e) => {
+            tracing::error!("forge: failed to count agents: {e}");
+        }
+    }
+}

--- a/agentmuxsrv-rs/src/backend/mod.rs
+++ b/agentmuxsrv-rs/src/backend/mod.rs
@@ -12,6 +12,7 @@ pub mod ds;
 pub mod envutil;
 pub mod eventbus;
 pub mod fileutil;
+pub mod forge_seed;
 pub mod messagebus;
 pub mod ijson;
 pub mod iochan;

--- a/agentmuxsrv-rs/src/backend/rpc_types.rs
+++ b/agentmuxsrv-rs/src/backend/rpc_types.rs
@@ -277,6 +277,9 @@ pub const COMMAND_SEARCH_FORGE_HISTORY: &str = "searchforgehistory";
 // Forge Import
 pub const COMMAND_IMPORT_FORGE_FROM_CLAW: &str = "importforgefromclaw";
 
+// Forge Seed
+pub const COMMAND_RESEED_FORGE_AGENTS: &str = "reseedforgeagents";
+
 // ---- Client type constants ----
 
 pub const CLIENT_TYPE_CONN_SERVER: &str = "connserver";
@@ -654,6 +657,16 @@ pub struct CommandCreateForgeAgentData {
     pub restart_on_crash: i64,
     #[serde(default)]
     pub idle_timeout_minutes: i64,
+    #[serde(default = "default_agent_type")]
+    pub agent_type: String,
+    #[serde(default)]
+    pub environment: String,
+    #[serde(default)]
+    pub agent_bus_id: String,
+}
+
+fn default_agent_type() -> String {
+    "standalone".to_string()
 }
 
 fn default_forge_icon() -> String {
@@ -681,6 +694,12 @@ pub struct CommandUpdateForgeAgentData {
     pub restart_on_crash: i64,
     #[serde(default)]
     pub idle_timeout_minutes: i64,
+    #[serde(default = "default_agent_type")]
+    pub agent_type: String,
+    #[serde(default)]
+    pub environment: String,
+    #[serde(default)]
+    pub agent_bus_id: String,
 }
 
 /// Input for deleteforgeagent

--- a/agentmuxsrv-rs/src/backend/storage/migrations.rs
+++ b/agentmuxsrv-rs/src/backend/storage/migrations.rs
@@ -76,6 +76,7 @@ pub fn run_forge_migrations(conn: &Connection) -> Result<(), StoreError> {
         );",
     )?;
     run_forge_v2_migrations(conn)?;
+    run_forge_v3_migrations(conn)?;
     Ok(())
 }
 
@@ -154,6 +155,38 @@ pub fn run_forge_v2_migrations(conn: &Connection) -> Result<(), StoreError> {
             ON db_forge_history(agent_id, session_date);",
     )?;
 
+    Ok(())
+}
+
+/// Forge v3 migrations: add agent_type, environment, agent_bus_id, and is_seeded
+/// to support host/container agent classification and seed-based preloading.
+pub fn run_forge_v3_migrations(conn: &Connection) -> Result<(), StoreError> {
+    let alter_statements = [
+        "ALTER TABLE db_forge_agents ADD COLUMN agent_type TEXT NOT NULL DEFAULT 'standalone'",
+        "ALTER TABLE db_forge_agents ADD COLUMN environment TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_forge_agents ADD COLUMN agent_bus_id TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_forge_agents ADD COLUMN is_seeded INTEGER NOT NULL DEFAULT 0",
+    ];
+    for stmt in &alter_statements {
+        match conn.execute_batch(stmt) {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("duplicate column") {
+                    // Column already exists, skip
+                } else {
+                    return Err(StoreError::Sqlite(
+                        match e {
+                            rusqlite::Error::SqliteFailure(code, _) => {
+                                rusqlite::Error::SqliteFailure(code, Some(msg))
+                            }
+                            other => other,
+                        },
+                    ));
+                }
+            }
+        }
+    }
     Ok(())
 }
 

--- a/agentmuxsrv-rs/src/backend/storage/wstore.rs
+++ b/agentmuxsrv-rs/src/backend/storage/wstore.rs
@@ -412,6 +412,18 @@ pub struct ForgeAgent {
     #[serde(default)]
     pub idle_timeout_minutes: i64,
     pub created_at: i64,
+    #[serde(default = "default_agent_type")]
+    pub agent_type: String,
+    #[serde(default)]
+    pub environment: String,
+    #[serde(default)]
+    pub agent_bus_id: String,
+    #[serde(default)]
+    pub is_seeded: i64,
+}
+
+fn default_agent_type() -> String {
+    "standalone".to_string()
 }
 
 /// A content blob associated with a forge agent.
@@ -452,7 +464,8 @@ impl WaveStore {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, icon, provider, description, working_directory, shell,
-                    provider_flags, auto_start, restart_on_crash, idle_timeout_minutes, created_at
+                    provider_flags, auto_start, restart_on_crash, idle_timeout_minutes, created_at,
+                    agent_type, environment, agent_bus_id, is_seeded
              FROM db_forge_agents ORDER BY created_at ASC",
         )?;
         let rows = stmt.query_map([], |row| {
@@ -469,6 +482,10 @@ impl WaveStore {
                 restart_on_crash: row.get(9)?,
                 idle_timeout_minutes: row.get(10)?,
                 created_at: row.get(11)?,
+                agent_type: row.get(12)?,
+                environment: row.get(13)?,
+                agent_bus_id: row.get(14)?,
+                is_seeded: row.get(15)?,
             })
         })?;
         let mut agents = Vec::new();
@@ -478,14 +495,32 @@ impl WaveStore {
         Ok(agents)
     }
 
+    /// Count forge agents (used by seed engine to check if seeding is needed).
+    pub fn forge_count(&self) -> Result<i64, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM db_forge_agents",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
+    /// Delete all seeded agents (is_seeded=1). Used by reseed to clear built-in agents.
+    pub fn forge_delete_seeded(&self) -> Result<usize, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute("DELETE FROM db_forge_agents WHERE is_seeded=1", [])?;
+        Ok(rows)
+    }
+
     /// Insert a new forge agent.
     pub fn forge_insert(&self, agent: &ForgeAgent) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
             "INSERT INTO db_forge_agents (id, name, icon, provider, description,
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
-             idle_timeout_minutes, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+             idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id, is_seeded)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
             params![
                 agent.id,
                 agent.name,
@@ -498,20 +533,25 @@ impl WaveStore {
                 agent.auto_start,
                 agent.restart_on_crash,
                 agent.idle_timeout_minutes,
-                agent.created_at
+                agent.created_at,
+                agent.agent_type,
+                agent.environment,
+                agent.agent_bus_id,
+                agent.is_seeded
             ],
         )?;
         Ok(())
     }
 
-    /// Update an existing forge agent (all fields except id and created_at).
+    /// Update an existing forge agent (all fields except id, created_at, is_seeded).
     pub fn forge_update(&self, agent: &ForgeAgent) -> Result<bool, StoreError> {
         let conn = self.conn.lock().unwrap();
         let rows = conn.execute(
             "UPDATE db_forge_agents SET name=?1, icon=?2, provider=?3, description=?4,
              working_directory=?5, shell=?6, provider_flags=?7, auto_start=?8,
-             restart_on_crash=?9, idle_timeout_minutes=?10
-             WHERE id=?11",
+             restart_on_crash=?9, idle_timeout_minutes=?10,
+             agent_type=?11, environment=?12, agent_bus_id=?13
+             WHERE id=?14",
             params![
                 agent.name,
                 agent.icon,
@@ -523,6 +563,9 @@ impl WaveStore {
                 agent.auto_start,
                 agent.restart_on_crash,
                 agent.idle_timeout_minutes,
+                agent.agent_type,
+                agent.environment,
+                agent.agent_bus_id,
                 agent.id
             ],
         )?;

--- a/agentmuxsrv-rs/src/main.rs
+++ b/agentmuxsrv-rs/src/main.rs
@@ -119,6 +119,9 @@ async fn main() {
         tracing::info!("First launch: created initial data");
     }
 
+    // Auto-seed Forge agents on first launch (or empty DB)
+    backend::forge_seed::auto_seed_on_startup(&wstore);
+
     // Event infrastructure
     let event_bus = Arc::new(EventBus::new());
     let broker = Arc::new(Broker::new());

--- a/agentmuxsrv-rs/src/server/websocket.rs
+++ b/agentmuxsrv-rs/src/server/websocket.rs
@@ -29,6 +29,7 @@ use crate::backend::rpc_types::{
     COMMAND_DELETE_FORGE_SKILL,
     COMMAND_APPEND_FORGE_HISTORY, COMMAND_LIST_FORGE_HISTORY, COMMAND_SEARCH_FORGE_HISTORY,
     COMMAND_IMPORT_FORGE_FROM_CLAW,
+    COMMAND_RESEED_FORGE_AGENTS,
     CommandCreateForgeAgentData, CommandUpdateForgeAgentData, CommandDeleteForgeAgentData,
     CommandGetForgeContentData, CommandSetForgeContentData, CommandGetAllForgeContentData,
     CommandListForgeSkillsData, CommandCreateForgeSkillData, CommandUpdateForgeSkillData,
@@ -782,6 +783,10 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     restart_on_crash: cmd.restart_on_crash,
                     idle_timeout_minutes: cmd.idle_timeout_minutes,
                     created_at: now,
+                    agent_type: cmd.agent_type,
+                    environment: cmd.environment,
+                    agent_bus_id: cmd.agent_bus_id,
+                    is_seeded: 0,
                 };
                 wstore.forge_insert(&agent).map_err(|e| format!("createforgeagent: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
@@ -824,6 +829,10 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     restart_on_crash: cmd.restart_on_crash,
                     idle_timeout_minutes: cmd.idle_timeout_minutes,
                     created_at: old.created_at,
+                    agent_type: cmd.agent_type,
+                    environment: cmd.environment,
+                    agent_bus_id: cmd.agent_bus_id,
+                    is_seeded: old.is_seeded,
                 };
                 let found = wstore.forge_update(&agent).map_err(|e| format!("updateforgeagent: {e}"))?;
                 if !found {
@@ -1165,6 +1174,10 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     restart_on_crash: 0,
                     idle_timeout_minutes: 0,
                     created_at: now,
+                    agent_type: "standalone".to_string(),
+                    environment: String::new(),
+                    agent_bus_id: String::new(),
+                    is_seeded: 0,
                 };
                 wstore.forge_insert(&agent).map_err(|e| format!("importforgefromclaw: {e}"))?;
 
@@ -1204,6 +1217,39 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     data: None,
                 });
                 Ok(Some(serde_json::to_value(&agent).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // reseedforgeagents → delete all seeded agents and re-run seed from manifest
+    let wstore_rsfa = state.wstore.clone();
+    let broker_rsfa = state.broker.clone();
+    engine.register_handler(
+        COMMAND_RESEED_FORGE_AGENTS,
+        Box::new(move |_data, _ctx| {
+            let wstore = wstore_rsfa.clone();
+            let broker = broker_rsfa.clone();
+            Box::pin(async move {
+                // Delete all previously seeded agents (cascade deletes content, skills, history)
+                let deleted = wstore.forge_delete_seeded()
+                    .map_err(|e| format!("reseedforgeagents: delete seeded: {e}"))?;
+
+                // Re-run seed
+                let report = crate::backend::forge_seed::seed_forge_agents(&wstore)
+                    .map_err(|e| format!("reseedforgeagents: seed: {e}"))?;
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "forgeagents:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(json!({
+                    "deleted": deleted,
+                    "created": report.created,
+                    "skipped": report.skipped,
+                })))
             })
         }),
     );

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -563,6 +563,11 @@ class RpcApiType {
         return client.wshRpcCall("importforgefromclaw", data, opts);
     }
 
+    // command "reseedforgeagents" [call]
+    ReseedForgeAgentsCommand(client: WshClient, opts?: RpcOpts): Promise<void> {
+        return client.wshRpcCall("reseedforgeagents", {}, opts);
+    }
+
 }
 
 export const RpcApi = new RpcApiType();

--- a/frontend/app/view/forge/forge-model.ts
+++ b/frontend/app/view/forge/forge-model.ts
@@ -380,6 +380,20 @@ export class ForgeViewModel implements ViewModel {
         }
     };
 
+    // ── Reseed built-in agents ──────────────────────────────────────────────
+
+    reseedAgents = async (): Promise<void> => {
+        this.setLoading(true);
+        this.setError(null);
+        try {
+            await RpcApi.ReseedForgeAgentsCommand(TabRpcClient);
+        } catch (e: any) {
+            this.setError(String(e?.message ?? e));
+        } finally {
+            this.setLoading(false);
+        }
+    };
+
     // ── Edit from detail ──────────────────────────────────────────────────
 
     startEditFromDetail = (): void => {

--- a/frontend/app/view/forge/forge-view.scss
+++ b/frontend/app/view/forge/forge-view.scss
@@ -78,6 +78,8 @@
     margin-top: 12px;
     display: flex;
     justify-content: flex-start;
+    gap: 6px;
+    flex-wrap: wrap;
 }
 
 // ── Agent card ────────────────────────────────────────────────────────────────
@@ -743,3 +745,70 @@
 .forge-import-btn {
     margin-left: 6px;
 }
+
+// ── Group headers ──────────────────────────────────────────────────────────
+
+.forge-group-header {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--secondary-text-color);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 8px 0 2px;
+    margin-top: 4px;
+
+    &:first-child {
+        margin-top: 0;
+    }
+}
+
+// ── Agent type badges ──────────────────────────────────────────────────────
+
+.forge-agent-type-badge {
+    font-size: 9px;
+    font-weight: 600;
+    padding: 1px 5px;
+    border-radius: 3px;
+    white-space: nowrap;
+    letter-spacing: 0.3px;
+    background: var(--highlight-bg-color);
+    color: var(--secondary-text-color);
+    border: 1px solid var(--border-color);
+
+    &.forge-agent-type-host {
+        color: #e8a040;
+        border-color: rgba(232, 160, 64, 0.3);
+        background: rgba(232, 160, 64, 0.1);
+    }
+
+    &.forge-agent-type-container {
+        color: #60a8e0;
+        border-color: rgba(96, 168, 224, 0.3);
+        background: rgba(96, 168, 224, 0.1);
+    }
+}
+
+.forge-card-name-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.forge-detail-name-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+// ── Reseed button ──────────────────────────────────────────────────────────
+
+.forge-reseed-btn {
+    margin-left: 6px;
+    color: var(--secondary-text-color);
+
+    &:hover {
+        border-color: var(--error-color, #e55);
+        color: var(--error-color, #e55);
+    }
+}
+

--- a/frontend/app/view/forge/forge-view.tsx
+++ b/frontend/app/view/forge/forge-view.tsx
@@ -38,6 +38,10 @@ function ForgeList(props: { model: ForgeViewModel }): JSX.Element {
     const agents = props.model.agentsAtom;
     const [showImport, setShowImport] = createSignal(false);
 
+    const hostAgents = () => agents().filter((a) => a.agent_type === "host");
+    const containerAgents = () => agents().filter((a) => a.agent_type === "container");
+    const customAgents = () => agents().filter((a) => a.agent_type !== "host" && a.agent_type !== "container");
+
     return (
         <div class="forge-pane">
             <div class="forge-header">
@@ -58,9 +62,24 @@ function ForgeList(props: { model: ForgeViewModel }): JSX.Element {
                 </div>
             }>
                 <div class="forge-list">
-                    <For each={agents()}>{(agent) =>
-                        <ForgeAgentCard agent={agent} model={props.model} />
-                    }</For>
+                    <Show when={hostAgents().length > 0}>
+                        <div class="forge-group-header">Host Agents</div>
+                        <For each={hostAgents()}>{(agent) =>
+                            <ForgeAgentCard agent={agent} model={props.model} />
+                        }</For>
+                    </Show>
+                    <Show when={containerAgents().length > 0}>
+                        <div class="forge-group-header">Container Agents</div>
+                        <For each={containerAgents()}>{(agent) =>
+                            <ForgeAgentCard agent={agent} model={props.model} />
+                        }</For>
+                    </Show>
+                    <Show when={customAgents().length > 0}>
+                        <div class="forge-group-header">Custom Agents</div>
+                        <For each={customAgents()}>{(agent) =>
+                            <ForgeAgentCard agent={agent} model={props.model} />
+                        }</For>
+                    </Show>
                 </div>
                 <div class="forge-list-footer">
                     <button class="forge-new-btn" onClick={() => props.model.startCreate()}>
@@ -68,6 +87,9 @@ function ForgeList(props: { model: ForgeViewModel }): JSX.Element {
                     </button>
                     <button class="forge-new-btn forge-import-btn" onClick={() => setShowImport(true)}>
                         Import from Claw
+                    </button>
+                    <button class="forge-new-btn forge-reseed-btn" onClick={() => props.model.reseedAgents()}>
+                        Reset Built-in Agents
                     </button>
                 </div>
             </Show>
@@ -107,12 +129,22 @@ function ForgeAgentCard(props: { agent: ForgeAgent; model: ForgeViewModel }): JS
     };
 
     const providerLabel = () => PROVIDERS.find((p) => p.id === props.agent.provider)?.label ?? props.agent.provider;
+    const typeBadge = () => {
+        if (props.agent.agent_type === "host") return "HOST";
+        if (props.agent.agent_type === "container") return "CTR";
+        return null;
+    };
 
     return (
         <div class="forge-card" onClick={handleClick}>
             <span class="forge-card-icon">{props.agent.icon}</span>
             <div class="forge-card-info">
-                <span class="forge-card-name">{props.agent.name}</span>
+                <div class="forge-card-name-row">
+                    <span class="forge-card-name">{props.agent.name}</span>
+                    <Show when={typeBadge()}>
+                        <span class={`forge-agent-type-badge forge-agent-type-${props.agent.agent_type}`}>{typeBadge()}</span>
+                    </Show>
+                </div>
                 <span class="forge-card-provider">{providerLabel()}</span>
                 <Show when={props.agent.description}>
                     <span class="forge-card-desc">{props.agent.description}</span>
@@ -151,6 +183,11 @@ function ForgeDetail(props: { model: ForgeViewModel }): JSX.Element {
         <Show when={agent()}>
             {(agentVal) => {
                 const providerLabel = () => PROVIDERS.find((p) => p.id === agentVal().provider)?.label ?? agentVal().provider;
+                const detailTypeBadge = () => {
+                    if (agentVal().agent_type === "host") return "HOST";
+                    if (agentVal().agent_type === "container") return "CTR";
+                    return null;
+                };
                 return (
                     <div class="forge-pane">
                         <div class="forge-detail-header">
@@ -159,7 +196,12 @@ function ForgeDetail(props: { model: ForgeViewModel }): JSX.Element {
                             </button>
                             <span class="forge-detail-icon">{agentVal().icon}</span>
                             <div class="forge-detail-info">
-                                <span class="forge-detail-name">{agentVal().name}</span>
+                                <div class="forge-detail-name-row">
+                                    <span class="forge-detail-name">{agentVal().name}</span>
+                                    <Show when={detailTypeBadge()}>
+                                        <span class={`forge-agent-type-badge forge-agent-type-${agentVal().agent_type}`}>{detailTypeBadge()}</span>
+                                    </Show>
+                                </div>
                                 <span class="forge-detail-sub">
                                     {providerLabel()}
                                     {agentVal().description ? ` \u2022 ${agentVal().description}` : ""}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -208,6 +208,10 @@ declare global {
         restart_on_crash: number;
         idle_timeout_minutes: number;
         created_at: number;
+        agent_type: string;
+        environment: string;
+        agent_bus_id: string;
+        is_seeded: number;
     };
 
     // ForgeContent
@@ -230,6 +234,9 @@ declare global {
         auto_start?: number;
         restart_on_crash?: number;
         idle_timeout_minutes?: number;
+        agent_type?: string;
+        environment?: string;
+        agent_bus_id?: string;
     };
 
     // CommandUpdateForgeAgentData
@@ -245,6 +252,9 @@ declare global {
         auto_start?: number;
         restart_on_crash?: number;
         idle_timeout_minutes?: number;
+        agent_type?: string;
+        environment?: string;
+        agent_bus_id?: string;
     };
 
     // CommandDeleteForgeAgentData


### PR DESCRIPTION
## Summary

- Adds agent type classification (`host` / `container` / `standalone`) to Forge agents with schema migration v3
- Implements a seed engine (`forge_seed.rs`) that auto-populates Forge with 7 claw agents (AgentX, AgentY, Agent1-5) on first launch from an embedded JSON manifest
- Each seeded agent includes full content blobs (env vars) and 13-15 skills
- Frontend groups agents by type (Host / Container / Custom) with colored badges and a "Reset Built-in Agents" button

## Changes

**Backend (Rust):**
- `migrations.rs` — v3 migration adding `agent_type`, `environment`, `agent_bus_id`, `is_seeded` columns
- `wstore.rs` — Updated `ForgeAgent` struct, `forge_count()`, `forge_delete_seeded()` methods
- `forge_seed.rs` — New seed engine with `auto_seed_on_startup()` + `reseedforgeagents` RPC
- `forge-seed.json` — 7 agent definitions with skills and content
- `websocket.rs` — Create/update/import handlers updated for new fields + reseed RPC handler
- `rpc_types.rs` — New fields on create/update data types + reseed command constant

**Frontend (TypeScript/SolidJS):**
- `forge-view.tsx` — Agent list grouped by type, HOST/CTR badges on cards and detail view
- `forge-model.ts` — `reseedAgents()` method
- `forge-view.scss` — Styles for group headers, type badges, reseed button
- `wshclientapi.ts` — `ReseedForgeAgentsCommand` RPC
- `gotypes.d.ts` — Updated type definitions

## Test plan
- [ ] Fresh launch: verify 7 agents auto-appear in Forge grouped by Host/Container
- [ ] Verify HOST (orange) and CTR (blue) badges display on agent cards and detail view
- [ ] Click "Reset Built-in Agents" — verify seeded agents are recreated
- [ ] Create a custom agent — verify it appears under "Custom Agents" group
- [ ] Delete a seeded agent, then reseed — verify it comes back
- [ ] Verify no interference with existing claw workspace files or containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)