### PR TITLE
Fix multi-window context menu on Linux/Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.32.13"
+version = "0.32.14"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.32.13"
+version = "0.32.14"
 dependencies = [
  "async-stream",
  "axum",
@@ -1129,17 +1129,17 @@ dependencies = [
 
 [[package]]
 name = "dom_query"
-version = "0.25.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9c2e7f1d22d0f2ce07626d259b8a55f4a47cb0938d4006dd8ae037f17d585e"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser 0.36.0",
  "foldhash 0.2.0",
- "html5ever 0.36.1",
+ "html5ever 0.38.0",
  "precomputed-hash",
- "selectors 0.35.0",
- "tendril",
+ "selectors 0.36.0",
+ "tendril 0.5.0",
 ]
 
 [[package]]
@@ -1967,12 +1967,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever 0.36.1",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
@@ -2615,17 +2615,17 @@ dependencies = [
  "phf_codegen 0.11.3",
  "string_cache 0.8.9",
  "string_cache_codegen 0.5.4",
- "tendril",
+ "tendril 0.4.3",
 ]
 
 [[package]]
 name = "markup5ever"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril",
+ "tendril 0.5.0",
  "web_atoms",
 ]
 
@@ -3666,7 +3666,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.4+spec-1.1.0",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -4289,9 +4289,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fdfed56cd634f04fe8b9ddf947ae3dc493483e819593d2ba17df9ad05db8b2"
+checksum = "223b960be86f7d302b7168cdbab137f9bdbf7e04a90c185312fab14dff49dc5f"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser 0.36.0",
@@ -5309,6 +5309,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5549,9 +5559,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
@@ -5582,30 +5592,30 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
 
 [[package]]
 name = "tower"
@@ -6956,6 +6966,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7088,9 +7107,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24eda84b5d488f99344e54b807138896cee8df0b2d16c793f1f6b80e6d8df1f"
+checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
 dependencies = [
  "base64 0.22.1",
  "block2 0.6.2",
@@ -7132,7 +7151,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.32.13"
+version = "0.32.14"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.32.13"
+version = "0.32.14"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.32.13",
+  "version": "0.32.14",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.32.13"
+version = "0.32.14"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/src/commands/contextmenu.rs
+++ b/src-tauri/src/commands/contextmenu.rs
@@ -4,8 +4,21 @@
 // Context menu command handler
 
 use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
 use tauri::menu::ContextMenu; // Trait providing .popup() / .popup_at() methods
-use tauri::{AppHandle, LogicalPosition, Manager, Runtime};
+use tauri::{AppHandle, Manager, Runtime, WebviewWindow};
+#[cfg(target_os = "linux")]
+use tauri::LogicalPosition;
+
+/// Tracks which window opened the most recent context menu so that
+/// `handle_menu_event` in menu.rs can route the click callback back
+/// to the correct window instead of guessing via `is_focused()`.
+static CONTEXT_MENU_ORIGIN: Mutex<Option<String>> = Mutex::new(None);
+
+/// Take (consume) the stored originating window label, if any.
+pub fn take_context_menu_origin() -> Option<String> {
+    CONTEXT_MENU_ORIGIN.lock().ok().and_then(|mut g| g.take())
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -37,26 +50,34 @@ pub struct MenuPosition {
 
 #[tauri::command(rename_all = "camelCase")]
 pub fn show_context_menu<R: Runtime>(
-    app: AppHandle<R>,
+    webview_window: WebviewWindow<R>,
     workspace_id: String,
     menu: Option<Vec<MenuItem>>,
     position: Option<MenuPosition>,
 ) -> Result<(), String> {
-    tracing::debug!("show_context_menu workspace={} menu={:?}", workspace_id, menu.is_some());
+    tracing::debug!(
+        "show_context_menu workspace={} window={} menu={:?}",
+        workspace_id,
+        webview_window.label(),
+        menu.is_some()
+    );
 
     if menu.is_none() {
         return Ok(());
     }
 
     let menu_items = menu.unwrap();
-
-    // Get the focused window
-    let webview_window = app.get_webview_window("main")
-        .ok_or_else(|| "Main window not found".to_string())?;
+    let app = webview_window.app_handle();
     let window = webview_window.as_ref().window();
 
+    // Store the originating window label so handle_menu_event can route
+    // the context-menu-click event back to the correct window.
+    if let Ok(mut guard) = CONTEXT_MENU_ORIGIN.lock() {
+        *guard = Some(webview_window.label().to_string());
+    }
+
     // Build Tauri menu from JSON structure
-    let context_menu = build_menu_items(&menu_items, &app)
+    let context_menu = build_menu_items(&menu_items, app)
         .map_err(|e| format!("Failed to build menu: {}", e))?;
 
     // On Linux/Wayland, popup() defaults to position (0,0) because the compositor

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -273,9 +273,13 @@ pub fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: MenuEvent) {
             // TODO: Call workspace service
         }
         _ => {
-            // Handle context menu clicks - emit to frontend
+            // Handle context menu clicks - emit to the window that opened the menu,
+            // not just whatever window happens to be focused right now.
             tracing::debug!("Context menu click: {}", event.id.as_ref());
-            if let Some(w) = window {
+            let origin_window = crate::commands::contextmenu::take_context_menu_origin()
+                .and_then(|label| app.get_webview_window(&label));
+            let target = origin_window.or(window);
+            if let Some(w) = target {
                 let _ = w.emit("context-menu-click", event.id.as_ref());
             }
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.32.13",
-  "identifier": "ai.agentmux.app.v0-32-13",
+  "version": "0.32.14",
+  "identifier": "ai.agentmux.app.v0-32-14",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.32.13"
+version = "0.32.14"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary
- Context menu appeared on the first (main) window when right-clicking in any secondary window on Linux and Windows
- Root cause: `show_context_menu` hardcoded `app.get_webview_window("main")` instead of using the calling window
- Replaced `AppHandle` parameter with Tauri's auto-injected `WebviewWindow` which resolves to the window that invoked the command
- Added `CONTEXT_MENU_ORIGIN` tracking so `handle_menu_event` routes `context-menu-click` callbacks to the originating window

## Test plan
- [ ] Right-click in main window — menu appears at cursor
- [ ] Open second window, right-click — menu appears in second window (not first)
- [ ] Alternate right-clicks between windows — each menu appears in correct window
- [ ] Context menu item callbacks fire in the correct window
- [ ] Test on Windows, Linux, and macOS (macOS should continue working as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)