### PR TITLE
fix: case-insensitive agent ID matching for local jekt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.32.18"
+version = "0.32.19"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.32.18"
+version = "0.32.19"
 dependencies = [
  "async-stream",
  "axum",
@@ -7152,7 +7152,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.32.18"
+version = "0.32.19"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.32.18"
+version = "0.32.19"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/agentmuxsrv-rs/src/backend/reactive/handler.rs
+++ b/agentmuxsrv-rs/src/backend/reactive/handler.rs
@@ -96,8 +96,10 @@ impl Handler {
             return Err(format!("invalid agent ID: {}", agent_id));
         }
 
+        let agent_key = agent_id.to_lowercase();
+
         // Remove existing registration for this agent
-        if let Some(old_block) = self.agent_to_block.remove(agent_id) {
+        if let Some(old_block) = self.agent_to_block.remove(&agent_key) {
             self.block_to_agent.remove(&old_block);
         }
 
@@ -109,11 +111,11 @@ impl Handler {
 
         let now = now_unix_millis();
         self.agent_to_block
-            .insert(agent_id.to_string(), block_id.to_string());
+            .insert(agent_key.clone(), block_id.to_string());
         self.block_to_agent
-            .insert(block_id.to_string(), agent_id.to_string());
+            .insert(block_id.to_string(), agent_key.clone());
         self.agent_info.insert(
-            agent_id.to_string(),
+            agent_key.clone(),
             AgentRegistration {
                 agent_id: agent_id.to_string(),
                 block_id: block_id.to_string(),
@@ -128,10 +130,11 @@ impl Handler {
 
     /// Unregister an agent.
     pub fn unregister_agent(&mut self, agent_id: &str) {
-        if let Some(block_id) = self.agent_to_block.remove(agent_id) {
+        let agent_key = agent_id.to_lowercase();
+        if let Some(block_id) = self.agent_to_block.remove(&agent_key) {
             self.block_to_agent.remove(&block_id);
         }
-        self.agent_info.remove(agent_id);
+        self.agent_info.remove(&agent_key);
     }
 
     /// Unregister by block ID.
@@ -144,14 +147,14 @@ impl Handler {
 
     /// Update the last_seen timestamp for an agent.
     pub fn update_last_seen(&mut self, agent_id: &str) {
-        if let Some(info) = self.agent_info.get_mut(agent_id) {
+        if let Some(info) = self.agent_info.get_mut(&agent_id.to_lowercase()) {
             info.last_seen = now_unix_millis();
         }
     }
 
     /// Get agent registration by agent ID.
     pub fn get_agent(&self, agent_id: &str) -> Option<&AgentRegistration> {
-        self.agent_info.get(agent_id)
+        self.agent_info.get(&agent_id.to_lowercase())
     }
 
     /// Get agent registration by block ID.
@@ -206,7 +209,7 @@ impl Handler {
         let sanitized = sanitize_message(&req.message);
 
         // Look up block ID
-        let block_id = match self.agent_to_block.get(&req.target_agent) {
+        let block_id = match self.agent_to_block.get(&req.target_agent.to_lowercase()) {
             Some(id) => id.clone(),
             None => {
                 let err = format!("agent not found: {}", req.target_agent);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.32.18",
+  "version": "0.32.19",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.32.18"
+version = "0.32.19"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.32.18",
-  "identifier": "ai.agentmux.app.v0-32-18",
+  "version": "0.32.19",
+  "identifier": "ai.agentmux.app.v0-32-19",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.32.18"
+version = "0.32.19"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

- Normalize agent IDs to lowercase on register and lookup in \`ReactiveHandler\`
- Mirrors the cloud-side \`toLowerCase()\` fix already in agentbus-client
- Fixes \`agent not found\` errors when inject uses lowercase (\`agenty\`) but registration used mixed case (\`AgentY\`)

## Root cause

\`agent_to_block\` HashMap uses case-sensitive keys. The MCP client sends lowercase agent IDs but the shell integration registers with mixed case. Lookup always missed → fell through to cloud path → delivered to MCP stderr → never appeared as user input.

## Changes

\`handler.rs\` — normalize to \`to_lowercase()\` in: \`register_agent\`, \`unregister_agent\`, \`update_last_seen\`, \`get_agent\`, \`inject_message\`

## Test plan
- [ ] Jekt from one agent to another — message arrives in terminal
- [ ] Self-jekt — message appears in own terminal
- [ ] Mixed-case agent ID in register + lowercase in inject — still resolves