### PR TITLE
fix: pane drag-and-drop via pragmatic-dnd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.32.35"
+version = "0.32.36"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.32.35"
+version = "0.32.36"
 dependencies = [
  "async-stream",
  "axum",
@@ -7151,7 +7151,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.32.35"
+version = "0.32.36"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.32.35"
+version = "0.32.36"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/docs/retros/retro-pane-dnd-solidjs-v2.md
+++ b/docs/retros/retro-pane-dnd-solidjs-v2.md
@@ -1,0 +1,208 @@
+# Retro: Pane Drag-and-Drop Regression (SolidJS Migration) — v2
+
+**Date:** 2026-03-19
+**Status:** In Progress
+**Branch:** `agenta/fix-pane-dnd-v2`
+
+---
+
+## Background
+
+Pane drag-and-drop (rearranging panes by dragging their title bar headers) has been broken since the SolidJS migration. Multiple fix attempts have been made across several commits and sessions.
+
+---
+
+## Timeline of Fix Attempts
+
+### Attempt 1: `cc1806d` — Gate onDragStart to header only
+**Approach:** SolidJS migration had put `draggable=true` on the entire tile-node div. Fixed by gating `onDragStart` to only fire when drag originates from the header (`dragHandleRef`).
+**Result:** Partial fix. Worked on some machines but not reliably.
+
+### Attempt 2: `27c9e72` — createEffect on dragHandleRef
+**Approach:** Register drag directly on `dragHandleRef` (header element) via `createEffect`, using `addEventListener` imperatively. Removed `draggable`/`onDragStart`/`onDragEnd` from tile-node JSX.
+**Result:** Did not work. The `createEffect` ran before `BlockFull` mounted (gated behind `Show when={ready()}` with 50ms delay), so `dragHandleRef.current` was null.
+
+### Attempt 3: `514a2af` — Track nodeModel.ready() in createEffect
+**Approach:** Added `nodeModel.ready()` as a reactive dependency in the `createEffect` so it re-runs after the 50ms delay when `BlockFull` renders and the header mounts.
+**Result:** Did not work reliably. The `ready()` signal from the layout model (50ms timer) fires before the block's own `ready` state (depends on backend data load via network). The `dragHandleRef.current` is still null when the effect re-runs because the `Show when={localReady()}` gate in block.tsx hasn't opened yet. **Root cause: two different "ready" signals with different timing.**
+
+### Attempt 4 (current session): Option 2 — Blockframe approach
+**Approach:** Move drag logic entirely to blockframe.tsx via NodeModel callbacks.
+- Remove `dragHandleRef` from NodeModel interface, replace with `dragHandlers: { onDragStart, onDragEnd }`
+- DisplayNode sets `nodeModel.dragHandlers = { ... }` synchronously in its body
+- blockframe.tsx reads `nodeModel.dragHandlers` and applies as JSX props on the header div
+- Eliminates ref timing issue because blockframe IS where the header lives
+
+**Changes made:**
+1. `types.ts` — Replaced `dragHandleRef` with `dragHandlers` in NodeModel interface
+2. `layoutNodeModels.ts` — Removed `dragHandleRef` from nodeModel creation
+3. `TileLayout.tsx` — Replaced old DnD functions + createEffect with direct `nodeModel.dragHandlers` assignment
+4. `blockframe.tsx` — Header div reads `dragHandlers` for `draggable`/event handlers
+
+**Sub-attempts within this session:**
+
+| # | Change | Result |
+|---|--------|--------|
+| 4a | `onDragStart`/`onDragEnd` as JSX props | Not working — no drag initiated |
+| 4b | Missing `createEffect` import | Runtime crash: `createEffect is not defined` |
+| 4c | Missing `onCleanup` import | Runtime crash: `onCleanup is not defined` |
+| 4d | `attr:draggable` instead of `draggable` | Not working |
+| 4e | `on:dragstart`/`on:dragend` instead of `onDragStart`/`onDragEnd` | Not working |
+
+---
+
+## Key Diagnostic Finding
+
+Debug logging confirmed:
+```
+[DnD-debug] dragHandlers: {} preview: false nodeId: 01add974-...
+```
+
+- `dragHandlers` is **NOT null** — the object with `onDragStart`/`onDragEnd` functions is set correctly
+- The `{}` display is because `console.log` serializes objects with function values as `{}`
+- The handlers ARE populated by the time blockframe reads them
+- Both `draggable` attribute and event handlers are present in the JSX
+
+**Yet dragging does not initiate.** Something else is preventing it.
+
+---
+
+## Working Reference: Tab Drag-and-Drop
+
+Tab drag works perfectly with this pattern in `tab.tsx:267`:
+```tsx
+<div
+    draggable={true}
+    onDragStart={props.onDragStart}
+    data-tauri-drag-region="false"
+>
+```
+
+Key differences from pane drag:
+1. `draggable={true}` — static boolean, not a computed expression
+2. `onDragStart` — passed as a **prop** (function reference), not read from a mutable object
+3. `data-tauri-drag-region="false"` — **explicitly opts out of Tauri window drag**
+
+---
+
+## Root Cause Theories
+
+### Theory 1: `data-tauri-drag-region` Conflict (HIGH probability)
+The pane header div does NOT have `data-tauri-drag-region="false"`. Tauri's window drag system may be intercepting the mousedown/dragstart on the header, preventing HTML5 DnD from initiating.
+
+**Evidence:**
+- Tab drag works and explicitly sets `data-tauri-drag-region="false"`
+- Window drag uses `data-tauri-drag-region` attributes
+- Previous fix `cc1806d` mentions macOS `setMovableByWindowBackground` intercepting drags
+- The `useWindowDrag.ts` hook manages drag region attributes
+
+**Test:** Add `data-tauri-drag-region="false"` to the block-frame-default-header div.
+
+### Theory 2: SolidJS Computed `draggable` Expression (MEDIUM probability)
+Tab drag uses `draggable={true}` (static). Pane drag uses:
+```tsx
+draggable={dragHandlers != null && !props.nodeModel.isEphemeral() && !props.nodeModel.isMagnified()}
+```
+
+In SolidJS, this creates a reactive expression. If SolidJS evaluates it once and the result is a function (accessor) rather than a boolean value, the HTML attribute may be set to a truthy non-"true" value, which browsers may not recognize as enabling drag.
+
+**Test:** Change to `draggable={true}` (hardcoded) and see if drag initiates.
+
+### Theory 3: CSS `user-select: none` or `pointer-events: none` (MEDIUM probability)
+A parent element's CSS may be preventing drag initiation. The `disablePointerEvents` signal on NodeModel is used to set `pointer-events: none` during active drags on OTHER panes, but if it's stuck in the wrong state, it could block everything.
+
+**Test:** Inspect the pane header in DevTools, check computed `pointer-events` and `user-select`.
+
+### Theory 4: Drag Event Listeners on Parent Intercepting (LOW probability)
+The tile-node div or display-container may have drag-related event listeners that call `e.preventDefault()` or `e.stopPropagation()` before the header's handlers fire.
+
+**Test:** Add `console.log` in the `on:dragstart` handler to see if it even fires.
+
+### Theory 5: `onDragStart` vs `on:dragstart` Event Binding (LOW probability)
+SolidJS's delegated events list may or may not include drag events. The tab component uses `onDragStart` (camelCase) and it works. We tried both `onDragStart` and `on:dragstart`.
+
+**But:** The tab's `onDragStart` is a direct function prop. Our pane's handler wraps through `(e) => dragHandlers?.onDragStart(e)`. The wrapper should be equivalent, but the optional chaining `?.` could be suspect if `dragHandlers` is a Proxy or getter.
+
+**Test:** Replace `(e) => dragHandlers?.onDragStart(e)` with a direct inline function that logs and calls the handler.
+
+---
+
+## Recommended Path Forward
+
+### Step 1: Quick Wins (try first)
+1. **Add `data-tauri-drag-region="false"`** to the header div — this is the most likely fix based on the tab drag precedent
+2. **Hardcode `draggable={true}`** temporarily to eliminate computed expression issues
+3. **Add logging inside the onDragStart handler** to confirm whether the event fires at all
+
+### Step 2: If Quick Wins Fail
+4. **Revert to createEffect approach** but fix the timing issue properly:
+   - Instead of tracking `nodeModel.ready()`, use `onMount` inside `BlockFrame_Header` to register drag listeners
+   - The header element IS available in its own `onMount` — no timing issue
+   - This is the simplest correct approach since it doesn't fight SolidJS reactivity
+
+### Step 3: Nuclear Option
+5. **Adopt the tab drag pattern exactly:**
+   - Pass `onDragStart`/`onDragEnd` as explicit props through the component tree
+   - Use `draggable={true}` (static)
+   - Use `data-tauri-drag-region="false"`
+   - Use `onDragStart` (camelCase, not `on:dragstart`)
+   - This is proven to work in the same codebase
+
+---
+
+## Files Modified (Current State)
+
+| File | Changes |
+|------|---------|
+| `frontend/layout/lib/types.ts` | `dragHandleRef` → `dragHandlers` in NodeModel |
+| `frontend/layout/lib/layoutNodeModels.ts` | Removed `dragHandleRef` from nodeModel creation |
+| `frontend/layout/lib/TileLayout.tsx` | Replaced createEffect with `nodeModel.dragHandlers = {...}` |
+| `frontend/app/block/blockframe.tsx` | Header div has drag props from `nodeModel.dragHandlers` |
+
+---
+
+## Research: @neodrag/solid
+
+**Verdict: Wrong tool for this job.**
+
+`@neodrag/solid` is a **pointer-event-based positional drag** library — it moves elements around freely on screen (like dragging a dialog/window). It does NOT implement HTML5 drag-and-drop.
+
+Our pane DnD system requires HTML5 DnD specifically because:
+- Uses `dataTransfer.setData()` to pass node IDs between drag source and drop target
+- Uses `onDragOver`/`onDrop` on overlay elements for drop zone detection
+- Uses `setDragImage()` for custom drag preview
+- Supports cross-window drag via `CrossWindowDragMonitor.tsx` (Tauri events)
+- Uses `dropEffect`/`effectAllowed` for cursor feedback
+
+`@neodrag/solid` provides none of these — it's `transform: translate()` based movement with pointer events. Using it would require rewriting the entire drop zone system, overlay rendering, and cross-window support.
+
+**Alternative considered: `@thisbeyond/solid-dnd`**
+This IS a proper DnD toolkit for SolidJS with sortable lists, droppable zones, etc. However:
+- It's a heavyweight abstraction over our already-working drop zone system
+- Our `onDragOver`/`onDrop` handlers on overlay nodes already work (the DROP side isn't broken)
+- Only the DRAG INITIATION on pane headers is broken
+- Adding a new dependency to fix one attribute/event issue is overkill
+
+---
+
+## Lessons Learned
+
+1. **Two different "ready" signals** caused confusion: layout's `nodeModel.ready` (50ms timer) vs block's local `ready` (backend data + viewModel loaded)
+2. **SolidJS ref timing** with `createEffect` is fundamentally different from React's `useEffect` — effects run synchronously during the reactive graph update, not after DOM commit
+3. **console.log({functions})** shows `{}` — always use explicit checks like `typeof obj.method === 'function'` for debugging
+4. **Working code in the same codebase** (tab drag) is the best reference — match its pattern exactly before trying novel approaches
+5. **Tauri window drag regions** can silently intercept HTML5 drag events — always check `data-tauri-drag-region` attributes
+6. **Don't reach for libraries** when the problem is one missing attribute — `@neodrag/solid` and `solid-dnd` are wrong tools for a simple HTML5 DnD initiation bug
+
+---
+
+## Next Steps (Prioritized)
+
+**Do these in order. Stop as soon as drag works.**
+
+1. Add `data-tauri-drag-region="false"` to the header div in blockframe.tsx
+2. Hardcode `draggable={true}` (remove computed expression)
+3. Add `console.log("DRAGSTART FIRED")` inside the handler to confirm event fires
+4. If event doesn't fire: use `onMount` in `BlockFrame_Header` with `addEventListener("dragstart", ...)` directly on the header ref
+5. If event fires but DnD doesn't work: check CSS `pointer-events` / `user-select` on parents
+6. If all else fails: match tab.tsx pattern exactly — `draggable={true}` + `onDragStart={fn}` + `data-tauri-drag-region="false"`

--- a/docs/specs/pane-dnd-fix-spec.md
+++ b/docs/specs/pane-dnd-fix-spec.md
@@ -1,0 +1,347 @@
+# Spec: Fix Pane Drag-and-Drop — Alternative Approaches
+
+**Date:** 2026-03-19
+**Status:** Proposal — **REVISED after research**
+**Problem:** HTML5 native DnD is fundamentally broken in Tauri v2 + WebView2 on Windows.
+
+---
+
+## Root Cause: WebView2 + HTML5 DnD Is A Known Platform Bug
+
+**This is NOT a SolidJS reactivity issue.** The HTML5 DnD API itself is broken in WebView2:
+
+1. **Tauri's `dragDropEnabled` (default: true) intercepts ALL drag events** for its own file-drop system, preventing HTML5 DnD from working. ([tauri-apps/tauri#4168](https://github.com/tauri-apps/tauri/issues/4168))
+2. **Even with `dragDropEnabled: false`, WebView2 freezes the canvas during HTML5 drag** — dragstart fires but the webview doesn't repaint until the drag ends. ([tauri-apps/tauri#9445](https://github.com/tauri-apps/tauri/issues/9445))
+3. **WebView2's `WINDOW_TO_VISUAL` hosting mode breaks DnD entirely** ([MicrosoftEdge/WebView2Feedback#5486](https://github.com/MicrosoftEdge/WebView2Feedback/issues/5486))
+
+**Any solution using the HTML5 DnD API (draggable, dragstart, dragover, drop, dataTransfer) will NOT work in Tauri WebView2 on Windows.** This rules out react-dnd, Pragmatic DnD, and all our manual HTML5 DnD attempts.
+
+**Tab drag works** only because it's a simpler interaction that doesn't need overlay repositioning during the drag — the tabbar is always visible.
+
+Additionally, our SolidJS reactive updates compound the issue:
+
+1. `dragstart` fires → our handler sets `activeDrag` signal → SolidJS immediately flushes DOM changes (overlay repositioning, CSS class changes) → WebView2 sees the drag source element mutated mid-event → cancels the drag
+2. Deferring state updates with `setTimeout` allows the drag to sustain, BUT the overlay drop zones are off-screen (positioned at `top: 10000px`) until `activeDrag` is set, creating a catch-22
+3. The window/document-level `dragover` handler with `e.preventDefault()` doesn't change the cursor from 🚫 to move — suggesting WebView2's drag subsystem isn't fully engaging
+
+**Tab drag works** because tabs use a simpler pattern: `draggable={true}` + `onDragStart={fn}` with no reactive state changes during dragstart, and the drop target (tabbar) is always visible (not gated behind an `activeDrag` signal).
+
+---
+
+## Option A: Pragmatic Drag and Drop (Recommended)
+
+**Library:** `@atlaskit/pragmatic-drag-and-drop`
+**Size:** ~4.7KB min+gzip (core only)
+**Maintained by:** Atlassian (active, used in Jira/Confluence)
+**Framework:** Vanilla JS — works with SolidJS directly, no bridge needed
+**DnD approach:** Uses browser's built-in DnD but with proper event management
+
+### Why This Option
+
+- Framework-agnostic vanilla JS — call `draggable()` and `dropTargetForElements()` on DOM elements
+- Already has a [SolidJS + Tailwind + Vite example](https://github.com/atlassian/pragmatic-drag-and-drop/discussions/71)
+- Handles the dragstart/dragover/drop lifecycle correctly across browsers
+- Supports custom drop zones (not just sortable lists)
+- Tiny bundle — just the core package, no optional Atlassian UI deps
+- No React dependency
+
+### Integration Plan
+
+```
+npm install @atlaskit/pragmatic-drag-and-drop
+```
+
+**Step 1: Make pane headers draggable**
+
+In `blockframe.tsx` — use `onMount` to register the header as a draggable:
+
+```tsx
+import { draggable } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+
+function BlockFrame_Header(props) {
+    let headerRef: HTMLDivElement;
+
+    onMount(() => {
+        if (props.preview) return;
+        const cleanup = draggable({
+            element: headerRef,
+            getInitialData: () => ({ nodeId: props.nodeModel.nodeId }),
+            onDragStart: () => {
+                props.nodeModel.dragHandlers?.onDragStart();
+            },
+            onDrop: () => {
+                props.nodeModel.dragHandlers?.onDragEnd();
+            },
+        });
+        onCleanup(cleanup);
+    });
+
+    return <div ref={headerRef} class="block-frame-default-header" ...>
+}
+```
+
+**Step 2: Make overlay nodes drop targets**
+
+In `TileLayout.tsx` — register overlay nodes as drop targets:
+
+```tsx
+import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+
+const OverlayNode = (props) => {
+    let overlayRef: HTMLDivElement;
+
+    onMount(() => {
+        const cleanup = dropTargetForElements({
+            element: overlayRef,
+            getData: () => ({ nodeId: props.node.id }),
+            onDragEnter: ({ source }) => {
+                // Compute drop direction, show preview
+                const dragNodeId = source.data.nodeId;
+                // ... existing ComputeMove logic
+            },
+            onDragLeave: () => {
+                // Clear pending action
+            },
+            onDrop: ({ source }) => {
+                // Execute the move
+                props.layoutModel.onDrop();
+            },
+        });
+        onCleanup(cleanup);
+    });
+
+    return <div ref={overlayRef} class="overlay-node" .../>
+};
+```
+
+**Step 3: Activate overlays**
+
+The key insight: pragmatic-dnd fires `onDragStart` AFTER the browser has fully committed the drag. So we can safely set `activeDrag` in the `onDragStart` callback without killing the drag:
+
+```tsx
+onDragStart: () => {
+    layoutModel.activeDrag._set(true);  // Safe — drag already committed
+    setIsDragging(true);
+},
+```
+
+**Step 4: Monitor for cross-window**
+
+```tsx
+import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+
+// In CrossWindowDragMonitor or TileLayoutComponent:
+onMount(() => {
+    const cleanup = monitorForElements({
+        onDragStart: ({ source }) => { /* track */ },
+        onDrop: ({ source, location }) => { /* handle */ },
+    });
+    onCleanup(cleanup);
+});
+```
+
+### Files to Modify
+
+| File | Changes |
+|------|---------|
+| `package.json` | Add `@atlaskit/pragmatic-drag-and-drop` |
+| `blockframe.tsx` | Register header as `draggable()` via `onMount` |
+| `TileLayout.tsx` | Register overlay nodes as `dropTargetForElements()` |
+| `TileLayout.tsx` | Remove old HTML5 DnD handlers (onDragStart/onDragOver/onDrop from JSX) |
+| `types.ts` | Update `dragHandlers` type to match pragmatic-dnd callbacks |
+| `layoutNodeModels.ts` | No change needed |
+| `CrossWindowDragMonitor.tsx` | Use `monitorForElements` instead of document dragend listener |
+
+### Risks
+
+- Cross-window drag may need additional work (pragmatic-dnd is single-window by default)
+- Custom drag preview images may need `setCustomNativeDragPreview` from pragmatic-dnd
+- Need to verify pragmatic-dnd works in Tauri WebView2 (likely yes — it wraps HTML5 DnD properly)
+
+---
+
+## Option B: React Shim + react-dnd
+
+**Libraries:** `react`, `react-dom`, `react-dnd`, `react-dnd-html5-backend`
+**Total size:** ~45KB+ min+gzip (React 18 + react-dnd)
+**Approach:** Mount a thin React wrapper inside a Solid-managed container
+
+### Why Consider This
+
+- react-dnd was the original DnD solution before the SolidJS migration
+- Known working — the exact same DnD logic worked for years in the React version
+- React's batched updates don't cause the same mid-event DOM mutation issue
+
+### Integration Pattern
+
+```tsx
+// react-dnd-bridge.tsx — React side
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { DndProvider, useDrag } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+
+interface DragHandleProps {
+    nodeId: string;
+    onDragStart: () => void;
+    onDragEnd: () => void;
+    children: React.ReactNode;
+}
+
+function DragHandle({ nodeId, onDragStart, onDragEnd, children }: DragHandleProps) {
+    const [, dragRef] = useDrag({
+        type: 'TILE_NODE',
+        item: () => { onDragStart(); return { nodeId }; },
+        end: () => onDragEnd(),
+    });
+    return <div ref={dragRef}>{children}</div>;
+}
+
+// Mount function called from SolidJS
+export function mountDragHandle(container: HTMLElement, props: Omit<DragHandleProps, 'children'>) {
+    const root = createRoot(container);
+    root.render(
+        <DndProvider backend={HTML5Backend}>
+            <DragHandle {...props}>
+                {/* Solid renders the actual header content elsewhere */}
+            </DragHandle>
+        </DndProvider>
+    );
+    return () => root.unmount();
+}
+```
+
+```tsx
+// In blockframe.tsx — SolidJS side
+import { mountDragHandle } from './react-dnd-bridge';
+
+function BlockFrame_Header(props) {
+    let wrapperRef: HTMLDivElement;
+
+    onMount(() => {
+        if (props.preview) return;
+        const cleanup = mountDragHandle(wrapperRef, {
+            nodeId: props.nodeModel.nodeId,
+            onDragStart: () => props.nodeModel.dragHandlers?.onDragStart(),
+            onDragEnd: () => props.nodeModel.dragHandlers?.onDragEnd(),
+        });
+        onCleanup(cleanup);
+    });
+
+    return <div ref={wrapperRef} class="block-frame-default-header" ...>
+}
+```
+
+### Problems With This Approach
+
+1. **+45KB bundle** for React runtime just for DnD
+2. **Two virtual DOMs** running simultaneously — React for drag handles, Solid for everything else
+3. **Content rendering** — the header content (icons, title, buttons) is rendered by Solid but needs to be inside the React drag handle wrapper. Requires portal-like tricks.
+4. **react-dnd HTML5Backend** uses the same HTML5 DnD API under the hood — if WebView2 is the problem, react-dnd will have the same issue. React's batched updates may help, but the core browser API issue remains.
+5. **Maintenance burden** — two frameworks to keep updated, version conflicts, build complexity
+
+---
+
+## Option C: Custom Pointer Events (No Library)
+
+**Size:** 0 bytes additional
+**Approach:** Replace HTML5 DnD entirely with pointer events (pointerdown/pointermove/pointerup)
+
+### Why Consider This
+
+- Pointer events work reliably everywhere — no browser DnD API quirks
+- No external dependencies
+- Full control over the drag visual (custom overlay element follows cursor)
+- No ghost image issues (we render our own drag preview)
+
+### Implementation Sketch
+
+```tsx
+// In blockframe.tsx header:
+onPointerDown={(e) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    const startX = e.clientX, startY = e.clientY;
+    let dragging = false;
+
+    const onMove = (me: PointerEvent) => {
+        if (!dragging && Math.hypot(me.clientX - startX, me.clientY - startY) > 5) {
+            dragging = true;
+            layoutModel.activeDrag._set(true);
+            // Show drag preview overlay at cursor position
+        }
+        if (dragging) {
+            // Update preview position, compute drop target
+            updateDragPreview(me.clientX, me.clientY);
+            computeDropTarget(me.clientX, me.clientY);
+        }
+    };
+
+    const onUp = (ue: PointerEvent) => {
+        document.removeEventListener('pointermove', onMove);
+        document.removeEventListener('pointerup', onUp);
+        if (dragging) {
+            executeDrop();
+            layoutModel.activeDrag._set(false);
+        }
+    };
+
+    document.addEventListener('pointermove', onMove);
+    document.addEventListener('pointerup', onUp);
+}}
+```
+
+### Tradeoffs
+
+- **Pro:** No HTML5 DnD API at all — sidesteps WebView2 issues entirely
+- **Pro:** Works identically on all platforms
+- **Pro:** No external dependencies
+- **Con:** Must implement our own drag preview overlay (follow cursor with a div)
+- **Con:** Must implement our own hit testing for drop zones
+- **Con:** Cross-window drag requires Tauri IPC (pointer events don't cross windows)
+- **Con:** ~200-300 lines of new code to replace existing DnD infrastructure
+
+---
+
+## Recommendation: @thisbeyond/solid-dnd (Option D)
+
+**After research, the best option is `@thisbeyond/solid-dnd`** — a SolidJS-native DnD library that uses **pointer events**, not the HTML5 DnD API.
+
+| Criteria | solid-dnd | Pragmatic DnD | react-dnd | Custom pointer |
+|----------|-----------|---------------|-----------|----------------|
+| Event system | **Pointer events** | HTML5 DnD | HTML5 DnD | Pointer events |
+| WebView2 safe | **YES** | NO | NO | YES |
+| SolidJS native | **YES** | Manual wiring | NO (React) | Manual |
+| Tile rearrangement | **YES** | YES | YES | DIY |
+| Bundle size | ~8-10KB | 4.7KB | 45KB+ | 0KB |
+| Maintenance | Stable v0.7.5 | Active | Dead (4yr) | N/A |
+
+### Why solid-dnd
+
+1. **Pointer events = WebView2 safe** — never touches HTML5 DnD API
+2. **SolidJS native** — `createDraggable`, `createDroppable`, `DragOverlay` primitives
+3. **Supports custom drop zones** — not just sortable lists
+4. **No framework bridge** — no React, no interop overhead
+5. **Stable** — v0.7.5, used in production SolidJS apps
+
+### Why NOT Pragmatic DnD or react-dnd
+
+Both use the HTML5 DnD API under the hood. They will hit the exact same WebView2 canvas-freeze and drag-cancel bugs we've been fighting.
+
+### Fallback: Custom Pointer Events (Option C)
+
+If solid-dnd has edge cases, implement pointer events manually (~200-300 lines). The drop zone infrastructure (overlay nodes, ComputeMove, etc.) already exists — we just need to replace the event source.
+
+### Future: @dnd-kit/dom + SolidJS adapter
+
+dnd-kit v2 uses pointer events and has a community SolidJS adapter (`dnd-kit-solid`). Currently pre-1.0 and not production-ready, but best long-term bet.
+
+---
+
+## Next Steps
+
+1. `npm install @atlaskit/pragmatic-drag-and-drop`
+2. Prototype: register one header as `draggable()` and one overlay as `dropTargetForElements()`
+3. Verify the drag ghost appears and drops work in WebView2
+4. If yes: migrate all DnD code to pragmatic-dnd
+5. If no: implement Option C (pointer events)

--- a/docs/specs/pane-dnd-pragmatic-vs-react-bridge.md
+++ b/docs/specs/pane-dnd-pragmatic-vs-react-bridge.md
@@ -1,0 +1,326 @@
+# Pane DnD Fix: Pragmatic DnD vs React-DnD Bridge
+
+**Date:** 2026-03-19
+**Context:** HTML5 DnD worked in the old React codebase via `react-dnd` + `react-dnd-html5-backend`. After the SolidJS migration, pane DnD broke. Multiple attempts to fix it with native HTML5 DnD attributes in SolidJS have failed because SolidJS's synchronous reactive updates mutate the DOM during `dragstart`, causing WebView2 to cancel the drag.
+
+**Key fact:** react-dnd with HTML5Backend DID work in this exact Tauri WebView2 environment. The problem is not "HTML5 DnD is broken in WebView2" — it's "raw HTML5 DnD without React's batched updates breaks in WebView2 because SolidJS mutates the DOM synchronously during drag events."
+
+---
+
+## How the Old React Code Worked
+
+From `git show 0adce7c -- frontend/layout/lib/TileLayout.tsx`:
+
+### Drag Source (DisplayNode)
+```tsx
+import { useDrag, useDragLayer, useDrop } from "react-dnd";
+
+// In DisplayNode component:
+const [{ isDragging }, drag, dragPreview] = useDrag(() => ({
+    type: tileItemType,
+    canDrag: () => !(isEphemeral || isMagnified),
+    item: () => node,
+    collect: (monitor) => ({
+        isDragging: monitor.isDragging(),
+    }),
+}), [node, addlProps, isEphemeral, isMagnified]);
+
+// Register drag handle
+useEffect(() => {
+    drag(nodeModel.dragHandleRef);
+}, [drag, nodeModel.dragHandleRef.current]);
+```
+
+### Drop Target (OverlayNode)
+```tsx
+const [, drop] = useDrop(() => ({
+    accept: tileItemType,
+    canDrop: (_, monitor) => {
+        const dragItem = monitor.getItem<LayoutNode>();
+        return monitor.isOver({ shallow: true }) && dragItem.id !== node.id;
+    },
+    drop: (_, monitor) => {
+        if (!monitor.didDrop()) layoutModel.onDrop();
+    },
+    hover: throttle(50, (_, monitor) => {
+        if (monitor.isOver({ shallow: true }) && monitor.canDrop()) {
+            const dragItem = monitor.getItem<LayoutNode>();
+            const offset = monitor.getClientOffset();
+            // ... compute drop direction, dispatch ComputeMove
+        }
+    }),
+}), [node, additionalProps]);
+```
+
+### Drag Layer (TileLayoutComponent)
+```tsx
+const { activeDrag, dragClientOffset } = useDragLayer((monitor) => ({
+    activeDrag: monitor.isDragging(),
+    dragClientOffset: monitor.getClientOffset(),
+    dragItemType: monitor.getItemType(),
+}));
+
+useEffect(() => {
+    setActiveDrag(activeDrag && dragItemType == tileItemType);
+}, [activeDrag, dragItemType]);
+```
+
+### Why React-DnD Worked
+1. **React batches state updates** — `isDragging`, `activeDrag` signals don't flush to DOM until after the event handler returns
+2. **react-dnd manages the HTML5 DnD lifecycle internally** — it calls `e.preventDefault()` at the right times, sets `dataTransfer` correctly, handles the dragover/drop coordination
+3. **`useDragLayer` provides `isDragging`** — no manual signal management needed, React re-renders on next frame after drag starts (not during dragstart)
+
+---
+
+## Option 1: Pragmatic Drag and Drop
+
+**Package:** `@atlaskit/pragmatic-drag-and-drop` (4.7KB core)
+**Maintained by:** Atlassian (used in Jira, Confluence, Trello)
+**DnD mechanism:** Wraps the HTML5 DnD API — but manages the lifecycle properly
+
+### API Pattern
+
+```tsx
+import { draggable, dropTargetForElements, monitorForElements }
+    from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+
+// DRAG SOURCE — in blockframe.tsx onMount:
+const cleanup = draggable({
+    element: headerRef,                    // the DOM element
+    getInitialData: () => ({               // data attached to drag
+        nodeId: props.nodeModel.nodeId,
+        type: 'tile-node',
+    }),
+    onGenerateDragPreview: ({ nativeSetDragImage }) => {
+        // Custom drag ghost image
+        nativeSetDragImage(previewImg, offsetX, offsetY);
+    },
+    onDragStart: () => {
+        // SAFE to set reactive state here — fires AFTER browser commits drag
+        layoutModel.activeDrag._set(true);
+        setIsDragging(true);
+    },
+    onDrop: () => {
+        layoutModel.activeDrag._set(false);
+        setIsDragging(false);
+    },
+});
+onCleanup(cleanup);
+
+// DROP TARGET — in OverlayNode onMount:
+const cleanup = dropTargetForElements({
+    element: overlayRef,
+    canDrop: ({ source }) => source.data.type === 'tile-node',
+    getData: () => ({ nodeId: props.node.id }),
+    onDragEnter: ({ source }) => {
+        // Compute drop direction
+    },
+    onDrag: ({ source, self }) => {
+        // Throttled (~60fps via rAF) — update drop preview
+    },
+    onDragLeave: () => {
+        layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+    },
+    onDrop: ({ source }) => {
+        layoutModel.onDrop();
+    },
+});
+onCleanup(cleanup);
+
+// MONITOR — in TileLayoutComponent onMount (replaces useDragLayer):
+const cleanup = monitorForElements({
+    onDragStart: ({ source }) => {
+        if (source.data.type === 'tile-node') {
+            globalDragNodeId = source.data.nodeId;
+        }
+    },
+    onDrop: () => {
+        globalDragNodeId = null;
+    },
+});
+onCleanup(cleanup);
+```
+
+### Why Pragmatic DnD Should Work
+
+1. **Callbacks fire at the RIGHT time** — `onDragStart` fires after browser commits the drag, not during `dragstart` event. DOM mutations are safe.
+2. **Manages `e.preventDefault()`** — calls it on dragover internally, so drop zones accept drops
+3. **`onDrag` is rAF-throttled** — ~60fps updates for drop position tracking
+4. **Framework agnostic** — vanilla JS, attaches to DOM elements via `onMount`, no React needed
+5. **Handles drag preview** — `onGenerateDragPreview` provides `nativeSetDragImage`
+6. **Tiny** — 4.7KB core, no optional Atlassian UI deps needed
+
+### Integration Plan
+
+| File | Changes |
+|------|---------|
+| `package.json` | `npm install @atlaskit/pragmatic-drag-and-drop` |
+| `blockframe.tsx` | `onMount` → `draggable({ element: headerRef, ... })` |
+| `TileLayout.tsx` (OverlayNode) | `onMount` → `dropTargetForElements({ element: overlayRef, ... })` |
+| `TileLayout.tsx` (Component) | `onMount` → `monitorForElements({ ... })` — replaces `useDragLayer` |
+| `TileLayout.tsx` (DisplayNode) | Remove `nodeModel.dragHandlers` assignment, remove old HTML5 DnD code |
+| `types.ts` | Remove `dragHandlers` from NodeModel (replace with pragmatic-dnd in onMount) |
+| `layoutNodeModels.ts` | No changes needed |
+| `CrossWindowDragMonitor.tsx` | Use `monitorForElements` `onDrop` instead of document `dragend` listener |
+
+### Estimated effort: ~2-3 hours
+
+### Risks
+- Pragmatic-dnd uses HTML5 DnD under the hood. If the issue is truly WebView2 (not SolidJS reactivity), this won't help. But since react-dnd (also HTML5 DnD) worked before, this is unlikely.
+- Cross-window drag needs testing — pragmatic-dnd may or may not support it natively
+
+---
+
+## Option 2: React-DnD Bridge
+
+**Packages:** `react` (44KB), `react-dom` (130KB), `react-dnd` (14KB), `react-dnd-html5-backend` (10KB)
+**Total additional:** ~50KB min+gzip (React runtime is the bulk)
+**Approach:** Mount a thin React component tree inside Solid-managed container divs
+
+### Architecture
+
+```
+SolidJS App
+├── TileLayout (Solid)
+│   ├── DisplayNode (Solid)
+│   │   └── BlockFrame_Header (Solid)
+│   │       └── [React DnD DragHandle mounted here via createRoot]
+│   └── OverlayNode (Solid)
+│       └── [React DnD DropTarget mounted here via createRoot]
+└── [React DndProvider wrapping all drag/drop React islands]
+```
+
+### Implementation
+
+**react-dnd-bridge.tsx** (React side):
+```tsx
+import React, { useEffect, useRef } from 'react';
+import { createRoot } from 'react-dom/client';
+import { DndProvider, useDrag, useDrop, useDragLayer } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+
+const tileItemType = 'TILE_NODE';
+
+// Shared DnD context — single React tree wraps all islands
+let sharedRoot: ReturnType<typeof createRoot> | null = null;
+let sharedContainer: HTMLDivElement | null = null;
+
+export function initDndProvider() {
+    sharedContainer = document.createElement('div');
+    sharedContainer.id = 'react-dnd-provider';
+    sharedContainer.style.display = 'contents'; // no layout impact
+    document.body.appendChild(sharedContainer);
+    sharedRoot = createRoot(sharedContainer);
+    sharedRoot.render(
+        <DndProvider backend={HTML5Backend}>
+            <DndIslandManager />
+        </DndProvider>
+    );
+}
+
+// Problem: react-dnd requires all useDrag/useDrop to be under the same DndProvider.
+// With Solid rendering the actual UI, we'd need to portal React drag handles INTO
+// Solid-rendered DOM, which requires a custom bridge for each drag source/drop target.
+```
+
+### The DndProvider Problem
+
+react-dnd requires ALL drag sources and drop targets to share a single `<DndProvider>`. This means:
+
+1. **Single React tree** — can't have independent React islands for each pane header
+2. **React must render the drag handles** — but Solid renders the headers, creating a DOM ownership conflict
+3. **State synchronization** — react-dnd's `isDragging`/`monitor` state lives in React context, but our layout state lives in SolidJS signals
+
+### Workaround: Invisible React Overlay
+
+Instead of mounting React inside Solid components, mount a single invisible React tree that overlays the entire tile layout. React renders invisible drag handles positioned exactly over each pane header, and invisible drop targets over each overlay node.
+
+```tsx
+// React component that mirrors Solid's layout
+function DndOverlay({ nodes, onDrop, onDragStart, onDragEnd }) {
+    return (
+        <DndProvider backend={HTML5Backend}>
+            {nodes.map(node => (
+                <DragHandle key={node.id} node={node} ... />
+                <DropTarget key={node.id} node={node} ... />
+            ))}
+        </DndProvider>
+    );
+}
+```
+
+**Problems with this approach:**
+- Must keep React's invisible overlay perfectly synchronized with Solid's layout
+- Position changes from resize/animation must be mirrored
+- Two independent render trees managing overlapping DOM = race conditions
+- Debugging nightmare
+
+### Integration Complexity
+
+| File | Changes |
+|------|---------|
+| `package.json` | `npm install react react-dom react-dnd react-dnd-html5-backend` |
+| NEW `react-dnd-bridge.tsx` | React DnD provider + drag/drop wrappers |
+| NEW `react-dnd-types.ts` | Shared types between React and Solid |
+| `blockframe.tsx` | Mount React drag handle inside header via `onMount` + `createRoot` |
+| `TileLayout.tsx` | Mount React drop targets inside overlay nodes |
+| `wave.ts` or `index.tsx` | Initialize DndProvider at app startup |
+| `vite.config.ts` | Add React to build config, JSX pragma config for dual React+Solid |
+| `tsconfig.json` | Handle dual JSX transform (React for bridge files, Solid for everything else) |
+
+### Estimated effort: ~6-10 hours
+
+### Risks
+- **Dual JSX problem** — Vite needs to compile some files with React JSX and others with Solid JSX. Requires careful config (file extensions, pragma comments, or separate tsconfig).
+- **Bundle size** — +50KB min+gzip for React runtime
+- **Maintenance** — two frameworks, two mental models, version conflicts
+- **Synchronization** — keeping React overlay positions in sync with Solid layout
+- **Proven BUT complex** — the DnD logic is proven, but the bridge architecture is novel and fragile
+
+---
+
+## Comparison
+
+| Criteria | Pragmatic DnD | React-DnD Bridge |
+|----------|--------------|-------------------|
+| Bundle size | +4.7KB | +50KB |
+| Framework | Vanilla JS | React (full runtime) |
+| Integration effort | ~2-3 hours | ~6-10 hours |
+| Dual JSX config | No | Yes (complex) |
+| Maintenance burden | Low | High |
+| API similarity to old code | Different (imperative) | Same (useDrag/useDrop) |
+| Proven in WebView2 | Not yet tested | Yes (old code worked) |
+| Cross-window drag | Needs investigation | Known working (old code) |
+| Risk level | Low-Medium | Medium-High |
+
+---
+
+## Recommendation
+
+**Try Pragmatic DnD first (Option 1).** Reasons:
+
+1. **10x simpler integration** — vanilla JS, no dual-framework complexity
+2. **10x smaller bundle** — 4.7KB vs 50KB
+3. **Solves the root cause** — callbacks fire after browser commits drag, so SolidJS reactive updates don't interfere
+4. **Clean migration path** — each drag source/drop target is independent, can migrate incrementally
+5. **Same underlying API** — pragmatic-dnd wraps HTML5 DnD just like react-dnd, so if react-dnd worked, pragmatic-dnd should too
+
+**Fall back to React-DnD Bridge (Option 2) ONLY if:**
+- Pragmatic-dnd fails in WebView2 (unlikely given react-dnd worked)
+- Cross-window drag can't be implemented with pragmatic-dnd
+- Some other showstopper discovered during prototyping
+
+**Quick validation test (30 min):**
+1. `npm install @atlaskit/pragmatic-drag-and-drop`
+2. In one pane header: `onMount(() => draggable({ element: headerRef, onDragStart: () => console.log("DRAG STARTED") }))`
+3. If we see "DRAG STARTED" in logs and the ghost image appears → pragmatic-dnd works → proceed with full migration
+4. If drag still dies → HTML5 DnD is truly broken in our WebView2 config → switch to React bridge or pointer events
+
+---
+
+## Next Steps
+
+1. Install pragmatic-dnd
+2. Quick validation test on one header
+3. If works: full migration (~2-3 hours)
+4. If fails: evaluate React bridge vs custom pointer events

--- a/frontend/layout/lib/TileLayout.tsx
+++ b/frontend/layout/lib/TileLayout.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getSettingsKeyAtom } from "@/app/store/global";
+import { draggable, dropTargetForElements, monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import clsx from "clsx";
 import { toPng } from "html-to-image";
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, onMount } from "solid-js";
@@ -296,34 +297,42 @@ const DisplayNode = (props: DisplayNodeProps) => {
         }
     };
 
-    const onDragStart = (e: DragEvent) => {
-        if (isEphemeral() || isMagnified()) {
-            e.preventDefault();
-            return;
-        }
-        e.dataTransfer?.setData(DRAG_DATA_KEY, props.node.id);
-        const img = previewImage();
-        if (img) {
-            const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
-            const offsetX = (DragPreviewWidth * dpr - DragPreviewWidth) / 2 + 10;
-            const offsetY = (DragPreviewHeight * dpr - DragPreviewHeight) / 2 + 10;
-            e.dataTransfer?.setDragImage(img, offsetX, offsetY);
-        }
-        globalDragNodeId = props.node.id;
-        globalDragLayoutModel = props.layoutModel;
-        props.layoutModel.activeDrag._set(true);
-        setIsDragging(true);
-    };
-
-    const onDragEnd = (e: DragEvent) => {
-        globalDragNodeId = null;
-        globalDragLayoutModel = null;
-        props.layoutModel.activeDrag._set(false);
-        setIsDragging(false);
-    };
-
-    // Attach drag handle ref to the drag handle element
+    // Register pragmatic-dnd draggable on the tile node, using the header
+    // (dragHandleRef) as the drag handle. pragmatic-dnd wraps HTML5 DnD but
+    // fires onDragStart AFTER the browser commits the drag, so SolidJS
+    // reactive state updates here won't cause mid-event DOM mutations.
     const dragHandleRef = nodeModel.dragHandleRef;
+    onMount(() => {
+        if (!tileNodeRef) return;
+        const cleanup = draggable({
+            element: tileNodeRef,
+            dragHandle: dragHandleRef?.current ?? undefined,
+            canDrag: () => !isEphemeral() && !isMagnified(),
+            getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
+            onGenerateDragPreview: ({ nativeSetDragImage }) => {
+                const img = previewImage();
+                if (img && nativeSetDragImage) {
+                    const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;
+                    const offsetX = (DragPreviewWidth * dpr - DragPreviewWidth) / 2 + 10;
+                    const offsetY = (DragPreviewHeight * dpr - DragPreviewHeight) / 2 + 10;
+                    nativeSetDragImage(img, offsetX, offsetY);
+                }
+            },
+            onDragStart: () => {
+                globalDragNodeId = props.node.id;
+                globalDragLayoutModel = props.layoutModel;
+                props.layoutModel.activeDrag._set(true);
+                setIsDragging(true);
+            },
+            onDrop: () => {
+                globalDragNodeId = null;
+                globalDragLayoutModel = null;
+                props.layoutModel.activeDrag._set(false);
+                setIsDragging(false);
+            },
+        });
+        onCleanup(cleanup);
+    });
 
     const leafContent = () => (
         <div class="tile-leaf">
@@ -358,9 +367,6 @@ const DisplayNode = (props: DisplayNodeProps) => {
             ref={tileNodeRef}
             id={props.node.id}
             style={tileTransform() as JSX.CSSProperties}
-            draggable={!isEphemeral() && !isMagnified()}
-            onDragStart={onDragStart}
-            onDragEnd={onDragEnd}
             onPointerEnter={generatePreviewImage}
             onPointerOver={(event) => event.stopPropagation()}
         >
@@ -377,9 +383,22 @@ interface OverlayNodeWrapperProps {
 const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     const leafs = () => props.layoutModel.leafs();
     const overlayTransform = () => props.layoutModel.overlayTransform();
+    const activeDrag = () => props.layoutModel.activeDrag();
+
+    // Overlay is always positioned at top:0 so pragmatic-dnd drop targets
+    // are registered in the correct location. pointer-events toggles between
+    // "none" (pass-through for normal clicks) and "auto" (receive drag events).
+    // activeDrag is set by pragmatic-dnd's onDragStart callback which fires
+    // AFTER the browser commits the drag, so this toggle is safe.
+    const isActiveDrag = () => props.layoutModel.activeDrag();
+    const overlayStyle = createMemo<JSX.CSSProperties>(() => ({
+        ...overlayTransform(),
+        top: "0px",
+        "pointer-events": isActiveDrag() ? "auto" : "none",
+    }));
 
     return (
-        <div class="overlay-container" style={{ top: "10000px", ...overlayTransform() }}>
+        <div class="overlay-container" style={overlayStyle()}>
             <Key each={leafs()} by={(node) => node.id}>
                 {(node) => <OverlayNode layoutModel={props.layoutModel} node={node()} />}
             </Key>
@@ -401,16 +420,14 @@ const OverlayNode = (props: OverlayNodeProps) => {
     const additionalProps = () => nodeModel.additionalProps();
     let overlayRef: HTMLDivElement | undefined;
 
-    const handleDragOver = throttle(50, (e: DragEvent) => {
-        e.preventDefault();
+    // Throttled drop-direction computation (same logic as before, used by pragmatic-dnd onDrag)
+    const computeDropDirection = throttle(50, (clientX: number, clientY: number) => {
         const dragNodeId = globalDragNodeId;
         if (!dragNodeId || dragNodeId === props.node.id) return;
 
         if (props.layoutModel.displayContainerRef?.current && additionalProps()?.rect) {
-            const offset = { x: e.clientX, y: e.clientY };
             const containerRect = props.layoutModel.displayContainerRef.current.getBoundingClientRect();
-            offset.x -= containerRect.x;
-            offset.y -= containerRect.y;
+            const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
             props.layoutModel.treeReducer({
                 type: LayoutTreeActionType.ComputeMove,
                 nodeId: props.node.id,
@@ -424,17 +441,24 @@ const OverlayNode = (props: OverlayNodeProps) => {
         }
     });
 
-    const handleDragLeave = (e: DragEvent) => {
-        // Only clear if leaving this overlay node entirely (not entering a child)
-        if (overlayRef && !overlayRef.contains(e.relatedTarget as Node)) {
-            props.layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
-        }
-    };
-
-    const handleDrop = (e: DragEvent) => {
-        e.preventDefault();
-        props.layoutModel.onDrop();
-    };
+    onMount(() => {
+        if (!overlayRef) return;
+        const cleanup = dropTargetForElements({
+            element: overlayRef,
+            canDrop: ({ source }) => source.data.type === tileItemType && source.data.nodeId !== props.node.id,
+            onDrag: ({ location }) => {
+                const cursor = location.current.input;
+                computeDropDirection(cursor.clientX, cursor.clientY);
+            },
+            onDragLeave: () => {
+                props.layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+            },
+            onDrop: () => {
+                props.layoutModel.onDrop();
+            },
+        });
+        onCleanup(cleanup);
+    });
 
     return (
         <div
@@ -442,9 +466,6 @@ const OverlayNode = (props: OverlayNodeProps) => {
             class="overlay-node"
             id={props.node.id}
             style={additionalProps()?.transform as JSX.CSSProperties}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
         />
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "agentmux",
-  "version": "0.32.32",
+  "version": "0.32.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.32.32",
+      "version": "0.32.36",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
       ],
       "dependencies": {
         "@ai-sdk/react": "^2.0.114",
+        "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
         "@floating-ui/react": "^0.27.16",
         "@observablehq/plot": "^0.6.17",
         "@radix-ui/react-label": "^2.1.8",
@@ -276,6 +277,17 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.7.9.tgz",
+      "integrity": "sha512-m/bcw5flyjfcF/rdX4JeomtIBrWuDNOwcQieiywHv7zkfIRmUC34Q9ZLeNGVoz73UiGsRqxysMuw4tC7lSJ89g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0",
+        "raf-schd": "^4.0.3"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -304,7 +316,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -512,7 +523,6 @@
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -746,6 +756,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -762,6 +773,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -778,6 +790,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -794,6 +807,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -810,6 +824,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -826,6 +841,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -842,6 +858,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -858,6 +875,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -874,6 +892,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -890,6 +909,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -906,6 +926,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -922,6 +943,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -938,6 +960,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -954,6 +977,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -970,6 +994,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,6 +1011,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1002,6 +1028,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1018,6 +1045,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1034,6 +1062,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1050,6 +1079,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1066,6 +1096,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1082,6 +1113,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1098,6 +1130,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1114,6 +1147,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1130,6 +1164,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1146,6 +1181,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2389,6 +2425,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2428,6 +2465,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2448,6 +2486,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2468,6 +2507,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2488,6 +2528,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2508,6 +2549,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2528,6 +2570,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2548,6 +2591,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2568,6 +2612,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2588,6 +2633,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2608,6 +2654,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2628,6 +2675,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2648,6 +2696,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2668,6 +2717,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2931,6 +2981,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2944,6 +2995,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2957,6 +3009,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2970,6 +3023,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2983,6 +3037,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2996,6 +3051,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3009,6 +3065,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3022,6 +3079,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3035,6 +3093,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3048,6 +3107,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3061,6 +3121,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3074,6 +3135,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3087,6 +3149,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3100,6 +3163,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3113,6 +3177,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3126,6 +3191,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3139,6 +3205,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3152,6 +3219,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3165,6 +3233,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3178,6 +3247,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3191,6 +3261,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3204,6 +3275,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3217,6 +3289,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3230,6 +3303,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3243,6 +3317,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3527,7 +3602,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3827,8 +3901,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@table-nav/core/-/core-0.0.9.tgz",
       "integrity": "sha512-9LhTDDeGpjgvwKa96EeLejzXqgq9bThvF3ngdcOGjlWtxwrej4rWs4xSX5EVEEUIeA4TU2Vwe7UifrHRLgU4dw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@table-nav/react": {
       "version": "0.0.9",
@@ -4950,9 +5023,8 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4985,8 +5057,8 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4995,9 +5067,8 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5168,7 +5239,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -5770,7 +5840,6 @@
       "integrity": "sha512-OmwPKV8c5ecLqo+EkytN7oUeYfNmRI4uOXGIR1ybP7AK5Zz+l9R0dGfoadEuwi1aZXAL0vwuhtq3p0OL3dfqHQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.20.0"
       },
@@ -5825,7 +5894,6 @@
       "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
@@ -5870,8 +5938,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-9.24.0.tgz",
       "integrity": "sha512-ozQKYddBLT4TRvU9J+fGrhVUtx3iDAe+KNCJcTDMFMxNSdDMR2xFQdNp8HLHypspk58oXTYCvz6ZYjySthhqsw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@wdio/repl": {
       "version": "9.16.2",
@@ -6095,8 +6162,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.21",
@@ -6135,7 +6201,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6718,30 +6783,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/big-integer": {
-      "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-      "dev": true,
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/binary": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -6768,11 +6809,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
-      "dev": true,
+    "node_modules/bind-event-listener": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+      "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
       "license": "MIT"
     },
     "node_modules/boolbase": {
@@ -6832,7 +6872,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6880,25 +6919,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/buffer-indexof-polyfill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.0"
       }
     },
     "node_modules/cac": {
@@ -6979,19 +6999,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-      "dev": true,
-      "license": "MIT/X11",
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/chalk": {
@@ -7136,7 +7143,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -7162,7 +7168,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -7172,39 +7178,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chrome-launcher": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.1.tgz",
-      "integrity": "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node": "*",
-        "escape-string-regexp": "^4.0.0",
-        "is-wsl": "^2.2.0",
-        "lighthouse-logger": "^2.0.1"
-      },
-      "bin": {
-        "print-chrome-path": "bin/print-chrome-path.cjs"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/chromium-bidi": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
-      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mitt": "3.0.1",
-        "urlpattern-polyfill": "10.0.0"
-      },
-      "peerDependencies": {
-        "devtools-protocol": "*"
       }
     },
     "node_modules/ci-info": {
@@ -7698,16 +7671,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cross-fetch": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -7790,7 +7753,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8200,7 +8162,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8452,7 +8413,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -8469,357 +8430,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/devtools": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-8.42.0.tgz",
-      "integrity": "sha512-Y9LRUJlGI0wjXLbeU6TEHufF9HnG2H22+/EABD0KtHlJt5AIRQnTGi8uLAJsE1aeQMF1YXd8l7ExaxBkfEBq8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^22.2.0",
-        "@wdio/config": "8.41.0",
-        "@wdio/logger": "8.38.0",
-        "@wdio/protocols": "8.40.3",
-        "@wdio/types": "8.41.0",
-        "@wdio/utils": "8.41.0",
-        "chrome-launcher": "^1.0.0",
-        "edge-paths": "^3.0.5",
-        "import-meta-resolve": "^4.0.0",
-        "puppeteer-core": "^21.11.0",
-        "query-selector-shadow-dom": "^1.0.0",
-        "ua-parser-js": "^1.0.37",
-        "uuid": "^10.0.0",
-        "which": "^4.0.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.1232444",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
-      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/devtools/node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      }
-    },
-    "node_modules/devtools/node_modules/@wdio/config": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-8.41.0.tgz",
-      "integrity": "sha512-/6Z3sfSyhX5oVde0l01fyHimbqRYIVUDBnhDG2EMSCoC2lsaJX3Bm3IYpYHYHHFsgoDCi3B3Gv++t9dn2eSZZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.41.0",
-        "@wdio/utils": "8.41.0",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.0.0",
-        "glob": "^10.2.2",
-        "import-meta-resolve": "^4.0.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/devtools/node_modules/@wdio/logger": {
-      "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.38.0.tgz",
-      "integrity": "sha512-kcHL86RmNbcQP+Gq/vQUGlArfU6IIcbbnNp32rRIraitomZow+iEoc519rdQmSVusDozMS5DZthkgDdxK+vz6Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.1.2",
-        "loglevel": "^1.6.0",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/devtools/node_modules/@wdio/protocols": {
-      "version": "8.40.3",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-8.40.3.tgz",
-      "integrity": "sha512-wK7+eyrB3TAei8RwbdkcyoNk2dPu+mduMBOdPJjp8jf/mavd15nIUXLID1zA+w5m1Qt1DsT1NbvaeO9+aJQ33A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/devtools/node_modules/@wdio/types": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-8.41.0.tgz",
-      "integrity": "sha512-t4NaNTvJZci3Xv/yUZPH4eTL0hxrVTf5wdwNnYIBrzMnlRDbNefjQ0P7FM7ZjQCLaH92AEH6t/XanUId7Webug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^22.2.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/devtools/node_modules/@wdio/utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-8.41.0.tgz",
-      "integrity": "sha512-0TcTjBiax1VxtJQ/iQA0ZyYOSHjjX2ARVmEI0AMo9+AuIq+xBfnY561+v8k9GqOMPKsiH/HrK3xwjx8xCVS03g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@puppeteer/browsers": "^1.6.0",
-        "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.41.0",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^5.1.0",
-        "edgedriver": "^5.5.0",
-        "geckodriver": "~4.2.0",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.1.0",
-        "safaridriver": "^0.1.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.0.4"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/devtools/node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/devtools/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/devtools/node_modules/deepmerge-ts": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-5.1.0.tgz",
-      "integrity": "sha512-eS8dRJOckyo9maw9Tu5O5RUi/4inFLrnoLkBe3cPfDMx3WZioXtmOew4TXQaxq7Rhl4xjDtR7c6x8nNTxOvbFw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/devtools/node_modules/edgedriver": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/edgedriver/-/edgedriver-5.6.1.tgz",
-      "integrity": "sha512-3Ve9cd5ziLByUdigw6zovVeWJjVs8QHVmqOB0sJ0WNeVPcwf4p18GnxMmVvlFmYRloUwf5suNuorea4QzwBIOA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/logger": "^8.38.0",
-        "@zip.js/zip.js": "^2.7.48",
-        "decamelize": "^6.0.0",
-        "edge-paths": "^3.0.5",
-        "fast-xml-parser": "^4.4.1",
-        "node-fetch": "^3.3.2",
-        "which": "^4.0.0"
-      },
-      "bin": {
-        "edgedriver": "bin/edgedriver.js"
-      }
-    },
-    "node_modules/devtools/node_modules/fast-xml-parser": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
-      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
-    "node_modules/devtools/node_modules/geckodriver": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-4.2.1.tgz",
-      "integrity": "sha512-4m/CRk0OI8MaANRuFIahvOxYTSjlNAO2p9JmE14zxueknq6cdtB5M9UGRQ8R9aMV0bLGNVHHDnDXmoXdOwJfWg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@wdio/logger": "^8.11.0",
-        "decamelize": "^6.0.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "node-fetch": "^3.3.1",
-        "tar-fs": "^3.0.4",
-        "unzipper": "^0.10.14",
-        "which": "^4.0.0"
-      },
-      "bin": {
-        "geckodriver": "bin/geckodriver.js"
-      },
-      "engines": {
-        "node": "^16.13 || >=18 || >=20"
-      }
-    },
-    "node_modules/devtools/node_modules/isexe": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/devtools/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/devtools/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/devtools/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/devtools/node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/devtools/node_modules/safaridriver": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/safaridriver/-/safaridriver-0.1.2.tgz",
-      "integrity": "sha512-4R309+gWflJktzPXBQCobbWEHlzC4aK3a+Ov3tz2Ib2aBxiwd11phkdIBH1l0EO22x24CJMUQkpKFumRriCSRg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/devtools/node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/devtools/node_modules/tar-fs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      }
-    },
-    "node_modules/devtools/node_modules/which": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^3.1.1"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/diff": {
@@ -8959,49 +8569,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "node_modules/duplexer2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/duplexer2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/duplexer2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/duplexify": {
@@ -9216,7 +8783,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9312,7 +8879,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9663,7 +9229,6 @@
       "integrity": "sha512-Bkoqs+39fHwjos51qab7ZWmvZrYNBbzgSAIykH2CrgLOLhHJXzC30DP9lZq2MsmaUsbBnN5c5m8VqAhOHTrCRw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/snapshot": "^4.0.16",
         "deep-eql": "^5.0.2",
@@ -10005,6 +9570,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -10016,30 +9582,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
       }
     },
     "node_modules/figures": {
@@ -10198,19 +9740,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -10222,6 +9751,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10230,59 +9760,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "deprecated": "This package is no longer supported.",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      },
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/fstream/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/fstream/node_modules/rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
       }
     },
     "node_modules/function-bind": {
@@ -10382,7 +9859,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -11138,7 +10615,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -11339,27 +10816,11 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11379,7 +10840,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -11473,19 +10934,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -11845,7 +11293,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -12198,22 +11646,11 @@
       ],
       "license": "MIT"
     },
-    "node_modules/lighthouse-logger": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
-      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.4.1",
-        "marky": "^1.2.2"
-      }
-    },
     "node_modules/lightningcss": {
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -12246,6 +11683,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12266,6 +11704,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12286,6 +11725,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12306,6 +11746,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12326,6 +11767,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12346,6 +11788,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12366,6 +11809,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12386,6 +11830,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12406,6 +11851,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12426,6 +11872,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12446,6 +11893,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12468,13 +11916,6 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
-    },
-    "node_modules/listenercount": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-      "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/lit": {
       "version": "3.3.2",
@@ -12838,13 +12279,6 @@
       "engines": {
         "node": ">= 20"
       }
-    },
-    "node_modules/marky": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
-      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
@@ -13224,7 +12658,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -13861,8 +13294,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -13917,16 +13349,6 @@
         "node": "*"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -13941,26 +13363,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true,
       "license": "MIT"
     },
@@ -14282,6 +13684,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -14341,50 +13744,9 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -14541,8 +13903,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.14.0.tgz",
       "integrity": "sha512-RjV0pqc79kYhQLC3vTcLRb5GLpI1n6qh0Oua3g+bGH4EgNOJHVBGP7u0zZtxoAa0dkHlAqTTSYRb9MMmxNLjig==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/overlayscrollbars-react": {
       "version": "0.5.6",
@@ -14907,6 +14268,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -15047,6 +14409,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -15098,7 +14461,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15304,135 +14666,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/puppeteer-core": {
-      "version": "21.11.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
-      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "1.9.1",
-        "chromium-bidi": "0.5.8",
-        "cross-fetch": "4.0.0",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1232444",
-        "ws": "8.16.0"
-      },
-      "engines": {
-        "node": ">=16.13.2"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
-      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.3.4",
-        "extract-zip": "2.0.1",
-        "progress": "2.0.3",
-        "proxy-agent": "6.3.1",
-        "tar-fs": "3.0.4",
-        "unbzip2-stream": "1.4.3",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "browsers": "lib/cjs/main-cli.js"
-      },
-      "engines": {
-        "node": ">=16.3.0"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/puppeteer-core/node_modules/proxy-agent": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
-      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.2",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/tar-fs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/query-selector-shadow-dom": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
@@ -15468,6 +14701,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -15483,7 +14722,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15532,7 +14770,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15823,7 +15060,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -16195,7 +15432,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -16302,8 +15539,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -16475,9 +15712,8 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -16559,7 +15795,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -16750,7 +15985,6 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -17278,8 +16512,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -17448,13 +16681,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -17481,6 +16707,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -17554,23 +16781,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "dev": true,
-      "license": "MIT/X11",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/tree-kill": {
@@ -17710,7 +16920,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -17730,6 +16940,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -17772,7 +16983,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17805,74 +17015,11 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
-      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
-    },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      }
-    },
-    "node_modules/unbzip2-stream/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
     },
     "node_modules/undici": {
       "version": "6.23.0",
@@ -17888,7 +17035,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -17909,7 +17056,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -18020,58 +17166,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unzipper": {
-      "version": "0.10.14",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-      "integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big-integer": "^1.6.17",
-        "binary": "~0.3.0",
-        "bluebird": "~3.4.1",
-        "buffer-indexof-polyfill": "~1.0.0",
-        "duplexer2": "~0.1.4",
-        "fstream": "^1.0.12",
-        "graceful-fs": "^4.2.2",
-        "listenercount": "~1.0.1",
-        "readable-stream": "~2.3.6",
-        "setimmediate": "~1.0.4"
-      }
-    },
-    "node_modules/unzipper/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/unzipper/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/unzipper/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -18154,20 +17248,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -18232,8 +17312,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -18416,6 +17496,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18432,6 +17513,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18448,6 +17530,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18464,6 +17547,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18480,6 +17564,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18496,6 +17581,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18512,6 +17598,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18528,6 +17615,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18544,6 +17632,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18560,6 +17649,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18576,6 +17666,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18592,6 +17683,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18608,6 +17700,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18624,6 +17717,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18640,6 +17734,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18656,6 +17751,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18672,6 +17768,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18688,6 +17785,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18704,6 +17802,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18720,6 +17819,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18736,6 +17836,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18752,6 +17853,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18768,6 +17870,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18784,6 +17887,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18800,6 +17904,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18816,6 +17921,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18829,6 +17935,7 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -18870,6 +17977,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -18905,7 +18013,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -19153,16 +18260,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/webdriver": {
       "version": "9.24.0",
       "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-9.24.0.tgz",
@@ -19202,7 +18299,6 @@
       "integrity": "sha512-LTJt6Z/iDM0ne/4ytd3BykoPv9CuJ+CAILOzlwFeMGn4Mj02i4Bk2Rg9o/jeJ89f52hnv4OPmNjD0e8nzWAy5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "^20.11.30",
         "@types/sinonjs__fake-timers": "^8.1.5",
@@ -19252,13 +18348,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -19281,17 +18370,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -19529,7 +18607,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -19760,7 +18837,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.32.35",
+  "version": "0.32.36",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"
@@ -81,6 +81,7 @@
   },
   "dependencies": {
     "@ai-sdk/react": "^2.0.114",
+    "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
     "@floating-ui/react": "^0.27.16",
     "@observablehq/plot": "^0.6.17",
     "@radix-ui/react-label": "^2.1.8",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.32.35"
+version = "0.32.36"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.32.35",
-  "identifier": "ai.agentmux.app.v0-32-35",
+  "version": "0.32.36",
+  "identifier": "ai.agentmux.app.v0-32-36",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",
@@ -22,7 +22,7 @@
         "decorations": false,
         "transparent": true,
         "backgroundColor": "#00000000",
-        "dragDropEnabled": true,
+        "dragDropEnabled": false,
         "visible": false
       }
     ],

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.32.35"
+version = "0.32.36"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary
- Fix pane drag-and-drop which has been broken since the SolidJS migration
- Root cause: Tauri's `dragDropEnabled: true` intercepts ALL HTML5 DnD events at the WebView2 level
- Replace raw HTML5 DnD with `@atlaskit/pragmatic-drag-and-drop` (4.7KB) which fires callbacks after the browser commits the drag, making SolidJS reactive state updates safe
- Set `dragDropEnabled: false` in tauri.conf.json

## Changes
- **TileLayout.tsx**: `draggable()` + `dropTargetForElements()` via `onMount` replace JSX drag attributes
- **TileLayout.tsx**: Overlay always positioned at `top:0`, `pointer-events` toggled by `activeDrag`
- **tauri.conf.json**: `dragDropEnabled: false`
- **package.json**: `@atlaskit/pragmatic-drag-and-drop` dependency
- **docs/**: Retro + specs documenting investigation and approach

## Test plan
- [ ] Open app with 3+ panes
- [ ] Drag pane header — should see ghost image and blur on source
- [ ] Drop on another pane — panes should rearrange
- [ ] Verify widgets (close, magnify) still work
- [ ] Verify tab drag still works
- [ ] Test on Windows (primary) and macOS if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)