### PR TITLE
feat: detect missing Node.js before Codex/Gemini install

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.32.48"
+version = "0.32.49"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.32.48"
+version = "0.32.49"
 dependencies = [
  "async-stream",
  "axum",
@@ -7152,7 +7152,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.32.48"
+version = "0.32.49"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.32.48"
+version = "0.32.49"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/docs/specs/codex-gemini-cli-integration.md
+++ b/docs/specs/codex-gemini-cli-integration.md
@@ -1,0 +1,276 @@
+# Spec: Codex CLI & Gemini CLI — Install, Auth, and Launch Integration
+
+**Date:** 2026-03-19
+**Status:** Draft
+**Priority:** High — Codex and Gemini agents currently fail on first launch
+
+---
+
+## Problem Statement
+
+When a user selects a Codex or Gemini agent from the Forge, the launch fails with:
+```
+[agent] AgentY selected (provider: Codex CLI)
+[env] working directory: ~/.agentmux/agents/agenty
+[cli] checking for codex...
+[cli] install failed: The filename, directory name, or volume label syntax is incorrect.
+[error] codex not available — install manually or check your internet connection
+```
+
+The Claude agent works end-to-end (install → auth → launch) because it has:
+1. A dedicated PowerShell/bash installer (`irm https://claude.ai/install.ps1 | iex`)
+2. A fast auth check via credentials file (`~/.claude/.credentials.json`)
+3. A well-tested stream-json output parser
+
+Codex and Gemini are defined in the provider registry but their install/auth/launch paths have gaps.
+
+---
+
+## Current State
+
+### What Works
+- Provider definitions exist in `frontend/app/view/agent/providers/index.ts`
+- `ResolveCliCommand` in the backend has 3-step resolution (versioned → system PATH → install)
+- `CheckCliAuthCommand` supports all 3 providers
+- Forge seed includes Codex (AgentY) and Gemini (AgentZ) agents
+- Agent config writing (CLAUDE.md, .mcp.json, skills) works for all providers
+
+### What's Broken
+
+#### 1. Installation Path (Windows)
+
+**Codex** `windowsInstallCommand`: `"npm install -g @openai/codex"`
+**Gemini** `windowsInstallCommand`: `"npm install -g @google/gemini-cli"`
+
+The "filename, directory name, or volume label syntax is incorrect" error comes from the backend's `ResolveCliCommand` trying to run the install. Likely causes:
+- The install command is run in a context where `npm` isn't on PATH
+- The working directory for the install subprocess is invalid
+- Windows path separators in the versioned install directory (`~/.agentmux/instances/v0.32.43/cli/codex/`)
+
+**Claude** uses a dedicated installer (`irm https://claude.ai/install.ps1 | iex`) that handles PATH setup internally. Codex and Gemini rely on `npm` being available globally.
+
+#### 2. npm Local Install Path
+
+The backend `ResolveCliCommand` tries `npm install --prefix <dir> <package>@<version>` for local installation. On Windows, the resulting binary is at:
+```
+~/.agentmux/instances/v<version>/cli/<provider>/node_modules/.bin/<provider>.cmd
+```
+
+Issues:
+- The `.cmd` extension must be appended on Windows
+- The `--prefix` path may have issues with Windows long paths or spaces
+- npm may not be available in the subprocess environment
+
+#### 3. Authentication
+
+**Codex auth:**
+- Check: `codex login status` (exit code 0 = authenticated)
+- Login: `codex login` (opens browser for OpenAI OAuth)
+- No fast path (no local credentials file to check)
+- API key alternative: `OPENAI_API_KEY` environment variable
+
+**Gemini auth:**
+- Check: `gemini auth status` (exit code 0 = authenticated)
+- Login: `gemini auth login` (opens browser for Google OAuth)
+- No fast path
+- API key alternative: `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable
+
+**Current gap:** The agent model's auth flow (`agent-model.ts`) is optimized for Claude's OAuth flow. It captures OAuth URLs from PTY output and opens them externally. Codex and Gemini may have different auth URL patterns.
+
+#### 4. Output Parsing
+
+- `styledOutputFormat: "codex-json"` and `"gemini-json"` are defined but the stream parsers may not be implemented
+- The `ParserCallbacks` system in `agent-model.ts` is designed for Claude's `stream-json` format
+- Codex uses `--full-auto` mode — output format needs investigation
+- Gemini uses `--yolo` mode — output format needs investigation
+
+---
+
+## Proposed Fix Plan
+
+### Phase 1: Fix Installation (Critical)
+
+**1a. Fix local npm install on Windows**
+
+In `cli_installer.rs` / `ResolveCliCommand`:
+- Ensure `npm` is resolved via full path (check `where npm` first)
+- Handle Windows path normalization (forward slashes → backslashes for subprocess)
+- Append `.cmd` extension when checking for installed binary on Windows
+- Add proper error messages with actionable guidance
+
+**1b. Add fallback to global install**
+
+If local `npm install --prefix` fails:
+1. Try `npm install -g <package>@<version>`
+2. Try the provider's `windowsInstallCommand` / `unixInstallCommand`
+3. Check system PATH again after install
+4. If all fail: show clear error with manual install instructions
+
+**1c. Validate install works**
+
+After installation, run `<cli> --version` to confirm the binary works before proceeding.
+
+### Phase 2: Fix Authentication
+
+**2a. Support API key auth for Codex**
+
+Codex can authenticate via `OPENAI_API_KEY` environment variable. The Forge agent config should support setting this:
+- Add `api_key` field to ForgeAgent or ForgeContent
+- If set, pass as environment variable to the subprocess
+- Skip OAuth flow when API key is present
+- UI: add API key input field in Forge agent settings
+
+**2b. Support API key auth for Gemini**
+
+Same pattern as Codex but with `GOOGLE_API_KEY` or `GEMINI_API_KEY`.
+
+**2c. OAuth flow for Codex/Gemini**
+
+Codex and Gemini both support interactive OAuth login:
+- `codex login` — opens browser for OpenAI login
+- `gemini auth login` — opens browser for Google login
+
+The agent model's `handleTerminalData()` already captures OAuth URLs from PTY output. Verify the URL regex patterns work for:
+- OpenAI: `https://platform.openai.com/...` or `https://auth0.openai.com/...`
+- Google: `https://accounts.google.com/...`
+
+If the regex doesn't match, add provider-specific URL patterns to the auth state machine.
+
+### Phase 3: Fix Output Parsing
+
+**3a. Codex output format investigation**
+
+Codex CLI with `--full-auto`:
+- Does it produce structured JSON output?
+- What format? (NDJSON, SSE, custom?)
+- Can we use `--output-format json` or similar flag?
+- If no structured output: use raw mode (display PTY output as-is)
+
+**3b. Gemini output format investigation**
+
+Gemini CLI with `--yolo`:
+- Same questions as Codex
+- Does `gemini --output-format json` exist?
+
+**3c. Implement parsers if needed**
+
+If structured output is available:
+- Add `codex-json` parser to the stream parser system
+- Add `gemini-json` parser
+- Map events to the existing `ParserCallbacks` interface
+
+If no structured output:
+- Use `outputFormat: "raw"` (already configured as default)
+- Display raw terminal output in the agent pane
+- This is functional but loses the structured tool-call display
+
+### Phase 4: End-to-End Testing
+
+For each provider (Claude, Codex, Gemini):
+1. Fresh install test — no CLI pre-installed, launch agent, verify auto-install
+2. Auth test — verify OAuth or API key flow works
+3. Launch test — send a prompt, verify output displays
+4. Restart test — close and reopen agent, verify it reconnects
+5. Cross-platform — test on Windows, macOS, Linux
+
+---
+
+## Implementation Details
+
+### Backend Changes (`agentmuxsrv-rs`)
+
+**`cli_installer.rs` / `websocket.rs`:**
+
+```rust
+// Fix: resolve npm path before running install
+fn resolve_npm_path() -> Option<PathBuf> {
+    // Check common locations:
+    // - Windows: C:\Program Files\nodejs\npm.cmd
+    // - macOS/Linux: /usr/local/bin/npm, /usr/bin/npm
+    // - nvm: ~/.nvm/versions/node/*/bin/npm
+    // - fnm: similar
+    which::which("npm").ok()
+}
+
+// Fix: Windows binary path resolution
+fn get_cli_binary_path(provider: &str, install_dir: &Path) -> PathBuf {
+    let bin_dir = install_dir.join("node_modules/.bin");
+    if cfg!(windows) {
+        bin_dir.join(format!("{}.cmd", provider))
+    } else {
+        bin_dir.join(provider)
+    }
+}
+```
+
+### Frontend Changes
+
+**`providers/index.ts`:**
+
+```typescript
+// Add API key environment variable names
+export interface ProviderDefinition {
+    // ... existing fields ...
+    apiKeyEnvVar?: string;  // e.g. "OPENAI_API_KEY" for Codex
+}
+
+// Update providers:
+codex: {
+    // ...
+    apiKeyEnvVar: "OPENAI_API_KEY",
+},
+gemini: {
+    // ...
+    apiKeyEnvVar: "GOOGLE_API_KEY",
+},
+```
+
+**`agent-model.ts`:**
+
+```typescript
+// Add provider-specific OAuth URL patterns
+const OAUTH_URL_PATTERNS: Record<string, RegExp> = {
+    claude: /https:\/\/claude\.ai\/oauth\/authorize\S+/,
+    codex: /https:\/\/(platform\.openai\.com|auth0\.openai\.com)\S+/,
+    gemini: /https:\/\/accounts\.google\.com\S+/,
+};
+```
+
+### Forge UI Changes
+
+**Agent settings panel:**
+- Add "API Key" field (password input) for Codex and Gemini agents
+- If API key is set, show "Authenticated via API key" status
+- If not set, show "Run `<cli> auth login` to authenticate" guidance
+- Store API key in ForgeContent (encrypted or in secure store)
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `agentmuxsrv-rs/src/commands/cli_installer.rs` | Fix npm path resolution, Windows binary paths |
+| `agentmuxsrv-rs/src/server/websocket.rs` | Fix `ResolveCliCommand` install fallback chain |
+| `frontend/app/view/agent/providers/index.ts` | Add `apiKeyEnvVar` field |
+| `frontend/app/view/agent/agent-model.ts` | Add provider-specific OAuth URL patterns |
+| `frontend/app/view/forge/forge-view.tsx` | Add API key input in agent settings |
+
+---
+
+## Priority Order
+
+1. **Fix npm install path on Windows** — unblocks Codex and Gemini immediately
+2. **API key auth support** — simplest auth path, no OAuth flow needed
+3. **OAuth URL patterns** — for users who prefer browser-based auth
+4. **Output parsers** — nice-to-have, raw mode works as fallback
+
+---
+
+## Open Questions
+
+1. Does Codex CLI have a structured JSON output mode? (Need to test with `codex --help`)
+2. Does Gemini CLI have a structured JSON output mode?
+3. Should API keys be stored in the Forge database or in a system keychain?
+4. Do we need provider-specific stream parsers, or is raw terminal output acceptable for v1?
+5. Codex `--full-auto` and Gemini `--yolo` flags — are these the right defaults for AgentMux's use case?

--- a/docs/specs/nodejs-detection-notification.md
+++ b/docs/specs/nodejs-detection-notification.md
@@ -1,0 +1,346 @@
+# Spec: Node.js Detection & User Notification
+
+**Date:** 2026-03-19
+**Status:** Implementation Ready
+**Priority:** High — Codex and Gemini agents fail silently when Node.js is missing
+**Effort:** ~2 hours
+
+---
+
+## Problem
+
+Codex and Gemini CLIs are npm packages that require Node.js to install and run. When Node.js is not installed, `npm.cmd` / `npm` fails with a cryptic OS error ("The filename, directory name, or volume label syntax is incorrect"). The user sees:
+
+```
+[cli] install failed: The filename, directory name, or volume label syntax is incorrect.
+[error] codex not available — install manually or check your internet connection
+```
+
+Claude doesn't have this problem because its installer (`irm https://claude.ai/install.ps1 | iex`) bundles its own Node runtime.
+
+---
+
+## Solution
+
+Add a Node.js detection check before attempting `npm install`. If Node.js is missing, show a clear notification with platform-specific install instructions instead of a cryptic error.
+
+---
+
+## Implementation
+
+### 1. New Tauri Command: `check_nodejs_available`
+
+**File:** `src-tauri/src/commands/cli_installer.rs`
+
+```rust
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NodejsStatus {
+    pub available: bool,
+    pub version: Option<String>,
+    pub npm_available: bool,
+    pub npm_version: Option<String>,
+    pub path: Option<String>,
+}
+
+/// Check if Node.js and npm are available on the system.
+/// Returns version info if found, or available=false if not.
+#[tauri::command]
+pub async fn check_nodejs_available() -> Result<NodejsStatus, String> {
+    let result = tokio::task::spawn_blocking(|| {
+        let node_cmd = if cfg!(windows) { "node.exe" } else { "node" };
+        let npm_cmd = if cfg!(windows) { "npm.cmd" } else { "npm" };
+
+        let mut status = NodejsStatus {
+            available: false,
+            version: None,
+            npm_available: false,
+            npm_version: None,
+            path: None,
+        };
+
+        // Check node
+        if let Ok(output) = std::process::Command::new(node_cmd)
+            .arg("--version")
+            .output()
+        {
+            if output.status.success() {
+                let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                status.available = true;
+                status.version = Some(ver);
+
+                // Get node path
+                let which_cmd = if cfg!(windows) { "where" } else { "which" };
+                if let Ok(path_out) = std::process::Command::new(which_cmd)
+                    .arg(node_cmd)
+                    .output()
+                {
+                    if path_out.status.success() {
+                        status.path = Some(
+                            String::from_utf8_lossy(&path_out.stdout)
+                                .lines()
+                                .next()
+                                .unwrap_or("")
+                                .trim()
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+
+        // Check npm
+        if let Ok(output) = std::process::Command::new(npm_cmd)
+            .arg("--version")
+            .output()
+        {
+            if output.status.success() {
+                let ver = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                status.npm_available = true;
+                status.npm_version = Some(ver);
+            }
+        }
+
+        status
+    })
+    .await
+    .map_err(|e| format!("Failed to check Node.js: {e}"))?;
+
+    Ok(result)
+}
+```
+
+**Register in `lib.rs`:**
+```rust
+commands::cli_installer::check_nodejs_available,
+```
+
+### 2. Pre-Flight Check in `install_cli`
+
+**File:** `src-tauri/src/commands/cli_installer.rs`
+
+Modify `install_via_npm` to check Node.js before attempting install:
+
+```rust
+fn install_via_npm(provider: &str) -> Result<String, String> {
+    // Pre-flight: check if npm is available
+    let npm_cmd = if cfg!(windows) { "npm.cmd" } else { "npm" };
+    match std::process::Command::new(npm_cmd).arg("--version").output() {
+        Ok(output) if output.status.success() => {
+            let ver = String::from_utf8_lossy(&output.stdout);
+            tracing::info!("npm {} available", ver.trim());
+        }
+        _ => {
+            return Err(
+                "NODEJS_NOT_FOUND: Node.js/npm is not installed. \
+                 Codex and Gemini CLIs require Node.js. \
+                 Install from https://nodejs.org/ (LTS recommended)."
+                    .to_string(),
+            );
+        }
+    }
+
+    // ... existing npm install logic ...
+}
+```
+
+### 3. Frontend: Detect Error and Show Notification
+
+**File:** `frontend/app/view/agent/agent-model.ts`
+
+In the launch flow, before calling `install_cli`, check for Node.js:
+
+```typescript
+import { getApi } from "@/store/global";
+
+async function ensureCliInstalled(provider: ProviderDefinition): Promise<string> {
+    // Step 1: Check if CLI is already installed
+    const existingPath = await getApi().getCliPath(provider.id);
+    if (existingPath) return existingPath;
+
+    // Step 2: For npm-based providers (not Claude), check Node.js first
+    if (provider.id !== "claude") {
+        const nodeStatus = await getApi().checkNodejsAvailable();
+        if (!nodeStatus.available || !nodeStatus.npm_available) {
+            throw new NodejsNotFoundError(provider);
+        }
+    }
+
+    // Step 3: Install
+    const result = await getApi().installCli(provider.id);
+    return result.cli_path;
+}
+```
+
+### 4. Notification UI
+
+**File:** `frontend/app/view/agent/agent-view.tsx`
+
+When `NodejsNotFoundError` is caught, show an in-pane notification:
+
+```tsx
+class NodejsNotFoundError extends Error {
+    provider: ProviderDefinition;
+    constructor(provider: ProviderDefinition) {
+        super(`Node.js is required to run ${provider.displayName}`);
+        this.provider = provider;
+    }
+}
+
+// In the agent view, render the error state:
+function NodejsRequiredNotice(props: { provider: ProviderDefinition }) {
+    const platform = getPlatform();
+
+    const installCommand = () => {
+        if (platform === "win32") return "winget install OpenJS.NodeJS.LTS";
+        if (platform === "darwin") return "brew install node";
+        return "sudo apt install nodejs npm";  // Linux
+    };
+
+    const downloadUrl = "https://nodejs.org/en/download/";
+
+    return (
+        <div class="agent-notice nodejs-required">
+            <div class="notice-icon">
+                <i class="fa-solid fa-circle-exclamation" />
+            </div>
+            <div class="notice-content">
+                <h3>Node.js Required</h3>
+                <p>
+                    {props.provider.displayName} requires Node.js to install and run.
+                    Node.js was not detected on your system.
+                </p>
+                <div class="notice-install-options">
+                    <div class="install-option">
+                        <strong>Option 1:</strong> Install via command line
+                        <code class="install-command">{installCommand()}</code>
+                    </div>
+                    <div class="install-option">
+                        <strong>Option 2:</strong> Download from{" "}
+                        <a href={downloadUrl} onClick={(e) => {
+                            e.preventDefault();
+                            getApi().openExternal(downloadUrl);
+                        }}>
+                            nodejs.org
+                        </a>
+                        {" "}(LTS recommended)
+                    </div>
+                </div>
+                <p class="notice-hint">
+                    After installing Node.js, restart AgentMux and try again.
+                </p>
+            </div>
+        </div>
+    );
+}
+```
+
+### 5. CSS for the Notice
+
+**File:** `frontend/app/view/agent/agent.scss` (or new file)
+
+```scss
+.agent-notice.nodejs-required {
+    display: flex;
+    gap: 16px;
+    padding: 24px;
+    margin: 24px;
+    border-radius: 8px;
+    background: var(--block-bg-color);
+    border: 1px solid var(--border-color);
+
+    .notice-icon {
+        font-size: 24px;
+        color: #f59e0b;  // amber warning
+    }
+
+    .notice-content {
+        h3 {
+            margin: 0 0 8px;
+            font-size: 16px;
+        }
+
+        p {
+            margin: 0 0 12px;
+            color: var(--secondary-text-color);
+        }
+
+        .install-command {
+            display: block;
+            margin-top: 4px;
+            padding: 8px 12px;
+            background: rgba(0, 0, 0, 0.3);
+            border-radius: 4px;
+            font-family: var(--termfontfamily);
+            font-size: 13px;
+            user-select: all;
+        }
+
+        .install-option {
+            margin-bottom: 12px;
+        }
+
+        .notice-hint {
+            font-style: italic;
+            font-size: 13px;
+        }
+    }
+}
+```
+
+---
+
+## Flow Diagram
+
+```
+User clicks "Launch Agent" (Codex/Gemini)
+    ↓
+ensureCliInstalled(provider)
+    ↓
+getCliPath() → null (not installed)
+    ↓
+Is provider === "claude"?
+    YES → use Claude's standalone installer
+    NO  → checkNodejsAvailable()
+            ↓
+        Node.js found?
+            YES → installCli() via npm
+            NO  → throw NodejsNotFoundError
+                    ↓
+                Show NodejsRequiredNotice in agent pane
+                (platform-specific install commands)
+```
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `src-tauri/src/commands/cli_installer.rs` | Add `check_nodejs_available` command, add pre-flight check in `install_via_npm` |
+| `src-tauri/src/lib.rs` | Register `check_nodejs_available` command |
+| `frontend/app/view/agent/agent-model.ts` | Add `ensureCliInstalled` with Node.js check |
+| `frontend/app/view/agent/agent-view.tsx` | Add `NodejsRequiredNotice` component |
+| `frontend/app/view/agent/agent.scss` | Add notice styles |
+
+---
+
+## What This Does NOT Change
+
+- Claude agent flow — unchanged, uses its own installer
+- Backend `ResolveCliCommand` — unchanged, frontend handles the pre-check
+- Provider definitions — unchanged
+- Forge agent config/launch — unchanged, just wraps the CLI resolution
+
+---
+
+## Edge Cases
+
+1. **Node.js installed after AgentMux starts:** User installs Node.js, comes back to AgentMux. The check runs on each launch attempt, so it will detect Node.js without restart. Add a "Retry" button to the notice.
+
+2. **Node.js installed but not on PATH:** The `node --version` check will fail. The notice should mention "Make sure Node.js is on your system PATH."
+
+3. **npm installed but node is not (unlikely):** Check both independently and report which is missing.
+
+4. **Corporate environments with proxy:** `npm install` may fail even with Node.js present. The error from `install_via_npm` handles this separately — it's not a Node.js detection issue.
+
+5. **nvm/fnm users:** Node.js may be available in the user's shell but not in the subprocess environment. The Tauri command inherits the app's environment, which may not include nvm's PATH modifications. Mention in the notice: "If using nvm/fnm, ensure the default Node.js version is set."

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -21,6 +21,7 @@ export class AgentViewModel implements ViewModel {
     viewText: () => string | HeaderElem[];
     viewComponent: ViewComponent;
     noPadding: () => boolean;
+    nodejsError: string | null = null;
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
@@ -44,6 +45,14 @@ export class AgentViewModel implements ViewModel {
         const provider = PROVIDERS[agentId];
         if (!provider) {
             Logger.error("agent", "Unknown agent", { agentId });
+            return;
+        }
+
+        // Check Node.js availability for npm-based providers
+        const nodejsError = await checkNodejsForProvider(provider.id);
+        if (nodejsError) {
+            this.nodejsError = nodejsError;
+            Logger.error("agent", "Node.js not available", { agentId, error: nodejsError });
             return;
         }
 
@@ -107,6 +116,14 @@ export class AgentViewModel implements ViewModel {
         const provider = PROVIDERS[agent.provider] ?? PROVIDERS[resolveProviderAlias(agent.provider)];
         if (!provider) {
             Logger.error("agent", "Unknown provider in forge agent", { agentId: agent.id, provider: agent.provider });
+            return;
+        }
+
+        // Check Node.js availability for npm-based providers
+        const nodejsError = await checkNodejsForProvider(provider.id);
+        if (nodejsError) {
+            this.nodejsError = nodejsError;
+            Logger.error("agent", "Node.js not available for forge agent", { agentId: agent.id, error: nodejsError });
             return;
         }
 
@@ -222,6 +239,26 @@ export class AgentViewModel implements ViewModel {
     }
 
     dispose(): void {}
+}
+
+/**
+ * Check if Node.js is available. Required for npm-based providers (Codex, Gemini).
+ * Claude has its own standalone installer and doesn't need Node.js.
+ * Returns null if Node.js is available or not needed, or an error message string.
+ */
+async function checkNodejsForProvider(providerId: string): Promise<string | null> {
+    if (providerId === "claude") return null; // Claude has standalone installer
+    try {
+        const status = await getApi().checkNodejsAvailable();
+        if (!status.available || !status.npm_available) {
+            const missing = !status.available ? "Node.js" : "npm";
+            return `${missing} is not installed. Install Node.js from https://nodejs.org/ (LTS recommended).`;
+        }
+        return null;
+    } catch (e) {
+        Logger.warn("agent", "Failed to check Node.js availability", { error: String(e) });
+        return null; // Don't block launch on check failure — let npm install fail with its own error
+    }
 }
 
 /**

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -181,6 +181,42 @@
         }
     }
 
+    .agent-nodejs-notice {
+        display: flex;
+        gap: 12px;
+        padding: 12px;
+        margin: 8px 0;
+        border-radius: 6px;
+        background: rgba(245, 158, 11, 0.08);
+        border: 1px solid rgba(245, 158, 11, 0.3);
+
+        .nodejs-notice-icon {
+            font-size: 18px;
+            color: #f59e0b;
+            flex-shrink: 0;
+            padding-top: 2px;
+        }
+
+        .nodejs-notice-title {
+            font-weight: 600;
+            font-size: 13px;
+            margin-bottom: 4px;
+        }
+
+        .nodejs-notice-text {
+            font-size: 12px;
+            color: var(--secondary-text-color);
+            line-height: 1.4;
+        }
+
+        .nodejs-notice-hint {
+            font-size: 11px;
+            color: var(--secondary-text-color);
+            font-style: italic;
+            margin-top: 6px;
+        }
+    }
+
     .agent-picker-footer {
         flex-shrink: 0;
         padding-top: 4px;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -75,12 +75,19 @@ AgentViewWrapper.displayName = "AgentViewWrapper";
 
 const AgentPicker = ({ model }: { model: AgentViewModel }): JSX.Element => {
     const [launching, setLaunching] = createSignal<string | null>(null);
+    const [nodejsError, setNodejsError] = createSignal<string | null>(null);
     const agents = useForgeAgents();
 
     const handleSelect = async (agent: ForgeAgent) => {
+        setNodejsError(null);
         setLaunching(agent.id);
         try {
             await model.launchForgeAgent(agent);
+            // Check if launch was blocked by missing Node.js
+            if (model.nodejsError) {
+                setNodejsError(model.nodejsError);
+                model.nodejsError = null;
+            }
         } catch {
             // model logs internally
         } finally {
@@ -130,6 +137,20 @@ const AgentPicker = ({ model }: { model: AgentViewModel }): JSX.Element => {
                             )}
                         </For>
                     </div>
+                    <Show when={nodejsError()}>
+                        <div class="agent-nodejs-notice">
+                            <div class="nodejs-notice-icon">
+                                <i class="fa-solid fa-circle-exclamation" />
+                            </div>
+                            <div class="nodejs-notice-content">
+                                <div class="nodejs-notice-title">Node.js Required</div>
+                                <div class="nodejs-notice-text">{nodejsError()}</div>
+                                <div class="nodejs-notice-hint">
+                                    After installing, restart AgentMux and try again.
+                                </div>
+                            </div>
+                        </div>
+                    </Show>
                     <div class="agent-picker-footer">
                         <button class="agent-picker-forge-btn" disabled>
                             + New agent in Forge

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -137,6 +137,7 @@ declare global {
         checkCliAuthStatus: (provider: string, cliPath?: string) => Promise<CliAuthStatus>;
         installCli: (provider: string) => Promise<CliInstallResult>;
         getCliPath: (provider: string) => Promise<string | null>;
+        checkNodejsAvailable: () => Promise<NodejsStatus>;
         listen: (event: string, callback: (event: any) => void) => Promise<() => void>;
         startCrossDrag: (
             dragType: "pane" | "tab",
@@ -490,6 +491,14 @@ declare global {
         cli_path: string;
         version: string;
         already_installed: boolean;
+    };
+
+    type NodejsStatus = {
+        available: boolean;
+        version: string | null;
+        npm_available: boolean;
+        npm_version: string | null;
+        path: string | null;
     };
 
     type DraggedFile = {

--- a/frontend/util/tauri-api.ts
+++ b/frontend/util/tauri-api.ts
@@ -369,6 +369,9 @@ export function buildTauriApi(): AppApi {
         getCliPath: async (provider: string) => {
             return await invoke<string | null>("get_cli_path", { provider });
         },
+        checkNodejsAvailable: async () => {
+            return await invoke<NodejsStatus>("check_nodejs_available");
+        },
 
         listen: async (event: string, callback: (event: any) => void) => {
             const unlisten = await listen(event, callback);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.32.48",
+  "version": "0.32.49",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.32.48"
+version = "0.32.49"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/src/commands/cli_installer.rs
+++ b/src-tauri/src/commands/cli_installer.rs
@@ -27,6 +27,15 @@ pub struct CliInstallResult {
     pub already_installed: bool,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NodejsStatus {
+    pub available: bool,
+    pub version: Option<String>,
+    pub npm_available: bool,
+    pub npm_version: Option<String>,
+    pub path: Option<String>,
+}
+
 /// Returns the base install directory: ~/.agentmux/instances/v<version>/cli/<provider>/
 fn get_provider_install_dir(provider: &str) -> Result<PathBuf, String> {
     let home = dirs::home_dir().ok_or("Could not determine home directory")?;
@@ -86,6 +95,27 @@ fn install_via_npm(provider: &str) -> Result<String, String> {
     let npm_package = get_npm_package(provider)?;
     let pinned_version = get_pinned_version(provider)?;
     let install_dir = get_provider_install_dir(provider)?;
+
+    // Pre-flight: verify npm is available before attempting install
+    let npm_cmd = if cfg!(windows) { "npm.cmd" } else { "npm" };
+    let mut check = std::process::Command::new(npm_cmd);
+    check.arg("--version");
+    #[cfg(windows)]
+    check.creation_flags(0x08000000);
+    match check.output() {
+        Ok(output) if output.status.success() => {
+            let ver = String::from_utf8_lossy(&output.stdout);
+            tracing::info!("npm {} available for install", ver.trim());
+        }
+        _ => {
+            return Err(
+                "NODEJS_NOT_FOUND: Node.js/npm is not installed. \
+                 Codex and Gemini CLIs require Node.js to install. \
+                 Install Node.js from https://nodejs.org/ (LTS recommended)."
+                    .to_string(),
+            );
+        }
+    }
 
     std::fs::create_dir_all(&install_dir)
         .map_err(|e| format!("Failed to create install dir: {e}"))?;
@@ -227,6 +257,75 @@ pub async fn install_cli(provider: String) -> Result<CliInstallResult, String> {
     .map_err(|e| format!("Install task failed: {e}"))?;
 
     result
+}
+
+/// Check if Node.js and npm are available on the system.
+#[tauri::command]
+pub async fn check_nodejs_available() -> Result<NodejsStatus, String> {
+    let result = tokio::task::spawn_blocking(|| {
+        let node_cmd = if cfg!(windows) { "node.exe" } else { "node" };
+        let npm_cmd = if cfg!(windows) { "npm.cmd" } else { "npm" };
+
+        let mut status = NodejsStatus {
+            available: false,
+            version: None,
+            npm_available: false,
+            npm_version: None,
+            path: None,
+        };
+
+        // Check node
+        let mut cmd = std::process::Command::new(node_cmd);
+        cmd.arg("--version");
+        #[cfg(windows)]
+        cmd.creation_flags(0x08000000);
+        if let Ok(output) = cmd.output() {
+            if output.status.success() {
+                status.available = true;
+                status.version = Some(
+                    String::from_utf8_lossy(&output.stdout).trim().to_string(),
+                );
+
+                let which_cmd = if cfg!(windows) { "where" } else { "which" };
+                let mut wcmd = std::process::Command::new(which_cmd);
+                wcmd.arg(node_cmd);
+                #[cfg(windows)]
+                wcmd.creation_flags(0x08000000);
+                if let Ok(path_out) = wcmd.output() {
+                    if path_out.status.success() {
+                        status.path = Some(
+                            String::from_utf8_lossy(&path_out.stdout)
+                                .lines()
+                                .next()
+                                .unwrap_or("")
+                                .trim()
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+
+        // Check npm
+        let mut cmd = std::process::Command::new(npm_cmd);
+        cmd.arg("--version");
+        #[cfg(windows)]
+        cmd.creation_flags(0x08000000);
+        if let Ok(output) = cmd.output() {
+            if output.status.success() {
+                status.npm_available = true;
+                status.npm_version = Some(
+                    String::from_utf8_lossy(&output.stdout).trim().to_string(),
+                );
+            }
+        }
+
+        status
+    })
+    .await
+    .map_err(|e| format!("Failed to check Node.js: {e}"))?;
+
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -109,6 +109,7 @@ pub fn run() {
             // CLI installer commands
             commands::cli_installer::install_cli,
             commands::cli_installer::get_cli_path,
+            commands::cli_installer::check_nodejs_available,
             // Cross-window drag commands
             commands::drag::start_cross_drag,
             commands::drag::update_cross_drag,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.32.48",
-  "identifier": "ai.agentmux.app.v0-32-48",
+  "version": "0.32.49",
+  "identifier": "ai.agentmux.app.v0-32-49",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.32.48"
+version = "0.32.49"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary
- Detect missing Node.js/npm before attempting to install Codex or Gemini CLIs
- New Tauri command `check_nodejs_available` — checks node and npm on PATH
- Pre-flight check in `install_via_npm` returns clear `NODEJS_NOT_FOUND` error
- Frontend shows amber warning notice in agent picker with platform install guidance
- Claude agent is unaffected (has standalone installer)

## Changes
- `src-tauri/src/commands/cli_installer.rs` — `check_nodejs_available` command + npm pre-flight
- `src-tauri/src/lib.rs` — register new command
- `frontend/types/custom.d.ts` — `NodejsStatus` type + API binding
- `frontend/util/tauri-api.ts` — `checkNodejsAvailable` API call
- `frontend/app/view/agent/agent-model.ts` — check Node.js before launch, `nodejsError` field
- `frontend/app/view/agent/agent-view.tsx` — `NodejsRequiredNotice` UI component
- `frontend/app/view/agent/agent-view.scss` — notice styles
- `docs/specs/` — implementation spec + broader Codex/Gemini integration spec

## Test plan
- [ ] Launch Codex agent with Node.js installed — should work normally
- [ ] Launch Codex agent without Node.js — should show amber notice
- [ ] Launch Claude agent without Node.js — should work (standalone installer)
- [ ] Launch Gemini agent without Node.js — should show amber notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)