### PR TITLE
chore: use npm-version strategy for cross-platform lockfile safety

### DIFF
--- a/.bump.json
+++ b/.bump.json
@@ -37,6 +37,7 @@
   "lockfiles": [
     {
       "type": "npm",
+      "strategy": "npm-version",
       "command": "npm install --package-lock-only",
       "allowFailure": true
     },


### PR DESCRIPTION
## Summary

- Switch `.bump.json` npm lockfile strategy from `npm install --package-lock-only` to `npm-version`
- `npm-version` uses `npm version <ver> --no-git-tag-version --allow-same-version` which updates `package-lock.json` without re-resolving deps
- Prevents the npm bug where platform-specific optional deps get pruned from the lockfile (npm/cli#4828, #7961, #8320), causing `npm ci` to fail on other platforms

## Dependency

Requires `@a5af/bump-cli` >= 0.2.0: https://github.com/a5af/dev-tools/pull/311

**Do not merge until dev-tools#311 is merged and bump-cli 0.2.0 is published.**

## Test plan

- [ ] After bump-cli 0.2.0 installed: `bump patch` on Windows
- [ ] `npm ci` on macOS from the bumped lockfile
- [ ] `npm ci` on Linux from the bumped lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)