### PR TITLE
fix: restrict pane DnD to header-only on Windows/WebView2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.32.60"
+version = "0.32.61"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.32.60"
+version = "0.32.61"
 dependencies = [
  "async-stream",
  "axum",
@@ -7152,7 +7152,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.32.60"
+version = "0.32.61"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.32.60"
+version = "0.32.61"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -301,27 +301,65 @@ const DisplayNode = (props: DisplayNodeProps) => {
         }
     };
 
-    // Register pragmatic-dnd draggable on the tile node, using the header
-    // (dragHandleRef) as the drag handle. pragmatic-dnd wraps HTML5 DnD but
-    // fires onDragStart AFTER the browser commits the drag, so SolidJS
-    // reactive state updates here won't cause mid-event DOM mutations.
+    // Register pragmatic-dnd draggable on the HEADER element directly.
+    // pragmatic-dnd wraps HTML5 DnD and fires onDragStart AFTER the browser
+    // commits the drag, so SolidJS reactive state updates won't cause
+    // mid-event DOM mutations.
+    //
+    // We register on the header (dragHandleRef) rather than on tileNodeRef
+    // for a critical WebView2 reason: pragmatic-dnd's dragHandle option sets
+    // draggable="true" on the handle AND draggable="false" on the element.
+    // WebView2 does not fire dragstart from a draggable="true" child inside
+    // a draggable="false" parent — breaking pane DnD entirely on Windows.
+    //
+    // By registering directly on the header element, only the header gets
+    // draggable="true". The tile-node is untouched (no draggable attr) so it
+    // defaults to non-draggable. The body and all pane content have no drag
+    // attribute, meaning clicks, text selection, and widget interaction all
+    // work normally. No canDrag() tricks, no preventDefault() on dragstart.
     //
     // The header ref may not be available at mount time (block content loads
-    // async behind a Show gate). Poll briefly until the ref is set, then
-    // register with the correct drag handle. Without a drag handle, the
-    // entire tile would be draggable — breaking text selection in panes.
-    const dragHandleRef = nodeModel.dragHandleRef;
+    // async behind a Show gate). Poll briefly until the ref is set.
+    // SolidJS's <Show> gate destroys/recreates the header element during block
+    // data loading. We must re-register whenever dragHandleRef.current changes
+    // or the element leaves the DOM. A persistent poll (cleared on unmount)
+    // handles all cases without needing to observe SolidJS internals.
     onMount(() => {
         if (!tileNodeRef) return;
         let cleanupFn: (() => void) | null = null;
+        let registeredHandle: HTMLElement | null = null;
+
+        // Query the actual live header from the DOM rather than relying on dragHandleRef.
+        // dragHandleRef is written by two BlockFrame_Header instances (primary + ErrorBoundary
+        // fallback), and the fallback (never inserted into the DOM) always overwrites the
+        // primary one last, so the ref always points to a detached element.
+        // querySelector from tileNodeRef finds the header that is ACTUALLY in the DOM.
+        const findHandle = (): HTMLElement | null =>
+            tileNodeRef?.querySelector<HTMLElement>('[data-role="block-header"]') ?? null;
 
         const register = () => {
-            // Windows: whole-tile drag (no dragHandle restriction).
-            // pragmatic-dnd's dragHandle sets draggable="true" on handle +
-            // draggable="false" on tile, which breaks drag on WebView2/Chromium.
+            const handle = findHandle();
+
+            // Nothing changed
+            if (handle === registeredHandle) return;
+
+            // NEVER tear down while a drag is in progress. If we call cleanupFn()
+            // mid-drag, pragmatic-dnd removes its onDrop listener and activeDrag
+            // never resets to false — leaving pointer-events:none permanently on
+            // all pane bodies ("widgets broken").
+            if (props.layoutModel.activeDrag()) return;
+
+            // Handle changed or left DOM — tear down old registration
+            cleanupFn?.();
+            cleanupFn = null;
+            registeredHandle = null;
+
+            if (!handle) return;
+
+            // New live handle — register draggable on it
+            registeredHandle = handle;
             cleanupFn = draggable({
-                element: tileNodeRef,
-                dragHandle: undefined,
+                element: handle,
                 canDrag: () => !isEphemeral() && !isMagnified(),
                 getInitialData: () => ({ nodeId: props.node.id, type: tileItemType }),
                 onGenerateDragPreview: ({ nativeSetDragImage }) => {
@@ -349,13 +387,16 @@ const DisplayNode = (props: DisplayNodeProps) => {
                     // out-of-window. Cleared in dropTargetForElements.onDrop instead.
                 },
             });
-            return true;
         };
 
-        // Register immediately — no dragHandle needed on Windows.
+        // Poll every 100ms for the lifetime of this tile. Handles initial load
+        // and any SolidJS Show-gate replacements during the tile's lifetime.
         register();
-
-        onCleanup(() => cleanupFn?.());
+        const interval = setInterval(register, 100);
+        onCleanup(() => {
+            clearInterval(interval);
+            cleanupFn?.();
+        });
     });
 
     const leafContent = () => (

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.32.60",
+  "version": "0.32.61",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.32.60"
+version = "0.32.61"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.32.60",
-  "identifier": "ai.agentmux.app.v0-32-60",
+  "version": "0.32.61",
+  "identifier": "ai.agentmux.app.v0-32-61",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.32.60"
+version = "0.32.61"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

- Pane drag-and-drop now only initiates from the pane **header bar**, not the body — enabling text selection and widget interaction inside panes
- Replaced `dragHandleRef.current` polling with `tileNodeRef.querySelector('[data-role="block-header"]')` to find the live, in-DOM header directly
- Root cause: `BlockFrame_Default_Component` eagerly creates **two** `BlockFrame_Header` instances (primary + `ErrorBoundary` fallback); the fallback element (never inserted into the DOM) always overwrites `dragHandleRef.current` last, so the ref always pointed to a detached element — causing registration to silently fail every 100ms

## Test plan

- [ ] Drag a pane header → pane reorders within the layout (drop targets appear)
- [ ] Click/drag inside pane body → text selection works, no drag initiated
- [ ] Widget interactions in pane body (buttons, inputs) work normally after dragging a header
- [ ] Drag pane header outside all windows → tears off into a new window
- [ ] Drag pane header to another window → moves pane to target window

🤖 Generated with [Claude Code](https://claude.com/claude-code)