### PR TITLE
fix(term): reduce Claude Code scroll jank (Tier 1 + Tier 2)

### DIFF
--- a/frontend/app/view/term/termwrap.ts
+++ b/frontend/app/view/term/termwrap.ts
@@ -105,7 +105,11 @@ export class TermWrap {
         this.handleResize_debounced = debounce(50, this.handleResize.bind(this));
 
         // Create terminal and load addons
-        this.terminal = new Terminal(options);
+        // scrollOnUserInput: false — prevents scroll-to-bottom on keystrokes, letting the user
+        //   read scrollback while the PTY is active (xterm.js >= 5.1.0).
+        // smoothScrollDuration: 0 — disables animated scrolling, which makes cursor-tracking
+        //   viewport jumps (caused by Ink's erase-and-redraw pattern) more disorienting.
+        this.terminal = new Terminal({ ...options, scrollOnUserInput: false, smoothScrollDuration: 0 });
         this.fitAddon = new FitAddon();
         this.fitAddon.noScrollbar = PLATFORM === PlatformMacOS;
         this.serializeAddon = new SerializeAddon();
@@ -150,6 +154,16 @@ export class TermWrap {
             return handleOscTitleCommand(data, this.blockId, this.loaded);
         });
         this.terminal.attachCustomKeyEventHandler(waveOptions.keydownHandler);
+
+        // Tier-2 scroll fix: block macOS trackpad momentum scroll events.
+        // After the user lifts their finger, the OS keeps emitting WheelEvents with small,
+        // decaying deltaY values. These compound with Ink's cursor-up sequences (which move
+        // the viewport) to produce "rocket scroll". Blocking events with |deltaY| < 4px
+        // eliminates the feedback loop without affecting normal wheel or trackpad scrolling.
+        this.terminal.attachCustomWheelEventHandler((ev: WheelEvent) => {
+            if (Math.abs(ev.deltaY) < 4) return false;
+            return true;
+        });
     }
 
     // ── Phase 2: INIT (async) ──────────────────────────────────────────


### PR DESCRIPTION
## Problem

When Claude Code (or any Ink-based CLI) runs in an AgentMux terminal pane, the xterm.js viewport repeatedly jumps — scrolling the full screen — without user interaction. Root cause: Ink emits \`ESC[2K ESC[1A]\` × N (erase-and-redraw) on every render, causing xterm.js to scroll the viewport to track the cursor. On macOS, trackpad momentum scroll compounds this into uncontrolled "rocket scroll."

Full analysis: \`docs/investigations/xterm-claude-code-scroll-issue.md\`

## Changes

**Tier 1 — xterm.js options** (\`termwrap.ts:112\`)
- \`scrollOnUserInput: false\` — prevents scroll-to-bottom on keystrokes. User can now read scrollback while the PTY is active without being yanked back to the bottom on every keypress.
- \`smoothScrollDuration: 0\` — disables animated scroll transitions. Ink's cursor-tracking jumps already cause one viewport snap per render; animation turns that into a visible back-and-forth oscillation.

**Tier 2 — momentum scroll blocker** (\`termwrap.ts:163–166\`)
- \`attachCustomWheelEventHandler\` blocks \`WheelEvent\`s with \`|deltaY| < 4px\`. After a macOS trackpad gesture ends, the OS continues emitting decaying wheel events. These compound with Ink's cursor-up sequences to produce rocket scroll. Sub-4px events are momentum artifacts — blocking them has no effect on intentional scrolling.

## Test plan

- [ ] Open a terminal pane, run \`claude\` (or any Ink app)
- [ ] Scroll up into scrollback while Claude is streaming — verify viewport stays where you put it
- [ ] Press a key while scrolled up — verify terminal does **not** snap back to bottom (Tier 1)
- [ ] On macOS: do a fast trackpad swipe in the terminal — verify no rocket scroll after lifting finger (Tier 2)
- [ ] Verify normal wheel/trackpad scrolling still works correctly
- [ ] Verify interactive terminal (vim, htop) still responds normally to scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)