### PR TITLE
fix: update Discord invite links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
       url: https://github.com/agentmuxai/agentmux/discussions
       about: Have a question on something? Start a new discussion thread.
     - name: Engage with us directly on Discord
-      url: https://discord.gg/XfvZ334gwU
+      url: https://discord.com/invite/96erama9Ar
       about: Join our Discord server to get updates on new features, bug fixes, and more.
     - name: Review open issues
       url: https://github.com/agentmuxai/agentmux/issues

--- a/frontend/app/element/quicktips.tsx
+++ b/frontend/app/element/quicktips.tsx
@@ -292,7 +292,7 @@ const QuickTips = (): JSX.Element => {
                         </IconBox>
                         <a
                             target="_blank"
-                            href="https://discord.gg/P5zSGXbP"
+                            href="https://discord.com/invite/96erama9Ar"
                             rel="noopener"
                             class="hover:text-accent-400 hover:underline transition-colors font-medium"
                         >


### PR DESCRIPTION
## Summary

- Update stale Discord invite links to `https://discord.com/invite/96erama9Ar`
- Fixed in help pane (`quicktips.tsx`) and GitHub issue template (`config.yml`)

## Files Changed

- `frontend/app/element/quicktips.tsx` — Help pane "Join Our Discord" link
- `.github/ISSUE_TEMPLATE/config.yml` — Issue template Discord contact link

## Test plan

- [ ] Open Help pane, verify Discord link opens correct server
- [ ] Create new issue on GitHub, verify Discord link in template

🤖 Generated with [Claude Code](https://claude.com/claude-code)