### PR TITLE
fix: FileStore cache unbounded memory leak (OOM crash)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.32.77"
+version = "0.32.78"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.32.77"
+version = "0.32.78"
 dependencies = [
  "async-stream",
  "axum",
@@ -7174,7 +7174,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.32.77"
+version = "0.32.78"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.32.77"
+version = "0.32.78"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/agentmuxsrv-rs/src/backend/storage/filestore/cache.rs
+++ b/agentmuxsrv-rs/src/backend/storage/filestore/cache.rs
@@ -22,4 +22,7 @@ pub(super) struct CacheEntry {
     pub(super) file: Option<WaveFile>,
     pub(super) data_entries: HashMap<i32, DataCacheEntry>,
     pub(super) dirty: bool,
+    /// Last time this entry was read or written (ms since epoch).
+    /// Used for TTL-based eviction of clean entries.
+    pub(super) last_access_ms: i64,
 }

--- a/agentmuxsrv-rs/src/backend/storage/filestore/core.rs
+++ b/agentmuxsrv-rs/src/backend/storage/filestore/core.rs
@@ -12,7 +12,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use rusqlite::{params, Connection};
 
-use super::cache::{CacheEntry, DataCacheEntry};
+use super::cache::CacheEntry;
 use super::types::{FileMeta, FileOpts, WaveFile};
 use crate::backend::storage::error::StoreError;
 use crate::backend::storage::migrations::run_filestore_migrations;
@@ -22,6 +22,9 @@ pub(super) const PART_DATA_SIZE: usize = 64 * 1024;
 
 /// Default flush interval in seconds.
 pub const DEFAULT_FLUSH_SECS: u64 = 5;
+
+/// Clean cache entries idle longer than this are evicted during flush.
+pub const CACHE_TTL_SECS: u64 = 60;
 
 /// SQLite-backed file storage with write-through cache.
 pub struct FileStore {
@@ -109,6 +112,7 @@ impl FileStore {
                 file: Some(file),
                 data_entries: HashMap::new(),
                 dirty: false,
+                last_access_ms: now,
             },
         );
 
@@ -170,8 +174,9 @@ impl FileStore {
         // Check cache first
         let key = (zone_id.to_string(), name.to_string());
         {
-            let cache = self.cache.lock().unwrap();
-            if let Some(entry) = cache.get(&key) {
+            let mut cache = self.cache.lock().unwrap();
+            if let Some(entry) = cache.get_mut(&key) {
+                entry.last_access_ms = Self::now_ms();
                 return Ok(entry.file.clone());
             }
         }
@@ -250,24 +255,14 @@ impl FileStore {
         }
         drop(conn);
 
-        // Update cache
+        // Update cache (metadata only — data parts are already in DB, read_file loads from DB)
         let mut cache = self.cache.lock().unwrap();
         if let Some(entry) = cache.get_mut(&key) {
             if let Some(ref mut file) = entry.file {
                 file.size = data.len() as i64;
                 file.modts = now;
             }
-            entry.data_entries.clear();
-            for (idx, part_data) in parts.into_iter().enumerate() {
-                entry.data_entries.insert(
-                    idx as i32,
-                    DataCacheEntry {
-                        part_idx: idx as i32,
-                        data: part_data,
-                    },
-                );
-            }
-            entry.dirty = false;
+            entry.last_access_ms = now;
         }
 
         Ok(())
@@ -403,6 +398,7 @@ impl FileStore {
                 f.size = new_size;
                 f.modts = now;
             }
+            entry.last_access_ms = now;
         }
 
         Ok(())
@@ -451,6 +447,7 @@ impl FileStore {
                 f.meta = new_meta;
                 f.modts = now;
             }
+            entry.last_access_ms = now;
         }
 
         Ok(())
@@ -489,17 +486,36 @@ impl FileStore {
             .map_err(StoreError::Sqlite)
     }
 
-    /// Flush all dirty cache entries to the database.
+    /// Flush dirty cache entries to the database and evict stale clean entries.
     /// Returns (files_flushed, parts_flushed).
     pub fn flush_cache(&self) -> Result<(usize, usize), StoreError> {
-        let dirty_keys: Vec<(String, String)> = {
+        let ttl_ms = (CACHE_TTL_SECS * 1000) as i64;
+        let now = Self::now_ms();
+        let cutoff_ms = now - ttl_ms;
+
+        let (dirty_keys, stale_keys): (Vec<_>, Vec<_>) = {
             let cache = self.cache.lock().unwrap();
-            cache
+            let dirty = cache
                 .iter()
                 .filter(|(_, e)| e.dirty)
                 .map(|(k, _)| k.clone())
-                .collect()
+                .collect();
+            let stale = cache
+                .iter()
+                .filter(|(_, e)| !e.dirty && e.last_access_ms < cutoff_ms)
+                .map(|(k, _)| k.clone())
+                .collect();
+            (dirty, stale)
         };
+
+        // Evict stale clean entries — they're already persisted in DB.
+        if !stale_keys.is_empty() {
+            let mut cache = self.cache.lock().unwrap();
+            for key in &stale_keys {
+                cache.remove(key);
+            }
+            tracing::debug!("filestore cache: evicted {} stale entries", stale_keys.len());
+        }
 
         let mut files_flushed = 0;
         let mut parts_flushed = 0;

--- a/agentmuxsrv-rs/src/backend/storage/filestore/tests.rs
+++ b/agentmuxsrv-rs/src/backend/storage/filestore/tests.rs
@@ -3,7 +3,7 @@
 
 //! Tests for FileStore.
 
-use super::core::PART_DATA_SIZE;
+use super::core::{PART_DATA_SIZE, CACHE_TTL_SECS};
 use super::{FileOpts, FileMeta, FileStore, WaveFile};
 use crate::backend::storage::error::StoreError;
 
@@ -253,6 +253,89 @@ fn test_flush_cache_no_dirty() {
     let (files, parts) = store.flush_cache().unwrap();
     assert_eq!(files, 0);
     assert_eq!(parts, 0);
+}
+
+#[test]
+fn test_cache_evicts_stale_clean_entries() {
+    let store = make_store();
+    store
+        .make_file("z1", "f1", FileMeta::new(), FileOpts::default())
+        .unwrap();
+    store.write_file("z1", "f1", b"data").unwrap();
+
+    // Entry should be in cache — stat hits cache (no DB round trip needed, but file is present)
+    assert!(store.stat("z1", "f1").unwrap().is_some());
+
+    // Backdate the cache entry's last_access_ms beyond the TTL
+    {
+        let ttl_ms = (CACHE_TTL_SECS * 1000 + 1000) as i64; // TTL + 1s in the past
+        let now = FileStore::now_ms();
+        let mut cache = store.cache.lock().unwrap();
+        if let Some(entry) = cache.get_mut(&("z1".to_string(), "f1".to_string())) {
+            entry.last_access_ms = now - ttl_ms;
+        }
+    }
+
+    // flush_cache should evict the stale clean entry
+    let (files, parts) = store.flush_cache().unwrap();
+    assert_eq!(files, 0); // no dirty files flushed
+    assert_eq!(parts, 0);
+
+    // Cache should be empty now
+    {
+        let cache = store.cache.lock().unwrap();
+        assert!(!cache.contains_key(&("z1".to_string(), "f1".to_string())),
+            "stale clean entry should have been evicted");
+    }
+
+    // File must still be readable from DB after eviction
+    let data = store.read_file("z1", "f1").unwrap().unwrap();
+    assert_eq!(data, b"data");
+}
+
+#[test]
+fn test_cache_does_not_evict_recently_accessed() {
+    let store = make_store();
+    store
+        .make_file("z1", "f1", FileMeta::new(), FileOpts::default())
+        .unwrap();
+    store.write_file("z1", "f1", b"data").unwrap();
+
+    // Access it (updates last_access_ms to now)
+    store.stat("z1", "f1").unwrap();
+
+    // flush_cache should NOT evict a recently accessed entry
+    store.flush_cache().unwrap();
+
+    {
+        let cache = store.cache.lock().unwrap();
+        assert!(cache.contains_key(&("z1".to_string(), "f1".to_string())),
+            "recently accessed entry should not be evicted");
+    }
+}
+
+#[test]
+fn test_write_file_does_not_cache_data_parts() {
+    let store = make_store();
+    store
+        .make_file("z1", "f1", FileMeta::new(), FileOpts::default())
+        .unwrap();
+
+    let data: Vec<u8> = vec![0xAB; PART_DATA_SIZE * 2];
+    store.write_file("z1", "f1", &data).unwrap();
+
+    // data_entries in the cache entry should be empty — no duplicate data copies in memory
+    {
+        let cache = store.cache.lock().unwrap();
+        if let Some(entry) = cache.get(&("z1".to_string(), "f1".to_string())) {
+            assert!(entry.data_entries.is_empty(),
+                "write_file must not cache data parts (they are already in DB)");
+        }
+    }
+
+    // Data must still be readable from DB
+    let read = store.read_file("z1", "f1").unwrap().unwrap();
+    assert_eq!(read, data);
 }
 
 // ---- write_at tests ----

--- a/agentmuxsrv-rs/src/server/tests.rs
+++ b/agentmuxsrv-rs/src/server/tests.rs
@@ -33,7 +33,7 @@ fn test_state() -> AppState {
         app_path: String::new(),
         wstore,
         filestore,
-        event_bus,
+        event_bus: event_bus.clone(),
         broker,
         reactive_handler,
         poller,
@@ -41,6 +41,8 @@ fn test_state() -> AppState {
         messagebus: Arc::new(crate::backend::messagebus::MessageBus::new()),
         http_client: reqwest::Client::new(),
         local_web_url: String::new(),
+        subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus)),
+        history_service: Arc::new(crate::backend::history::HistoryService::new()),
     }
 }
 

--- a/docs/OOM_FILESTORE_CACHE_ANALYSIS.md
+++ b/docs/OOM_FILESTORE_CACHE_ANALYSIS.md
@@ -1,0 +1,117 @@
+# OOM Crash Analysis: FileStore Cache Memory Leak
+
+**Date:** 2026-03-24
+**Severity:** Critical — process crash (OOM)
+**Component:** `agentmuxsrv-rs` → `backend/storage/filestore/core.rs`
+
+---
+
+## Incident Timeline
+
+| Time (UTC) | Event |
+|---|---|
+| 2026-03-22 ~21:30 | sidecar pid=2700 starts, uptime clock begins |
+| 2026-03-23 21:24–21:40 | Agent 1 runs in block `25d5f273`, exits cleanly (exit_code=0) |
+| 2026-03-24 01:23 | Last terminal activity logged (`[raf-write]`) |
+| **2026-03-24 01:32:52** | **OOM crash: `memory allocation of 1733122 bytes failed`** |
+| 2026-03-24 01:32:52 | `TERMINATED exit_code=-1073740791 (0xC0000409)` — Windows `__fastfail` from Rust allocator |
+| 2026-03-24 03:42:12 | App reopened, new sidecar pid=5552 starts |
+
+Sidecar uptime at crash: **15,002 seconds (~4.2 hours)**
+
+---
+
+## Investigation Chain (Agents 1–3)
+
+- **Agent 1** was running in block `25d5f273`. Had multiple clean subprocess exits (exit_code=0) between 21:24–21:40 — these were normal completions.
+- **Agent 2** investigated Agent 1's death. Searched the March 23 sidecar log, found only clean exits, concluded "no crash." **This was wrong.** The crash happened at 01:32:52 on March 24 and was logged in the March 24 **host log** (`agentmux-host-v0.32.77.log.2026-03-24`), not the sidecar's own log file (which is date-stamped by start date). Agent 2 looked at the wrong log.
+- **Agent 2's own death:** When the sidecar OOM-crashed, Windows job objects killed all sidecar child processes. Agent 2's Claude Code subprocess was a child of the sidecar — it was killed collaterally mid-operation, producing the "file not found" error.
+- **Agent 3** (this agent) found the crash in `agentmux-host-v0.32.77.log.2026-03-24` at line with timestamp `2026-03-24T01:32:52`.
+
+---
+
+## Root Cause: Two Bugs in FileStore Cache
+
+### Bug 1: Cache entries are never evicted (primary leak)
+
+**File:** `agentmuxsrv-rs/src/backend/storage/filestore/core.rs`
+
+`flush_cache()` only removes entries where `dirty == true`:
+
+```rust
+// flush_cache — lines 495–502
+cache
+    .iter()
+    .filter(|(_, e)| e.dirty)   // ← only dirty entries
+    .map(|(k, _)| k.clone())
+    .collect()
+```
+
+However, **nothing in the codebase ever sets `dirty = true`**. Every write path (`make_file`, `write_file`, `append_data`, `write_meta`) writes directly to SQLite and sets `dirty = false`. Result: `flush_cache()` is a no-op. The cache HashMap grows monotonically for the lifetime of the process.
+
+With multiple concurrent agents, each creating output files, object files, and terminal state — the cache accumulates one `CacheEntry` per file, per block, per zone, and none of them are ever removed.
+
+### Bug 2: `data_entries` populated but never read (memory waste)
+
+**File:** `agentmuxsrv-rs/src/backend/storage/filestore/core.rs`, `write_file` (lines 260–270)
+
+`write_file` populates `data_entries` in the cache entry with full data part copies after writing them to DB:
+
+```rust
+entry.data_entries.clear();
+for (idx, part_data) in parts.into_iter().enumerate() {
+    entry.data_entries.insert(idx as i32, DataCacheEntry { ... });
+}
+entry.dirty = false;  // ← already in DB, dirty=false
+```
+
+But `read_file` never reads from `cache.data_entries` — it always loads parts directly from SQLite. So every `write_file` call stores a full duplicate copy of the file data in memory, which is then never used and never freed (due to Bug 1).
+
+For a terminal scroll buffer file that grows to 1.7MB (the failing allocation size), this means ~1.7MB of data is stored in the cache entry's `data_entries` and stays there for the process lifetime.
+
+---
+
+## Memory Growth Model
+
+Each active block has files for:
+- Terminal output (circular, up to `maxsize`)
+- Agent stream-json output (append-only, grows with every token)
+- Object state (`ijson` files, metadata)
+
+With 4+ hours of agent activity across multiple blocks:
+- Object meta updates via `UpdateObjectMeta` → each creates/updates a CacheEntry, stored forever
+- Agent output appends → `append_data` doesn't touch `data_entries`, but `make_file` creates entries that stay
+- `write_file` calls (e.g., for ijson compaction, terminal state saves) → copies data into `data_entries`, never freed
+
+The sidecar's last activity before the crash was `[raf-write]` (terminal data) followed 9 minutes of silence, then OOM. The terminal data write likely triggered a `write_file` for a ~1.7MB terminal state blob that couldn't be allocated because the heap was already exhausted by accumulated cache entries.
+
+---
+
+## Fix
+
+Two changes to `agentmuxsrv-rs/src/backend/storage/filestore/`:
+
+### 1. Add TTL-based eviction to `CacheEntry` (`cache.rs`)
+
+Add `last_access_ms: i64` field. Update on every cache read/write. In `flush_cache`, evict clean entries older than `CACHE_TTL_SECS` (60s).
+
+### 2. Remove dead `data_entries` population in `write_file` (`core.rs`)
+
+Since `read_file` always loads from DB, there's no benefit to caching data parts for non-dirty entries. Remove the `data_entries` population block in `write_file` — this eliminates the duplicate data copies entirely.
+
+---
+
+## Testing
+
+New test `test_cache_eviction_after_ttl` in `tests.rs` verifies:
+1. A file created and accessed is in cache
+2. After simulated TTL expiry, `flush_cache` evicts it
+3. The file is still readable from DB after eviction (correctness preserved)
+
+---
+
+## Lessons
+
+1. **`flush_cache` was always a no-op** — the dirty flag was never set. The periodic flusher was running every 5s and doing nothing.
+2. **`data_entries` is vestigial** — likely carried over from a write-buffering design that was then changed to write-through. The field exists in the struct and is populated, but no read path ever consults it.
+3. **Log file date-stamping** — sidecar log files are named by start date. A sidecar that starts on March 23 and crashes on March 24 will have its crash appear in the host log under March 24 but in its own log under March 23. Always check the host log for termination events.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.32.77",
+  "version": "0.32.78",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.32.77"
+version = "0.32.78"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.32.77",
-  "identifier": "ai.agentmux.app.v0-32-77",
+  "version": "0.32.78",
+  "identifier": "ai.agentmux.app.v0-32-78",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.32.77"
+version = "0.32.78"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

- **Root cause:** `agentmuxsrv-rs` sidecar OOM-crashed at `2026-03-24T01:32:52Z` (pid=2700, uptime=4.2h) while trying to allocate 1,733,122 bytes — `exit_code=0xC0000409` (Rust `__fastfail`). All agent panes were killed collaterally via Windows job objects.
- **Bug 1:** `flush_cache()` only removed `dirty=true` entries, but nothing ever set `dirty=true` — every write path is write-through to SQLite. The cache HashMap grew monotonically for the process lifetime.
- **Bug 2:** `write_file()` populated `data_entries` in cache with full data part copies after writing to DB. `read_file()` never reads from `data_entries` — dead duplicate data, never freed.

## Changes

- Add `last_access_ms: i64` to `CacheEntry`; updated on every cache read/write
- `flush_cache()` now evicts clean entries idle > `CACHE_TTL_SECS` (60s) in addition to flushing dirty ones
- `write_file()` no longer caches data parts — metadata-only cache update (data already in DB, reads go to DB)
- Fix pre-existing `server/tests.rs` compile error: missing `subagent_watcher` and `history_service` fields in `AppState` initializer
- Add `docs/OOM_FILESTORE_CACHE_ANALYSIS.md` with full incident analysis

## Tests

3 new tests in `filestore/tests.rs`:
- `test_cache_evicts_stale_clean_entries` — TTL eviction removes idle entries, file still readable from DB
- `test_cache_does_not_evict_recently_accessed` — hot entries are not evicted
- `test_write_file_does_not_cache_data_parts` — `data_entries` stays empty after `write_file`

All 37 filestore tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)