### PR TITLE
fix: cleanup_stale_backends skips backends with live agentmux parent (v0.32.88)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.32.87"
+version = "0.32.88"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.32.87"
+version = "0.32.88"
 dependencies = [
  "async-stream",
  "axum",
@@ -7174,7 +7174,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.32.87"
+version = "0.32.88"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.32.87"
+version = "0.32.88"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.32.87",
+  "version": "0.32.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.32.87",
+      "version": "0.32.88",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.32.87",
+  "version": "0.32.88",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.32.87"
+version = "0.32.88"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -257,11 +257,109 @@ pub async fn spawn_backend(app: &tauri::AppHandle) -> Result<BackendSpawnResult,
     Ok(result)
 }
 
+/// Returns true if `pid` (an agentmuxsrv-rs process) has no live agentmux parent,
+/// meaning it is safe to kill as an orphan.
+///
+/// When a Tauri frontend spawns the backend, the backend's OS-level PPID is the
+/// frontend's PID. If the frontend dies (SIGKILL, crash, force-quit), the kernel
+/// reparents the backend to launchd (PID 1). We use this to distinguish a truly
+/// orphaned backend (frontend gone) from a live backend serving an active frontend
+/// (multi-version coexistence scenario).
+#[cfg(unix)]
+fn is_orphaned_backend(pid: u32) -> bool {
+    // Get the backend's PPID from the OS process table.
+    let ppid_output = match std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "ppid="])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            tracing::warn!(
+                "cleanup_stale_backends: ppid lookup failed for PID {}: {}, treating as orphaned",
+                pid, e
+            );
+            return true;
+        }
+    };
+
+    if !ppid_output.status.success() {
+        // Process vanished between pgrep and now — nothing to kill.
+        tracing::info!("cleanup_stale_backends: PID {} vanished during ppid lookup", pid);
+        return true;
+    }
+
+    let ppid: u32 = match String::from_utf8_lossy(&ppid_output.stdout)
+        .trim()
+        .parse()
+    {
+        Ok(p) => p,
+        Err(_) => {
+            tracing::warn!(
+                "cleanup_stale_backends: could not parse ppid for PID {}, treating as orphaned",
+                pid
+            );
+            return true;
+        }
+    };
+
+    // ppid <= 1 means reparented to launchd — frontend is definitely dead.
+    if ppid <= 1 {
+        tracing::info!(
+            "cleanup_stale_backends: PID {} is orphaned (ppid={})",
+            pid, ppid
+        );
+        return true;
+    }
+
+    // Check whether the parent process is still alive.
+    let parent_alive = unsafe { libc::kill(ppid as i32, 0) } == 0;
+    if !parent_alive {
+        tracing::info!(
+            "cleanup_stale_backends: PID {} is orphaned (ppid={} dead)",
+            pid, ppid
+        );
+        return true;
+    }
+
+    // Parent is alive — verify it's actually an agentmux frontend, not a recycled PID.
+    let comm_output = std::process::Command::new("ps")
+        .args(["-p", &ppid.to_string(), "-o", "comm="])
+        .output();
+
+    match comm_output {
+        Ok(o) if o.status.success() => {
+            let comm = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            if comm.contains("agentmux") {
+                tracing::info!(
+                    "cleanup_stale_backends: PID {} has live parent {} (ppid={}), skipping — multi-version coexistence",
+                    pid, comm, ppid
+                );
+                false // NOT orphaned — leave it alone
+            } else {
+                tracing::warn!(
+                    "cleanup_stale_backends: PID {} has unexpected parent '{}' (ppid={}), treating as orphaned",
+                    pid, comm, ppid
+                );
+                true
+            }
+        }
+        _ => {
+            tracing::warn!(
+                "cleanup_stale_backends: comm lookup failed for ppid={}, treating PID {} as orphaned",
+                ppid, pid
+            );
+            true
+        }
+    }
+}
+
 /// Find and kill stale agentmuxsrv-rs processes left behind by previous versions.
 ///
 /// When the frontend crashes or is force-killed, the backend process may survive.
 /// On the next launch we find all running agentmuxsrv-rs processes, inspect their
 /// `--instance` argument, and kill any whose version differs from `current_version`.
+/// A version-mismatched backend is only killed if it is truly orphaned (no live
+/// agentmux parent) — see `is_orphaned_backend`.
 #[cfg(unix)]
 fn cleanup_stale_backends(current_version: &str) {
     let current_instance = format!("v{}", current_version);
@@ -377,8 +475,14 @@ fn cleanup_stale_backends(current_version: &str) {
             continue;
         }
 
+        // Step 4b: Only kill if the backend is truly orphaned (no live agentmux parent).
+        // If the old frontend is still running, this is multi-version coexistence — leave it alone.
+        if !is_orphaned_backend(pid) {
+            continue;
+        }
+
         tracing::info!(
-            "cleanup_stale_backends: PID {} is stale (instance={}, current={}), terminating",
+            "cleanup_stale_backends: PID {} is stale (instance={}, current={}) and orphaned, terminating",
             pid, instance_version, current_instance
         );
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.32.87",
-  "identifier": "ai.agentmux.app.v0-32-87",
+  "version": "0.32.88",
+  "identifier": "ai.agentmux.app.v0-32-88",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.32.87"
+version = "0.32.88"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Problem

`cleanup_stale_backends` (introduced in #144) kills any `agentmuxsrv-rs` process whose `--instance` version differs from the launching version — without checking whether that backend still has a live frontend connected.

This broke multi-version coexistence: opening v0.32.83 killed the v0.32.78 backend mid-session while the v0.32.78 frontend was still running.

**Confirmed incident:** v0.32.78 sidecar (pid 4645, 22h uptime) killed by v0.32.83 startup. v0.32.78 frontend (pid 4640) survived with no backend.

## Fix

Adds `is_orphaned_backend(pid)` — called after the version-mismatch check, before any kill. It inspects the stale backend's PPID via `ps -o ppid=`:

| PPID state | Decision |
|---|---|
| `ppid <= 1` (reparented to launchd) | Frontend dead → **kill** |
| `kill(ppid, 0)` returns ESRCH | Frontend dead → **kill** |
| Parent alive, `comm` contains `agentmux` | Live frontend → **skip** (logs "multi-version coexistence") |
| Parent alive, unexpected process name | PID reuse → **kill** (conservative) |

No protocol changes, no new CLI args, no network calls — uses the OS process table only.

## Test plan

- [ ] Open v0.32.83 while v0.32.84 is running → v0.32.83 backend survives
- [ ] `kill -9` v0.32.83 frontend, then open v0.32.84 → v0.32.83 backend is cleaned up
- [ ] Log shows `"has live parent agentmux … skipping — multi-version coexistence"` in case 1
- [ ] Log shows `"is orphaned (ppid=1)"` in case 2

## References

- Spec: `specs/SPEC_CLEANUP_STALE_ORPHAN_CHECK.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)