### PR TITLE
feat: display hostname in status bar

### DIFF
--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -113,6 +113,17 @@
         }
     }
 
+    .status-hostname {
+        opacity: 0.4;
+        font-size: 10px;
+        padding: 0 5px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 200px;
+        user-select: text;
+    }
+
     .status-version {
         opacity: 0.4;
         font-size: 10px;

--- a/frontend/app/statusbar/StatusBar.tsx
+++ b/frontend/app/statusbar/StatusBar.tsx
@@ -12,6 +12,7 @@ import "./StatusBar.scss";
 
 const StatusBar = (): JSX.Element => {
     const version = getApi().getAboutModalDetails()?.version ?? "";
+    const hostname = getApi().getHostName();
     const instanceNum = windowInstanceNumAtom;
     const windowCount = windowCountAtom;
 
@@ -35,6 +36,11 @@ const StatusBar = (): JSX.Element => {
                 <ConnectionStatus />
                 <ConfigStatus />
                 <UpdateStatus />
+                <Show when={hostname && hostname !== "unknown"}>
+                    <span class="status-hostname" title={`Host: ${hostname}`}>
+                        {hostname}
+                    </span>
+                </Show>
                 <Show when={version}>
                     <Show
                         when={backendStatusAtom() !== "crashed"}


### PR DESCRIPTION
## Summary

- Adds system hostname display to the status bar right section, positioned before the version indicator
- Uses existing `getApi().getHostName()` (cached at startup via Tauri `get_host_name` command)
- Hidden when hostname is unavailable or "unknown"
- Long hostnames truncate with ellipsis at 200px, full name in tooltip
- Styled to match version display (10px, 0.4 opacity, selectable text)

## Test plan

- [ ] Verify hostname appears in status bar to the left of the version
- [ ] Hover hostname to see `Host: <full-hostname>` tooltip
- [ ] Confirm hostname text is selectable (for copy/paste)
- [ ] Test with long FQDN hostnames (should truncate with ellipsis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)