### PR TITLE
fix: remove Docker download promotion for MS Store certification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.32.92"
+version = "0.32.93"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.32.92"
+version = "0.32.93"
 dependencies = [
  "async-stream",
  "axum",
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -7245,7 +7245,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.32.92"
+version = "0.32.93"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.32.92"
+version = "0.32.93"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -194,11 +194,11 @@ async function runLaunchFlow(
 
     const oref = WOS.makeORef("block", blockId);
 
-    // Phase 0: Container agents require Docker
+    // Phase 0: Container agents require a container runtime
     const blockData = WOS.getWaveObjectAtom<Block>(oref)();
     const agentMode = blockData?.meta?.agentMode ?? "host";
     if (agentMode === "container") {
-        log("docker", "container agent — checking for Docker...");
+        log("docker", "container agent — checking for container runtime...");
         try {
             const dockerResult = await RpcApi.ResolveCliCommand(TabRpcClient, {
                 provider_id: "docker",
@@ -210,9 +210,8 @@ async function runLaunchFlow(
             }, { timeout: 10000 });
             log("docker", `found: ${dockerResult.cli_path} (${dockerResult.version})`);
         } catch {
-            log("docker", "Docker is not installed", "error");
-            log("docker", "Container agents require Docker Desktop to run.", "error");
-            log("docker", "Install from: https://www.docker.com/products/docker-desktop/", "error");
+            log("docker", "Container runtime not found", "error");
+            log("docker", "Container agents require a compatible container runtime (e.g. Docker) to run.", "error");
             return "fatal";
         }
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.32.92",
+  "version": "0.32.93",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.32.92"
+version = "0.32.93"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.32.92",
-  "identifier": "ai.agentmux.app.v0-32-92",
+  "version": "0.32.93",
+  "identifier": "ai.agentmux.app.v0-32-93",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.32.92"
+version = "0.32.93"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

- Removes direct Docker Desktop download URL from container agent error messages
- Replaces "Docker Desktop" branding with generic "container runtime" language
- Resolves Microsoft Store certification rejection (policy 10.1.5 - Software Distribution)

## Changes

`frontend/app/view/agent/agent-view.tsx` — Phase 0 container runtime check:

**Before:**
```
[docker] Docker is not installed
[docker] Container agents require Docker Desktop to run.
[docker] Install from: https://www.docker.com/products/docker-desktop/
```

**After:**
```
[docker] Container runtime not found
[docker] Container agents require a compatible container runtime (e.g. Docker) to run.
```

## Context

Microsoft Store policy 10.1.5 prohibits promoting downloads of software outside the Store. The previous error messages included a direct URL to docker.com, which triggered the rejection.

## Test plan

- [ ] Select a container agent when Docker is not installed — verify new messages appear without download URL
- [ ] Select a container agent when Docker is installed — verify normal flow works unchanged
- [ ] Resubmit to Microsoft Store certification