### PR TITLE
fix(portable-build): replace bash packaging with PowerShell + CEF cache auto-detect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.33.22"
+version = "0.33.23"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.22"
+version = "0.33.23"
 dependencies = [
  "axum 0.8.8",
  "cef",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.22"
+version = "0.33.23"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.33.22"
+version = "0.33.23"
 dependencies = [
  "async-stream",
  "axum 0.7.9",
@@ -7858,7 +7858,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.33.22"
+version = "0.33.23"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -720,7 +720,21 @@ tasks:
         internal: true
         platforms: [windows]
         cmds:
-            - cargo build --release -p agentmux-cef
+            - cmd: |
+                # Auto-detect cached CEF extraction to avoid re-downloading on
+                # every new cef-dll-sys hash. Picks the newest cef_windows_x86_64
+                # dir that has a valid archive.json (written by a prior successful
+                # build). Falls back to no CEF_PATH on first-ever build.
+                cefPath=$(find target/release/build -name "archive.json" \
+                  -path "*/cef_windows_x86_64/*" 2>/dev/null \
+                  | sort | tail -1 | xargs -r dirname 2>/dev/null)
+                if [ -n "$cefPath" ]; then
+                  echo "✓ Using cached CEF: $cefPath"
+                  export CEF_PATH="$(cygpath -w "$cefPath")"
+                else
+                  echo "ℹ No cached CEF found — will download (first build)"
+                fi
+                cargo build --release -p agentmux-cef
             - cmd: powershell -Command "New-Item -ItemType Directory -Force -Path dist/cef | Out-Null; Copy-Item target/release/agentmux-cef.exe dist/cef/agentmux-cef.exe -Force"
             - echo "✓ Built agentmux-cef for Windows"
 
@@ -882,7 +896,7 @@ tasks:
         desc: Package CEF build as a portable directory + ZIP (Windows). Outputs to ~/Desktop by default.
         platforms: [windows]
         cmds:
-            - bash scripts/package-cef-portable.sh
+            - pwsh scripts/package-cef-portable.ps1
 
     cef:clean:
         desc: Clean CEF build artifacts.

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.22"
+version = "0.33.23"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.22"
+version = "0.33.23"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.33.22"
+version = "0.33.23"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.22",
+  "version": "0.33.23",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/package-cef-portable.ps1
+++ b/scripts/package-cef-portable.ps1
@@ -1,0 +1,224 @@
+# Package AgentMux CEF as a portable directory + ZIP (Windows x64).
+# Usage: pwsh scripts/package-cef-portable.ps1 [-OutputDir <path>]
+#
+# Default output: ~/Desktop/agentmux-cef-{version}-x64-portable/
+#
+# Exits with code 1 on any error. All steps are logged — no silent failures.
+
+param(
+    [string]$OutputDir = (Join-Path $HOME "Desktop")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+function Log-Step  { param([string]$msg) Write-Host "  → $msg" }
+function Log-Ok    { param([string]$msg) Write-Host "  ✓ $msg" -ForegroundColor Green }
+function Log-Warn  { param([string]$msg) Write-Host "  ⚠ $msg" -ForegroundColor Yellow }
+function Log-Error { param([string]$msg) Write-Host "  ✗ $msg" -ForegroundColor Red }
+
+function Assert-File {
+    param([string]$Path, [string]$Label)
+    if (-not (Test-Path $Path)) {
+        Log-Error "Required file not found: $Label"
+        Log-Error "  Expected at: $Path"
+        Log-Error "  Run 'task build:backend' and 'task cef:build' first."
+        exit 1
+    }
+    Log-Ok "Found: $Label"
+}
+
+function Get-VersionFromBinary {
+    param([string]$Path, [string]$Version)
+    $bytes = [System.IO.File]::ReadAllBytes($Path)
+    $ascii = [System.Text.Encoding]::ASCII.GetString($bytes)
+    if ($ascii -match [regex]::Escape($Version)) { return $Version }
+    return $null
+}
+
+function Copy-Required {
+    param([string]$Src, [string]$Dst, [string]$Label)
+    if (-not (Test-Path $Src)) {
+        Log-Error "Cannot copy $Label — source not found: $Src"
+        exit 1
+    }
+    Copy-Item $Src $Dst -Force
+    Log-Ok "Copied: $Label"
+}
+
+function Copy-Optional {
+    param([string]$Src, [string]$Dst, [string]$Label)
+    if (Test-Path $Src) {
+        Copy-Item $Src $Dst -Force
+        Log-Ok "Copied: $Label"
+    } else {
+        Log-Warn "Optional file not found (skipped): $Label"
+    }
+}
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Base      = Split-Path -Parent $ScriptDir
+
+Push-Location $Base
+try {
+
+$VERSION = (Get-Content "$Base\package.json" -Raw | ConvertFrom-Json).version
+if (-not $VERSION) {
+    Log-Error "Could not read version from package.json"
+    exit 1
+}
+
+$PORTABLE = Join-Path $OutputDir "agentmux-cef-$VERSION-x64-portable"
+$ZIPPATH  = Join-Path $OutputDir "agentmux-cef-$VERSION-x64-portable.zip"
+
+Write-Host ""
+Write-Host "AgentMux CEF Portable Builder" -ForegroundColor Cyan
+Write-Host "  Version : $VERSION"
+Write-Host "  Output  : $PORTABLE"
+Write-Host ""
+
+# ── 1. Verify required source files ──────────────────────────────────────────
+
+Write-Host "[1/6] Verifying source files..."
+Assert-File "$Base\target\release\agentmux-cef.exe"        "agentmux-cef.exe"
+Assert-File "$Base\target\release\agentmux-launcher.exe"   "agentmux-launcher.exe"
+Assert-File "$Base\dist\bin\agentmuxsrv-rs.x64.exe"        "agentmuxsrv-rs.x64.exe"
+Assert-File "$Base\dist\frontend\index.html"               "dist/frontend/index.html"
+Assert-File "$Base\dist\cef\libcef.dll"                    "dist/cef/libcef.dll"
+
+$wshPath = "$Base\dist\bin\wsh-$VERSION-windows.x64.exe"
+if (Test-Path $wshPath) {
+    Log-Ok "Found: wsh-$VERSION-windows.x64.exe"
+} else {
+    Log-Warn "wsh-$VERSION-windows.x64.exe not found — wsh will be absent from portable"
+    Log-Warn "  Run 'task build:wsh' to include it"
+}
+
+# ── 2. Verify embedded versions in binaries ───────────────────────────────────
+
+Write-Host ""
+Write-Host "[2/6] Verifying embedded versions in binaries..."
+
+$cefVer = Get-VersionFromBinary "$Base\target\release\agentmux-cef.exe" $VERSION
+if (-not $cefVer) {
+    Log-Error "agentmux-cef.exe does not contain version $VERSION"
+    Log-Error "  Rebuild with: cargo build --release -p agentmux-cef"
+    exit 1
+}
+Log-Ok "agentmux-cef.exe contains $VERSION"
+
+$srvVer = Get-VersionFromBinary "$Base\dist\bin\agentmuxsrv-rs.x64.exe" $VERSION
+if (-not $srvVer) {
+    Log-Error "agentmuxsrv-rs.x64.exe does not contain version $VERSION"
+    Log-Error "  Rebuild with: task build:backend"
+    exit 1
+}
+Log-Ok "agentmuxsrv-rs.x64.exe contains $VERSION"
+
+# agentmux-launcher is a tiny pass-through binary (sets DLL path, spawns CEF host).
+# It intentionally embeds no version string — no check needed.
+
+# ── 3. Create directory structure ─────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "[3/6] Creating portable directory..."
+
+if (Test-Path $PORTABLE) {
+    Log-Step "Removing previous: $PORTABLE"
+    Remove-Item $PORTABLE -Recurse -Force
+}
+if (Test-Path $ZIPPATH) {
+    Log-Step "Removing previous ZIP"
+    Remove-Item $ZIPPATH -Force
+}
+
+New-Item -ItemType Directory -Force -Path "$PORTABLE\runtime\locales"  | Out-Null
+New-Item -ItemType Directory -Force -Path "$PORTABLE\runtime\frontend" | Out-Null
+Log-Ok "Created directory structure"
+
+# ── 4. Copy files ─────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "[4/6] Copying files..."
+
+# Launcher → root as agentmux.exe (user-facing entry point)
+Copy-Required "$Base\target\release\agentmux-launcher.exe" "$PORTABLE\agentmux.exe"     "launcher → agentmux.exe"
+
+# Runtime binaries
+Copy-Required "$Base\target\release\agentmux-cef.exe"      "$PORTABLE\runtime\"         "agentmux-cef.exe"
+Copy-Required "$Base\dist\bin\agentmuxsrv-rs.x64.exe"      "$PORTABLE\runtime\"         "agentmuxsrv-rs.x64.exe"
+
+# wsh (optional)
+if (Test-Path $wshPath) {
+    Copy-Item $wshPath "$PORTABLE\runtime\wsh.exe" -Force
+    Log-Ok "Copied: wsh.exe"
+}
+
+# Frontend
+Copy-Item "$Base\dist\frontend\*" "$PORTABLE\runtime\frontend\" -Recurse -Force
+Log-Ok "Copied: dist/frontend → runtime/frontend/"
+
+# CEF core (required)
+Copy-Required "$Base\dist\cef\libcef.dll"  "$PORTABLE\runtime\" "libcef.dll"
+
+# CEF optional runtime files
+Copy-Optional "$Base\dist\cef\chrome_elf.dll"           "$PORTABLE\runtime\" "chrome_elf.dll"
+Copy-Optional "$Base\dist\cef\icudtl.dat"               "$PORTABLE\runtime\" "icudtl.dat"
+Copy-Optional "$Base\dist\cef\v8_context_snapshot.bin"  "$PORTABLE\runtime\" "v8_context_snapshot.bin"
+Copy-Optional "$Base\dist\cef\libEGL.dll"               "$PORTABLE\runtime\" "libEGL.dll"
+Copy-Optional "$Base\dist\cef\libGLESv2.dll"            "$PORTABLE\runtime\" "libGLESv2.dll"
+Copy-Optional "$Base\dist\cef\d3dcompiler_47.dll"       "$PORTABLE\runtime\" "d3dcompiler_47.dll"
+Copy-Optional "$Base\dist\cef\chrome_100_percent.pak"   "$PORTABLE\runtime\" "chrome_100_percent.pak"
+Copy-Optional "$Base\dist\cef\chrome_200_percent.pak"   "$PORTABLE\runtime\" "chrome_200_percent.pak"
+Copy-Optional "$Base\dist\cef\resources.pak"            "$PORTABLE\runtime\" "resources.pak"
+Copy-Optional "$Base\dist\cef\locales\en-US.pak"        "$PORTABLE\runtime\locales\" "locales/en-US.pak"
+
+# README
+@"
+AgentMux v$VERSION - Portable Edition
+
+Quick Start:
+  1. Extract this folder (or ZIP) anywhere
+  2. Run agentmux.exe
+
+Requirements:
+  - Windows 10/11 x64
+  - No installation needed
+  - No admin rights required
+"@ | Set-Content "$PORTABLE\README.txt" -Encoding UTF8
+Log-Ok "Created README.txt"
+
+# ── 5. Size report ────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "[5/6] Computing size..."
+$dirBytes = (Get-ChildItem $PORTABLE -Recurse -File | Measure-Object -Property Length -Sum).Sum
+$dirMB    = [math]::Round($dirBytes / 1MB, 1)
+Log-Ok "Directory: $dirMB MB"
+
+# ── 6. ZIP ────────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "[6/6] Creating ZIP..."
+Log-Step "Compressing to $ZIPPATH"
+Compress-Archive -Path "$PORTABLE\*" -DestinationPath $ZIPPATH -Force
+$zipMB = [math]::Round((Get-Item $ZIPPATH).Length / 1MB, 1)
+Log-Ok "ZIP: $zipMB MB"
+
+# ── Done ──────────────────────────────────────────────────────────────────────
+
+Write-Host ""
+Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
+Write-Host " SUCCESS  AgentMux CEF Portable v$VERSION" -ForegroundColor Green
+Write-Host "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" -ForegroundColor Cyan
+Write-Host "  Directory : $PORTABLE ($dirMB MB)"
+Write-Host "  ZIP       : $ZIPPATH ($zipMB MB)"
+Write-Host ""
+
+} finally {
+    Pop-Location
+}

--- a/scripts/package-cef-portable.sh
+++ b/scripts/package-cef-portable.sh
@@ -3,8 +3,21 @@
 # Usage: bash scripts/package-cef-portable.sh [output-dir]
 #
 # Default output: ~/Desktop/agentmux-cef-{version}-x64-portable/
+#
+# NOTE: On Windows use scripts/package-cef-portable.ps1 instead.
+# This script is kept for Linux/macOS CI reference only.
+# It is NOT called by 'task cef:package:portable' on Windows.
 
 set -euo pipefail
+
+# Fail loudly if accidentally run on Windows (MSYS2/Git Bash).
+# grep -ao on .exe binaries does not work on Windows bash, causing silent
+# failures in the version verification step below.
+if [[ "${OS:-}" == "Windows_NT" ]]; then
+    echo "ERROR: Run 'task cef:package:portable' or 'pwsh scripts/package-cef-portable.ps1' on Windows." >&2
+    echo "       This bash script is Linux/macOS only." >&2
+    exit 1
+fi
 
 VERSION=$(node -p "require('./package.json').version")
 OUTDIR="${1:-$HOME/Desktop}"

--- a/specs/portable-build-cleanup.md
+++ b/specs/portable-build-cleanup.md
@@ -1,0 +1,107 @@
+# Spec: Portable Build Cleanup
+
+## Problem
+
+`task cef:package:portable` is brittle on Windows and fails silently.
+Two independent issues cause it to break:
+
+---
+
+### Issue 1: `scripts/package-cef-portable.sh` fails silently on Windows
+
+**Root cause:** The script uses `grep -ao` on `.exe` binary files to verify the
+embedded version string. On Windows (MSYS2/Git Bash), `grep -a` does not handle
+binary files correctly — it returns exit code 1 (no match) even when the version
+IS present. Combined with `set -euo pipefail`, the script exits silently with no
+error message at the version-check step (line 78).
+
+**Evidence:** Running `grep -ao "0.33.17" target/release/agentmux-cef.exe` in
+MSYS2 bash returns nothing. The same check via PowerShell `[System.IO.File]
+::ReadAllBytes` + ASCII string search finds the version correctly.
+
+**Fix:** Replace `scripts/package-cef-portable.sh` with
+`scripts/package-cef-portable.ps1` and update `task cef:package:portable` to
+call `pwsh scripts/package-cef-portable.ps1`. The PowerShell script does
+everything the bash script does but uses `.NET` byte array search for binary
+version verification instead of `grep`.
+
+---
+
+### Issue 2: `cef:build:windows` (`cargo build -p agentmux-cef`) fails with "Access Denied"
+
+**Root cause:** `cef-dll-sys` build script downloads the CEF binary distribution
+(~100 MB) on first build for a new hash. On this machine it gets "File I/O error:
+Access is denied. (os error 5)" during the download/extraction step.
+
+The crate supports a `CEF_PATH` env var: if it points to a directory containing
+a valid `archive.json` and the CEF SDK files (`libcef.lib`, `CMakeLists.txt`,
+etc.), the build script skips the download entirely and uses that directory. Once
+a successful build has happened, the extraction lives at:
+
+```
+target/release/build/cef-dll-sys-{hash}/out/cef_windows_x86_64/
+```
+
+Subsequent builds with a new crate hash fail again because they don't know about
+the existing extraction.
+
+**Fix:** Auto-detect the cached CEF extraction and set `CEF_PATH` automatically
+in `task cef:build:windows` before calling `cargo build`. Detection logic:
+
+```bash
+# Find newest cef_windows_x86_64 dir with a valid archive.json
+cefPath=$(find target/release/build -name "archive.json" \
+  -path "*/cef_windows_x86_64/*" 2>/dev/null \
+  | sort | tail -1 | xargs dirname)
+```
+
+If found, export `CEF_PATH=$cefPath` before `cargo build`. If not found (first
+ever build), proceed without `CEF_PATH` and the download will run normally.
+
+Updated `task cef:build:windows`:
+
+```yaml
+cef:build:windows:
+    internal: true
+    platforms: [windows]
+    cmds:
+        - cmd: |
+            cefPath=$(find target/release/build -name "archive.json" \
+              -path "*/cef_windows_x86_64/*" 2>/dev/null \
+              | sort | tail -1 | xargs -r dirname)
+            if [ -n "$cefPath" ]; then
+              echo "Using cached CEF at: $cefPath"
+              export CEF_PATH="$(cygpath -w "$cefPath")"
+            fi
+            cargo build --release -p agentmux-cef
+        - cmd: powershell -Command "New-Item -ItemType Directory -Force -Path dist/cef | Out-Null; Copy-Item target/release/agentmux-cef.exe dist/cef/agentmux-cef.exe -Force"
+        - echo "✓ Built agentmux-cef for Windows"
+```
+
+---
+
+## Deliverables
+
+1. **`scripts/package-cef-portable.ps1`** — PowerShell port of the bash script.
+   - Same logic: verify files exist, create directory structure, copy, verify
+     embedded version (via byte search), ZIP.
+   - Uses `[System.IO.File]::ReadAllBytes` + `-match` for version check instead
+     of `grep -ao`.
+   - Accepts optional `$OutputDir` parameter (default `$HOME\Desktop`).
+
+2. **`Taskfile.yml` — update `cef:build:windows`** — add CEF cache auto-detect
+   before `cargo build`.
+
+3. **`Taskfile.yml` — update `cef:package:portable`** — call
+   `pwsh scripts/package-cef-portable.ps1` instead of
+   `bash scripts/package-cef-portable.sh`.
+
+4. **`scripts/package-cef-portable.sh`** — keep as fallback for Linux/macOS CI,
+   but add a comment noting it is not used on Windows.
+
+## Out of Scope
+
+- Fixing the root cause of the "Access Denied" on the first-ever CEF download
+  (likely a machine-specific antivirus or temp-dir policy). The auto-detect
+  workaround is sufficient for day-to-day development.
+- Changing the portable directory structure or contents.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.33.22"
+version = "0.33.23"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.33.22",
-  "identifier": "ai.agentmux.app.v0-33-22",
+  "version": "0.33.23",
+  "identifier": "ai.agentmux.app.v0-33-23",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.33.22"
+version = "0.33.23"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

- **\`scripts/package-cef-portable.ps1\`** — new PowerShell script replaces the bash equivalent on Windows. Six numbered steps with per-step logging; zero silent failures. Uses \`.NET\` byte-array search for binary version verification (\`grep -ao\` on \`.exe\` files silently fails in MSYS2 bash due to \`set -euo pipefail\`).
- **\`Taskfile.yml\` \`cef:package:portable\`** — calls \`pwsh package-cef-portable.ps1\` instead of \`bash package-cef-portable.sh\` on Windows.
- **\`Taskfile.yml\` \`cef:build:windows\`** — auto-detects existing \`cef_windows_x86_64\` extraction in \`target/release/build/\` and exports as \`CEF_PATH\` before \`cargo build\`. Prevents \`cef-dll-sys\` from re-downloading CEF (~100 MB) on every new build hash, which fails with \`Access Denied (os error 5)\`.
- **\`scripts/package-cef-portable.sh\`** — adds Windows guard (exits with clear error if run on Windows) and Linux/macOS-only header comment.
- **\`specs/portable-build-cleanup.md\`** — spec documenting both root causes and fixes.

## Test plan
- [x] \`task cef:package:portable\` completes with all 6 steps logged, produces portable dir + ZIP on Desktop
- [x] Version mismatch: script exits with explicit error + rebuild instructions
- [x] Missing file: script exits with explicit error + rebuild instructions
- [ ] First-ever CEF build (no cache): falls back to download path

🤖 Generated with [Claude Code](https://claude.com/claude-code)