### PR TITLE
feat: default widget bar to icon-only mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.66"
+version = "0.33.67"
 dependencies = [
  "axum 0.8.8",
  "cef",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.66"
+version = "0.33.67"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.66"
+version = "0.33.67"
 dependencies = [
  "async-stream",
  "axum 0.7.9",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.66"
+version = "0.33.67"
 dependencies = [
  "base64",
  "clap",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -532,8 +532,9 @@ tasks:
                 # Copy staging dir to session dir so dist/cef/ is never locked
                 # by the running process. Next build can overwrite dist/cef/ freely.
                 DEV_DIR="dist/cef-dev"
-                rm -rf "$DEV_DIR"
-                cp -r dist/cef "$DEV_DIR"
+                rm -rf "$DEV_DIR" 2>/dev/null || true
+                mkdir -p "$DEV_DIR"
+                cp -r dist/cef/* "$DEV_DIR"/
                 echo "Copied dist/cef → $DEV_DIR (isolation)"
 
                 npx vite --config vite.config.ts --port 5173 &

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.66"
+version = "0.33.67"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.66"
+version = "0.33.67"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.66"
+version = "0.33.67"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.66"
+version = "0.33.67"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -205,7 +205,7 @@ const ActionWidgets = (): JSX.Element => {
     const fullConfig = atoms.fullConfigAtom;
     const settings = (): Record<string, any> => fullConfig()?.settings ?? {};
     const wmap = (): Record<string, WidgetConfigType> => fullConfig()?.widgets ?? {};
-    const iconOnly = (): boolean => settings()["widget:icononly"] ?? false;
+    const iconOnly = (): boolean => settings()["widget:icononly"] ?? true;
     const pinnedWidgets = () => getPinnedWidgets(settings(), wmap());
     const moreWidgets = () => getMoreWidgets(settings(), wmap());
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.66",
+  "version": "0.33.67",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Default `widget:icononly` to `true` — top bar shows compact icons instead of icon + label
- Users can toggle back via right-click context menu on the widget bar

## Test plan
- [ ] Fresh launch: widget bar shows icons only (no labels)
- [ ] Right-click widget bar → uncheck "Icon Only" → labels appear
- [ ] Setting persists across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)