### PR TITLE
fix: cmd wrapper resolution, auth fallback, loading spinner, layout healing

### DIFF
--- a/.bump.json
+++ b/.bump.json
@@ -25,6 +25,11 @@
       "file": "agentmux-launcher/Cargo.toml",
       "type": "toml",
       "path": "package.version"
+    },
+    {
+      "file": "agentmux-common/Cargo.toml",
+      "type": "toml",
+      "path": "package.version"
     }
   ],
   "lockfiles": [
@@ -53,7 +58,8 @@
       "agentmux-srv/Cargo.toml",
       "agentmux-wsh/Cargo.toml",
       "agentmux-cef/Cargo.toml",
-      "agentmux-launcher/Cargo.toml"
+      "agentmux-launcher/Cargo.toml",
+      "agentmux-common/Cargo.toml"
     ],
     "commitMessage": "chore: bump version to {{version}}"
   }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.67"
+version = "0.33.68"
 dependencies = [
  "axum 0.8.8",
  "cef",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.67"
+version = "0.33.68"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.67"
+version = "0.33.68"
 dependencies = [
  "async-stream",
  "axum 0.7.9",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.67"
+version = "0.33.68"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.68"
+version = "0.33.69"
 dependencies = [
  "axum 0.8.8",
  "cef",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.68"
+version = "0.33.69"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.68"
+version = "0.33.69"
 dependencies = [
  "async-stream",
  "axum 0.7.9",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.68"
+version = "0.33.69"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "agentmux-cef"
 version = "0.33.69"
 dependencies = [
+ "agentmux-common",
  "axum 0.8.8",
  "cef",
  "chrono",
@@ -32,6 +33,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "agentmux-common"
+version = "0.33.69"
+dependencies = [
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "agentmux-launcher"
 version = "0.33.69"
 dependencies = [
@@ -43,6 +52,7 @@ dependencies = [
 name = "agentmux-srv"
 version = "0.33.69"
 dependencies = [
+ "agentmux-common",
  "async-stream",
  "axum 0.7.9",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["agentmux-srv", "agentmux-wsh", "agentmux-cef", "agentmux-launcher"]
+members = ["agentmux-srv", "agentmux-wsh", "agentmux-cef", "agentmux-launcher", "agentmux-common"]
 
 [profile.release]
 strip = true

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.68"
+version = "0.33.69"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -20,6 +20,7 @@ sandbox = ["cef/sandbox"]
 resources_path = "resources"
 
 [dependencies]
+agentmux-common = { path = "../agentmux-common" }
 cef = { version = "146", default-features = false, features = ["build-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.67"
+version = "0.33.68"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -355,56 +355,8 @@ pub fn cancel_cli_login(state: &Arc<AppState>) -> Result<serde_json::Value, Stri
 
 // --- CLI command helpers ---
 
-/// Create a Command for a CLI binary.
-///
-/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
-/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost.
-/// Instead, we parse the `.cmd` file to extract the Node.js entry script path
-/// and invoke `node <script>` directly.
 fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
-    #[cfg(windows)]
-    if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
-        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
-            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
-            let mut c = tokio::process::Command::new("node");
-            c.arg(&entry_script);
-            return c;
-        }
-        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
-        let mut c = tokio::process::Command::new("cmd.exe");
-        c.args(["/C", cli_path]);
-        return c;
-    }
-    tokio::process::Command::new(cli_path)
-}
-
-/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
-#[cfg(windows)]
-fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
-    let content = std::fs::read_to_string(cmd_path).ok()?;
-    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
-
-    for line in content.lines() {
-        let line_trimmed = line.trim();
-        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
-            continue;
-        }
-        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
-            let after_dp0 = &line_trimmed[dp0_idx + 6..];
-            let end = after_dp0.find('"')
-                .or_else(|| after_dp0.find(" %*"))
-                .unwrap_or(after_dp0.len());
-            let relative_path = &after_dp0[..end];
-            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
-                let resolved = cmd_dir.join(relative_path);
-                if let Ok(canonical) = resolved.canonicalize() {
-                    return Some(canonical.to_string_lossy().to_string());
-                }
-                return Some(resolved.to_string_lossy().to_string());
-            }
-        }
-    }
-    None
+    agentmux_common::make_cli_cmd(cli_path)
 }
 
 // --- Settings helpers (ported from src-tauri/src/commands/platform.rs) ---

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -292,7 +292,7 @@ pub async fn run_cli_login(
         })
         .unwrap_or_default();
 
-    let mut cmd = tokio::process::Command::new(&cli_path);
+    let mut cmd = make_cli_cmd(&cli_path);
     cmd.args(&login_args)
         .envs(&auth_env)
         .stdin(std::process::Stdio::null())
@@ -351,6 +351,60 @@ pub fn cancel_cli_login(state: &Arc<AppState>) -> Result<serde_json::Value, Stri
         tracing::info!("cancel_cli_login: cancel signal sent");
     }
     Ok(serde_json::Value::Null)
+}
+
+// --- CLI command helpers ---
+
+/// Create a Command for a CLI binary.
+///
+/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
+/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost.
+/// Instead, we parse the `.cmd` file to extract the Node.js entry script path
+/// and invoke `node <script>` directly.
+fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
+    #[cfg(windows)]
+    if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
+        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
+            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
+            let mut c = tokio::process::Command::new("node");
+            c.arg(&entry_script);
+            return c;
+        }
+        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
+        let mut c = tokio::process::Command::new("cmd.exe");
+        c.args(["/C", cli_path]);
+        return c;
+    }
+    tokio::process::Command::new(cli_path)
+}
+
+/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
+#[cfg(windows)]
+fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
+    let content = std::fs::read_to_string(cmd_path).ok()?;
+    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
+
+    for line in content.lines() {
+        let line_trimmed = line.trim();
+        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
+            continue;
+        }
+        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
+            let after_dp0 = &line_trimmed[dp0_idx + 6..];
+            let end = after_dp0.find('"')
+                .or_else(|| after_dp0.find(" %*"))
+                .unwrap_or(after_dp0.len());
+            let relative_path = &after_dp0[..end];
+            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
+                let resolved = cmd_dir.join(relative_path);
+                if let Ok(canonical) = resolved.canonicalize() {
+                    return Some(canonical.to_string_lossy().to_string());
+                }
+                return Some(resolved.to_string_lossy().to_string());
+            }
+        }
+    }
+    None
 }
 
 // --- Settings helpers (ported from src-tauri/src/commands/platform.rs) ---

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "agentmux-common"
+version = "0.33.69"
+edition = "2021"
+description = "Shared utilities for AgentMux crates"
+
+[dependencies]
+tokio = { version = "1", features = ["process"] }
+tracing = "0.1"

--- a/agentmux-common/src/cli.rs
+++ b/agentmux-common/src/cli.rs
@@ -1,0 +1,56 @@
+/// Create a Command for a CLI binary.
+///
+/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
+/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost,
+/// and the underlying CLI never executes. Instead, we parse the `.cmd` file to
+/// extract the Node.js entry script path and invoke `node <script>` directly.
+pub fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
+    #[cfg(windows)]
+    if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
+        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
+            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
+            let mut c = tokio::process::Command::new("node");
+            c.arg(&entry_script);
+            return c;
+        }
+        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
+        let mut c = tokio::process::Command::new("cmd.exe");
+        c.args(["/C", cli_path]);
+        return c;
+    }
+    tokio::process::Command::new(cli_path)
+}
+
+/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
+///
+/// npm `.cmd` wrappers contain a line like:
+///   `"%_prog%"  "%dp0%\..\@anthropic-ai\claude-code\cli.js" %*`
+/// where `%dp0%` is the directory containing the `.cmd` file itself.
+/// We extract the relative path after `%dp0%\` and resolve it to an absolute path.
+#[cfg(windows)]
+fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
+    let content = std::fs::read_to_string(cmd_path).ok()?;
+    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
+
+    for line in content.lines() {
+        let line_trimmed = line.trim();
+        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
+            continue;
+        }
+        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
+            let after_dp0 = &line_trimmed[dp0_idx + 6..]; // skip "%dp0%\"
+            let end = after_dp0.find('"')
+                .or_else(|| after_dp0.find(" %*"))
+                .unwrap_or(after_dp0.len());
+            let relative_path = &after_dp0[..end];
+            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
+                let resolved = cmd_dir.join(relative_path);
+                if let Ok(canonical) = resolved.canonicalize() {
+                    return Some(canonical.to_string_lossy().to_string());
+                }
+                return Some(resolved.to_string_lossy().to_string());
+            }
+        }
+    }
+    None
+}

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -1,0 +1,5 @@
+//! Shared utilities for AgentMux crates.
+
+mod cli;
+
+pub use cli::make_cli_cmd;

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.68"
+version = "0.33.69"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.67"
+version = "0.33.68"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.68"
+version = "0.33.69"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -9,6 +9,7 @@ name = "agentmux-srv"
 path = "src/main.rs"
 
 [dependencies]
+agentmux-common = { path = "../agentmux-common" }
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.7", features = ["ws"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.67"
+version = "0.33.68"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::Command;
+
 
 use super::{
     BlockControllerRuntimeStatus, BlockInputUnion, Controller, STATUS_DONE, STATUS_INIT,
@@ -211,24 +211,10 @@ impl SubprocessController {
         self.publish_status();
         self.health_monitor.set_active_turn(true);
 
-        // Build command — on Windows, .cmd batch scripts must be run via cmd.exe /C
-        #[cfg(windows)]
-        let mut cmd = if config.cli_command.ends_with(".cmd") || config.cli_command.ends_with(".bat") {
-            let mut c = Command::new("cmd.exe");
-            c.args(["/C", &config.cli_command]);
-            c.args(&args);
-            c
-        } else {
-            let mut c = Command::new(&config.cli_command);
-            c.args(&args);
-            c
-        };
-        #[cfg(not(windows))]
-        let mut cmd = {
-            let mut c = Command::new(&config.cli_command);
-            c.args(&args);
-            c
-        };
+        // Build command — on Windows, .cmd batch wrappers can't be reliably spawned
+        // via cmd.exe /C with piped stdio. Resolve to node <script> instead.
+        let mut cmd = crate::server::cli_handlers::make_cli_cmd(&config.cli_command);
+        cmd.args(&args);
         if !config.working_dir.is_empty() {
             // Expand ~ to home directory (cross-platform)
             let expanded_dir = if config.working_dir.starts_with("~/") || config.working_dir == "~" {

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -48,11 +48,14 @@ pub fn delete_block(
     // frontend update races with the delete or is lost, the orphaned node
     // persists in the database.
     if !tab.layoutstate.is_empty() {
-        if let Ok(mut layout) = store.get::<LayoutState>(&tab.layoutstate) {
-            if let Some(ref mut layout) = layout {
-                prune_block_from_layout(layout, block_id);
-                let _ = store.update(layout);
-            }
+        if let Ok(Some(mut layout)) = store.get::<LayoutState>(&tab.layoutstate) {
+            tracing::info!(
+                block_id = %block_id,
+                layout_id = %tab.layoutstate,
+                "pruning deleted block from layout tree"
+            );
+            prune_block_from_layout(&mut layout, block_id);
+            let _ = store.update(&mut layout);
         }
     }
     Ok(())

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -32,7 +32,7 @@ pub fn create_block(
     Ok(block)
 }
 
-/// Delete a block from its parent tab.
+/// Delete a block from its parent tab and prune it from the layout tree.
 pub fn delete_block(
     store: &WaveStore,
     tab_id: &str,
@@ -42,7 +42,100 @@ pub fn delete_block(
     tab.blockids.retain(|id| id != block_id);
     store.update(&mut tab)?;
     store.delete::<Block>(block_id)?;
+
+    // Prune the deleted block's node from the layout tree so it doesn't
+    // leave a blank pane. The frontend also removes the node, but if the
+    // frontend update races with the delete or is lost, the orphaned node
+    // persists in the database.
+    if !tab.layoutstate.is_empty() {
+        if let Ok(mut layout) = store.get::<LayoutState>(&tab.layoutstate) {
+            if let Some(ref mut layout) = layout {
+                prune_block_from_layout(layout, block_id);
+                let _ = store.update(layout);
+            }
+        }
+    }
     Ok(())
+}
+
+/// Remove all references to `block_id` from a layout's rootnode tree and leaforder.
+fn prune_block_from_layout(layout: &mut LayoutState, block_id: &str) {
+    // Prune leaforder
+    if let Some(ref mut leaves) = layout.leaforder {
+        leaves.retain(|entry| entry.blockid != block_id);
+    }
+    // Prune rootnode tree (recursive JSON walk)
+    if let Some(ref mut root) = layout.rootnode {
+        prune_node(root, block_id);
+    }
+}
+
+/// Recursively remove child nodes whose `data.blockId` matches `block_id`.
+/// If removing a child leaves a parent with only one child, collapse it.
+fn prune_node(node: &mut serde_json::Value, block_id: &str) {
+    if let Some(children) = node.get_mut("children").and_then(|c| c.as_array_mut()) {
+        // Remove children that are leaves matching block_id
+        children.retain(|child| {
+            child.get("data")
+                .and_then(|d| d.get("blockId"))
+                .and_then(|id| id.as_str())
+                .map(|id| id != block_id)
+                .unwrap_or(true) // keep non-leaf nodes
+        });
+        // Recurse into remaining children
+        for child in children.iter_mut() {
+            prune_node(child, block_id);
+        }
+        // If only one child remains, promote it to replace this node
+        // (preserving the tree's flex layout invariant)
+    }
+}
+
+/// Validate a layout against the set of existing block IDs, removing any
+/// orphaned leaf nodes. Called on tab activation as a self-healing pass.
+pub fn heal_layout(
+    store: &WaveStore,
+    tab_id: &str,
+) -> Result<bool, StoreError> {
+    let tab = store.must_get::<Tab>(tab_id)?;
+    if tab.layoutstate.is_empty() {
+        return Ok(false);
+    }
+    let mut layout = match store.get::<LayoutState>(&tab.layoutstate)? {
+        Some(l) => l,
+        None => return Ok(false),
+    };
+
+    let valid_blocks: std::collections::HashSet<&str> =
+        tab.blockids.iter().map(|s| s.as_str()).collect();
+
+    // Collect orphaned block IDs from leaforder
+    let orphans: Vec<String> = layout.leaforder
+        .as_ref()
+        .map(|leaves| {
+            leaves.iter()
+                .filter(|e| !valid_blocks.contains(e.blockid.as_str()))
+                .map(|e| e.blockid.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if orphans.is_empty() {
+        return Ok(false);
+    }
+
+    tracing::warn!(
+        tab_id = %tab_id,
+        orphan_count = orphans.len(),
+        orphans = ?orphans,
+        "healing layout: removing orphaned block nodes"
+    );
+
+    for orphan_id in &orphans {
+        prune_block_from_layout(&mut layout, orphan_id);
+    }
+    store.update(&mut layout)?;
+    Ok(true)
 }
 
 /// Resolve a block ID from an 8-character prefix within a tab.

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -74,7 +74,8 @@ fn prune_block_from_layout(layout: &mut LayoutState, block_id: &str) {
 }
 
 /// Recursively remove child nodes whose `data.blockId` matches `block_id`.
-/// If removing a child leaves a parent with only one child, collapse it.
+/// If removing a child leaves a parent with only one child, collapse by
+/// promoting the sole child to replace the parent node.
 fn prune_node(node: &mut serde_json::Value, block_id: &str) {
     if let Some(children) = node.get_mut("children").and_then(|c| c.as_array_mut()) {
         // Remove children that are leaves matching block_id
@@ -89,8 +90,30 @@ fn prune_node(node: &mut serde_json::Value, block_id: &str) {
         for child in children.iter_mut() {
             prune_node(child, block_id);
         }
-        // If only one child remains, promote it to replace this node
-        // (preserving the tree's flex layout invariant)
+    }
+    // If only one child remains, promote it to replace this split node.
+    // This avoids degenerate single-child splits in the layout tree.
+    let should_collapse = node.get("children")
+        .and_then(|c| c.as_array())
+        .map(|c| c.len() == 1)
+        .unwrap_or(false);
+    if should_collapse {
+        if let Some(sole_child) = node.get("children")
+            .and_then(|c| c.as_array())
+            .and_then(|c| c.first())
+            .cloned()
+        {
+            // Preserve the parent's id and size, replace everything else
+            let parent_id = node.get("id").cloned();
+            let parent_size = node.get("size").cloned();
+            *node = sole_child;
+            if let Some(id) = parent_id {
+                node["id"] = id;
+            }
+            if let Some(size) = parent_size {
+                node["size"] = size;
+            }
+        }
     }
 }
 

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -312,6 +312,10 @@ async fn main() {
         tracing::info!("First launch: created initial data");
     }
 
+    // Self-heal layouts: remove orphaned block nodes that cause blank panes.
+    // Runs on every startup to catch any corruption from prior sessions.
+    heal_all_layouts(&wstore);
+
     // Auto-seed Forge agents on first launch (or empty DB)
     backend::forge_seed::auto_seed_on_startup(&wstore);
 
@@ -604,4 +608,36 @@ fn init_logging() -> tracing_appender::non_blocking::WorkerGuard {
     );
 
     guard
+}
+
+/// Walk all tabs and heal their layouts by removing orphaned block references.
+fn heal_all_layouts(store: &WaveStore) {
+    use backend::obj::Tab;
+
+    let tabs: Vec<Tab> = match store.get_all::<Tab>() {
+        Ok(tabs) => tabs,
+        Err(e) => {
+            tracing::warn!(error = %e, "heal_all_layouts: failed to list tabs");
+            return;
+        }
+    };
+
+    let mut healed = 0;
+    for tab in &tabs {
+        match backend::wcore::heal_layout(store, &tab.oid) {
+            Ok(true) => {
+                tracing::info!(tab_id = %tab.oid, tab_name = %tab.name, "layout healed on startup");
+                healed += 1;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(tab_id = %tab.oid, error = %e, "heal_layout failed");
+            }
+        }
+    }
+    if healed > 0 {
+        tracing::info!(tabs_healed = healed, "layout self-healing complete");
+    } else {
+        tracing::info!("layout self-healing: all layouts clean");
+    }
 }

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -586,16 +586,68 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
-/// Create a Command for a CLI binary, transparently wrapping Windows `.cmd` batch scripts
-/// with `cmd.exe /C` so they can be spawned via the Win32 API.
+/// Create a Command for a CLI binary.
+///
+/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
+/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost,
+/// and the underlying CLI never executes. Instead, we parse the `.cmd` file to
+/// extract the Node.js entry script path and invoke `node <script>` directly.
 pub(crate) fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
     #[cfg(windows)]
     if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
+        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
+            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
+            let mut c = tokio::process::Command::new("node");
+            c.arg(&entry_script);
+            return c;
+        }
+        // Fallback: if we can't parse the .cmd, try cmd.exe /C (may still break)
+        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
         let mut c = tokio::process::Command::new("cmd.exe");
         c.args(["/C", cli_path]);
         return c;
     }
     tokio::process::Command::new(cli_path)
+}
+
+/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
+///
+/// npm `.cmd` wrappers contain a line like:
+///   `"%_prog%"  "%dp0%\..\@anthropic-ai\claude-code\cli.js" %*`
+/// where `%dp0%` is the directory containing the `.cmd` file itself.
+/// We extract the relative path after `%dp0%\` and resolve it to an absolute path.
+#[cfg(windows)]
+fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
+    let content = std::fs::read_to_string(cmd_path).ok()?;
+    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
+
+    for line in content.lines() {
+        // Look for the line that has %dp0%\...\something.js and %*
+        // Pattern: "%dp0%\<relative_path>" %*
+        let line_trimmed = line.trim();
+        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
+            continue;
+        }
+        // Extract the path between %dp0%\ and the closing quote (or next space/%)
+        // The pattern is: "%dp0%\<path>"
+        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
+            let after_dp0 = &line_trimmed[dp0_idx + 6..]; // skip "%dp0%\"
+            // Find the end — either a closing quote or %*
+            let end = after_dp0.find('"')
+                .or_else(|| after_dp0.find(" %*"))
+                .unwrap_or(after_dp0.len());
+            let relative_path = &after_dp0[..end];
+            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
+                let resolved = cmd_dir.join(relative_path);
+                if let Ok(canonical) = resolved.canonicalize() {
+                    return Some(canonical.to_string_lossy().to_string());
+                }
+                // canonicalize failed but path looks valid — return joined path
+                return Some(resolved.to_string_lossy().to_string());
+            }
+        }
+    }
+    None
 }
 
 async fn get_cli_version(cli_path: &str) -> String {

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -595,68 +595,9 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
-/// Create a Command for a CLI binary.
-///
-/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
-/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost,
-/// and the underlying CLI never executes. Instead, we parse the `.cmd` file to
-/// extract the Node.js entry script path and invoke `node <script>` directly.
+/// Re-export from shared crate for internal use.
 pub(crate) fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
-    #[cfg(windows)]
-    if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
-        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
-            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
-            let mut c = tokio::process::Command::new("node");
-            c.arg(&entry_script);
-            return c;
-        }
-        // Fallback: if we can't parse the .cmd, try cmd.exe /C (may still break)
-        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
-        let mut c = tokio::process::Command::new("cmd.exe");
-        c.args(["/C", cli_path]);
-        return c;
-    }
-    tokio::process::Command::new(cli_path)
-}
-
-/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
-///
-/// npm `.cmd` wrappers contain a line like:
-///   `"%_prog%"  "%dp0%\..\@anthropic-ai\claude-code\cli.js" %*`
-/// where `%dp0%` is the directory containing the `.cmd` file itself.
-/// We extract the relative path after `%dp0%\` and resolve it to an absolute path.
-#[cfg(windows)]
-fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
-    let content = std::fs::read_to_string(cmd_path).ok()?;
-    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
-
-    for line in content.lines() {
-        // Look for the line that has %dp0%\...\something.js and %*
-        // Pattern: "%dp0%\<relative_path>" %*
-        let line_trimmed = line.trim();
-        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
-            continue;
-        }
-        // Extract the path between %dp0%\ and the closing quote (or next space/%)
-        // The pattern is: "%dp0%\<path>"
-        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
-            let after_dp0 = &line_trimmed[dp0_idx + 6..]; // skip "%dp0%\"
-            // Find the end — either a closing quote or %*
-            let end = after_dp0.find('"')
-                .or_else(|| after_dp0.find(" %*"))
-                .unwrap_or(after_dp0.len());
-            let relative_path = &after_dp0[..end];
-            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
-                let resolved = cmd_dir.join(relative_path);
-                if let Ok(canonical) = resolved.canonicalize() {
-                    return Some(canonical.to_string_lossy().to_string());
-                }
-                // canonicalize failed but path looks valid — return joined path
-                return Some(resolved.to_string_lossy().to_string());
-            }
-        }
-    }
-    None
+    agentmux_common::make_cli_cmd(cli_path)
 }
 
 async fn get_cli_version(cli_path: &str) -> String {

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -442,16 +442,25 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 // Fast path: read credentials file directly (Claude)
                 if cmd.cli_path.contains("claude") {
-                    // Use CLAUDE_CONFIG_DIR from auth_env if provided (isolated auth dir).
-                    // Fall back to ~/.claude/ for legacy/non-isolated invocations.
-                    let creds_path = if let Some(config_dir) = cmd.auth_env.get("CLAUDE_CONFIG_DIR") {
-                        format!("{}/.credentials.json", config_dir)
-                    } else {
-                        let home = std::env::var("HOME")
-                            .or_else(|_| std::env::var("USERPROFILE"))
-                            .unwrap_or_default();
-                        format!("{}/.claude/.credentials.json", home)
-                    };
+                    // Check isolated auth dir first (CLAUDE_CONFIG_DIR), then fall back
+                    // to global ~/.claude/. Users may be authenticated globally but not
+                    // yet in the per-version isolated dir.
+                    let home = std::env::var("HOME")
+                        .or_else(|_| std::env::var("USERPROFILE"))
+                        .unwrap_or_default();
+                    let global_creds = format!("{}/.claude/.credentials.json", home);
+
+                    let mut creds_candidates: Vec<String> = Vec::new();
+                    if let Some(config_dir) = cmd.auth_env.get("CLAUDE_CONFIG_DIR") {
+                        creds_candidates.push(format!("{}/.credentials.json", config_dir));
+                    }
+                    creds_candidates.push(global_creds);
+
+                    // Try each candidate path — first one with valid credentials wins
+                    let creds_path = creds_candidates.iter()
+                        .find(|p| std::path::Path::new(p.as_str()).exists())
+                        .cloned()
+                        .unwrap_or_else(|| creds_candidates.last().unwrap().clone());
 
                     if let Ok(content) = std::fs::read_to_string(&creds_path) {
                         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -1,4 +1,4 @@
-mod cli_handlers;
+pub(crate) mod cli_handlers;
 mod files;
 mod forge_handlers;
 mod messagebus;

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -416,6 +416,10 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
+            // Self-heal the layout before activating — remove any orphaned
+            // block nodes that would render as blank panes.
+            let _ = wcore::heal_layout(store, &tab_id);
+
             match wcore::set_active_tab(store, &ws_id, &tab_id) {
                 Ok(()) => {
                     if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.68"
+version = "0.33.69"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.67"
+version = "0.33.68"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1096,6 +1096,31 @@
                 opacity: 0.5;
                 padding: 0 2px;
                 line-height: 1.2;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+            }
+
+            .agent-loading-spinner {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                opacity: 1;
+                color: var(--accent-color, #58a6ff);
+                font-size: 9px;
+            }
+
+            .agent-spinner-dot {
+                width: 6px;
+                height: 6px;
+                border-radius: 50%;
+                background: var(--accent-color, #58a6ff);
+                animation: agent-pulse 1s ease-in-out infinite;
+            }
+
+            @keyframes agent-pulse {
+                0%, 100% { opacity: 0.3; transform: scale(0.8); }
+                50% { opacity: 1; transform: scale(1.2); }
             }
         }
     }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -661,7 +661,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 </div>
             </Show>
 
-            <AgentFooter agentId={agentId} onSendMessage={handleSendMessage} />
+            <AgentFooter agentId={agentId} onSendMessage={handleSendMessage} loading={flowRunning()} />
         </div>
     );
 };

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -5,14 +5,15 @@
  * AgentFooter - Minimal Claude Code-style input
  */
 
-import { createSignal, type JSX } from "solid-js";
+import { createSignal, Show, type JSX } from "solid-js";
 
 interface AgentFooterProps {
     agentId: string;
     onSendMessage?: (message: string) => void;
+    loading?: boolean;
 }
 
-export const AgentFooter = ({ agentId, onSendMessage }: AgentFooterProps): JSX.Element => {
+export const AgentFooter = ({ agentId, onSendMessage, loading }: AgentFooterProps): JSX.Element => {
     const [message, setMessage] = createSignal("");
 
     const handleSend = () => {
@@ -41,7 +42,15 @@ export const AgentFooter = ({ agentId, onSendMessage }: AgentFooterProps): JSX.E
                     onKeyDown={handleKeyDown}
                     rows={2}
                 />
-                <div class="agent-input-hint">Enter to send • Shift+Enter for newline</div>
+                <div class="agent-input-hint">
+                    <span>Enter to send • Shift+Enter for newline</span>
+                    <Show when={loading}>
+                        <span class="agent-loading-spinner">
+                            <span class="agent-spinner-dot" />
+                            loading
+                        </span>
+                    </Show>
+                </div>
             </div>
         </div>
     );

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -13,13 +13,13 @@ interface AgentFooterProps {
     loading?: boolean;
 }
 
-export const AgentFooter = ({ agentId, onSendMessage, loading }: AgentFooterProps): JSX.Element => {
+export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     const [message, setMessage] = createSignal("");
 
     const handleSend = () => {
         if (!message().trim()) return;
-        if (onSendMessage) {
-            onSendMessage(message());
+        if (props.onSendMessage) {
+            props.onSendMessage(message());
             setMessage("");
         }
     };
@@ -36,7 +36,7 @@ export const AgentFooter = ({ agentId, onSendMessage, loading }: AgentFooterProp
             <div class="agent-input-container">
                 <textarea
                     class="agent-input"
-                    placeholder={`Send message to ${agentId}...`}
+                    placeholder={`Send message to ${props.agentId}...`}
                     value={message()}
                     onInput={(e) => setMessage((e.target as HTMLTextAreaElement).value)}
                     onKeyDown={handleKeyDown}
@@ -44,7 +44,7 @@ export const AgentFooter = ({ agentId, onSendMessage, loading }: AgentFooterProp
                 />
                 <div class="agent-input-hint">
                     <span>Enter to send • Shift+Enter for newline</span>
-                    <Show when={loading}>
+                    <Show when={props.loading}>
                         <span class="agent-loading-spinner">
                             <span class="agent-spinner-dot" />
                             loading

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.66",
+  "version": "0.33.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.66",
+      "version": "0.33.67",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.67",
+  "version": "0.33.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.67",
+      "version": "0.33.69",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.68",
+  "version": "0.33.69",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.67",
+  "version": "0.33.68",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- **`.cmd` wrapper resolution**: Parse npm `.cmd` wrappers to extract the Node.js entry script and invoke `node <script>` directly — bypasses broken `cmd.exe /C` with piped stdio. Applied in all 3 spawn sites.
- **Auth fallback**: Check isolated auth dir first, then fall back to global `~/.claude/.credentials.json`.
- **Loading spinner**: Pulsing dot + "loading" text in agent footer during the launch flow.
- **Layout self-healing**: On startup, walk all tabs and prune orphaned block nodes from layouts. Also prune on every `DeleteBlock`. Prevents blank panes from ever persisting.

Closes #314

## Test plan
- [ ] Agent pane: CLI resolves, auth passes, controller registers
- [ ] Loading spinner visible during launch flow
- [ ] Close a pane, reopen app — no blank spots
- [ ] Backend logs show `layout self-healing` messages on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)