### PR TITLE
feat: logging P1/P2 — launcher logging, retention, muxlog helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,23 @@ Widgets are defined in `agentmux-srv/src/config/widgets.json`. These are the **o
 
 ---
 
+## Log Access
+
+All logs land in `~/.agentmux/logs/` (`$AGENTMUX_LOG_DIR` in terminals). Pointer files resolve the current filename.
+
+| What | Command |
+|------|---------|
+| Tail host log | `muxlog host` |
+| Tail sidecar log | `muxlog srv` |
+| Frontend logs | `muxlog host '[fe]'` |
+| Memory heartbeat | `muxlog host mem_heartbeat` |
+| Full host log | `muxlog host cat` |
+| Launcher log | `cat "$AGENTMUX_LOG_DIR/agentmux-launcher.log"` |
+
+Works identically across `task dev`, portable, and install builds. Logs auto-rotate daily and are retained for 7 days.
+
+---
+
 ## Version Management
 
 **CRITICAL:** Always use `@a5af/bump-cli` - never manually edit version numbers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.67"
+version = "0.33.68"
 dependencies = [
  "axum 0.8.8",
  "cef",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.67"
+version = "0.33.68"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.67"
+version = "0.33.68"
 dependencies = [
  "async-stream",
  "axum 0.7.9",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.67"
+version = "0.33.68"
 dependencies = [
  "base64",
  "clap",
@@ -1036,9 +1036,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1324,12 +1324,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1478,14 +1478,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2178,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.68"
+version = "0.33.69"
 dependencies = [
  "axum 0.8.8",
  "cef",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.68"
+version = "0.33.69"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.68"
+version = "0.33.69"
 dependencies = [
  "async-stream",
  "axum 0.7.9",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.68"
+version = "0.33.69"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.68"
+version = "0.33.69"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.67"
+version = "0.33.68"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -305,6 +305,9 @@ fn init_logging() -> tracing_appender::non_blocking::WorkerGuard {
         .join("logs");
     let _ = std::fs::create_dir_all(&log_dir);
 
+    // Delete log files older than 7 days to prevent unbounded growth.
+    cleanup_old_logs(&log_dir, 7);
+
     let log_prefix = format!("agentmux-host-v{}.log", version);
     let file_appender = tracing_appender::rolling::daily(&log_dir, &log_prefix);
     let (non_blocking_file, guard) = tracing_appender::non_blocking(file_appender);
@@ -346,4 +349,23 @@ fn init_logging() -> tracing_appender::non_blocking::WorkerGuard {
     );
 
     guard
+}
+
+fn cleanup_old_logs(log_dir: &std::path::Path, days: u64) {
+    let cutoff = std::time::SystemTime::now()
+        - std::time::Duration::from_secs(days * 86400);
+    let Ok(entries) = std::fs::read_dir(log_dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.to_string_lossy().contains(".log.") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+        }
+    }
 }

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.68"
+version = "0.33.69"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.67"
+version = "0.33.68"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -19,6 +19,8 @@ fn main() {
     let exe_dir = exe_path.parent().expect("exe has no parent directory");
     let runtime_dir = exe_dir.join("runtime");
 
+    log(&format!("starting — exe={} runtime={}", exe_path.display(), runtime_dir.display()));
+
     // Set DLL search path so libcef.dll (in runtime/) is found by the child process
     #[cfg(target_os = "windows")]
     {
@@ -32,14 +34,14 @@ fn main() {
             windows_sys::Win32::System::LibraryLoader::SetDllDirectoryW(wide.as_ptr());
         }
     }
+    log("SetDllDirectoryW done");
 
     // Resolve the real CEF host binary in runtime/.
-    // Prefer the versioned binary (e.g., agentmux-cef-0.33.43.exe) so that Task Manager,
-    // WER crash dumps, and Event Viewer all show the version in the process/filename.
-    // Falls back to plain name for dev mode.
     let real_exe = find_cef_binary(&runtime_dir);
+    log(&format!("resolved CEF binary: {}", real_exe.display()));
 
     if !real_exe.exists() {
+        log(&format!("FATAL: CEF binary not found at {}", real_exe.display()));
         eprintln!(
             "AgentMux runtime not found in: {}\nMake sure the runtime/ folder is intact.",
             runtime_dir.display()
@@ -49,17 +51,22 @@ fn main() {
 
     // Forward all CLI arguments
     let args: Vec<String> = std::env::args().skip(1).collect();
+    log(&format!("spawning CEF host with {} args", args.len()));
 
     #[cfg(target_os = "windows")]
     {
-        // Spawn the CEF host and wait for it to exit
         let status = std::process::Command::new(&real_exe)
             .args(&args)
             .status();
 
         match status {
-            Ok(s) => std::process::exit(s.code().unwrap_or(1)),
+            Ok(s) => {
+                let code = s.code().unwrap_or(1);
+                log(&format!("CEF host exited with code {}", code));
+                std::process::exit(code);
+            }
             Err(e) => {
+                log(&format!("FATAL: failed to spawn CEF host: {}", e));
                 eprintln!("Failed to launch AgentMux: {}", e);
                 std::process::exit(1);
             }
@@ -68,12 +75,41 @@ fn main() {
 
     #[cfg(not(target_os = "windows"))]
     {
-        // On Unix, exec replaces this process entirely
+        log("exec into CEF host (Unix)");
         use std::os::unix::process::CommandExt;
         let err = std::process::Command::new(&real_exe).args(&args).exec();
+        log(&format!("FATAL: exec failed: {}", err));
         eprintln!("Failed to launch AgentMux: {}", err);
         std::process::exit(1);
     }
+}
+
+/// Append a timestamped line to ~/.agentmux/logs/agentmux-launcher.log.
+/// Best-effort — silently no-ops if the log dir doesn't exist yet.
+fn log(msg: &str) {
+    let log_dir = dirs_fallback_home().join(".agentmux").join("logs");
+    let _ = std::fs::create_dir_all(&log_dir);
+    let path = log_dir.join("agentmux-launcher.log");
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        use std::io::Write;
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let _ = writeln!(f, "[{}] v{} {}", secs, env!("CARGO_PKG_VERSION"), msg);
+    }
+}
+
+/// Home dir without the `dirs` crate (keep launcher zero-dep beyond windows-sys).
+fn dirs_fallback_home() -> std::path::PathBuf {
+    std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
 }
 
 /// Find the CEF host binary in the runtime directory.

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.68"
+version = "0.33.69"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.67"
+version = "0.33.68"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/shellintegration/bash.sh
+++ b/agentmux-srv/src/backend/shellintegration/bash.sh
@@ -88,6 +88,30 @@ _agentmux_si_prompt_command() {
     _agentmux_si_agent_env
 }
 
+# ─── muxlog helper ────────────────────────────────────────────────────────────
+# Usage: muxlog [host|srv] [tail|cat|<pattern>]
+muxlog() {
+    local target="${1:-host}"
+    local action="${2:-tail}"
+    if [ -z "$AGENTMUX_LOG_DIR" ]; then
+        echo "AGENTMUX_LOG_DIR not set — run inside an AgentMux terminal" >&2
+        return 1
+    fi
+    local ptr="$AGENTMUX_LOG_DIR/current-${target}-v${AGENTMUX_VERSION}.path"
+    if [ ! -f "$ptr" ]; then
+        echo "Unknown log target '$target'. Available:" >&2
+        ls "$AGENTMUX_LOG_DIR"/current-*.path 2>/dev/null \
+            | sed 's|.*/current-||;s|\.path||' >&2
+        return 1
+    fi
+    local logfile="$AGENTMUX_LOG_DIR/$(cat "$ptr")"
+    case "$action" in
+        tail) tail -f "$logfile" ;;
+        cat)  cat "$logfile" ;;
+        *)    grep "$action" "$logfile" ;;
+    esac
+}
+
 # Append to PROMPT_COMMAND (array-safe)
 if [[ $(declare -p PROMPT_COMMAND 2>/dev/null) == "declare -a"* ]]; then
     PROMPT_COMMAND+=(_agentmux_si_prompt_command)

--- a/agentmux-srv/src/backend/shellintegration/fish.fish
+++ b/agentmux-srv/src/backend/shellintegration/fish.fish
@@ -56,6 +56,30 @@ function _agentmux_si_agent_env
     end
 end
 
+# ─── muxlog helper ────────────────────────────────────────────────────────────
+function muxlog
+    set -l target (test (count $argv) -ge 1; and echo $argv[1]; or echo "host")
+    set -l action (test (count $argv) -ge 2; and echo $argv[2]; or echo "tail")
+    if not set -q AGENTMUX_LOG_DIR
+        echo "AGENTMUX_LOG_DIR not set — run inside an AgentMux terminal" >&2
+        return 1
+    end
+    set -l ptr "$AGENTMUX_LOG_DIR/current-$target-v$AGENTMUX_VERSION.path"
+    if not test -f "$ptr"
+        echo "Unknown log target '$target'. Check $AGENTMUX_LOG_DIR for current-*.path files." >&2
+        return 1
+    end
+    set -l logfile "$AGENTMUX_LOG_DIR/"(cat "$ptr")
+    switch $action
+        case tail
+            tail -f "$logfile"
+        case cat
+            cat "$logfile"
+        case '*'
+            grep "$action" "$logfile"
+    end
+end
+
 function _agentmux_si_prompt --on-event fish_prompt
     _agentmux_si_osc7
     _agentmux_si_agent_env

--- a/agentmux-srv/src/backend/shellintegration/pwsh.ps1
+++ b/agentmux-srv/src/backend/shellintegration/pwsh.ps1
@@ -65,6 +65,26 @@ function Global:_agentmux_si_prompt {
     _agentmux_si_agent_env
 }
 
+# ─── muxlog helper ────────────────────────────────────────────────────────────
+function Global:muxlog {
+    param([string]$Target = "host", [string]$Action = "tail")
+    if (-not $env:AGENTMUX_LOG_DIR) {
+        Write-Error "AGENTMUX_LOG_DIR not set - run inside an AgentMux terminal"
+        return
+    }
+    $ptr = Join-Path $env:AGENTMUX_LOG_DIR "current-$Target-v$($env:AGENTMUX_VERSION).path"
+    if (-not (Test-Path $ptr)) {
+        Write-Error "Unknown log target '$Target'. Check $env:AGENTMUX_LOG_DIR for current-*.path files."
+        return
+    }
+    $logfile = Join-Path $env:AGENTMUX_LOG_DIR (Get-Content $ptr)
+    switch ($Action) {
+        "tail" { Get-Content $logfile -Wait -Tail 50 }
+        "cat"  { Get-Content $logfile }
+        default { Select-String $Action $logfile }
+    }
+}
+
 # Hook into the prompt function
 if (Test-Path Function:\prompt) {
     $global:_agentmux_original_prompt = $function:prompt

--- a/agentmux-srv/src/backend/shellintegration/zsh.sh
+++ b/agentmux-srv/src/backend/shellintegration/zsh.sh
@@ -89,6 +89,29 @@ _agentmux_si_precmd() {
     _agentmux_si_agent_env
 }
 
+# ─── muxlog helper ────────────────────────────────────────────────────────────
+muxlog() {
+    local target="${1:-host}"
+    local action="${2:-tail}"
+    if [ -z "$AGENTMUX_LOG_DIR" ]; then
+        echo "AGENTMUX_LOG_DIR not set — run inside an AgentMux terminal" >&2
+        return 1
+    fi
+    local ptr="$AGENTMUX_LOG_DIR/current-${target}-v${AGENTMUX_VERSION}.path"
+    if [ ! -f "$ptr" ]; then
+        echo "Unknown log target '$target'. Available:" >&2
+        ls "$AGENTMUX_LOG_DIR"/current-*.path 2>/dev/null \
+            | sed 's|.*/current-||;s|\.path||' >&2
+        return 1
+    fi
+    local logfile="$AGENTMUX_LOG_DIR/$(cat "$ptr")"
+    case "$action" in
+        tail) tail -f "$logfile" ;;
+        cat)  cat "$logfile" ;;
+        *)    grep "$action" "$logfile" ;;
+    esac
+}
+
 autoload -U add-zsh-hook
 add-zsh-hook precmd _agentmux_si_precmd
 add-zsh-hook chpwd  _agentmux_si_osc7

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -540,6 +540,9 @@ fn init_logging() -> tracing_appender::non_blocking::WorkerGuard {
         .join("logs");
     let _ = std::fs::create_dir_all(&log_dir);
 
+    // Delete log files older than 7 days to prevent unbounded growth.
+    cleanup_old_logs(&log_dir, 7);
+
     // Rolling daily log file with JSON structured output
     let log_prefix = format!("agentmuxsrv-v{}.log", version);
     let file_appender = tracing_appender::rolling::daily(&log_dir, &log_prefix);
@@ -604,4 +607,25 @@ fn init_logging() -> tracing_appender::non_blocking::WorkerGuard {
     );
 
     guard
+}
+
+/// Delete log files (*.log.*) older than `days` to prevent unbounded growth.
+/// Only touches files with `.log.` in the name — pointer files and other data are safe.
+fn cleanup_old_logs(log_dir: &std::path::Path, days: u64) {
+    let cutoff = std::time::SystemTime::now()
+        - std::time::Duration::from_secs(days * 86400);
+    let Ok(entries) = std::fs::read_dir(log_dir) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.to_string_lossy().contains(".log.") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+        }
+    }
 }

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.68"
+version = "0.33.69"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.67"
+version = "0.33.68"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.66",
+  "version": "0.33.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.66",
+      "version": "0.33.68",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.68",
+  "version": "0.33.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.68",
+      "version": "0.33.69",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.68",
+  "version": "0.33.69",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.67",
+  "version": "0.33.68",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Completes all remaining items from `docs/LOG_RESOLUTION_SPEC.md`:

- **Launcher file logging** (P1): Append-only log at `~/.agentmux/logs/agentmux-launcher.log`. Zero deps (no tracing/chrono), ~5 lines per session covering: start, DLL setup, CEF binary resolution, spawn, exit code.
- **7-day log retention** (P2): Both CEF host and sidecar `init_logging()` now delete `.log.*` files older than 7 days on startup.
- **`muxlog` shell helper** (P2): `muxlog host` / `muxlog srv [tail|cat|<pattern>]` available in bash, zsh, and PowerShell terminals. Uses `$AGENTMUX_LOG_DIR` and version-qualified pointer files.
- **CLAUDE.md docs** (P2): Log access table added.

## Test plan
- [ ] Launch portable — check `~/.agentmux/logs/agentmux-launcher.log` has entries
- [ ] Open terminal pane, run `muxlog host` — should tail the host log
- [ ] Run `muxlog srv` — should tail the sidecar log
- [ ] Verify old logs (>7 days) are cleaned on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)