### PR TITLE
feat: agent pane runtime controls (mode, model, effort)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.70"
+version = "0.33.71"
 dependencies = [
  "axum 0.8.8",
  "cef",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.70"
+version = "0.33.71"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.70"
+version = "0.33.71"
 dependencies = [
  "async-stream",
  "axum 0.7.9",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.70"
+version = "0.33.71"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.70"
+version = "0.33.71"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.70"
+version = "0.33.71"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.70"
+version = "0.33.71"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.70"
+version = "0.33.71"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/docs/specs/agent-input-auto-grow.md
+++ b/docs/specs/agent-input-auto-grow.md
@@ -1,0 +1,70 @@
+# Agent Input Auto-Grow Textarea
+
+**Status:** Proposed
+**Date:** 2026-04-09
+
+## Summary
+
+The agent pane input textarea should start at 1 line and automatically
+grow vertically as the user types multi-line content. The manual resize
+handle (bottom-right drag) should be removed — height is driven purely
+by content.
+
+## Current Behavior
+
+- Fixed at `rows={2}` (always 2 lines tall regardless of content)
+- `resize: vertical` CSS allows manual drag-to-resize
+- `min-height: 28px`
+
+## Desired Behavior
+
+- Start at 1 line tall (single row)
+- Grow vertically as the user adds newlines or wraps long lines
+- Shrink back down when text is deleted
+- Cap at a max height (e.g., 200px / ~10 lines) to avoid consuming the
+  whole pane — overflow scrolls within the textarea after that
+- Reset to 1 line after sending a message
+- No manual resize handle
+
+## Implementation
+
+### AgentFooter.tsx
+
+1. Change `rows={2}` → `rows={1}`
+2. Add an `autoGrow` function that sets `textarea.style.height` based
+   on `scrollHeight` after each input event
+3. Reset height on send (message cleared → textarea shrinks)
+4. Use a ref to access the textarea DOM element
+
+```typescript
+const autoGrow = (el: HTMLTextAreaElement) => {
+    el.style.height = "auto";            // reset to measure
+    el.style.height = el.scrollHeight + "px";  // set to content
+};
+```
+
+Call `autoGrow` in `onInput` after updating the signal, and after
+`setMessage("")` in `handleSend`.
+
+### agent-view.scss
+
+1. Change `resize: vertical` → `resize: none`
+2. Add `max-height: 200px` and `overflow-y: auto`
+3. Keep `min-height` at one line (~20px with current font-size)
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `frontend/app/view/agent/components/AgentFooter.tsx` | Auto-grow logic, rows=1, ref |
+| `frontend/app/view/agent/agent-view.scss` | `resize: none`, `max-height`, adjust `min-height` |
+
+## Testing
+
+1. Open agent pane → textarea shows as a single line
+2. Type a long message → wraps, textarea grows
+3. Press Shift+Enter → new line, textarea grows
+4. Delete lines → textarea shrinks
+5. Send message → textarea resets to 1 line
+6. Paste a 20-line block → grows to max-height, scrollbar appears
+7. No resize handle visible in bottom-right corner

--- a/docs/specs/agent-pane-runtime-controls.md
+++ b/docs/specs/agent-pane-runtime-controls.md
@@ -1,0 +1,267 @@
+# Agent Pane Runtime Controls
+
+**Status:** Proposed
+**Date:** 2026-04-09
+
+## Summary
+
+Surface Claude Code CLI runtime flags as interactive controls in the agent
+pane. The user can change permission mode, model, effort level, and tool
+restrictions **between turns** without restarting the session.
+
+## Background
+
+The agent pane spawns a CLI subprocess per turn via `SubprocessController`.
+Each turn reads `cmd:args` and `cmd:env` from block metadata
+(`websocket.rs:739-762`), appends `--resume <session_id>`, then spawns a
+fresh process. This means **any metadata change the frontend writes between
+turns takes effect on the next spawn** — no protocol changes needed.
+
+Currently, all flags are set once at launch (`agent-model.ts:73,173`) and
+never updated. The CLI supports rich runtime modes that users can't access.
+
+## CLI Flags to Surface
+
+### 1. Permission Mode (Claude only)
+
+| Mode | Flag | Behavior |
+|------|------|----------|
+| Bypass | `--dangerously-skip-permissions` | Current default. No prompts. |
+| Auto | `--permission-mode auto` | AI classifier approves safe ops, blocks risky ones. |
+| Accept Edits | `--permission-mode acceptEdits` | Auto-approve file edits, prompt for commands. |
+| Plan | `--permission-mode plan` | Read-only research. No edits, no commands. Outputs a plan. |
+| Default | `--permission-mode default` | Prompt for everything. |
+
+**Note:** `--dangerously-skip-permissions` and `--permission-mode` are
+mutually exclusive. When switching away from Bypass, remove the
+`--dangerously-skip-permissions` flag and add `--permission-mode <mode>`.
+
+**Gemini equivalent:** `--yolo` (bypass) vs removing `--yolo` (prompt).
+**Codex equivalent:** `--dangerously-bypass-approvals-and-sandbox` vs
+`--full-auto` / no flag.
+
+### 2. Model Selection (Claude only)
+
+| Value | Flag |
+|-------|------|
+| Default (provider decides) | *(no flag)* |
+| Opus | `--model opus` |
+| Sonnet | `--model sonnet` |
+| Haiku | `--model haiku` |
+
+### 3. Effort Level (Claude only, Opus)
+
+| Value | Flag |
+|-------|------|
+| Low | `--effort low` |
+| Medium | `--effort medium` |
+| High (default) | `--effort high` |
+| Max (Opus only) | `--effort max` |
+
+### 4. Tool Restrictions (Claude only)
+
+| Control | Flag |
+|---------|------|
+| Allow specific tools | `--allowedTools "Read,Grep,Glob"` |
+| Block specific tools | `--disallowedTools "Bash"` |
+
+### 5. Budget Guard (Claude only)
+
+| Control | Flag |
+|---------|------|
+| Max spend per turn | `--max-budget-usd 5.00` |
+| Max agentic turns | `--max-turns 20` |
+
+## Architecture
+
+### Data Flow
+
+```
+User changes control in pane header
+  → Frontend updates block metadata (cmd:args and/or cmd:env)
+  → User sends next message
+  → Backend reads metadata (websocket.rs:739)
+  → spawn_turn() uses updated args
+  → CLI starts with new flags + --resume <session_id>
+```
+
+No backend changes required. The backend already re-reads `cmd:args` and
+`cmd:env` from block metadata on every turn.
+
+### Block Metadata Schema
+
+Add a new metadata key for runtime overrides, separate from the base
+`cmd:args` set at launch. This avoids stomping the provider's base flags.
+
+```
+"agent:runtime" → {
+    "permissionMode": "bypass" | "auto" | "acceptEdits" | "plan" | "default",
+    "model": null | "opus" | "sonnet" | "haiku",
+    "effort": null | "low" | "medium" | "high" | "max",
+    "allowedTools": null | string[],
+    "disallowedTools": null | string[],
+    "maxBudgetUsd": null | number,
+    "maxTurns": null | number
+}
+```
+
+### Arg Assembly (Frontend)
+
+When the user sends a message, the frontend should:
+
+1. Start with the provider's base `launchArgs` (from `providers/index.ts`).
+2. Read `agent:runtime` from block metadata.
+3. Apply overrides:
+   - If `permissionMode !== "bypass"`: remove `--dangerously-skip-permissions`,
+     add `--permission-mode <mode>`.
+   - If `model` is set: add `--model <model>`.
+   - If `effort` is set: add `--effort <effort>`.
+   - If `allowedTools` is set: add `--allowedTools` entries.
+   - If `disallowedTools` is set: add `--disallowedTools` entries.
+   - If `maxBudgetUsd` is set: add `--max-budget-usd <n>`.
+   - If `maxTurns` is set: add `--max-turns <n>`.
+4. Write the assembled args to `cmd:args` in block metadata.
+5. Then send the `AgentInput` RPC as normal.
+
+This can be done in a new function `buildRuntimeArgs(provider, runtime)`
+called from `agent-view.tsx` before sending the message, or from
+`agent-model.ts` in a new `updateRuntimeArgs()` method.
+
+### Alternative: Backend Arg Assembly
+
+Instead of the frontend assembling args, the backend could read
+`agent:runtime` and merge flags in `websocket.rs` before spawning. This
+keeps flag logic in one place but requires a Rust change. The frontend
+approach is simpler for Phase 1 since it requires zero backend changes.
+
+**Recommendation:** Frontend for Phase 1, migrate to backend if the logic
+gets complex.
+
+## UI Design
+
+### Controls Location
+
+Add a **control bar** between the agent header and the document view. It
+should be collapsible (chevron toggle) to avoid taking space when not needed.
+
+```
+┌─────────────────────────────────────────────────┐
+│ 🟢 Agent: agentx        PID: 12345  Connected  │  ← existing header
+├─────────────────────────────────────────────────┤
+│ ▾ Controls                                      │  ← new control bar
+│  Mode: [Bypass ▾]  Model: [Default ▾]          │
+│  Effort: [High ▾]  Budget: [___] USD            │
+├─────────────────────────────────────────────────┤
+│                                                  │
+│  (document view)                                 │
+│                                                  │
+├─────────────────────────────────────────────────┤
+│ Send message to agentx...              [Enter]   │  ← existing footer
+└─────────────────────────────────────────────────┘
+```
+
+When collapsed:
+
+```
+│ ▸ Controls: Bypass · Opus · High                │
+```
+
+The collapsed line shows current settings as a compact summary.
+
+### Control Components
+
+1. **PermissionModeSelect** — Dropdown with 5 modes. Color-coded:
+   - Bypass = red badge (dangerous)
+   - Auto = blue
+   - Accept Edits = yellow
+   - Plan = green (safe/read-only)
+   - Default = gray
+
+2. **ModelSelect** — Dropdown: Default, Opus, Sonnet, Haiku.
+   Only shown for Claude provider.
+
+3. **EffortSelect** — Dropdown: Low, Medium, High, Max.
+   Only shown for Claude provider. "Max" only enabled when model is Opus.
+
+4. **BudgetInput** — Number input for max USD per turn. Optional.
+
+5. **ToolRestrictions** — Future phase. Checkbox list of tools to
+   allow/block. Complex UX — defer to Phase 2.
+
+### State Management
+
+Runtime settings live in block metadata (`agent:runtime`). The control bar
+reads from and writes to this metadata via `RpcApi.SetMetaCommand`. This
+means:
+
+- Settings persist across page refreshes (metadata is in SQLite).
+- Settings are per-pane (each agent pane has its own block).
+- Changes take effect on the next turn (not mid-turn).
+
+### Visual Feedback
+
+When settings differ from the provider's defaults, show a small indicator
+in the collapsed control bar:
+
+```
+│ ▸ Controls: Plan · Sonnet · Low  ⚠ non-default │
+```
+
+This warns the user that the agent is running in a non-standard config
+(e.g., Plan mode won't make edits, which might confuse them if they
+expect code changes).
+
+## Phases
+
+### Phase 1: Permission Mode + Model + Effort
+
+- New `AgentControlBar` component
+- `buildRuntimeArgs()` function
+- `agent:runtime` metadata key
+- Claude provider only (Gemini/Codex have simpler flag sets)
+- No backend changes
+
+**Files to create:**
+- `frontend/app/view/agent/components/AgentControlBar.tsx`
+
+**Files to modify:**
+- `frontend/app/view/agent/agent-view.tsx` — insert control bar
+- `frontend/app/view/agent/agent-model.ts` — add `updateRuntimeArgs()`
+- `frontend/app/view/agent/agent-view.scss` — control bar styles
+- `frontend/app/view/agent/types.ts` — `AgentRuntimeConfig` interface
+
+### Phase 2: Budget Guards + Tool Restrictions
+
+- `--max-budget-usd` and `--max-turns` inputs
+- Tool allow/block list UI
+- Per-provider flag mapping (Gemini `--yolo`, Codex bypass flag)
+
+### Phase 3: Backend Arg Assembly
+
+- Move flag assembly from frontend to `websocket.rs`
+- Backend reads `agent:runtime` and merges with base `cmd:args`
+- Enables future features like server-side policy enforcement
+
+## Provider Compatibility Matrix
+
+| Control | Claude | Codex | Gemini |
+|---------|--------|-------|--------|
+| Permission mode | `--permission-mode` | partial (`--full-auto`) | `--yolo` toggle |
+| Model selection | `--model` | `--model` | `--model` |
+| Effort level | `--effort` | — | — |
+| Tool restrictions | `--allowedTools` | — | — |
+| Budget guard | `--max-budget-usd` | — | — |
+| Max turns | `--max-turns` | — | — |
+
+Phase 1 targets Claude only. Gemini/Codex support can be added by extending
+`buildRuntimeArgs()` with provider-specific flag mapping.
+
+## Testing
+
+1. Launch an agent pane with default settings → verify `--dangerously-skip-permissions` is in args.
+2. Switch to Plan mode → send a message → verify `--permission-mode plan` in spawn args (check sidecar log).
+3. Switch back to Bypass → verify `--dangerously-skip-permissions` returns.
+4. Set model to Sonnet → verify `--model sonnet` in next spawn.
+5. Collapse/expand control bar → verify state persists.
+6. Close and reopen pane → verify settings persist from block metadata.
+7. Verify controls are hidden for non-Claude providers.

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1209,8 +1209,10 @@
                 color: var(--main-text-color);
                 font-family: inherit;
                 font-size: 12px;
-                resize: vertical;
-                min-height: 28px;
+                resize: none;
+                min-height: 20px;
+                max-height: 200px;
+                overflow-y: auto;
 
                 &:focus {
                     outline: none;

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -386,6 +386,88 @@
         }
     }
 
+    // === Control Bar ===
+    .agent-control-bar {
+        border-bottom: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
+        flex-shrink: 0;
+        font-size: 11px;
+    }
+
+    .agent-control-bar-header {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 3px 6px;
+        cursor: pointer;
+        user-select: none;
+        color: var(--secondary-text-color);
+
+        &:hover {
+            color: var(--main-text-color);
+            background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+        }
+    }
+
+    .agent-control-chevron {
+        font-size: 9px;
+        width: 10px;
+        flex-shrink: 0;
+    }
+
+    .agent-control-summary {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .agent-control-nondefault {
+        color: var(--warning-color, #eab308);
+        font-weight: 700;
+    }
+
+    .agent-control-bar-body {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        padding: 4px 8px 6px 16px;
+    }
+
+    .agent-control-row {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .agent-control-label {
+        color: var(--secondary-text-color);
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        min-width: 36px;
+    }
+
+    .agent-control-select {
+        background: var(--main-bg-color);
+        color: var(--main-text-color);
+        border: 1px solid var(--border-color);
+        border-radius: 3px;
+        padding: 2px 4px;
+        font-size: 11px;
+        font-family: inherit;
+        cursor: pointer;
+        outline: none;
+
+        &:hover {
+            border-color: var(--accent-color);
+        }
+
+        &:focus {
+            border-color: var(--accent-color);
+            box-shadow: 0 0 0 1px var(--accent-color);
+        }
+    }
+
     @keyframes agent-spin {
         to { transform: rotate(360deg); }
     }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -4,11 +4,13 @@
 import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import type { AgentViewModel } from "./agent-model";
+import { buildRuntimeArgs, getRuntimeConfig } from "./buildRuntimeArgs";
 import { getProvider, type ProviderDefinition } from "./providers";
 import { createAgentAtoms } from "./state";
 import type { DocumentNode, SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
+import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
 import { RpcApi } from "@/app/store/wshclientapi";
@@ -540,7 +542,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     });
 
     // Send user message
-    const handleSendMessage = (message: string) => {
+    const handleSendMessage = async (message: string) => {
         // Add user message as a document node so it appears in the chat
         const [, setDocument] = agentAtoms().documentAtom;
         setDocument((prev) => [
@@ -554,6 +556,22 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 summary: "",
             } as DocumentNode,
         ]);
+
+        // Apply runtime args (permission mode, model, effort) before this turn
+        const prov = provider();
+        if (prov) {
+            const runtimeConfig = getRuntimeConfig(block()?.meta);
+            const updatedArgs = buildRuntimeArgs(prov.launchArgs, runtimeConfig);
+            const oref = WOS.makeORef("block", model.blockId);
+            try {
+                await RpcApi.SetMetaCommand(TabRpcClient, {
+                    oref,
+                    meta: { "cmd:args": updatedArgs },
+                });
+            } catch (err) {
+                log("error", `Failed to update runtime args: ${err}`, "error");
+            }
+        }
 
         RpcApi.AgentInputCommand(TabRpcClient, {
             blockid: model.blockId,
@@ -637,6 +655,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     {"\u2715"}
                 </button>
             </div>
+
+            <AgentControlBar
+                blockId={model.blockId}
+                blockAtom={block}
+                providerId={provider()?.id ?? ""}
+            />
 
             <AgentDocumentView
                 documentAtom={agentAtoms().documentAtom}

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -1,0 +1,98 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Builds CLI args from provider base args + runtime overrides.
+ *
+ * Called before each turn so the user can change permission mode, model,
+ * and effort level between messages without restarting the session.
+ */
+
+import type { AgentRuntimeConfig, PermissionMode } from "./types";
+import { DEFAULT_RUNTIME_CONFIG } from "./types";
+
+/**
+ * Permission mode → CLI flags mapping.
+ * "bypass" uses the legacy flag; all others use --permission-mode.
+ */
+const PERMISSION_FLAGS: Record<PermissionMode, string[]> = {
+    bypass: ["--dangerously-skip-permissions"],
+    auto: ["--permission-mode", "auto"],
+    acceptEdits: ["--permission-mode", "acceptEdits"],
+    plan: ["--permission-mode", "plan"],
+    default: ["--permission-mode", "default"],
+};
+
+/** Flags that must be removed before applying permission mode. */
+const PERMISSION_STRIP = new Set([
+    "--dangerously-skip-permissions",
+    "--permission-mode",
+]);
+
+/**
+ * Build final CLI args from base provider args and runtime config.
+ *
+ * The base args come from ProviderDefinition.launchArgs (e.g.
+ * ["-p", "--output-format", "stream-json", "--verbose", ...]).
+ * Runtime overrides are applied on top, replacing conflicting flags.
+ */
+export function buildRuntimeArgs(
+    baseLaunchArgs: string[],
+    runtime: AgentRuntimeConfig | null | undefined,
+): string[] {
+    const config = runtime ?? DEFAULT_RUNTIME_CONFIG;
+    const args: string[] = [];
+
+    // Copy base args, stripping flags we'll re-add from runtime config
+    let i = 0;
+    while (i < baseLaunchArgs.length) {
+        const arg = baseLaunchArgs[i];
+        if (PERMISSION_STRIP.has(arg)) {
+            // Skip this flag. If it takes a value (--permission-mode <val>), skip that too.
+            if (arg === "--permission-mode" && i + 1 < baseLaunchArgs.length) {
+                i += 2;
+            } else {
+                i += 1;
+            }
+            continue;
+        }
+        if (arg === "--model" && i + 1 < baseLaunchArgs.length) {
+            i += 2; // strip existing --model <val>
+            continue;
+        }
+        if (arg === "--effort" && i + 1 < baseLaunchArgs.length) {
+            i += 2; // strip existing --effort <val>
+            continue;
+        }
+        args.push(arg);
+        i++;
+    }
+
+    // Apply permission mode
+    args.push(...PERMISSION_FLAGS[config.permissionMode]);
+
+    // Apply model if set
+    if (config.model) {
+        args.push("--model", config.model);
+    }
+
+    // Apply effort if set
+    if (config.effort) {
+        args.push("--effort", config.effort);
+    }
+
+    return args;
+}
+
+/**
+ * Read AgentRuntimeConfig from block metadata, falling back to defaults.
+ */
+export function getRuntimeConfig(blockMeta: Record<string, any> | undefined): AgentRuntimeConfig {
+    const raw = blockMeta?.["agent:runtime"];
+    if (!raw || typeof raw !== "object") return { ...DEFAULT_RUNTIME_CONFIG };
+    return {
+        permissionMode: raw.permissionMode ?? DEFAULT_RUNTIME_CONFIG.permissionMode,
+        model: raw.model ?? DEFAULT_RUNTIME_CONFIG.model,
+        effort: raw.effort ?? DEFAULT_RUNTIME_CONFIG.effort,
+    };
+}

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -68,8 +68,9 @@ export function buildRuntimeArgs(
         i++;
     }
 
-    // Apply permission mode
-    args.push(...PERMISSION_FLAGS[config.permissionMode]);
+    // Apply permission mode (fall back to bypass if metadata contains an invalid value)
+    const permFlags = PERMISSION_FLAGS[config.permissionMode] ?? PERMISSION_FLAGS.bypass;
+    args.push(...permFlags);
 
     // Apply model if set
     if (config.model) {

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -1,0 +1,156 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentControlBar - Collapsible runtime controls for permission mode,
+ * model, and effort level. Changes take effect on the next turn.
+ */
+
+import { createSignal, Show, type JSX } from "solid-js";
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import * as WOS from "@/app/store/wos";
+import type { AgentRuntimeConfig, PermissionMode, ModelChoice, EffortLevel } from "../types";
+import { DEFAULT_RUNTIME_CONFIG } from "../types";
+import { getRuntimeConfig } from "../buildRuntimeArgs";
+
+interface AgentControlBarProps {
+    blockId: string;
+    blockAtom: () => Block | undefined;
+    providerId: string;
+}
+
+const PERMISSION_LABELS: Record<PermissionMode, string> = {
+    bypass: "Bypass",
+    auto: "Auto",
+    acceptEdits: "Accept Edits",
+    plan: "Plan",
+    default: "Default",
+};
+
+const PERMISSION_COLORS: Record<PermissionMode, string> = {
+    bypass: "var(--error-color, #ef4444)",
+    auto: "var(--accent-color, #3b82f6)",
+    acceptEdits: "var(--warning-color, #eab308)",
+    plan: "var(--success-color, #22c55e)",
+    default: "var(--main-text-color)",
+};
+
+const MODEL_LABELS: Record<string, string> = {
+    "": "Default",
+    opus: "Opus",
+    sonnet: "Sonnet",
+    haiku: "Haiku",
+};
+
+const EFFORT_LABELS: Record<string, string> = {
+    "": "Default",
+    low: "Low",
+    medium: "Medium",
+    high: "High",
+    max: "Max",
+};
+
+export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControlBarProps): JSX.Element => {
+    const [expanded, setExpanded] = createSignal(false);
+
+    const runtime = (): AgentRuntimeConfig => getRuntimeConfig(blockAtom()?.meta);
+
+    const isNonDefault = (): boolean => {
+        const r = runtime();
+        return (
+            r.permissionMode !== DEFAULT_RUNTIME_CONFIG.permissionMode ||
+            r.model !== DEFAULT_RUNTIME_CONFIG.model ||
+            r.effort !== DEFAULT_RUNTIME_CONFIG.effort
+        );
+    };
+
+    const updateRuntime = async (patch: Partial<AgentRuntimeConfig>) => {
+        const current = runtime();
+        const updated = { ...current, ...patch };
+        const oref = WOS.makeORef("block", blockId);
+        await RpcApi.SetMetaCommand(TabRpcClient, {
+            oref,
+            meta: { "agent:runtime": updated },
+        });
+    };
+
+    const compactSummary = (): string => {
+        const r = runtime();
+        const parts: string[] = [PERMISSION_LABELS[r.permissionMode]];
+        if (r.model) parts.push(MODEL_LABELS[r.model] || r.model);
+        if (r.effort) parts.push(`Effort: ${EFFORT_LABELS[r.effort] || r.effort}`);
+        return parts.join(" · ");
+    };
+
+    // Only show for Claude provider (Phase 1)
+    if (providerId !== "claude") return null;
+
+    return (
+        <div class="agent-control-bar">
+            <div
+                class="agent-control-bar-header"
+                onClick={() => setExpanded(!expanded())}
+            >
+                <span class="agent-control-chevron">{expanded() ? "▾" : "▸"}</span>
+                <span class="agent-control-summary">
+                    <Show when={!expanded()}>
+                        {compactSummary()}
+                        <Show when={isNonDefault()}>
+                            <span class="agent-control-nondefault" title="Non-default settings active">*</span>
+                        </Show>
+                    </Show>
+                    <Show when={expanded()}>
+                        Controls
+                    </Show>
+                </span>
+            </div>
+            <Show when={expanded()}>
+                <div class="agent-control-bar-body">
+                    <div class="agent-control-row">
+                        <label class="agent-control-label">Mode</label>
+                        <select
+                            class="agent-control-select"
+                            value={runtime().permissionMode}
+                            style={{ "border-left": `3px solid ${PERMISSION_COLORS[runtime().permissionMode]}` }}
+                            onChange={(e) => updateRuntime({ permissionMode: e.target.value as PermissionMode })}
+                        >
+                            <option value="bypass">Bypass (no prompts)</option>
+                            <option value="auto">Auto (AI classifier)</option>
+                            <option value="acceptEdits">Accept Edits</option>
+                            <option value="plan">Plan (read-only)</option>
+                            <option value="default">Default (prompt all)</option>
+                        </select>
+                    </div>
+                    <div class="agent-control-row">
+                        <label class="agent-control-label">Model</label>
+                        <select
+                            class="agent-control-select"
+                            value={runtime().model ?? ""}
+                            onChange={(e) => updateRuntime({ model: (e.target.value || null) as ModelChoice })}
+                        >
+                            <option value="">Default</option>
+                            <option value="opus">Opus</option>
+                            <option value="sonnet">Sonnet</option>
+                            <option value="haiku">Haiku</option>
+                        </select>
+                    </div>
+                    <div class="agent-control-row">
+                        <label class="agent-control-label">Effort</label>
+                        <select
+                            class="agent-control-select"
+                            value={runtime().effort ?? ""}
+                            onChange={(e) => updateRuntime({ effort: (e.target.value || null) as EffortLevel })}
+                        >
+                            <option value="">Default</option>
+                            <option value="low">Low</option>
+                            <option value="medium">Medium</option>
+                            <option value="high">High</option>
+                            <option value="max">Max (Opus only)</option>
+                        </select>
+                    </div>
+                </div>
+            </Show>
+        </div>
+    );
+};

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -69,10 +69,14 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
         const current = runtime();
         const updated = { ...current, ...patch };
         const oref = WOS.makeORef("block", blockId);
-        await RpcApi.SetMetaCommand(TabRpcClient, {
-            oref,
-            meta: { "agent:runtime": updated },
-        });
+        try {
+            await RpcApi.SetMetaCommand(TabRpcClient, {
+                oref,
+                meta: { "agent:runtime": updated },
+            });
+        } catch {
+            // Silently ignore — settings will retry on next change
+        }
     };
 
     const compactSummary = (): string => {

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -14,12 +14,21 @@ interface AgentFooterProps {
 
 export const AgentFooter = ({ agentId, onSendMessage }: AgentFooterProps): JSX.Element => {
     const [message, setMessage] = createSignal("");
+    let textareaRef: HTMLTextAreaElement | undefined;
+
+    const autoGrow = (el: HTMLTextAreaElement) => {
+        el.style.height = "auto";
+        el.style.height = el.scrollHeight + "px";
+    };
 
     const handleSend = () => {
         if (!message().trim()) return;
         if (onSendMessage) {
             onSendMessage(message());
             setMessage("");
+            if (textareaRef) {
+                textareaRef.style.height = "auto";
+            }
         }
     };
 
@@ -30,16 +39,23 @@ export const AgentFooter = ({ agentId, onSendMessage }: AgentFooterProps): JSX.E
         }
     };
 
+    const handleInput = (e: Event) => {
+        const el = e.target as HTMLTextAreaElement;
+        setMessage(el.value);
+        autoGrow(el);
+    };
+
     return (
         <div class="agent-footer">
             <div class="agent-input-container">
                 <textarea
+                    ref={textareaRef}
                     class="agent-input"
                     placeholder={`Send message to ${agentId}...`}
                     value={message()}
-                    onInput={(e) => setMessage((e.target as HTMLTextAreaElement).value)}
+                    onInput={handleInput}
                     onKeyDown={handleKeyDown}
-                    rows={2}
+                    rows={1}
                 />
                 <div class="agent-input-hint">Enter to send • Shift+Enter for newline</div>
             </div>

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -306,6 +306,27 @@ export interface UserInfo {
 }
 
 /**
+ * Runtime configuration for agent pane controls.
+ * Stored in block metadata as "agent:runtime".
+ * Applied as CLI flags on each turn (between --resume spawns).
+ */
+export type PermissionMode = "bypass" | "auto" | "acceptEdits" | "plan" | "default";
+export type ModelChoice = null | "opus" | "sonnet" | "haiku";
+export type EffortLevel = null | "low" | "medium" | "high" | "max";
+
+export interface AgentRuntimeConfig {
+    permissionMode: PermissionMode;
+    model: ModelChoice;
+    effort: EffortLevel;
+}
+
+export const DEFAULT_RUNTIME_CONFIG: AgentRuntimeConfig = {
+    permissionMode: "bypass",
+    model: null,
+    effort: null,
+};
+
+/**
  * Tool icon mapping
  */
 export const TOOL_ICONS: Record<string, string> = {

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -853,6 +853,11 @@ declare global {
         "agent:resume_flag"?: string;
         "agent:session_id_field"?: string;
         "agent:sessionid"?: string;
+        "agent:runtime"?: {
+            permissionMode?: string;
+            model?: string | null;
+            effort?: string | null;
+        };
         "subagent:*"?: boolean;
         "subagent:id"?: string;
         "subagent:slug"?: string;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.70",
+  "version": "0.33.71",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Add a collapsible **control bar** to the agent pane for changing CLI flags between turns
- **Permission mode**: bypass / auto / acceptEdits / plan / default — switches between `--dangerously-skip-permissions` and `--permission-mode <mode>`
- **Model selection**: opus / sonnet / haiku / default — adds `--model <choice>`
- **Effort level**: low / medium / high / max / default — adds `--effort <level>`
- Settings persist in block metadata (`agent:runtime`) via SQLite — survives refresh
- Changes applied before each `spawn_turn()` by updating `cmd:args` — zero backend changes needed
- Phase 1: Claude provider only (Gemini/Codex have simpler flag sets)

## Architecture

The backend already re-reads `cmd:args` from block metadata on every turn (`websocket.rs:739`). The frontend updates metadata before sending `AgentInputCommand`, so the next CLI spawn picks up the new flags alongside `--resume <session_id>`.

## New files

- `frontend/app/view/agent/buildRuntimeArgs.ts` — pure function: base args + runtime config → final CLI args
- `frontend/app/view/agent/components/AgentControlBar.tsx` — collapsible control bar UI
- `docs/specs/agent-pane-runtime-controls.md` — full spec

## Modified files

- `frontend/app/view/agent/agent-view.tsx` — insert control bar, apply runtime args before send
- `frontend/app/view/agent/agent-view.scss` — control bar styles
- `frontend/app/view/agent/types.ts` — `AgentRuntimeConfig` interface
- `frontend/types/gotypes.d.ts` — `agent:runtime` metadata type

## Test plan

- [ ] Open agent pane → control bar shows collapsed with "Bypass" summary
- [ ] Expand control bar → dropdowns for Mode, Model, Effort visible
- [ ] Change Mode to "Plan" → send message → verify `--permission-mode plan` in sidecar log (no `--dangerously-skip-permissions`)
- [ ] Change Model to "Sonnet" → send message → verify `--model sonnet` in args
- [ ] Close/reopen pane → settings persist
- [ ] Non-Claude provider (Codex/Gemini) → control bar not shown
- [ ] `npx vitest run frontend/app/view/agent/` — 43/43 pass
- [ ] `npx tsc --noEmit` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)