### PR TITLE
feat: persistent process mode for agent pane (mid-turn input)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.72"
+version = "0.33.73"
 dependencies = [
  "axum 0.8.8",
  "cef",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.72"
+version = "0.33.73"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.72"
+version = "0.33.73"
 dependencies = [
  "async-stream",
  "axum 0.7.9",
@@ -78,7 +78,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.72"
+version = "0.33.73"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.72"
+version = "0.33.73"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.72"
+version = "0.33.73"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.72"
+version = "0.33.73"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -12,6 +12,7 @@
 //! - Controllers dispatch I/O between the user and the process/service
 
 pub mod health;
+pub mod persistent;
 pub mod pidregistry;
 pub mod process_tree;
 pub mod shell;
@@ -41,6 +42,7 @@ pub const BLOCK_CONTROLLER_SHELL: &str = "shell";
 pub const BLOCK_CONTROLLER_CMD: &str = "cmd";
 pub const BLOCK_CONTROLLER_TSUNAMI: &str = "tsunami";
 pub const BLOCK_CONTROLLER_SUBPROCESS: &str = "subprocess";
+pub const BLOCK_CONTROLLER_PERSISTENT: &str = "persistent";
 
 // ---- Block metadata key constants (match Go) ----
 
@@ -348,6 +350,18 @@ pub fn resync_controller(
         }
         BLOCK_CONTROLLER_SUBPROCESS => {
             let ctrl = subprocess::SubprocessController::new(
+                tab_id.to_string(),
+                block_id.to_string(),
+                broker,
+                event_bus,
+                wstore,
+            );
+            let ctrl = Arc::new(ctrl);
+            register_controller(block_id, ctrl.clone());
+            ctrl.start(block_meta.clone(), rt_opts, force)
+        }
+        BLOCK_CONTROLLER_PERSISTENT => {
+            let ctrl = persistent::PersistentSubprocessController::new(
                 tab_id.to_string(),
                 block_id.to_string(),
                 broker,

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -1,0 +1,486 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! PersistentSubprocessController: manages agent CLI as a long-running process
+//! with bidirectional NDJSON streaming via stdin/stdout.
+//!
+//! Architecture:
+//!   A single CLI process is spawned on first message and kept alive for the
+//!   entire session. User messages are written as NDJSON lines to stdin without
+//!   closing it. This enables mid-turn input (redirecting the agent while it
+//!   is still processing).
+//!
+//! State machine:
+//!   INIT ─(first message)─> RUNNING ─(idle between turns)─> RUNNING
+//!   RUNNING ─(kill/stop)─> DONE
+//!   RUNNING ─(process crash)─> DONE (auto-restart possible via session_id)
+//!
+//! I/O model (3 async tasks per session):
+//! 1. stdin_writer: mpsc channel → process stdin (NDJSON lines)
+//! 2. stdout_reader: process stdout → .jsonl persistence + WPS blockfile events
+//! 3. process_waiter: wait for exit, update status
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+
+use super::{
+    BlockControllerRuntimeStatus, BlockInputUnion, Controller, STATUS_DONE, STATUS_INIT,
+    STATUS_RUNNING,
+};
+use super::health::{classify_output_line, HealthMonitor};
+use crate::backend::eventbus::EventBus;
+use crate::backend::storage::wstore::WaveStore;
+use crate::backend::wps;
+
+/// WPS file subject name for persistent subprocess output.
+pub const PERSISTENT_OUTPUT_SUBJECT: &str = "output";
+
+/// Controller type constant.
+pub const BLOCK_CONTROLLER_PERSISTENT: &str = "persistent";
+
+/// Configuration for spawning the persistent process.
+#[derive(Debug, Clone)]
+pub struct PersistentSpawnConfig {
+    pub cli_command: String,
+    pub cli_args: Vec<String>,
+    pub working_dir: String,
+    pub env_vars: HashMap<String, String>,
+    pub session_id_field: String,
+}
+
+/// Inner state protected by mutex.
+struct PersistentInner {
+    proc_status: String,
+    proc_exit_code: i32,
+    status_version: i32,
+    session_id: Option<String>,
+    current_pid: Option<u32>,
+    /// Channel to send messages to the stdin writer task.
+    stdin_tx: Option<mpsc::Sender<String>>,
+    /// Handle to kill the process.
+    kill_tx: Option<tokio::sync::oneshot::Sender<bool>>,
+}
+
+/// PersistentSubprocessController keeps a long-running CLI process alive,
+/// sending user messages as NDJSON lines on stdin.
+pub struct PersistentSubprocessController {
+    #[allow(dead_code)]
+    tab_id: String,
+    block_id: String,
+    inner: Arc<Mutex<PersistentInner>>,
+    broker: Option<Arc<wps::Broker>>,
+    event_bus: Option<Arc<EventBus>>,
+    wstore: Option<Arc<WaveStore>>,
+    health_monitor: Arc<HealthMonitor>,
+}
+
+impl PersistentSubprocessController {
+    pub fn new(
+        tab_id: String,
+        block_id: String,
+        broker: Option<Arc<wps::Broker>>,
+        event_bus: Option<Arc<EventBus>>,
+        wstore: Option<Arc<WaveStore>>,
+    ) -> Self {
+        let health_monitor = Arc::new(HealthMonitor::new(
+            block_id.clone(),
+            broker.clone(),
+        ));
+        Self {
+            tab_id,
+            block_id,
+            inner: Arc::new(Mutex::new(PersistentInner {
+                proc_status: STATUS_INIT.to_string(),
+                proc_exit_code: 0,
+                status_version: 0,
+                session_id: None,
+                current_pid: None,
+                stdin_tx: None,
+                kill_tx: None,
+            })),
+            broker,
+            event_bus,
+            wstore,
+            health_monitor,
+        }
+    }
+
+    fn set_status(inner: &mut PersistentInner, status: &str) {
+        inner.proc_status = status.to_string();
+        inner.status_version += 1;
+    }
+
+    fn get_status_snapshot(&self) -> BlockControllerRuntimeStatus {
+        let inner = self.inner.lock().unwrap();
+        BlockControllerRuntimeStatus {
+            blockid: self.block_id.clone(),
+            version: inner.status_version,
+            shellprocstatus: inner.proc_status.clone(),
+            shellprocconnname: "local".to_string(),
+            shellprocexitcode: inner.proc_exit_code,
+            spawn_ts_ms: None,
+            is_agent_pane: true,
+        }
+    }
+
+    fn publish_status(&self) {
+        if let Some(ref broker) = self.broker {
+            let status = self.get_status_snapshot();
+            super::publish_controller_status(broker, &status);
+        }
+    }
+
+    fn is_running(&self) -> bool {
+        let inner = self.inner.lock().unwrap();
+        inner.stdin_tx.is_some()
+    }
+
+    /// Send a user message to the running CLI process.
+    /// If the process isn't spawned yet, spawns it first.
+    pub fn send_message(&self, message: String, config: PersistentSpawnConfig) -> Result<(), String> {
+        // Spawn process if not running
+        if !self.is_running() {
+            self.spawn_process(config)?;
+        }
+
+        // Format as stream-json user message
+        let json_msg = serde_json::json!({
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": message
+            }
+        });
+
+        let inner = self.inner.lock().unwrap();
+        let tx = inner.stdin_tx.as_ref()
+            .ok_or("persistent process not running after spawn")?;
+        tx.try_send(json_msg.to_string())
+            .map_err(|e| format!("stdin send failed: {e}"))
+    }
+
+    /// Spawn the persistent CLI process.
+    fn spawn_process(&self, config: PersistentSpawnConfig) -> Result<(), String> {
+        // Build command
+        let mut cmd = Command::new(&config.cli_command);
+        cmd.args(&config.cli_args);
+
+        // Working directory
+        if !config.working_dir.is_empty() {
+            let expanded_dir = if config.working_dir.starts_with("~/") || config.working_dir == "~" {
+                if let Some(home) = dirs::home_dir() {
+                    home.join(config.working_dir.trim_start_matches("~/")).to_string_lossy().to_string()
+                } else {
+                    config.working_dir.clone()
+                }
+            } else {
+                config.working_dir.clone()
+            };
+            let dir_path = std::path::Path::new(&expanded_dir);
+            if !dir_path.exists() {
+                if let Err(e) = std::fs::create_dir_all(dir_path) {
+                    tracing::warn!(
+                        block_id = %self.block_id,
+                        dir = %expanded_dir,
+                        error = %e,
+                        "failed to create working directory"
+                    );
+                }
+            }
+            if dir_path.exists() {
+                cmd.current_dir(&expanded_dir);
+            }
+        }
+
+        // Environment variables (with tilde expansion)
+        for (k, v) in &config.env_vars {
+            let expanded = crate::backend::base::expand_home_dir_safe(v);
+            cmd.env(k, expanded.to_string_lossy().as_ref());
+        }
+
+        cmd.stdin(std::process::Stdio::piped());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(|e| {
+            tracing::error!(block_id = %self.block_id, error = %e, "persistent process spawn failed");
+            format!("failed to spawn persistent process: {e}")
+        })?;
+
+        let pid = child.id().unwrap_or(0);
+        tracing::info!(
+            block_id = %self.block_id,
+            pid = pid,
+            cmd = %config.cli_command,
+            "persistent process spawned"
+        );
+
+        let (kill_tx, kill_rx) = tokio::sync::oneshot::channel::<bool>();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let _stderr = child.stderr.take().unwrap();
+
+        // Create stdin writer channel
+        let (msg_tx, mut msg_rx) = mpsc::channel::<String>(32);
+
+        {
+            let mut inner = self.inner.lock().unwrap();
+            inner.current_pid = Some(pid);
+            inner.kill_tx = Some(kill_tx);
+            inner.stdin_tx = Some(msg_tx);
+            Self::set_status(&mut inner, STATUS_RUNNING);
+        }
+        self.publish_status();
+
+        // Spawn stdin writer task
+        tokio::spawn(async move {
+            let mut stdin = stdin;
+            while let Some(msg) = msg_rx.recv().await {
+                if let Err(e) = stdin.write_all(msg.as_bytes()).await {
+                    tracing::warn!("persistent stdin write error: {}", e);
+                    break;
+                }
+                if let Err(e) = stdin.write_all(b"\n").await {
+                    tracing::warn!("persistent stdin newline error: {}", e);
+                    break;
+                }
+                if let Err(e) = stdin.flush().await {
+                    tracing::warn!("persistent stdin flush error: {}", e);
+                    break;
+                }
+            }
+            // Channel closed or write error → stdin drops → process gets EOF
+            drop(stdin);
+        });
+
+        // Spawn stdout reader task
+        let block_id_read = self.block_id.clone();
+        let broker_read = self.broker.clone();
+        let inner_read = Arc::clone(&self.inner);
+        let wstore_read = self.wstore.clone();
+        let event_bus_read = self.event_bus.clone();
+        let health_read = Arc::clone(&self.health_monitor);
+        let session_id_field = config.session_id_field.clone();
+
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() {
+                    continue;
+                }
+
+                // Parse JSON for health monitoring and session ID capture
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&line) {
+                    let (meaningful, _error) = classify_output_line(&parsed);
+                    health_read.record_output(meaningful);
+                    if let Some(sid) = parsed.get(&session_id_field).and_then(|v| v.as_str()) {
+                        let sid_string = sid.to_string();
+                        let already_captured = inner_read.lock().unwrap().session_id.is_some();
+                        if !already_captured {
+                            tracing::info!(
+                                block_id = %block_id_read,
+                                session_id = %sid_string,
+                                "persistent session ID captured"
+                            );
+                            {
+                                let mut inner = inner_read.lock().unwrap();
+                                inner.session_id = Some(sid_string.clone());
+                            }
+                            // Persist to block metadata (same pattern as subprocess.rs)
+                            if let Some(ref store) = wstore_read {
+                                let oref_str = format!("block:{}", block_id_read);
+                                let mut meta_update =
+                                    crate::backend::obj::MetaMapType::new();
+                                meta_update.insert(
+                                    "agent:sessionid".to_string(),
+                                    serde_json::Value::String(sid_string),
+                                );
+                                if let Err(e) = crate::server::service::update_object_meta(
+                                    store, &oref_str, &meta_update,
+                                ) {
+                                    tracing::warn!(
+                                        block_id = %block_id_read,
+                                        error = %e,
+                                        "failed to persist agent:sessionid"
+                                    );
+                                } else if let Some(ref event_bus) = event_bus_read {
+                                    if let Ok(updated_block) = store.must_get::<crate::backend::obj::Block>(&block_id_read) {
+                                        let update_data = serde_json::to_value(
+                                            &crate::backend::obj::WaveObjUpdate {
+                                                updatetype: "update".into(),
+                                                otype: "block".into(),
+                                                oid: block_id_read.clone(),
+                                                obj: Some(crate::backend::obj::wave_obj_to_value(&updated_block)),
+                                            },
+                                        )
+                                        .ok();
+                                        event_bus.broadcast_event(
+                                            &crate::backend::eventbus::WSEventType {
+                                                eventtype: "waveobj:update".to_string(),
+                                                oref: oref_str,
+                                                data: update_data,
+                                            },
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Publish line as WPS blockfile event
+                let line_with_newline = format!("{}\n", line);
+                if let Some(ref broker) = broker_read {
+                    super::shell::handle_append_block_file(
+                        broker,
+                        &block_id_read,
+                        PERSISTENT_OUTPUT_SUBJECT,
+                        line_with_newline.as_bytes(),
+                    );
+                }
+            }
+
+            tracing::info!(block_id = %block_id_read, "persistent stdout reader finished");
+        });
+
+        // Spawn process waiter task
+        let block_id_wait = self.block_id.clone();
+        let inner_wait = Arc::clone(&self.inner);
+        let broker_wait = self.broker.clone();
+
+        tokio::spawn(async move {
+            tokio::select! {
+                status = child.wait() => {
+                    let exit_code = status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
+                    tracing::info!(
+                        block_id = %block_id_wait,
+                        exit_code = exit_code,
+                        "persistent process exited"
+                    );
+
+                    let mut inner = inner_wait.lock().unwrap();
+                    inner.proc_exit_code = exit_code;
+                    inner.current_pid = None;
+                    inner.stdin_tx = None;
+                    inner.kill_tx = None;
+                    Self::set_status(&mut inner, STATUS_DONE);
+                    drop(inner);
+
+                    // Publish status
+                    if let Some(ref broker) = broker_wait {
+                        let status = BlockControllerRuntimeStatus {
+                            blockid: block_id_wait.clone(),
+                            version: 0,
+                            shellprocstatus: STATUS_DONE.to_string(),
+                            shellprocconnname: "local".to_string(),
+                            shellprocexitcode: exit_code,
+                            spawn_ts_ms: None,
+                            is_agent_pane: true,
+                        };
+                        super::publish_controller_status(broker, &status);
+                    }
+                }
+                Ok(force) = kill_rx => {
+                    tracing::info!(
+                        block_id = %block_id_wait,
+                        force = force,
+                        "persistent process kill requested"
+                    );
+                    if force {
+                        let _ = child.kill().await;
+                    } else {
+                        // Graceful: drop stdin to send EOF, then wait briefly
+                        {
+                            let mut inner = inner_wait.lock().unwrap();
+                            inner.stdin_tx = None; // drops the sender → stdin writer exits → stdin closes
+                        }
+                        tokio::select! {
+                            _ = child.wait() => {}
+                            _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                                let _ = child.kill().await;
+                            }
+                        }
+                    }
+
+                    let mut inner = inner_wait.lock().unwrap();
+                    inner.proc_exit_code = -1;
+                    inner.current_pid = None;
+                    inner.stdin_tx = None;
+                    inner.kill_tx = None;
+                    Self::set_status(&mut inner, STATUS_DONE);
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    pub fn stop_process(&self, force: bool) -> Result<(), String> {
+        let kill_tx = {
+            let mut inner = self.inner.lock().unwrap();
+            inner.kill_tx.take()
+        };
+        match kill_tx {
+            Some(tx) => {
+                let _ = tx.send(force);
+                Ok(())
+            }
+            None => Ok(()),
+        }
+    }
+
+    pub fn session_id(&self) -> Option<String> {
+        self.inner.lock().unwrap().session_id.clone()
+    }
+}
+
+impl Controller for PersistentSubprocessController {
+    fn start(
+        &self,
+        _block_meta: super::super::obj::MetaMapType,
+        _rt_opts: Option<serde_json::Value>,
+        _force: bool,
+    ) -> Result<(), String> {
+        tracing::info!(
+            block_id = %self.block_id,
+            "persistent controller registered (spawns on first message)"
+        );
+        Ok(())
+    }
+
+    fn stop(&self, _graceful: bool, new_status: &str) -> Result<(), String> {
+        self.stop_process(true)?;
+        let mut inner = self.inner.lock().unwrap();
+        if inner.proc_status != new_status {
+            Self::set_status(&mut inner, new_status);
+        }
+        Ok(())
+    }
+
+    fn get_runtime_status(&self) -> BlockControllerRuntimeStatus {
+        self.get_status_snapshot()
+    }
+
+    fn send_input(&self, _input: BlockInputUnion) -> Result<(), String> {
+        Err("persistent controller does not accept raw input; use send_message()".to_string())
+    }
+
+    fn controller_type(&self) -> &str {
+        BLOCK_CONTROLLER_PERSISTENT
+    }
+
+    fn block_id(&self) -> &str {
+        &self.block_id
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -708,7 +708,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
         }),
     );
 
-    // agentinput → send follow-up message to agent (re-spawns with --resume)
+    // agentinput → send message to agent (persistent or per-turn subprocess)
     let wstore_ai = state.wstore.clone();
     engine.register_handler(
         COMMAND_AGENT_INPUT,
@@ -722,12 +722,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let ctrl = blockcontroller::get_controller(&cmd.blockid)
                     .ok_or_else(|| format!("no controller for block {}", cmd.blockid))?;
 
-                let subprocess_ctrl = ctrl
-                    .as_any()
-                    .downcast_ref::<blockcontroller::subprocess::SubprocessController>()
-                    .ok_or_else(|| "controller is not a SubprocessController".to_string())?;
-
-                // Re-read the original spawn config from block metadata
+                // Re-read the spawn config from block metadata
                 let block: Block = wstore
                     .get(&cmd.blockid)
                     .map_err(|e| format!("agentinput: load block: {e}"))?
@@ -741,7 +736,6 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                         .iter()
                         .filter_map(|v| v.as_str().map(|s| s.to_string()))
                         .collect(),
-                    // Fallback: Claude-style args for blocks created before launchArgs was added
                     _ => vec![
                         "-p".to_string(),
                         "--input-format".to_string(),
@@ -760,23 +754,44 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                         .collect(),
                     _ => std::collections::HashMap::new(),
                 };
-                let resume_flag = crate::backend::obj::meta_get_string(
-                    &block.meta, "agent:resume_flag", "--resume",
-                );
                 let session_id_field = crate::backend::obj::meta_get_string(
                     &block.meta, "agent:session_id_field", "session_id",
                 );
 
-                let config = blockcontroller::subprocess::SubprocessSpawnConfig {
-                    cli_command,
-                    cli_args,
-                    working_dir,
-                    env_vars,
-                    message: cmd.message,
-                    resume_flag,
-                    session_id_field,
-                };
-                subprocess_ctrl.spawn_turn(config)?;
+                // Try persistent controller first, fall back to subprocess
+                if let Some(persistent_ctrl) = ctrl
+                    .as_any()
+                    .downcast_ref::<blockcontroller::persistent::PersistentSubprocessController>()
+                {
+                    let config = blockcontroller::persistent::PersistentSpawnConfig {
+                        cli_command,
+                        cli_args,
+                        working_dir,
+                        env_vars,
+                        session_id_field,
+                    };
+                    persistent_ctrl.send_message(cmd.message, config)?;
+                } else if let Some(subprocess_ctrl) = ctrl
+                    .as_any()
+                    .downcast_ref::<blockcontroller::subprocess::SubprocessController>()
+                {
+                    let resume_flag = crate::backend::obj::meta_get_string(
+                        &block.meta, "agent:resume_flag", "--resume",
+                    );
+                    let config = blockcontroller::subprocess::SubprocessSpawnConfig {
+                        cli_command,
+                        cli_args,
+                        working_dir,
+                        env_vars,
+                        message: cmd.message,
+                        resume_flag,
+                        session_id_field,
+                    };
+                    subprocess_ctrl.spawn_turn(config)?;
+                } else {
+                    return Err("controller is not a SubprocessController or PersistentSubprocessController".to_string());
+                }
+
                 Ok(None)
             })
         }),

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.72"
+version = "0.33.73"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/docs/specs/persistent-process-mode.md
+++ b/docs/specs/persistent-process-mode.md
@@ -1,0 +1,279 @@
+# Persistent Process Mode for Agent Pane
+
+**Status:** Proposed
+**Date:** 2026-04-09
+
+## Summary
+
+Replace the per-turn subprocess model with a persistent long-running CLI
+process that accepts messages via stdin streaming. This enables sending
+new input while the agent is still processing — the key UX gap between
+the AgentMux agent pane and the native Claude Code CLI.
+
+## Background
+
+### Current Architecture (per-turn subprocess)
+
+```
+Turn 1: spawn claude -p --output-format stream-json "<prompt>"
+        → capture session_id → stream output → process exits
+
+Turn 2: spawn claude -p --output-format stream-json --resume <sid> "<prompt>"
+        → stream output → process exits
+```
+
+Each turn spawns a **fresh process**. Stdin is written once then closed.
+No way to send input mid-turn. Designed this way because of
+anthropics/claude-code#3187 (`--input-format stream-json` hung on
+Windows via WSL/.NET).
+
+### Why Revisit
+
+- Issue #3187 is **closed** (filed against CLI v1.44, closed July 2025).
+  Someone confirmed it works. The bug was specific to WSL-via-cmd in
+  .NET — not Rust's `Command` API which handles Windows handle
+  inheritance correctly.
+- Users can't redirect agents mid-task — a core AgentMux value prop.
+- Per-turn respawn adds latency: process startup + session reload per
+  message.
+- The CLI now has mature `--input-format stream-json` support.
+
+## Proposed Architecture
+
+### Persistent process with bidirectional NDJSON
+
+```
+Spawn once:
+  claude --input-format stream-json \
+         --output-format stream-json \
+         --verbose \
+         --include-partial-messages \
+         --dangerously-skip-permissions
+
+Stdin (write NDJSON lines, keep open):
+  {"type":"user","message":{"role":"user","content":"fix the bug in auth.ts"}}
+  {"type":"user","message":{"role":"user","content":"actually, use a different approach"}}
+
+Stdout (read NDJSON lines):
+  {"type":"system","subtype":"init","session_id":"...","version":"..."}
+  {"type":"assistant","message":{"role":"assistant","content":[...]}}
+  {"type":"result","cost_usd":0.03,"duration_ms":4200,...}
+  ... (next turn's events follow after next stdin message)
+```
+
+### State Machine
+
+```
+INIT ─(first message)─> SPAWNING ─(process alive)─> IDLE
+IDLE ─(user message)─> STREAMING ─(result event)─> IDLE
+STREAMING ─(user message)─> INTERRUPTED ─(new result)─> IDLE
+IDLE ─(kill)─> DONE
+any ─(process crash)─> CRASHED ─(auto-restart or user action)─> INIT
+```
+
+Key new state: **STREAMING + user input = INTERRUPTED**. The CLI receives
+the new message while still processing and handles the interruption.
+
+### Stdin Protocol
+
+Based on Claude CLI `--input-format stream-json` docs, each stdin line is
+a JSON object. The message format for a user turn:
+
+```json
+{"type":"user","message":{"role":"user","content":"your message here"}}
+```
+
+The process does NOT need to be restarted between turns. The session ID
+is captured once from the first `system/init` event and remains valid
+for the lifetime of the process.
+
+## Implementation Plan
+
+### Phase 1: PersistentSubprocessController (new controller)
+
+Create a new controller alongside the existing `SubprocessController`
+(don't modify it — keep it as fallback).
+
+**New file:** `agentmux-srv/src/backend/blockcontroller/persistent.rs`
+
+Key differences from `subprocess.rs`:
+
+| Aspect | SubprocessController | PersistentSubprocessController |
+|--------|---------------------|-------------------------------|
+| Process lifetime | Per-turn | Per-session (minutes to hours) |
+| Stdin | Write once, close | Keep open, write NDJSON lines |
+| Resume | `--resume <sid>` flag | Not needed (same process) |
+| CLI flags | `-p` (print mode) | `--input-format stream-json` |
+| Mid-turn input | Impossible | Write new NDJSON line to stdin |
+| Session ID | Captured, used on respawn | Captured once, informational |
+
+**Inner state additions:**
+```rust
+struct PersistentInner {
+    proc_status: String,
+    session_id: Option<String>,
+    current_pid: Option<u32>,
+    kill_tx: Option<oneshot::Sender<bool>>,
+    // NEW: handle to write to the running process's stdin
+    stdin_tx: Option<mpsc::Sender<String>>,
+    // NEW: track whether a turn is in progress
+    turn_active: bool,
+}
+```
+
+**Stdin writer task:**
+```rust
+// Long-lived task that writes messages to stdin
+async fn stdin_writer(
+    mut rx: mpsc::Receiver<String>,
+    mut stdin: tokio::process::ChildStdin,
+) {
+    while let Some(msg) = rx.recv().await {
+        if let Err(e) = stdin.write_all(msg.as_bytes()).await { break; }
+        if let Err(e) = stdin.write_all(b"\n").await { break; }
+        if let Err(e) = stdin.flush().await { break; }
+    }
+    // Channel closed or write error → stdin drops → process gets EOF
+}
+```
+
+**send_message (replaces spawn_turn):**
+```rust
+fn send_message(&self, message: String) -> Result<(), String> {
+    let inner = self.inner.lock().unwrap();
+    let tx = inner.stdin_tx.as_ref()
+        .ok_or("process not running")?;
+    // Format as stream-json user message
+    let json_msg = serde_json::json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": message
+        }
+    });
+    tx.try_send(json_msg.to_string())
+        .map_err(|e| format!("stdin send failed: {e}"))
+}
+```
+
+### Phase 2: WebSocket handler update
+
+Update `websocket.rs` `agentinput` handler to detect controller type
+and call `send_message()` instead of `spawn_turn()`:
+
+```rust
+// Try persistent controller first
+if let Some(persistent) = ctrl.as_any()
+    .downcast_ref::<PersistentSubprocessController>()
+{
+    persistent.send_message(cmd.message)?;
+} else if let Some(subprocess) = ctrl.as_any()
+    .downcast_ref::<SubprocessController>()
+{
+    subprocess.spawn_turn(config)?;
+}
+```
+
+### Phase 3: Frontend — send while streaming
+
+Update `AgentFooter` to allow sending messages while the agent is
+streaming (currently the send button may be disabled during streaming).
+The `handleSendMessage` in `agent-view.tsx` doesn't need to change —
+it already calls `AgentInputCommand` which routes to the backend.
+
+### Phase 4: Runtime args update
+
+The `buildRuntimeArgs` feature (PR #322) currently writes updated
+`cmd:args` before each turn. With a persistent process, CLI flags are
+set at spawn time and can't change mid-session. Options:
+
+- **Option A:** Apply runtime args only when spawning (not per-turn).
+  Changing permission mode/model requires restarting the process.
+- **Option B:** Use stdin control messages if the CLI supports them
+  (e.g., `{"type":"config","permission_mode":"plan"}`). Unlikely to
+  be supported currently.
+- **Option C:** Keep the per-turn subprocess as fallback. If the user
+  changes runtime settings, kill the persistent process and respawn
+  with new flags. Show a brief "restarting with new settings..." message.
+
+**Recommendation:** Option C — restart on settings change. It's rare
+that users change settings mid-session, and the restart is fast (~500ms).
+
+## CLI Flags Comparison
+
+| Flag | Per-turn (current) | Persistent (proposed) |
+|------|-------------------|----------------------|
+| `-p` | Yes (print mode) | No (not needed) |
+| `--input-format stream-json` | No | **Yes** |
+| `--output-format stream-json` | Yes | Yes |
+| `--verbose` | Yes | Yes |
+| `--include-partial-messages` | Yes | Yes |
+| `--dangerously-skip-permissions` | Yes | Yes |
+| `--resume <sid>` | Yes (turn 2+) | No (same process) |
+
+## Risks and Mitigations
+
+### 1. Stdin hang on Windows (original #3187 concern)
+
+**Mitigation:** AgentMux uses Rust's `tokio::process::Command` which
+handles Windows handle inheritance correctly (no WSL, no .NET). The
+original bug was specific to WSL-via-cmd in .NET.
+
+**Testing:** Before shipping, verify:
+- Send 5+ consecutive messages via stdin NDJSON on Windows
+- Send a message while a previous turn is still streaming
+- Process doesn't hang after any message
+
+### 2. Process crash mid-session
+
+**Mitigation:** Monitor process exit. If the process dies unexpectedly,
+set status to CRASHED and either auto-respawn or show a "reconnect"
+button. The session ID is captured, so a new process can `--resume` it.
+
+### 3. Memory growth in long-running process
+
+**Mitigation:** Monitor process memory via PID. If it exceeds a
+threshold (e.g., 2GB), warn the user or auto-restart with `--resume`.
+
+### 4. Backward compatibility
+
+**Mitigation:** Keep `SubprocessController` as-is. Add
+`PersistentSubprocessController` as a new controller type. Toggle via
+block metadata `controller: "persistent"` vs `controller: "subprocess"`.
+Default to persistent for Claude, keep subprocess for Codex/Gemini
+until their stdin streaming support is verified.
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `agentmux-srv/src/backend/blockcontroller/persistent.rs` | New controller |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `agentmux-srv/src/backend/blockcontroller/mod.rs` | Register new controller type |
+| `agentmux-srv/src/server/websocket.rs` | Route agentinput to send_message() |
+| `frontend/app/view/agent/agent-model.ts` | Set controller type, update launchArgs |
+| `frontend/app/view/agent/providers/index.ts` | Add persistent-mode launchArgs |
+| `frontend/app/view/agent/components/AgentFooter.tsx` | Allow send during streaming |
+
+## Testing
+
+1. Launch agent pane → persistent process spawns
+2. Send message → output streams, turn completes, process stays alive
+3. Send second message → no new process spawn, output streams
+4. Send message **while previous turn is streaming** → agent receives
+   interrupt, responds to new message
+5. Kill process → status shows CRASHED, restart button works
+6. Change permission mode → process restarts with new flags
+7. Close pane → process is killed cleanly
+8. 10+ consecutive turns → no stdin hang, no memory leak
+
+## Migration Path
+
+1. Ship as opt-in (`controller: "persistent"`) behind a setting
+2. Test with real users for 1-2 weeks
+3. If stable, make it the default for Claude provider
+4. Keep `SubprocessController` for Codex/Gemini and as fallback

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -69,8 +69,11 @@ export class AgentViewModel implements ViewModel {
         const oref = WOS.makeORef("block", this.blockId);
         const blockId = this.blockId;
 
-        // Build CLI args from provider's launch args (provider-specific, not hardcoded -p)
-        const cliArgs = [...provider.launchArgs];
+        // Build CLI args: use persistent args if available, otherwise standard launch args
+        const isPersistent = provider.controllerType === "persistent";
+        const cliArgs = isPersistent && provider.persistentLaunchArgs
+            ? [...provider.persistentLaunchArgs]
+            : [...provider.launchArgs];
 
         // Build env vars: unset nested-session guards by setting them empty
         const envVars: Record<string, string> = {};
@@ -95,7 +98,7 @@ export class AgentViewModel implements ViewModel {
                 meta: {
                     agentId: agentId,
                     agentOutputFormat: provider.styledOutputFormat,
-                    controller: "subprocess",
+                    controller: isPersistent ? "persistent" : "subprocess",
                     cmd: cliBin,
                     "cmd:args": cliArgs,
                     "cmd:env": envVars,
@@ -169,8 +172,11 @@ export class AgentViewModel implements ViewModel {
         // Determine working directory
         const workDir = agent.working_directory || `~/.agentmux/agents/${agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-")}`;
 
-        // Build CLI args from provider's launch args (provider-specific, not hardcoded -p)
-        const cliArgs = [...provider.launchArgs];
+        // Build CLI args: use persistent args if available, otherwise standard launch args
+        const isPersistent = provider.controllerType === "persistent";
+        const cliArgs = isPersistent && provider.persistentLaunchArgs
+            ? [...provider.persistentLaunchArgs]
+            : [...provider.launchArgs];
         if (agent.provider_flags) {
             cliArgs.push(...agent.provider_flags.split(/\s+/).filter(Boolean));
         }
@@ -227,7 +233,7 @@ export class AgentViewModel implements ViewModel {
                     agentName: agent.name,
                     agentIcon: agent.icon,
                     agentMode: agent.agent_type || "host",
-                    controller: "subprocess",
+                    controller: isPersistent ? "persistent" : "subprocess",
                     cmd: cliBin,
                     "cmd:args": cliArgs,
                     "cmd:cwd": workDir,

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -31,6 +31,12 @@ export interface ProviderDefinition {
     resumeFlag: string | null;
     // JSON field name containing the session/thread ID in the CLI's init event.
     sessionIdField: string;
+    // Controller type: "persistent" keeps a long-running process with stdin streaming,
+    // "subprocess" spawns a fresh process per turn with --resume.
+    controllerType: "persistent" | "subprocess";
+    // Launch args for persistent mode (--input-format stream-json, no -p).
+    // Only used when controllerType is "persistent".
+    persistentLaunchArgs?: string[];
 }
 
 export const PROVIDERS: Record<string, ProviderDefinition> = {
@@ -57,6 +63,8 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         launchArgs: ["-p", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"],
         resumeFlag: "--resume",
         sessionIdField: "session_id",
+        controllerType: "persistent",
+        persistentLaunchArgs: ["--input-format", "stream-json", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"],
     },
     codex: {
         id: "codex",
@@ -83,6 +91,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // Multi-turn is handled by re-running exec; null disables automatic --resume append.
         resumeFlag: null,
         sessionIdField: "thread_id",
+        controllerType: "subprocess",
     },
     gemini: {
         id: "gemini",
@@ -109,6 +118,7 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         launchArgs: ["--output-format", "stream-json", "--yolo", "-p", ""],
         resumeFlag: "-r",
         sessionIdField: "session_id",
+        controllerType: "subprocess",
     },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.69",
+  "version": "0.33.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.69",
+      "version": "0.33.72",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.72",
+  "version": "0.33.73",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Replace the per-turn subprocess model with a persistent long-running CLI process for Claude. The process stays alive across turns, accepting user messages as NDJSON lines on stdin. This enables **sending input while the agent is still processing** — the key UX gap between AgentMux and the native Claude CLI.

### Architecture change

| | Before (subprocess) | After (persistent) |
|---|---|---|
| Process lifetime | Per-turn (spawn + exit) | Per-session (stays alive) |
| Stdin | Write once, close (EOF) | Keep open, write NDJSON lines |
| Resume | `--resume <sid>` per turn | Not needed (same process) |
| CLI flags | `-p` (print mode) | `--input-format stream-json` |
| Mid-turn input | Impossible | Write new line to stdin |

### Why now

The per-turn architecture was chosen because of anthropics/claude-code#3187 (`--input-format stream-json` hung on Windows). That issue is now **closed** — it was specific to WSL-via-cmd in .NET. AgentMux uses Rust's `tokio::process::Command` which handles Windows fd inheritance correctly.

## New files

- `agentmux-srv/src/backend/blockcontroller/persistent.rs` — `PersistentSubprocessController`
- `docs/specs/persistent-process-mode.md` — full spec

## Modified files

- `agentmux-srv/src/backend/blockcontroller/mod.rs` — register persistent controller
- `agentmux-srv/src/server/websocket.rs` — route agentinput to persistent or subprocess
- `frontend/app/view/agent/providers/index.ts` — add controllerType + persistentLaunchArgs
- `frontend/app/view/agent/agent-model.ts` — select controller type from provider

## Test plan

- [ ] Launch Claude agent pane → persistent process spawns on first message
- [ ] Send 5+ consecutive messages → no process respawn, all via stdin
- [ ] Send message while previous turn is streaming → agent receives it
- [ ] Stop agent → process killed cleanly
- [ ] Codex/Gemini agents → still use per-turn subprocess (unchanged)
- [ ] `cargo check -p agentmux-srv` passes
- [ ] `npx vitest run frontend/app/view/agent/` — 43/43 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)