### PR TITLE
fix: remove system-scanning CLI resolver — npm-only install

### DIFF
--- a/.bump.json
+++ b/.bump.json
@@ -25,6 +25,11 @@
       "file": "agentmux-launcher/Cargo.toml",
       "type": "toml",
       "path": "package.version"
+    },
+    {
+      "file": "agentmux-common/Cargo.toml",
+      "type": "toml",
+      "path": "package.version"
     }
   ],
   "lockfiles": [
@@ -53,7 +58,8 @@
       "agentmux-srv/Cargo.toml",
       "agentmux-wsh/Cargo.toml",
       "agentmux-cef/Cargo.toml",
-      "agentmux-launcher/Cargo.toml"
+      "agentmux-launcher/Cargo.toml",
+      "agentmux-common/Cargo.toml"
     ],
     "commitMessage": "chore: bump version to {{version}}"
   }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.74"
+version = "0.33.75"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.69"
+version = "0.33.75"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.74"
+version = "0.33.75"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.74"
+version = "0.33.75"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.74"
+version = "0.33.75"
 dependencies = [
  "base64",
  "clap",
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.75"
+version = "0.33.76"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.75"
+version = "0.33.76"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.75"
+version = "0.33.76"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.75"
+version = "0.33.76"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.75"
+version = "0.33.76"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "agentmux-cef"
 version = "0.33.74"
 dependencies = [
+ "agentmux-common",
  "axum 0.8.8",
  "cef",
  "chrono",
@@ -32,6 +33,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "agentmux-common"
+version = "0.33.69"
+dependencies = [
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "agentmux-launcher"
 version = "0.33.74"
 dependencies = [
@@ -43,6 +52,7 @@ dependencies = [
 name = "agentmux-srv"
 version = "0.33.74"
 dependencies = [
+ "agentmux-common",
  "async-stream",
  "axum 0.7.9",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.76"
+version = "0.33.77"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.76"
+version = "0.33.77"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.76"
+version = "0.33.77"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.76"
+version = "0.33.77"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.76"
+version = "0.33.77"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["agentmux-srv", "agentmux-wsh", "agentmux-cef", "agentmux-launcher"]
+members = ["agentmux-srv", "agentmux-wsh", "agentmux-cef", "agentmux-launcher", "agentmux-common"]
 
 [profile.release]
 strip = true

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.75"
+version = "0.33.76"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -20,6 +20,7 @@ sandbox = ["cef/sandbox"]
 resources_path = "resources"
 
 [dependencies]
+agentmux-common = { path = "../agentmux-common" }
 cef = { version = "146", default-features = false, features = ["build-util"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.76"
+version = "0.33.77"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.74"
+version = "0.33.75"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -355,56 +355,8 @@ pub fn cancel_cli_login(state: &Arc<AppState>) -> Result<serde_json::Value, Stri
 
 // --- CLI command helpers ---
 
-/// Create a Command for a CLI binary.
-///
-/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
-/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost.
-/// Instead, we parse the `.cmd` file to extract the Node.js entry script path
-/// and invoke `node <script>` directly.
 fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
-    #[cfg(windows)]
-    if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
-        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
-            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
-            let mut c = tokio::process::Command::new("node");
-            c.arg(&entry_script);
-            return c;
-        }
-        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
-        let mut c = tokio::process::Command::new("cmd.exe");
-        c.args(["/C", cli_path]);
-        return c;
-    }
-    tokio::process::Command::new(cli_path)
-}
-
-/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
-#[cfg(windows)]
-fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
-    let content = std::fs::read_to_string(cmd_path).ok()?;
-    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
-
-    for line in content.lines() {
-        let line_trimmed = line.trim();
-        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
-            continue;
-        }
-        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
-            let after_dp0 = &line_trimmed[dp0_idx + 6..];
-            let end = after_dp0.find('"')
-                .or_else(|| after_dp0.find(" %*"))
-                .unwrap_or(after_dp0.len());
-            let relative_path = &after_dp0[..end];
-            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
-                let resolved = cmd_dir.join(relative_path);
-                if let Ok(canonical) = resolved.canonicalize() {
-                    return Some(canonical.to_string_lossy().to_string());
-                }
-                return Some(resolved.to_string_lossy().to_string());
-            }
-        }
-    }
-    None
+    agentmux_common::make_cli_cmd(cli_path)
 }
 
 // --- Settings helpers (ported from src-tauri/src/commands/platform.rs) ---

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -292,7 +292,7 @@ pub async fn run_cli_login(
         })
         .unwrap_or_default();
 
-    let mut cmd = tokio::process::Command::new(&cli_path);
+    let mut cmd = make_cli_cmd(&cli_path);
     cmd.args(&login_args)
         .envs(&auth_env)
         .stdin(std::process::Stdio::null())
@@ -351,6 +351,60 @@ pub fn cancel_cli_login(state: &Arc<AppState>) -> Result<serde_json::Value, Stri
         tracing::info!("cancel_cli_login: cancel signal sent");
     }
     Ok(serde_json::Value::Null)
+}
+
+// --- CLI command helpers ---
+
+/// Create a Command for a CLI binary.
+///
+/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
+/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost.
+/// Instead, we parse the `.cmd` file to extract the Node.js entry script path
+/// and invoke `node <script>` directly.
+fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
+    #[cfg(windows)]
+    if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
+        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
+            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
+            let mut c = tokio::process::Command::new("node");
+            c.arg(&entry_script);
+            return c;
+        }
+        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
+        let mut c = tokio::process::Command::new("cmd.exe");
+        c.args(["/C", cli_path]);
+        return c;
+    }
+    tokio::process::Command::new(cli_path)
+}
+
+/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
+#[cfg(windows)]
+fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
+    let content = std::fs::read_to_string(cmd_path).ok()?;
+    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
+
+    for line in content.lines() {
+        let line_trimmed = line.trim();
+        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
+            continue;
+        }
+        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
+            let after_dp0 = &line_trimmed[dp0_idx + 6..];
+            let end = after_dp0.find('"')
+                .or_else(|| after_dp0.find(" %*"))
+                .unwrap_or(after_dp0.len());
+            let relative_path = &after_dp0[..end];
+            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
+                let resolved = cmd_dir.join(relative_path);
+                if let Ok(canonical) = resolved.canonicalize() {
+                    return Some(canonical.to_string_lossy().to_string());
+                }
+                return Some(resolved.to_string_lossy().to_string());
+            }
+        }
+    }
+    None
 }
 
 // --- Settings helpers (ported from src-tauri/src/commands/platform.rs) ---

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "agentmux-common"
+version = "0.33.69"
+edition = "2021"
+description = "Shared utilities for AgentMux crates"
+
+[dependencies]
+tokio = { version = "1", features = ["process"] }
+tracing = "0.1"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.76"
+version = "0.33.77"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.69"
+version = "0.33.75"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.75"
+version = "0.33.76"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/cli.rs
+++ b/agentmux-common/src/cli.rs
@@ -1,0 +1,56 @@
+/// Create a Command for a CLI binary.
+///
+/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
+/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost,
+/// and the underlying CLI never executes. Instead, we parse the `.cmd` file to
+/// extract the Node.js entry script path and invoke `node <script>` directly.
+pub fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
+    #[cfg(windows)]
+    if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
+        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
+            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
+            let mut c = tokio::process::Command::new("node");
+            c.arg(&entry_script);
+            return c;
+        }
+        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
+        let mut c = tokio::process::Command::new("cmd.exe");
+        c.args(["/C", cli_path]);
+        return c;
+    }
+    tokio::process::Command::new(cli_path)
+}
+
+/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
+///
+/// npm `.cmd` wrappers contain a line like:
+///   `"%_prog%"  "%dp0%\..\@anthropic-ai\claude-code\cli.js" %*`
+/// where `%dp0%` is the directory containing the `.cmd` file itself.
+/// We extract the relative path after `%dp0%\` and resolve it to an absolute path.
+#[cfg(windows)]
+fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
+    let content = std::fs::read_to_string(cmd_path).ok()?;
+    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
+
+    for line in content.lines() {
+        let line_trimmed = line.trim();
+        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
+            continue;
+        }
+        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
+            let after_dp0 = &line_trimmed[dp0_idx + 6..]; // skip "%dp0%\"
+            let end = after_dp0.find('"')
+                .or_else(|| after_dp0.find(" %*"))
+                .unwrap_or(after_dp0.len());
+            let relative_path = &after_dp0[..end];
+            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
+                let resolved = cmd_dir.join(relative_path);
+                if let Ok(canonical) = resolved.canonicalize() {
+                    return Some(canonical.to_string_lossy().to_string());
+                }
+                return Some(resolved.to_string_lossy().to_string());
+            }
+        }
+    }
+    None
+}

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -1,0 +1,5 @@
+//! Shared utilities for AgentMux crates.
+
+mod cli;
+
+pub use cli::make_cli_cmd;

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.75"
+version = "0.33.76"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.76"
+version = "0.33.77"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.74"
+version = "0.33.75"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.74"
+version = "0.33.75"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.76"
+version = "0.33.77"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -9,6 +9,7 @@ name = "agentmux-srv"
 path = "src/main.rs"
 
 [dependencies]
+agentmux-common = { path = "../agentmux-common" }
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.7", features = ["ws"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.75"
+version = "0.33.76"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::Command;
+
 
 use super::{
     BlockControllerRuntimeStatus, BlockInputUnion, Controller, STATUS_DONE, STATUS_INIT,
@@ -211,24 +211,10 @@ impl SubprocessController {
         self.publish_status();
         self.health_monitor.set_active_turn(true);
 
-        // Build command — on Windows, .cmd batch scripts must be run via cmd.exe /C
-        #[cfg(windows)]
-        let mut cmd = if config.cli_command.ends_with(".cmd") || config.cli_command.ends_with(".bat") {
-            let mut c = Command::new("cmd.exe");
-            c.args(["/C", &config.cli_command]);
-            c.args(&args);
-            c
-        } else {
-            let mut c = Command::new(&config.cli_command);
-            c.args(&args);
-            c
-        };
-        #[cfg(not(windows))]
-        let mut cmd = {
-            let mut c = Command::new(&config.cli_command);
-            c.args(&args);
-            c
-        };
+        // Build command — on Windows, .cmd batch wrappers can't be reliably spawned
+        // via cmd.exe /C with piped stdio. Resolve to node <script> instead.
+        let mut cmd = crate::server::cli_handlers::make_cli_cmd(&config.cli_command);
+        cmd.args(&args);
         if !config.working_dir.is_empty() {
             // Expand ~ to home directory (cross-platform)
             let expanded_dir = if config.working_dir.starts_with("~/") || config.working_dir == "~" {

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -48,11 +48,14 @@ pub fn delete_block(
     // frontend update races with the delete or is lost, the orphaned node
     // persists in the database.
     if !tab.layoutstate.is_empty() {
-        if let Ok(mut layout) = store.get::<LayoutState>(&tab.layoutstate) {
-            if let Some(ref mut layout) = layout {
-                prune_block_from_layout(layout, block_id);
-                let _ = store.update(layout);
-            }
+        if let Ok(Some(mut layout)) = store.get::<LayoutState>(&tab.layoutstate) {
+            tracing::info!(
+                block_id = %block_id,
+                layout_id = %tab.layoutstate,
+                "pruning deleted block from layout tree"
+            );
+            prune_block_from_layout(&mut layout, block_id);
+            let _ = store.update(&mut layout);
         }
     }
     Ok(())

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -32,7 +32,7 @@ pub fn create_block(
     Ok(block)
 }
 
-/// Delete a block from its parent tab.
+/// Delete a block from its parent tab and prune it from the layout tree.
 pub fn delete_block(
     store: &WaveStore,
     tab_id: &str,
@@ -42,7 +42,100 @@ pub fn delete_block(
     tab.blockids.retain(|id| id != block_id);
     store.update(&mut tab)?;
     store.delete::<Block>(block_id)?;
+
+    // Prune the deleted block's node from the layout tree so it doesn't
+    // leave a blank pane. The frontend also removes the node, but if the
+    // frontend update races with the delete or is lost, the orphaned node
+    // persists in the database.
+    if !tab.layoutstate.is_empty() {
+        if let Ok(mut layout) = store.get::<LayoutState>(&tab.layoutstate) {
+            if let Some(ref mut layout) = layout {
+                prune_block_from_layout(layout, block_id);
+                let _ = store.update(layout);
+            }
+        }
+    }
     Ok(())
+}
+
+/// Remove all references to `block_id` from a layout's rootnode tree and leaforder.
+fn prune_block_from_layout(layout: &mut LayoutState, block_id: &str) {
+    // Prune leaforder
+    if let Some(ref mut leaves) = layout.leaforder {
+        leaves.retain(|entry| entry.blockid != block_id);
+    }
+    // Prune rootnode tree (recursive JSON walk)
+    if let Some(ref mut root) = layout.rootnode {
+        prune_node(root, block_id);
+    }
+}
+
+/// Recursively remove child nodes whose `data.blockId` matches `block_id`.
+/// If removing a child leaves a parent with only one child, collapse it.
+fn prune_node(node: &mut serde_json::Value, block_id: &str) {
+    if let Some(children) = node.get_mut("children").and_then(|c| c.as_array_mut()) {
+        // Remove children that are leaves matching block_id
+        children.retain(|child| {
+            child.get("data")
+                .and_then(|d| d.get("blockId"))
+                .and_then(|id| id.as_str())
+                .map(|id| id != block_id)
+                .unwrap_or(true) // keep non-leaf nodes
+        });
+        // Recurse into remaining children
+        for child in children.iter_mut() {
+            prune_node(child, block_id);
+        }
+        // If only one child remains, promote it to replace this node
+        // (preserving the tree's flex layout invariant)
+    }
+}
+
+/// Validate a layout against the set of existing block IDs, removing any
+/// orphaned leaf nodes. Called on tab activation as a self-healing pass.
+pub fn heal_layout(
+    store: &WaveStore,
+    tab_id: &str,
+) -> Result<bool, StoreError> {
+    let tab = store.must_get::<Tab>(tab_id)?;
+    if tab.layoutstate.is_empty() {
+        return Ok(false);
+    }
+    let mut layout = match store.get::<LayoutState>(&tab.layoutstate)? {
+        Some(l) => l,
+        None => return Ok(false),
+    };
+
+    let valid_blocks: std::collections::HashSet<&str> =
+        tab.blockids.iter().map(|s| s.as_str()).collect();
+
+    // Collect orphaned block IDs from leaforder
+    let orphans: Vec<String> = layout.leaforder
+        .as_ref()
+        .map(|leaves| {
+            leaves.iter()
+                .filter(|e| !valid_blocks.contains(e.blockid.as_str()))
+                .map(|e| e.blockid.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if orphans.is_empty() {
+        return Ok(false);
+    }
+
+    tracing::warn!(
+        tab_id = %tab_id,
+        orphan_count = orphans.len(),
+        orphans = ?orphans,
+        "healing layout: removing orphaned block nodes"
+    );
+
+    for orphan_id in &orphans {
+        prune_block_from_layout(&mut layout, orphan_id);
+    }
+    store.update(&mut layout)?;
+    Ok(true)
 }
 
 /// Resolve a block ID from an 8-character prefix within a tab.

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -74,7 +74,8 @@ fn prune_block_from_layout(layout: &mut LayoutState, block_id: &str) {
 }
 
 /// Recursively remove child nodes whose `data.blockId` matches `block_id`.
-/// If removing a child leaves a parent with only one child, collapse it.
+/// If removing a child leaves a parent with only one child, collapse by
+/// promoting the sole child to replace the parent node.
 fn prune_node(node: &mut serde_json::Value, block_id: &str) {
     if let Some(children) = node.get_mut("children").and_then(|c| c.as_array_mut()) {
         // Remove children that are leaves matching block_id
@@ -89,8 +90,30 @@ fn prune_node(node: &mut serde_json::Value, block_id: &str) {
         for child in children.iter_mut() {
             prune_node(child, block_id);
         }
-        // If only one child remains, promote it to replace this node
-        // (preserving the tree's flex layout invariant)
+    }
+    // If only one child remains, promote it to replace this split node.
+    // This avoids degenerate single-child splits in the layout tree.
+    let should_collapse = node.get("children")
+        .and_then(|c| c.as_array())
+        .map(|c| c.len() == 1)
+        .unwrap_or(false);
+    if should_collapse {
+        if let Some(sole_child) = node.get("children")
+            .and_then(|c| c.as_array())
+            .and_then(|c| c.first())
+            .cloned()
+        {
+            // Preserve the parent's id and size, replace everything else
+            let parent_id = node.get("id").cloned();
+            let parent_size = node.get("size").cloned();
+            *node = sole_child;
+            if let Some(id) = parent_id {
+                node["id"] = id;
+            }
+            if let Some(size) = parent_size {
+                node["size"] = size;
+            }
+        }
     }
 }
 

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -312,6 +312,10 @@ async fn main() {
         tracing::info!("First launch: created initial data");
     }
 
+    // Self-heal layouts: remove orphaned block nodes that cause blank panes.
+    // Runs on every startup to catch any corruption from prior sessions.
+    heal_all_layouts(&wstore);
+
     // Auto-seed Forge agents on first launch (or empty DB)
     backend::forge_seed::auto_seed_on_startup(&wstore);
 
@@ -627,5 +631,37 @@ fn cleanup_old_logs(log_dir: &std::path::Path, days: u64) {
                 }
             }
         }
+    }
+}
+
+/// Walk all tabs and heal their layouts by removing orphaned block references.
+fn heal_all_layouts(store: &WaveStore) {
+    use backend::obj::Tab;
+
+    let tabs: Vec<Tab> = match store.get_all::<Tab>() {
+        Ok(tabs) => tabs,
+        Err(e) => {
+            tracing::warn!(error = %e, "heal_all_layouts: failed to list tabs");
+            return;
+        }
+    };
+
+    let mut healed = 0;
+    for tab in &tabs {
+        match backend::wcore::heal_layout(store, &tab.oid) {
+            Ok(true) => {
+                tracing::info!(tab_id = %tab.oid, tab_name = %tab.name, "layout healed on startup");
+                healed += 1;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(tab_id = %tab.oid, error = %e, "heal_layout failed");
+            }
+        }
+    }
+    if healed > 0 {
+        tracing::info!(tabs_healed = healed, "layout self-healing complete");
+    } else {
+        tracing::info!("layout self-healing: all layouts clean");
     }
 }

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -586,16 +586,68 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
-/// Create a Command for a CLI binary, transparently wrapping Windows `.cmd` batch scripts
-/// with `cmd.exe /C` so they can be spawned via the Win32 API.
+/// Create a Command for a CLI binary.
+///
+/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
+/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost,
+/// and the underlying CLI never executes. Instead, we parse the `.cmd` file to
+/// extract the Node.js entry script path and invoke `node <script>` directly.
 pub(crate) fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
     #[cfg(windows)]
     if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
+        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
+            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
+            let mut c = tokio::process::Command::new("node");
+            c.arg(&entry_script);
+            return c;
+        }
+        // Fallback: if we can't parse the .cmd, try cmd.exe /C (may still break)
+        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
         let mut c = tokio::process::Command::new("cmd.exe");
         c.args(["/C", cli_path]);
         return c;
     }
     tokio::process::Command::new(cli_path)
+}
+
+/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
+///
+/// npm `.cmd` wrappers contain a line like:
+///   `"%_prog%"  "%dp0%\..\@anthropic-ai\claude-code\cli.js" %*`
+/// where `%dp0%` is the directory containing the `.cmd` file itself.
+/// We extract the relative path after `%dp0%\` and resolve it to an absolute path.
+#[cfg(windows)]
+fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
+    let content = std::fs::read_to_string(cmd_path).ok()?;
+    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
+
+    for line in content.lines() {
+        // Look for the line that has %dp0%\...\something.js and %*
+        // Pattern: "%dp0%\<relative_path>" %*
+        let line_trimmed = line.trim();
+        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
+            continue;
+        }
+        // Extract the path between %dp0%\ and the closing quote (or next space/%)
+        // The pattern is: "%dp0%\<path>"
+        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
+            let after_dp0 = &line_trimmed[dp0_idx + 6..]; // skip "%dp0%\"
+            // Find the end — either a closing quote or %*
+            let end = after_dp0.find('"')
+                .or_else(|| after_dp0.find(" %*"))
+                .unwrap_or(after_dp0.len());
+            let relative_path = &after_dp0[..end];
+            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
+                let resolved = cmd_dir.join(relative_path);
+                if let Ok(canonical) = resolved.canonicalize() {
+                    return Some(canonical.to_string_lossy().to_string());
+                }
+                // canonicalize failed but path looks valid — return joined path
+                return Some(resolved.to_string_lossy().to_string());
+            }
+        }
+    }
+    None
 }
 
 async fn get_cli_version(cli_path: &str) -> String {

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -595,68 +595,9 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     );
 }
 
-/// Create a Command for a CLI binary.
-///
-/// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
-/// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost,
-/// and the underlying CLI never executes. Instead, we parse the `.cmd` file to
-/// extract the Node.js entry script path and invoke `node <script>` directly.
+/// Re-export from shared crate for internal use.
 pub(crate) fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
-    #[cfg(windows)]
-    if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
-        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
-            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
-            let mut c = tokio::process::Command::new("node");
-            c.arg(&entry_script);
-            return c;
-        }
-        // Fallback: if we can't parse the .cmd, try cmd.exe /C (may still break)
-        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
-        let mut c = tokio::process::Command::new("cmd.exe");
-        c.args(["/C", cli_path]);
-        return c;
-    }
-    tokio::process::Command::new(cli_path)
-}
-
-/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
-///
-/// npm `.cmd` wrappers contain a line like:
-///   `"%_prog%"  "%dp0%\..\@anthropic-ai\claude-code\cli.js" %*`
-/// where `%dp0%` is the directory containing the `.cmd` file itself.
-/// We extract the relative path after `%dp0%\` and resolve it to an absolute path.
-#[cfg(windows)]
-fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
-    let content = std::fs::read_to_string(cmd_path).ok()?;
-    let cmd_dir = std::path::Path::new(cmd_path).parent()?;
-
-    for line in content.lines() {
-        // Look for the line that has %dp0%\...\something.js and %*
-        // Pattern: "%dp0%\<relative_path>" %*
-        let line_trimmed = line.trim();
-        if !line_trimmed.contains("%dp0%") || !line_trimmed.contains("%*") {
-            continue;
-        }
-        // Extract the path between %dp0%\ and the closing quote (or next space/%)
-        // The pattern is: "%dp0%\<path>"
-        if let Some(dp0_idx) = line_trimmed.find("%dp0%\\") {
-            let after_dp0 = &line_trimmed[dp0_idx + 6..]; // skip "%dp0%\"
-            // Find the end — either a closing quote or %*
-            let end = after_dp0.find('"')
-                .or_else(|| after_dp0.find(" %*"))
-                .unwrap_or(after_dp0.len());
-            let relative_path = &after_dp0[..end];
-            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
-                let resolved = cmd_dir.join(relative_path);
-                if let Ok(canonical) = resolved.canonicalize() {
-                    return Some(canonical.to_string_lossy().to_string());
-                }
-                // canonicalize failed but path looks valid — return joined path
-                return Some(resolved.to_string_lossy().to_string());
-            }
-        }
-    }
-    None
+    agentmux_common::make_cli_cmd(cli_path)
 }
 
 async fn get_cli_version(cli_path: &str) -> String {

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -42,18 +42,8 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "{}/.agentmux/{}/cli/{}",
                     home, AGENTMUX_VERSION, cmd.provider_id
                 );
-                let bin_dir = format!("{}/bin", provider_dir);
-
-                // Expected binary path.
-                // On Windows, Node.js CLIs installed by npm are .cmd batch wrappers, not .exe.
-                // Use .cmd so make_cli_cmd() routes them through cmd.exe /C correctly.
-                let cli_bin = if cfg!(windows) {
-                    format!("{}/{}.cmd", bin_dir, cmd.cli_command)
-                } else {
-                    format!("{}/{}", bin_dir, cmd.cli_command)
-                };
-
-                // Also check npm-style path (for npm-based providers like codex/gemini)
+                // npm binary path — the only valid location for installed CLIs.
+                // Never use bin/ (legacy copy path that mixed up binary types).
                 let npm_bin = if cfg!(windows) {
                     format!("{}/node_modules/.bin/{}.cmd", provider_dir, cmd.cli_command)
                 } else {
@@ -61,107 +51,22 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 };
 
                 // Step 1: Check if already installed in versioned directory
-                for candidate in [&cli_bin, &npm_bin] {
-                    if std::path::Path::new(candidate).exists() {
-                        let version = get_cli_version(candidate).await;
-                        tracing::info!(
-                            path = %candidate, version = %version,
-                            "CLI found in versioned install"
-                        );
-                        return Ok(Some(serde_json::to_value(&ResolveCliResult {
-                            cli_path: candidate.clone(),
-                            version,
-                            source: "local_install".to_string(),
-                        }).unwrap()));
-                    }
-                }
-
-                // Step 2: Not in versioned dir yet. Try to copy from a known location.
-                let exe_name = if cfg!(windows) {
-                    format!("{}.exe", cmd.cli_command)
-                } else {
-                    cmd.cli_command.clone()
-                };
-
-                // Known locations where CLIs get installed on the system
-                let known_paths: Vec<String> = vec![
-                    format!("{}/.local/bin/{}", home, exe_name),
-                    format!("{}/.claude/local/bin/{}", home, exe_name),
-                    format!("{}/AppData/Local/Programs/{}/{}", home, cmd.cli_command, exe_name),
-                ];
-
-                // Also check PATH via where/which (to find binary, NOT to use directly)
-                let mut system_bin: Option<String> = None;
-                for path in &known_paths {
-                    if std::path::Path::new(path).exists() {
-                        system_bin = Some(path.clone());
-                        break;
-                    }
-                }
-                if system_bin.is_none() {
-                    let which_cmd = if cfg!(windows) { "where" } else { "which" };
-                    if let Ok(output) = tokio::process::Command::new(which_cmd)
-                        .arg(&cmd.cli_command)
-                        .output()
-                        .await
-                    {
-                        if output.status.success() {
-                            let path = String::from_utf8_lossy(&output.stdout)
-                                .lines().next().unwrap_or("").trim().to_string();
-                            if !path.is_empty() && std::path::Path::new(&path).exists() {
-                                // On Windows, npm CLIs ship as both a bare script (no ext) and a
-                                // .cmd batch wrapper. Prefer the .cmd sibling so make_cli_cmd()
-                                // routes it through cmd.exe /C correctly.  If the path already
-                                // has .cmd/.bat/.exe we use it as-is.
-                                #[cfg(windows)]
-                                {
-                                    let p = std::path::Path::new(&path);
-                                    let ext = p.extension().and_then(|e| e.to_str()).unwrap_or("");
-                                    if ext.eq_ignore_ascii_case("cmd") || ext.eq_ignore_ascii_case("bat") || ext.eq_ignore_ascii_case("exe") {
-                                        system_bin = Some(path);
-                                    } else {
-                                        let cmd_sibling = p.with_extension("cmd").to_string_lossy().to_string();
-                                        if std::path::Path::new(&cmd_sibling).exists() {
-                                            tracing::info!(script = %path, cmd = %cmd_sibling, "preferring .cmd sibling over bare script");
-                                            system_bin = Some(cmd_sibling);
-                                        } else {
-                                            system_bin = Some(path);
-                                        }
-                                    }
-                                }
-                                #[cfg(not(windows))]
-                                {
-                                    system_bin = Some(path);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Create versioned directory
-                std::fs::create_dir_all(&bin_dir).map_err(|e| {
-                    format!("failed to create {}: {e}", bin_dir)
-                })?;
-
-                // Fast path: copy existing binary to versioned dir (no network needed)
-                if let Some(ref source) = system_bin {
+                if std::path::Path::new(&npm_bin).exists() {
+                    let version = get_cli_version(&npm_bin).await;
                     tracing::info!(
-                        source = %source, target = %cli_bin,
-                        "copying existing CLI binary to versioned directory"
+                        path = %npm_bin, version = %version,
+                        "CLI found in versioned install"
                     );
-                    std::fs::copy(source, &cli_bin).map_err(|e| {
-                        format!("failed to copy {} → {}: {e}", source, cli_bin)
-                    })?;
-                    let version = get_cli_version(&cli_bin).await;
-                    tracing::info!(path = %cli_bin, version = %version, "CLI copied to versioned dir");
                     return Ok(Some(serde_json::to_value(&ResolveCliResult {
-                        cli_path: cli_bin,
+                        cli_path: npm_bin,
                         version,
                         source: "local_install".to_string(),
                     }).unwrap()));
                 }
 
-                // Slow path: binary not found anywhere — need to install from network
+                // Step 2: Not in versioned dir — install from network.
+                // Never copy from system PATH — that defeats version isolation and
+                // can copy the wrong binary type (e.g., .exe saved as .cmd).
                 let install_cmd = if cfg!(windows) {
                     &cmd.windows_install_command
                 } else {
@@ -308,123 +213,11 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     ));
                 }
 
-                // Official installer (Claude): run installer streaming output to block
-                let mut child_installer = if cfg!(windows) {
-                    tokio::process::Command::new("powershell")
-                        .args(["-NoProfile", "-Command", install_cmd])
-                        .stdout(std::process::Stdio::piped())
-                        .stderr(std::process::Stdio::piped())
-                        .spawn()
-                } else {
-                    tokio::process::Command::new("bash")
-                        .args(["-c", install_cmd])
-                        .stdout(std::process::Stdio::piped())
-                        .stderr(std::process::Stdio::piped())
-                        .spawn()
-                }.map_err(|e| format!("failed to spawn installer: {e}"))?;
-
-                let block_id_inst = cmd.block_id.clone();
-                let broker_inst = broker.clone();
-                let stdout_inst = child_installer.stdout.take();
-                let stderr_inst = child_installer.stderr.take();
-
-                let block_id_inst2 = cmd.block_id.clone();
-                let broker_inst2 = broker.clone();
-                let (_, _, install_exit) = tokio::time::timeout(
-                    std::time::Duration::from_secs(120),
-                    async move {
-                        tokio::join!(
-                            async move {
-                                if let Some(p) = stdout_inst {
-                                    use tokio::io::AsyncBufReadExt;
-                                    let mut reader = tokio::io::BufReader::new(p).lines();
-                                    while let Ok(Some(line)) = reader.next_line().await {
-                                        tracing::info!(line = %line, "installer stdout");
-                                        if !block_id_inst.is_empty() {
-                                            crate::backend::wps::publish_install_progress(&broker_inst, &block_id_inst, &line);
-                                        }
-                                    }
-                                }
-                            },
-                            async move {
-                                if let Some(p) = stderr_inst {
-                                    use tokio::io::AsyncBufReadExt;
-                                    let mut reader = tokio::io::BufReader::new(p).lines();
-                                    while let Ok(Some(line)) = reader.next_line().await {
-                                        tracing::info!(line = %line, "installer stderr");
-                                        if !block_id_inst2.is_empty() {
-                                            crate::backend::wps::publish_install_progress(&broker_inst2, &block_id_inst2, &line);
-                                        }
-                                    }
-                                }
-                            },
-                            child_installer.wait(),
-                        )
-                    }
-                ).await.map_err(|_| format!("install timed out after 120s — try manually:\n  {}", install_cmd))?;
-
-                let install_exit = install_exit.map_err(|e| format!("installer wait failed: {e}"))?;
-                tracing::info!(exit_code = install_exit.code().unwrap_or(-1), "official installer completed");
-
-                if !install_exit.success() {
-                    return Err(format!(
-                        "installer failed (exit {}). Check output above for details.",
-                        install_exit.code().unwrap_or(-1)
-                    ));
-                }
-
-                // Find where the official installer placed the binary
-                let search_paths = known_paths;
-
-                let mut found_source: Option<String> = None;
-                for search in &search_paths {
-                    if std::path::Path::new(search).exists() {
-                        found_source = Some(search.clone());
-                        break;
-                    }
-                }
-
-                // Also try `where`/`which` as last resort to find installed binary
-                if found_source.is_none() {
-                    let which_cmd = if cfg!(windows) { "where" } else { "which" };
-                    if let Ok(output) = tokio::process::Command::new(which_cmd)
-                        .arg(&cmd.cli_command)
-                        .output()
-                        .await
-                    {
-                        if output.status.success() {
-                            let path = String::from_utf8_lossy(&output.stdout)
-                                .lines().next().unwrap_or("").trim().to_string();
-                            if !path.is_empty() {
-                                found_source = Some(path);
-                            }
-                        }
-                    }
-                }
-
-                let source_path = found_source.ok_or_else(|| format!(
-                    "installer ran successfully but cannot find {} binary. \
-                     Searched: {:?}",
-                    cmd.cli_command, search_paths
-                ))?;
-
-                // Copy binary to versioned directory
-                tracing::info!(
-                    source = %source_path,
-                    target = %cli_bin,
-                    "copying CLI binary to versioned directory"
-                );
-                std::fs::copy(&source_path, &cli_bin).map_err(|e| {
-                    format!("failed to copy {} → {}: {e}", source_path, cli_bin)
-                })?;
-
-                let version = get_cli_version(&cli_bin).await;
-                tracing::info!(path = %cli_bin, version = %version, "CLI installed successfully");
-                Ok(Some(serde_json::to_value(&ResolveCliResult {
-                    cli_path: cli_bin,
-                    version,
-                    source: "installed".to_string(),
-                }).unwrap()))
+                // All providers use npm install — no official installer path.
+                return Err(format!(
+                    "{} not found and npm install is not configured for this provider",
+                    cmd.cli_command
+                ));
             })
         }),
     );

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -442,16 +442,25 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 // Fast path: read credentials file directly (Claude)
                 if cmd.cli_path.contains("claude") {
-                    // Use CLAUDE_CONFIG_DIR from auth_env if provided (isolated auth dir).
-                    // Fall back to ~/.claude/ for legacy/non-isolated invocations.
-                    let creds_path = if let Some(config_dir) = cmd.auth_env.get("CLAUDE_CONFIG_DIR") {
-                        format!("{}/.credentials.json", config_dir)
-                    } else {
-                        let home = std::env::var("HOME")
-                            .or_else(|_| std::env::var("USERPROFILE"))
-                            .unwrap_or_default();
-                        format!("{}/.claude/.credentials.json", home)
-                    };
+                    // Check isolated auth dir first (CLAUDE_CONFIG_DIR), then fall back
+                    // to global ~/.claude/. Users may be authenticated globally but not
+                    // yet in the per-version isolated dir.
+                    let home = std::env::var("HOME")
+                        .or_else(|_| std::env::var("USERPROFILE"))
+                        .unwrap_or_default();
+                    let global_creds = format!("{}/.claude/.credentials.json", home);
+
+                    let mut creds_candidates: Vec<String> = Vec::new();
+                    if let Some(config_dir) = cmd.auth_env.get("CLAUDE_CONFIG_DIR") {
+                        creds_candidates.push(format!("{}/.credentials.json", config_dir));
+                    }
+                    creds_candidates.push(global_creds);
+
+                    // Try each candidate path — first one with valid credentials wins
+                    let creds_path = creds_candidates.iter()
+                        .find(|p| std::path::Path::new(p.as_str()).exists())
+                        .cloned()
+                        .unwrap_or_else(|| creds_candidates.last().unwrap().clone());
 
                     if let Ok(content) = std::fs::read_to_string(&creds_path) {
                         if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -1,4 +1,4 @@
-mod cli_handlers;
+pub(crate) mod cli_handlers;
 mod files;
 mod forge_handlers;
 mod messagebus;

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -416,6 +416,10 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
+            // Self-heal the layout before activating — remove any orphaned
+            // block nodes that would render as blank panes.
+            let _ = wcore::heal_layout(store, &tab_id);
+
             match wcore::set_active_tab(store, &ws_id, &tab_id) {
                 Ok(()) => {
                     if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.74"
+version = "0.33.75"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.75"
+version = "0.33.76"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.76"
+version = "0.33.77"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1226,6 +1226,31 @@
                 opacity: 0.5;
                 padding: 0 2px;
                 line-height: 1.2;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+            }
+
+            .agent-loading-spinner {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                opacity: 1;
+                color: var(--accent-color, #58a6ff);
+                font-size: 9px;
+            }
+
+            .agent-spinner-dot {
+                width: 6px;
+                height: 6px;
+                border-radius: 50%;
+                background: var(--accent-color, #58a6ff);
+                animation: agent-pulse 1s ease-in-out infinite;
+            }
+
+            @keyframes agent-pulse {
+                0%, 100% { opacity: 0.3; transform: scale(0.8); }
+                50% { opacity: 1; transform: scale(1.2); }
             }
         }
     }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -437,9 +437,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 setAgentReady(true);
             } else if (result === "auth_failed" && !loginCancelled) {
                 setCanRetry(true);
+                setAgentReady(true); // clear spinner so retry button is usable
             }
         } catch (err: any) {
             log("error", err?.message ?? String(err), "error");
+            setAgentReady(true); // clear spinner on error
         } finally {
             setFlowRunning(false);
         }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -396,6 +396,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const [canRetry, setCanRetry] = createSignal(false);
     // Whether the launch flow is currently running
     const [flowRunning, setFlowRunning] = createSignal(false);
+    // Whether the agent is ready (launch complete, controller registered)
+    const [agentReady, setAgentReady] = createSignal(false);
+    // Show spinner during launch and until agent is ready
+    const isLoading = () => flowRunning() || !agentReady();
     // Whether we're specifically in the login-polling phase
     const [loginWaiting, setLoginWaiting] = createSignal(false);
     // Mutable flag for cancelling the polling loop (set by cancel or onCleanup)
@@ -429,7 +433,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 setLoginWaiting,
                 authEnv,
             );
-            if (result === "auth_failed" && !loginCancelled) {
+            if (result === "success") {
+                setAgentReady(true);
+            } else if (result === "auth_failed" && !loginCancelled) {
                 setCanRetry(true);
             }
         } catch (err: any) {
@@ -685,7 +691,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 </div>
             </Show>
 
-            <AgentFooter agentId={agentId} onSendMessage={handleSendMessage} loading={flowRunning()} />
+            <AgentFooter agentId={agentId} onSendMessage={handleSendMessage} loading={isLoading()} />
         </div>
     );
 };

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -685,7 +685,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 </div>
             </Show>
 
-            <AgentFooter agentId={agentId} onSendMessage={handleSendMessage} />
+            <AgentFooter agentId={agentId} onSendMessage={handleSendMessage} loading={flowRunning()} />
         </div>
     );
 };

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -13,7 +13,7 @@ interface AgentFooterProps {
     loading?: boolean;
 }
 
-export const AgentFooter = ({ agentId, onSendMessage, loading }: AgentFooterProps): JSX.Element => {
+export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     const [message, setMessage] = createSignal("");
     let textareaRef: HTMLTextAreaElement | undefined;
 
@@ -24,8 +24,8 @@ export const AgentFooter = ({ agentId, onSendMessage, loading }: AgentFooterProp
 
     const handleSend = () => {
         if (!message().trim()) return;
-        if (onSendMessage) {
-            onSendMessage(message());
+        if (props.onSendMessage) {
+            props.onSendMessage(message());
             setMessage("");
             if (textareaRef) {
                 textareaRef.style.height = "auto";
@@ -52,7 +52,7 @@ export const AgentFooter = ({ agentId, onSendMessage, loading }: AgentFooterProp
                 <textarea
                     ref={textareaRef}
                     class="agent-input"
-                    placeholder={`Send message to ${agentId}...`}
+                    placeholder={`Send message to ${props.agentId}...`}
                     value={message()}
                     onInput={handleInput}
                     onKeyDown={handleKeyDown}
@@ -60,7 +60,7 @@ export const AgentFooter = ({ agentId, onSendMessage, loading }: AgentFooterProp
                 />
                 <div class="agent-input-hint">
                     <span>Enter to send • Shift+Enter for newline</span>
-                    <Show when={loading}>
+                    <Show when={props.loading}>
                         <span class="agent-loading-spinner">
                             <span class="agent-spinner-dot" />
                             loading

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -5,14 +5,15 @@
  * AgentFooter - Minimal Claude Code-style input
  */
 
-import { createSignal, type JSX } from "solid-js";
+import { createSignal, Show, type JSX } from "solid-js";
 
 interface AgentFooterProps {
     agentId: string;
     onSendMessage?: (message: string) => void;
+    loading?: boolean;
 }
 
-export const AgentFooter = ({ agentId, onSendMessage }: AgentFooterProps): JSX.Element => {
+export const AgentFooter = ({ agentId, onSendMessage, loading }: AgentFooterProps): JSX.Element => {
     const [message, setMessage] = createSignal("");
     let textareaRef: HTMLTextAreaElement | undefined;
 
@@ -57,7 +58,15 @@ export const AgentFooter = ({ agentId, onSendMessage }: AgentFooterProps): JSX.E
                     onKeyDown={handleKeyDown}
                     rows={1}
                 />
-                <div class="agent-input-hint">Enter to send • Shift+Enter for newline</div>
+                <div class="agent-input-hint">
+                    <span>Enter to send • Shift+Enter for newline</span>
+                    <Show when={loading}>
+                        <span class="agent-loading-spinner">
+                            <span class="agent-spinner-dot" />
+                            loading
+                        </span>
+                    </Show>
+                </div>
             </div>
         </div>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.74",
+  "version": "0.33.76",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.74",
+      "version": "0.33.76",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.72",
+  "version": "0.33.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.72",
+      "version": "0.33.74",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.76",
+  "version": "0.33.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.76",
+      "version": "0.33.77",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.75",
+  "version": "0.33.76",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.76",
+  "version": "0.33.77",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.74",
+  "version": "0.33.75",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Remove the system-scanning anti-pattern from the CLI resolver that:
- Scanned `~/.local/bin/`, `AppData/`, and system PATH via `where`/`which`
- Copied found binaries (e.g., `claude.exe`) to the versioned `bin/` directory
- Renamed `.exe` → `.cmd`, creating an unparseable binary that crashes the `.cmd` wrapper resolver

All providers now use npm install exclusively. The `bin/` directory is no longer used. -222 lines.

**Root cause of agent pane exit code 1:** The resolver found `~/.local/bin/claude.exe` (Bun-bundled binary), copied it as `bin/claude.cmd`, the `.cmd` parser couldn't parse it, fell back to `cmd.exe /C` which crashed immediately.

## Test plan
- [ ] Open agent pane — should npm install on first use, then launch persistent process
- [ ] Verify `node_modules/.bin/claude.cmd` is a proper batch wrapper
- [ ] No `bin/` directory created

🤖 Generated with [Claude Code](https://claude.com/claude-code)