### PR TITLE
fix: always use npm install for all providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.77"
+version = "0.33.78"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.77"
+version = "0.33.78"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.77"
+version = "0.33.78"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.77"
+version = "0.33.78"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.77"
+version = "0.33.78"
 dependencies = [
  "base64",
  "clap",
@@ -1416,9 +1416,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2347,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3276,9 +3276,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3299,9 +3299,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3309,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3322,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3365,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.77"
+version = "0.33.78"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.77"
+version = "0.33.78"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.77"
+version = "0.33.78"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.77"
+version = "0.33.78"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -66,30 +66,22 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // Step 2: Not in versioned dir — install from network.
                 // Never copy from system PATH — that defeats version isolation and
                 // can copy the wrong binary type (e.g., .exe saved as .cmd).
-                let install_cmd = if cfg!(windows) {
-                    &cmd.windows_install_command
-                } else {
-                    &cmd.unix_install_command
-                };
-
-                if install_cmd.is_empty() {
+                if cmd.npm_package.is_empty() {
                     return Err(format!(
-                        "{} not found and no install command configured for this provider",
+                        "{} not found and no npm package configured for this provider",
                         cmd.cli_command
                     ));
                 }
 
                 tracing::info!(
                     provider = %cmd.provider_id,
-                    install_cmd = %install_cmd,
+                    npm_package = %cmd.npm_package,
+                    pinned_version = %cmd.pinned_version,
                     target_dir = %provider_dir,
-                    "CLI not found locally, installing from network"
+                    "CLI not found locally, installing via npm"
                 );
 
-                // Determine if this is an npm-based provider or official installer
-                let is_npm_install = install_cmd.contains("npm install");
-
-                if is_npm_install {
+                {
                     // Verify npm is available before attempting install.
                     let npm_available = if cfg!(windows) {
                         tokio::process::Command::new("where").arg("npm").output().await
@@ -206,17 +198,11 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         }).unwrap()));
                     }
 
-                    return Err(format!(
+                    Err(format!(
                         "npm install completed but binary not found at {}",
                         npm_bin
-                    ));
+                    ))
                 }
-
-                // All providers use npm install — no official installer path needed.
-                Err(format!(
-                    "{} not found and npm install is not configured for this provider",
-                    cmd.cli_command
-                ))
             })
         }),
     );

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.77"
+version = "0.33.78"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.77",
+  "version": "0.33.78",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.77",
+      "version": "0.33.78",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.77",
+  "version": "0.33.78",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
The resolver gated npm install on `install_cmd.contains("npm install")`. Claude's provider has an official installer string, not "npm install", so it skipped npm and errored with "not configured for this provider".

Now uses `npm_package` field directly — all providers with a package name get npm installed.

## Test plan
- [ ] Open agent pane — npm installs Claude Code successfully
- [ ] Persistent process launches and responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)