### PR TITLE
fix: persistent controller must use make_cli_cmd for .cmd resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.78"
+version = "0.33.79"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.78"
+version = "0.33.79"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.78"
+version = "0.33.79"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.78"
+version = "0.33.79"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.78"
+version = "0.33.79"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.78"
+version = "0.33.79"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.78"
+version = "0.33.79"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.78"
+version = "0.33.79"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.78"
+version = "0.33.79"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -25,7 +25,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::Command;
 use tokio::sync::mpsc;
 
 use super::{

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -166,8 +166,8 @@ impl PersistentSubprocessController {
 
     /// Spawn the persistent CLI process.
     fn spawn_process(&self, config: PersistentSpawnConfig) -> Result<(), String> {
-        // Build command
-        let mut cmd = Command::new(&config.cli_command);
+        // Build command — use make_cli_cmd to resolve .cmd wrappers to node on Windows
+        let mut cmd = crate::server::cli_handlers::make_cli_cmd(&config.cli_command);
         cmd.args(&config.cli_args);
 
         // Working directory

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.78"
+version = "0.33.79"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.78",
+  "version": "0.33.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.78",
+      "version": "0.33.79",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.78",
+  "version": "0.33.79",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
`persistent.rs` used raw `Command::new()` which spawned `cmd.exe /C` for `.cmd` wrappers. `subprocess.rs` already used `make_cli_cmd()` which parses the `.cmd` wrapper and resolves to `node <script>` directly.

Without this, stdin/stdout piping through `cmd.exe /C` doesn't work for persistent processes — the process spawns but produces no output and stdin writes are lost.

One-line fix: `Command::new()` → `make_cli_cmd()`.

## Test plan
- [ ] Open agent pane — persistent process spawns via node, not cmd.exe
- [ ] Send message — stdout streams back
- [ ] Multi-turn works without respawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)