### PR TITLE
fix: strip UNC prefix from canonicalize, capture persistent stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.80"
+version = "0.33.81"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.81"
+version = "0.33.82"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.79"
+version = "0.33.80"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.81"
+version = "0.33.82"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.79"
+version = "0.33.80"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.80"
+version = "0.33.81"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/cli.rs
+++ b/agentmux-common/src/cli.rs
@@ -46,7 +46,13 @@ fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
             if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
                 let resolved = cmd_dir.join(relative_path);
                 if let Ok(canonical) = resolved.canonicalize() {
-                    return Some(canonical.to_string_lossy().to_string());
+                    let mut path_str = canonical.to_string_lossy().to_string();
+                    // Windows canonicalize() returns \\?\C:\... (UNC extended path)
+                    // which Node.js cannot handle — strip the prefix.
+                    if path_str.starts_with(r"\\?\") {
+                        path_str = path_str[4..].to_string();
+                    }
+                    return Some(path_str);
                 }
                 return Some(resolved.to_string_lossy().to_string());
             }

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.79"
+version = "0.33.80"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.80"
+version = "0.33.81"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.81"
+version = "0.33.82"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.80"
+version = "0.33.81"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.79"
+version = "0.33.80"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.81"
+version = "0.33.82"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -204,9 +204,7 @@ impl PersistentSubprocessController {
 
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
-        // Use null for stderr — piped stderr that is immediately dropped would
-        // cause SIGPIPE/EPIPE on the child's first stderr write, killing it.
-        cmd.stderr(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::piped());
 
         let mut child = cmd.spawn().map_err(|e| {
             tracing::error!(block_id = %self.block_id, error = %e, "persistent process spawn failed");
@@ -218,12 +216,30 @@ impl PersistentSubprocessController {
             block_id = %self.block_id,
             pid = pid,
             cmd = %config.cli_command,
+            args = ?config.cli_args,
+            working_dir = %config.working_dir,
             "persistent process spawned"
         );
 
         let (kill_tx, kill_rx) = tokio::sync::oneshot::channel::<bool>();
         let stdin = child.stdin.take().unwrap();
         let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take();
+
+        // Drain stderr in background — log lines for debugging
+        if let Some(stderr_pipe) = stderr {
+            let block_id_stderr = self.block_id.clone();
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(stderr_pipe).lines();
+                while let Ok(Some(line)) = reader.next_line().await {
+                    tracing::warn!(
+                        block_id = %block_id_stderr,
+                        line = %line,
+                        "persistent stderr"
+                    );
+                }
+            });
+        }
 
         // Create stdin writer channel
         let (msg_tx, mut msg_rx) = mpsc::channel::<String>(32);

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.79"
+version = "0.33.80"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.80"
+version = "0.33.81"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.81"
+version = "0.33.82"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/docs/analysis/persistent-process-retro-2026-04-10.md
+++ b/docs/analysis/persistent-process-retro-2026-04-10.md
@@ -1,0 +1,105 @@
+# Persistent Process Mode — Debug Retro (2026-04-10)
+
+**Goal:** Replace per-turn subprocess with persistent long-running CLI process
+using `--input-format stream-json` for bidirectional communication.
+
+**Spec:** `docs/specs/persistent-process-mode.md`
+**Implementation:** `agentmux-srv/src/backend/blockcontroller/persistent.rs`
+
+---
+
+## Issues Found (chronological)
+
+### 1. System-scanning CLI resolver copies .exe as .cmd (PR #327, v0.33.77)
+- **Symptom:** Agent pane subprocess exits with code 1 immediately
+- **Root cause:** Resolver found `~/.local/bin/claude.exe` (Bun-bundled binary),
+  copied it to `bin/claude.cmd`. The `.cmd` parser (`parse_cmd_wrapper`) couldn't
+  parse a PE binary, fell back to `cmd.exe /C` which crashed.
+- **Fix:** Removed entire system-scanning copy path. All providers use npm install
+  exclusively to `node_modules/.bin/`.
+- **Lesson:** Never copy system binaries — version isolation requires independent installs.
+
+### 2. npm install gate on install_cmd string (PR #328, v0.33.78)
+- **Symptom:** "claude not found and npm install is not configured for this provider"
+- **Root cause:** Resolver checked `install_cmd.contains("npm install")`. Claude's
+  provider had an official installer string, not "npm install", so it skipped npm
+  entirely.
+- **Fix:** Gate on `npm_package` field instead — all providers with a package name
+  get npm installed.
+- **Lesson:** Don't branch on string matching of config values; use explicit type fields.
+
+### 3. persistent.rs used raw Command::new() instead of make_cli_cmd() (PR #329, v0.33.79)
+- **Symptom:** Process spawned as `cmd.exe` (pid visible in tasklist), no stdout
+  output, exits with code 1.
+- **Root cause:** `persistent.rs` used `Command::new(&config.cli_command)` which
+  on Windows spawns `cmd.exe /C claude.cmd`. `subprocess.rs` already used
+  `make_cli_cmd()` which parses `.cmd` → `node <script>`. Stdin/stdout piping
+  through `cmd.exe /C` doesn't reliably work for persistent processes.
+- **Fix:** One-line change: `Command::new()` → `make_cli_cmd()`.
+- **Lesson:** Any new controller that spawns CLI processes must use the shared
+  `make_cli_cmd()` helper, not raw `Command::new()`.
+
+### 4. Stale portables built before fix commits (v0.33.79, v0.33.80)
+- **Symptom:** Portable shows correct version but doesn't have the fix
+- **Root cause:** `task cef:package:portable` was run on the branch before the
+  fix commit was pushed. The version bump happened first, then the fix, but the
+  binary was compiled from pre-fix code.
+- **Fix:** Rebuild v0.33.80 from main after all PRs merged.
+- **Lesson:** Always verify the fix is in the built binary, not just in source.
+  `git log --oneline -1` before building.
+
+### 5. No stderr capture — blind to exit code 1 cause (v0.33.80)
+- **Symptom:** Process spawns, stdout reader finishes in ~40ms, exit code 1. No
+  error info because stderr was `Stdio::null()`.
+- **Root cause:** Original `persistent.rs` set `stderr(Stdio::null())` with a
+  comment about SIGPIPE/EPIPE. On Windows there's no SIGPIPE — the real effect
+  was hiding all error messages.
+- **Fix:** Changed to `Stdio::piped()` with a background tokio task draining
+  stderr lines to `tracing::warn!`.
+- **Lesson:** Never null stderr on a process you need to debug. Pipe + drain.
+
+### 6. Windows canonicalize() returns \\?\C:\... — Node.js can't parse it (v0.33.81)
+- **Symptom:** `Error: EISDIR: illegal operation on a directory, lstat 'C:'`
+- **Root cause:** `parse_cmd_wrapper` calls `resolved.canonicalize()` which on
+  Windows returns `\\?\C:\Users\...` (UNC extended-length path). Node.js
+  `realpathSync` in `run_main` can't handle the `\\?\` prefix and interprets
+  `C:` as a directory.
+- **Fix:** Strip `\\?\` prefix after `canonicalize()`:
+  `if path_str.starts_with(r"\\?\") { path_str = path_str[4..].to_string(); }`
+- **Lesson:** Always strip Windows UNC prefix when passing paths to external
+  programs (Node, Python, etc.). Rust's `canonicalize()` is the only stdlib
+  function that produces these paths.
+
+---
+
+## Architecture Decisions
+
+### Why npm install over system copy
+- Version isolation: each AgentMux version gets its own CLI install
+- No binary type confusion (.exe vs .cmd vs node script)
+- Reproducible: `npm install @anthropic-ai/claude-code@latest` always produces
+  a proper `node_modules/.bin/claude.cmd` wrapper
+
+### Why make_cli_cmd() over Command::new()
+- On Windows, npm `.cmd` wrappers must be parsed to extract the node entry script
+- `cmd.exe /C` drops arguments and breaks stdin/stdout piping for long-running processes
+- `make_cli_cmd()` centralizes this logic in `agentmux-common` for all crates
+
+### Why persistent over per-turn subprocess
+- No process startup latency per message
+- Session continuity without `--resume`
+- Mid-turn interruption (send while streaming)
+- Simpler state machine (no respawn logic)
+
+---
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `agentmux-srv/src/server/cli_handlers.rs` | Removed system scanner (-219 lines), npm gate fix |
+| `agentmux-srv/src/backend/blockcontroller/persistent.rs` | make_cli_cmd, stderr capture, args logging |
+| `agentmux-common/src/cli.rs` | Shared make_cli_cmd + .cmd parser |
+| `frontend/app/view/agent/providers/index.ts` | Claude → controllerType: "persistent" |
+| `frontend/app/view/agent/agent-model.ts` | persistentLaunchArgs routing |
+| `frontend/app/view/agent/agent-view.tsx` | Loading spinner clears on failure |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.79",
+  "version": "0.33.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.79",
+      "version": "0.33.80",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.80",
+  "version": "0.33.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.80",
+      "version": "0.33.81",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.81",
+  "version": "0.33.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.81",
+      "version": "0.33.82",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.80",
+  "version": "0.33.81",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.79",
+  "version": "0.33.80",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.81",
+  "version": "0.33.82",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- `canonicalize()` on Windows returns `\?\C:\...` (UNC extended path) which Node.js can't parse — `EISDIR: lstat 'C:'`, exit code 1
- Strip `\?\` prefix before passing script path to `node`
- Capture persistent process stderr (was `Stdio::null`) — drain to `tracing::warn` for debugging
- Add retro doc: `docs/analysis/persistent-process-retro-2026-04-10.md`

This is issue #6 in the persistent process debug session. See retro doc for full timeline.

## Test plan
- [ ] Open agent pane — persistent process launches via `node <script>` with clean path
- [ ] Send message — stdout streams back, response visible
- [ ] If process crashes, stderr is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)