### PR TITLE
feat: App API Tier 1 — agent lifecycle commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.83"
+version = "0.33.84"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.83"
+version = "0.33.84"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.83"
+version = "0.33.84"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.83"
+version = "0.33.84"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.83"
+version = "0.33.84"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.80"
+version = "0.33.81"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.86"
+version = "0.33.87"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.86"
+version = "0.33.87"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.86"
+version = "0.33.87"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.86"
+version = "0.33.87"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.86"
+version = "0.33.87"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.79"
+version = "0.33.80"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.81"
+version = "0.33.82"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.85"
+version = "0.33.86"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.85"
+version = "0.33.86"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.85"
+version = "0.33.86"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.85"
+version = "0.33.86"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.85"
+version = "0.33.86"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.84"
+version = "0.33.85"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.84"
+version = "0.33.85"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.84"
+version = "0.33.85"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.84"
+version = "0.33.85"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.84"
+version = "0.33.85"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.85"
+version = "0.33.86"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.83"
+version = "0.33.84"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.84"
+version = "0.33.85"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.80"
+version = "0.33.81"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.82"
+version = "0.33.83"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.86"
+version = "0.33.87"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.81"
+version = "0.33.82"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.79"
+version = "0.33.80"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.83"
+version = "0.33.84"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.81"
+version = "0.33.82"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.82"
+version = "0.33.83"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.84"
+version = "0.33.85"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.79"
+version = "0.33.80"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.85"
+version = "0.33.86"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.86"
+version = "0.33.87"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.80"
+version = "0.33.81"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/cli.rs
+++ b/agentmux-common/src/cli.rs
@@ -46,7 +46,13 @@ fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
             if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
                 let resolved = cmd_dir.join(relative_path);
                 if let Ok(canonical) = resolved.canonicalize() {
-                    return Some(canonical.to_string_lossy().to_string());
+                    let mut path_str = canonical.to_string_lossy().to_string();
+                    // Windows canonicalize() returns \\?\C:\... (UNC extended path)
+                    // which Node.js cannot handle — strip the prefix.
+                    if path_str.starts_with(r"\\?\") {
+                        path_str = path_str[4..].to_string();
+                    }
+                    return Some(path_str);
                 }
                 return Some(resolved.to_string_lossy().to_string());
             }

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.83"
+version = "0.33.84"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.79"
+version = "0.33.80"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.85"
+version = "0.33.86"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.80"
+version = "0.33.81"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.86"
+version = "0.33.87"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.82"
+version = "0.33.83"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.84"
+version = "0.33.85"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.81"
+version = "0.33.82"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.82"
+version = "0.33.83"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.86"
+version = "0.33.87"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.80"
+version = "0.33.81"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.79"
+version = "0.33.80"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.84"
+version = "0.33.85"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.85"
+version = "0.33.86"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.81"
+version = "0.33.82"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.83"
+version = "0.33.84"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -1,0 +1,464 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pure config-building logic for Forge agents.
+//!
+//! Ports the `buildConfigFiles`, `buildMcpConfig`, and `expandTemplate`
+//! functions from `frontend/app/view/agent/agent-model.ts`.
+//! All functions are pure — no I/O, no async.
+
+use std::collections::HashMap;
+
+use chrono::Utc;
+use serde_json::{json, Value};
+
+use crate::backend::storage::wstore::ForgeSkill;
+
+/// A single file to be written to the agent working directory.
+#[derive(Debug, Clone)]
+pub struct AgentConfigFile {
+    /// Path relative to the agent working directory (e.g. `"CLAUDE.md"`, `".mcp.json"`).
+    pub filename: String,
+    /// UTF-8 file content.
+    pub content: String,
+}
+
+/// Build the list of config files to write to the agent working directory.
+///
+/// Assembles `CLAUDE.md` from `soul` + `agentmd` + `memory` + skills index,
+/// writes each skill as a slash command under `.claude/commands/<trigger>.md`,
+/// writes `.claude/hooks.json` if a `hooks` content entry is present,
+/// auto-injects the AgentMux MCP server entry, and applies `{{VARIABLE}}`
+/// template substitution throughout.
+///
+/// Mirrors `buildConfigFiles()` in `frontend/app/view/agent/agent-model.ts`.
+pub fn build_config_files(
+    content_map: &HashMap<String, String>,
+    skills: &[ForgeSkill],
+    agent_name: &str,
+    agent_id: &str,
+) -> Vec<AgentConfigFile> {
+    let mut files: Vec<AgentConfigFile> = Vec::new();
+
+    // Template variables for {{}} substitution
+    let mut template_vars: HashMap<String, String> = HashMap::new();
+    template_vars.insert("AGENT".to_string(), agent_name.to_string());
+    template_vars.insert("AGENT_DISPLAY".to_string(), agent_name.to_string());
+    template_vars.insert("AGENT_ID".to_string(), agent_id.to_string());
+    // DATE in YYYY-MM-DD format, UTC
+    template_vars.insert("DATE".to_string(), Utc::now().format("%Y-%m-%d").to_string());
+    // WORKING_DIR is not available in this signature; leave it empty for callers
+    // that don't pass it — expansion will leave {{WORKING_DIR}} intact if absent.
+
+    // ----------------------------------------------------------------
+    // Build CLAUDE.md: Soul + AgentMD + Memory + Skills index
+    // ----------------------------------------------------------------
+    let mut claude_md_parts: Vec<String> = Vec::new();
+
+    if let Some(soul) = content_map.get("soul") {
+        claude_md_parts.push(expand_template(soul, &template_vars));
+    }
+    if let Some(agentmd) = content_map.get("agentmd") {
+        if !claude_md_parts.is_empty() {
+            claude_md_parts.push("\n---\n".to_string());
+        }
+        claude_md_parts.push(expand_template(agentmd, &template_vars));
+    }
+    if let Some(memory) = content_map.get("memory") {
+        claude_md_parts.push("\n# Memory\n".to_string());
+        claude_md_parts.push(memory.clone());
+    }
+
+    // Append skill index with trigger references
+    if !skills.is_empty() {
+        claude_md_parts.push("\n# Available Skills\n\n".to_string());
+        claude_md_parts.push("Use `/<trigger>` to invoke a skill.\n\n".to_string());
+        for skill in skills {
+            let trigger_part = if skill.trigger.is_empty() {
+                String::new()
+            } else {
+                format!(" (trigger: /{})", skill.trigger)
+            };
+            let desc_part = if skill.description.is_empty() {
+                String::new()
+            } else {
+                format!(" \u{2014} {}", skill.description)
+            };
+            claude_md_parts.push(format!("- **{}**{}{}\n", skill.name, trigger_part, desc_part));
+        }
+    }
+
+    if !claude_md_parts.is_empty() {
+        files.push(AgentConfigFile {
+            filename: "CLAUDE.md".to_string(),
+            content: claude_md_parts.join(""),
+        });
+    }
+
+    // ----------------------------------------------------------------
+    // Write each skill as a slash command: .claude/commands/{trigger}.md
+    // ----------------------------------------------------------------
+    for skill in skills {
+        if !skill.trigger.is_empty() && !skill.content.is_empty() {
+            let content = expand_template(&skill.content, &template_vars);
+            files.push(AgentConfigFile {
+                filename: format!(".claude/commands/{}.md", skill.trigger),
+                content,
+            });
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Write .claude/hooks.json if hooks content is present
+    // ----------------------------------------------------------------
+    if let Some(hooks) = content_map.get("hooks") {
+        files.push(AgentConfigFile {
+            filename: ".claude/hooks.json".to_string(),
+            content: hooks.clone(),
+        });
+    }
+
+    // ----------------------------------------------------------------
+    // Build .mcp.json with auto-injected AgentMux MCP server
+    // ----------------------------------------------------------------
+    // agent_bus_id is not in the function signature; callers that have it
+    // should call build_mcp_config directly and push the result themselves,
+    // or use the variant below.
+    let mcp_content = content_map.get("mcp").map(|s| s.as_str());
+    if let Some(mcp_json) = build_mcp_config(mcp_content, agent_name, "") {
+        files.push(AgentConfigFile {
+            filename: ".mcp.json".to_string(),
+            content: mcp_json,
+        });
+    }
+
+    files
+}
+
+/// Build the list of config files with a known `agent_bus_id`.
+///
+/// Same as [`build_config_files`] but also accepts an `agent_bus_id` so the
+/// MCP server entry can include `AGENTMUX_AGENT_BUS_ID`.  Prefer this overload
+/// when the caller has the full `ForgeAgent` available.
+pub fn build_config_files_with_bus(
+    content_map: &HashMap<String, String>,
+    skills: &[ForgeSkill],
+    agent_name: &str,
+    agent_id: &str,
+    agent_bus_id: &str,
+    working_directory: &str,
+) -> Vec<AgentConfigFile> {
+    let mut files: Vec<AgentConfigFile> = Vec::new();
+
+    let mut template_vars: HashMap<String, String> = HashMap::new();
+    template_vars.insert("AGENT".to_string(), agent_name.to_string());
+    template_vars.insert("AGENT_DISPLAY".to_string(), agent_name.to_string());
+    template_vars.insert("AGENT_ID".to_string(), agent_id.to_string());
+    template_vars.insert("WORKING_DIR".to_string(), working_directory.to_string());
+    template_vars.insert("DATE".to_string(), Utc::now().format("%Y-%m-%d").to_string());
+
+    // CLAUDE.md
+    let mut claude_md_parts: Vec<String> = Vec::new();
+    if let Some(soul) = content_map.get("soul") {
+        claude_md_parts.push(expand_template(soul, &template_vars));
+    }
+    if let Some(agentmd) = content_map.get("agentmd") {
+        if !claude_md_parts.is_empty() {
+            claude_md_parts.push("\n---\n".to_string());
+        }
+        claude_md_parts.push(expand_template(agentmd, &template_vars));
+    }
+    if let Some(memory) = content_map.get("memory") {
+        claude_md_parts.push("\n# Memory\n".to_string());
+        claude_md_parts.push(memory.clone());
+    }
+    if !skills.is_empty() {
+        claude_md_parts.push("\n# Available Skills\n\n".to_string());
+        claude_md_parts.push("Use `/<trigger>` to invoke a skill.\n\n".to_string());
+        for skill in skills {
+            let trigger_part = if skill.trigger.is_empty() {
+                String::new()
+            } else {
+                format!(" (trigger: /{})", skill.trigger)
+            };
+            let desc_part = if skill.description.is_empty() {
+                String::new()
+            } else {
+                format!(" \u{2014} {}", skill.description)
+            };
+            claude_md_parts.push(format!("- **{}**{}{}\n", skill.name, trigger_part, desc_part));
+        }
+    }
+    if !claude_md_parts.is_empty() {
+        files.push(AgentConfigFile {
+            filename: "CLAUDE.md".to_string(),
+            content: claude_md_parts.join(""),
+        });
+    }
+
+    // Skill slash commands
+    for skill in skills {
+        if !skill.trigger.is_empty() && !skill.content.is_empty() {
+            let content = expand_template(&skill.content, &template_vars);
+            files.push(AgentConfigFile {
+                filename: format!(".claude/commands/{}.md", skill.trigger),
+                content,
+            });
+        }
+    }
+
+    // Hooks
+    if let Some(hooks) = content_map.get("hooks") {
+        files.push(AgentConfigFile {
+            filename: ".claude/hooks.json".to_string(),
+            content: hooks.clone(),
+        });
+    }
+
+    // MCP — use full bus_id variant
+    let mcp_content = content_map.get("mcp").map(|s| s.as_str());
+    if let Some(mcp_json) = build_mcp_config(mcp_content, agent_name, agent_bus_id) {
+        files.push(AgentConfigFile {
+            filename: ".mcp.json".to_string(),
+            content: mcp_json,
+        });
+    }
+
+    files
+}
+
+/// Build `.mcp.json` content with the auto-injected AgentMux MCP server entry.
+///
+/// The AgentMux server is always present as `mcpServers.agentmux`.
+/// If `user_mcp_content` is `Some`, its `mcpServers` entries are merged on top
+/// (user entries win over the auto-injected entry if the key collides).
+/// If the user content is not valid JSON the auto-injected-only config is
+/// returned and no error is propagated (mirrors TS behavior).
+///
+/// Returns `None` only if serialization unexpectedly fails (should never happen).
+///
+/// Mirrors `buildMcpConfig()` in `frontend/app/view/agent/agent-model.ts`.
+pub fn build_mcp_config(
+    user_mcp_content: Option<&str>,
+    agent_name: &str,
+    agent_bus_id: &str,
+) -> Option<String> {
+    // Auto-injected AgentMux MCP server entry
+    let mut env_map = serde_json::Map::new();
+    if !agent_name.is_empty() {
+        env_map.insert("AGENTMUX_AGENT_ID".to_string(), json!(agent_name));
+    }
+    if !agent_bus_id.is_empty() {
+        env_map.insert("AGENTMUX_AGENT_BUS_ID".to_string(), json!(agent_bus_id));
+    }
+
+    let agentmux_server = json!({
+        "type": "stdio",
+        "command": "agentmux-mcp",
+        "args": [],
+        "env": Value::Object(env_map),
+    });
+
+    let mut mcp_servers = serde_json::Map::new();
+    mcp_servers.insert("agentmux".to_string(), agentmux_server);
+
+    // Merge user-provided MCP config if present
+    if let Some(raw) = user_mcp_content {
+        match serde_json::from_str::<Value>(raw) {
+            Ok(Value::Object(user_obj)) => {
+                if let Some(Value::Object(user_servers)) = user_obj.get("mcpServers") {
+                    for (k, v) in user_servers {
+                        mcp_servers.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+            Ok(_) => {
+                // User content parsed but isn't an object — skip merge silently
+            }
+            Err(_) => {
+                // Invalid JSON in forge content — keep auto-injected only (mirrors TS behavior)
+                tracing::error!("agent_config: invalid MCP JSON in forge content, using auto-injected only");
+            }
+        }
+    }
+
+    let result = json!({ "mcpServers": Value::Object(mcp_servers) });
+    match serde_json::to_string_pretty(&result) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            tracing::error!("agent_config: failed to serialize MCP config: {e}");
+            None
+        }
+    }
+}
+
+/// Replace `{{VARIABLE}}` placeholders in `content` with values from `vars`.
+///
+/// Placeholders that have no corresponding key in `vars` are left unchanged
+/// (the original `{{VARIABLE}}` text is preserved).
+///
+/// Mirrors `expandTemplate()` in `frontend/app/view/agent/agent-model.ts`.
+pub fn expand_template(content: &str, vars: &HashMap<String, String>) -> String {
+    // Hand-rolled replacement to avoid pulling in a regex dependency.
+    // Scans for `{{`, extracts the key name up to `}}`, and substitutes.
+    let mut result = String::with_capacity(content.len());
+    let bytes = content.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        // Look for '{{'
+        if i + 1 < len && bytes[i] == b'{' && bytes[i + 1] == b'{' {
+            // Find closing '}}'
+            if let Some(rel) = content[i + 2..].find("}}") {
+                let key = &content[i + 2..i + 2 + rel];
+                // Only substitute if key is a simple word (alphanumeric + underscore)
+                if key.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+                    if let Some(val) = vars.get(key) {
+                        result.push_str(val);
+                    } else {
+                        // No match — preserve the original placeholder
+                        result.push_str(&content[i..i + 2 + rel + 2]);
+                    }
+                    i += 2 + rel + 2; // skip past '}}'
+                    continue;
+                }
+            }
+        }
+        // Not a placeholder start — copy character verbatim
+        // Safety: i is always on a valid char boundary because we only advance
+        // by 1 when not inside a placeholder, and UTF-8 single-byte characters
+        // are the only ones we index directly.
+        let ch = content[i..].chars().next().unwrap();
+        result.push(ch);
+        i += ch.len_utf8();
+    }
+
+    result
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_skill(name: &str, trigger: &str, description: &str, content: &str) -> ForgeSkill {
+        ForgeSkill {
+            id: format!("skill-{}", trigger),
+            agent_id: "agent-1".to_string(),
+            name: name.to_string(),
+            trigger: trigger.to_string(),
+            skill_type: "prompt".to_string(),
+            description: description.to_string(),
+            content: content.to_string(),
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn test_expand_template_basic() {
+        let mut vars = HashMap::new();
+        vars.insert("AGENT".to_string(), "Aria".to_string());
+        vars.insert("DATE".to_string(), "2026-04-10".to_string());
+
+        let out = expand_template("Hello {{AGENT}}, today is {{DATE}}.", &vars);
+        assert_eq!(out, "Hello Aria, today is 2026-04-10.");
+    }
+
+    #[test]
+    fn test_expand_template_unknown_placeholder_preserved() {
+        let vars = HashMap::new();
+        let out = expand_template("Value: {{UNKNOWN}}", &vars);
+        assert_eq!(out, "Value: {{UNKNOWN}}");
+    }
+
+    #[test]
+    fn test_expand_template_empty_vars() {
+        let vars = HashMap::new();
+        let out = expand_template("No placeholders here.", &vars);
+        assert_eq!(out, "No placeholders here.");
+    }
+
+    #[test]
+    fn test_build_mcp_config_no_user_content() {
+        let result = build_mcp_config(None, "Aria", "bus-42").unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let servers = &parsed["mcpServers"];
+        assert!(servers["agentmux"].is_object());
+        assert_eq!(servers["agentmux"]["command"], "agentmux-mcp");
+        assert_eq!(servers["agentmux"]["env"]["AGENTMUX_AGENT_ID"], "Aria");
+        assert_eq!(servers["agentmux"]["env"]["AGENTMUX_AGENT_BUS_ID"], "bus-42");
+    }
+
+    #[test]
+    fn test_build_mcp_config_merges_user_servers() {
+        let user_mcp = r#"{"mcpServers": {"mytool": {"type": "stdio", "command": "mytool"}}}"#;
+        let result = build_mcp_config(Some(user_mcp), "Aria", "").unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let servers = &parsed["mcpServers"];
+        assert!(servers["agentmux"].is_object());
+        assert!(servers["mytool"].is_object());
+    }
+
+    #[test]
+    fn test_build_mcp_config_invalid_user_json_uses_auto_injected() {
+        let result = build_mcp_config(Some("not json {{"), "Aria", "").unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["mcpServers"]["agentmux"].is_object());
+    }
+
+    #[test]
+    fn test_build_config_files_claude_md_assembled() {
+        let mut content_map = HashMap::new();
+        content_map.insert("soul".to_string(), "You are {{AGENT}}.".to_string());
+        content_map.insert("agentmd".to_string(), "## Instructions\nDo stuff.".to_string());
+
+        let files = build_config_files(&content_map, &[], "Aria", "agent-1");
+        let claude_md = files.iter().find(|f| f.filename == "CLAUDE.md").unwrap();
+        assert!(claude_md.content.contains("You are Aria."));
+        assert!(claude_md.content.contains("---"));
+        assert!(claude_md.content.contains("## Instructions"));
+    }
+
+    #[test]
+    fn test_build_config_files_skills_index_and_commands() {
+        let content_map = HashMap::new();
+        let skills = vec![
+            make_skill("Deploy", "deploy", "Deploy the app", "Run: deploy all"),
+            make_skill("Test", "test", "Run tests", "Run: test suite"),
+        ];
+
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1");
+
+        // CLAUDE.md should have the skills index
+        let claude_md = files.iter().find(|f| f.filename == "CLAUDE.md").unwrap();
+        assert!(claude_md.content.contains("Available Skills"));
+        assert!(claude_md.content.contains("/deploy"));
+        assert!(claude_md.content.contains("/test"));
+
+        // Individual skill command files
+        assert!(files.iter().any(|f| f.filename == ".claude/commands/deploy.md"));
+        assert!(files.iter().any(|f| f.filename == ".claude/commands/test.md"));
+    }
+
+    #[test]
+    fn test_build_config_files_hooks_written() {
+        let mut content_map = HashMap::new();
+        content_map.insert("hooks".to_string(), r#"{"hooks":[]}"#.to_string());
+
+        let files = build_config_files(&content_map, &[], "Aria", "agent-1");
+        assert!(files.iter().any(|f| f.filename == ".claude/hooks.json"));
+    }
+
+    #[test]
+    fn test_build_config_files_mcp_written() {
+        let content_map = HashMap::new();
+        let files = build_config_files(&content_map, &[], "Aria", "agent-1");
+        let mcp = files.iter().find(|f| f.filename == ".mcp.json").unwrap();
+        let parsed: Value = serde_json::from_str(&mcp.content).unwrap();
+        assert!(parsed["mcpServers"]["agentmux"].is_object());
+    }
+}

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -204,9 +204,7 @@ impl PersistentSubprocessController {
 
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
-        // Use null for stderr — piped stderr that is immediately dropped would
-        // cause SIGPIPE/EPIPE on the child's first stderr write, killing it.
-        cmd.stderr(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::piped());
 
         let mut child = cmd.spawn().map_err(|e| {
             tracing::error!(block_id = %self.block_id, error = %e, "persistent process spawn failed");
@@ -218,12 +216,30 @@ impl PersistentSubprocessController {
             block_id = %self.block_id,
             pid = pid,
             cmd = %config.cli_command,
+            args = ?config.cli_args,
+            working_dir = %config.working_dir,
             "persistent process spawned"
         );
 
         let (kill_tx, kill_rx) = tokio::sync::oneshot::channel::<bool>();
         let stdin = child.stdin.take().unwrap();
         let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take();
+
+        // Drain stderr in background — log lines for debugging
+        if let Some(stderr_pipe) = stderr {
+            let block_id_stderr = self.block_id.clone();
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(stderr_pipe).lines();
+                while let Ok(Some(line)) = reader.next_line().await {
+                    tracing::warn!(
+                        block_id = %block_id_stderr,
+                        line = %line,
+                        "persistent stderr"
+                    );
+                }
+            });
+        }
 
         // Create stdin writer channel
         let (msg_tx, mut msg_rx) = mpsc::channel::<String>(32);

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -352,6 +352,11 @@ impl PersistentSubprocessController {
                 }
 
                 // Publish line as WPS blockfile event
+                tracing::info!(
+                    block_id = %block_id_read,
+                    line_len = line.len(),
+                    "persistent stdout → blockfile"
+                );
                 let line_with_newline = format!("{}\n", line);
                 if let Some(ref broker) = broker_read {
                     super::shell::handle_append_block_file(
@@ -360,6 +365,8 @@ impl PersistentSubprocessController {
                         PERSISTENT_OUTPUT_SUBJECT,
                         line_with_newline.as_bytes(),
                     );
+                } else {
+                    tracing::warn!(block_id = %block_id_read, "persistent stdout: no broker available");
                 }
             }
 

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+pub mod agent_config;
 pub mod blockcontroller;
+pub mod providers;
 pub mod config_watcher_fs;
 pub mod ijson;
 pub mod docsite;

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -1,0 +1,287 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Static provider registry — Rust equivalent of
+//! `frontend/app/view/agent/providers/index.ts`.
+//!
+//! All string data is `&'static str` / `&'static [&'static str]` so lookups
+//! are zero-allocation.  The registry is initialised once via `LazyLock` and
+//! then read-only for the lifetime of the process.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+// ─── Controller type ─────────────────────────────────────────────────────────
+
+/// How the provider process is managed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControllerType {
+    /// A single long-running process; input is streamed to stdin.
+    Persistent,
+    /// A fresh subprocess is spawned for every turn; prior sessions are
+    /// resumed via `resume_flag`.
+    Subprocess,
+}
+
+// ─── ProviderConfig ──────────────────────────────────────────────────────────
+
+/// All configuration needed to launch, authenticate, and stream output from
+/// a provider CLI.
+#[derive(Debug)]
+pub struct ProviderConfig {
+    /// Canonical provider identifier (e.g. `"claude"`).
+    pub id: &'static str,
+    /// Human-readable name shown in the UI.
+    pub display_name: &'static str,
+    /// Executable name on PATH (e.g. `"claude"`).
+    pub cli_command: &'static str,
+    /// Whether the provider keeps a persistent subprocess or spawns per turn.
+    pub controller_type: ControllerType,
+    /// Complete CLI args for a single-turn (subprocess) invocation.
+    /// The user prompt is written to the process's stdin.
+    pub launch_args: &'static [&'static str],
+    /// CLI args for persistent (long-running) mode.
+    /// `None` when `controller_type` is `Subprocess`.
+    pub persistent_launch_args: Option<&'static [&'static str]>,
+    /// Flag passed to resume a prior session, e.g. `"--resume"`.
+    /// `None` when the provider does not support simple-flag resume.
+    pub resume_flag: Option<&'static str>,
+    /// JSON field name in the CLI's init event that carries the session /
+    /// thread ID, e.g. `"session_id"` or `"thread_id"`.
+    pub session_id_field: &'static str,
+    /// Output format produced by the CLI in styled / streaming mode.
+    pub styled_output_format: &'static str,
+    // ── Auth isolation ───────────────────────────────────────────────────────
+    /// Environment variable that redirects the provider's config / auth
+    /// directory, e.g. `"CLAUDE_CONFIG_DIR"`.
+    pub auth_config_dir_env_var: &'static str,
+    /// Sub-directory name under `{dataDir}/auth/`, e.g. `"claude"`.
+    pub auth_dir_name: &'static str,
+    /// Extra environment variables required for auth isolation.
+    /// Each entry is a `(key, value)` pair.
+    pub auth_extra_env: &'static [(&'static str, &'static str)],
+    /// Environment variables that must be *unset* before launching the CLI
+    /// (guards against nested-session issues, etc.).
+    pub unset_env: &'static [&'static str],
+    // ── npm install ──────────────────────────────────────────────────────────
+    /// npm package name used for local installation, e.g.
+    /// `"@anthropic-ai/claude-code"`.
+    pub npm_package: &'static str,
+    /// Version string passed to `npm install`, e.g. `"latest"` or `"0.116.0"`.
+    pub pinned_version: &'static str,
+    // ── Misc ─────────────────────────────────────────────────────────────────
+    /// Icon identifier used by the frontend.
+    pub icon: &'static str,
+    /// URL of the provider's documentation.
+    pub docs_url: &'static str,
+}
+
+impl ProviderConfig {
+    /// Return the controller type as the string used in block metadata.
+    pub fn controller_type_str(&self) -> &'static str {
+        match self.controller_type {
+            ControllerType::Persistent => "persistent",
+            ControllerType::Subprocess => "subprocess",
+        }
+    }
+}
+
+// ─── Provider definitions ────────────────────────────────────────────────────
+
+static CLAUDE: ProviderConfig = ProviderConfig {
+    id: "claude",
+    display_name: "Claude Code",
+    cli_command: "claude",
+    controller_type: ControllerType::Persistent,
+    launch_args: &[
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--dangerously-skip-permissions",
+    ],
+    persistent_launch_args: Some(&[
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--dangerously-skip-permissions",
+    ]),
+    resume_flag: Some("--resume"),
+    session_id_field: "session_id",
+    styled_output_format: "claude-stream-json",
+    auth_config_dir_env_var: "CLAUDE_CONFIG_DIR",
+    auth_dir_name: "claude",
+    auth_extra_env: &[],
+    unset_env: &["CLAUDECODE"],
+    npm_package: "@anthropic-ai/claude-code",
+    pinned_version: "latest",
+    icon: "sparkles",
+    docs_url: "https://docs.anthropic.com/claude-code",
+};
+
+static CODEX: ProviderConfig = ProviderConfig {
+    id: "codex",
+    display_name: "Codex CLI",
+    cli_command: "codex",
+    controller_type: ControllerType::Subprocess,
+    // exec subcommand runs non-interactively; --json emits NDJSON events; - reads prompt from stdin
+    launch_args: &[
+        "exec",
+        "--json",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "-",
+    ],
+    // Codex resume requires a subcommand change (exec resume <id>), not a simple flag.
+    // Multi-turn is handled by re-running exec; None disables automatic --resume append.
+    persistent_launch_args: None,
+    resume_flag: None,
+    session_id_field: "thread_id",
+    styled_output_format: "codex-json",
+    auth_config_dir_env_var: "CODEX_HOME",
+    auth_dir_name: "codex",
+    auth_extra_env: &[],
+    unset_env: &[],
+    npm_package: "@openai/codex",
+    pinned_version: "0.116.0",
+    icon: "robot",
+    docs_url: "https://platform.openai.com/docs/codex",
+};
+
+static GEMINI: ProviderConfig = ProviderConfig {
+    id: "gemini",
+    display_name: "Gemini CLI",
+    cli_command: "gemini",
+    controller_type: ControllerType::Subprocess,
+    // --output-format stream-json: NDJSON events; --yolo: auto-approve all tools;
+    // -p "": enable headless/non-interactive mode (prompt comes from stdin)
+    launch_args: &["--output-format", "stream-json", "--yolo", "-p", ""],
+    persistent_launch_args: None,
+    resume_flag: Some("-r"),
+    session_id_field: "session_id",
+    styled_output_format: "gemini-json",
+    auth_config_dir_env_var: "GEMINI_CLI_HOME",
+    auth_dir_name: "gemini",
+    auth_extra_env: &[("GEMINI_FORCE_FILE_STORAGE", "true")],
+    unset_env: &[],
+    npm_package: "@google/gemini-cli",
+    pinned_version: "0.32.1",
+    icon: "diamond",
+    docs_url: "https://ai.google.dev/gemini-cli",
+};
+
+// ─── Static registry ─────────────────────────────────────────────────────────
+
+static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+    m.insert(CLAUDE.id, &CLAUDE);
+    m.insert(CODEX.id, &CODEX);
+    m.insert(GEMINI.id, &GEMINI);
+    m
+});
+
+// Aliases for provider IDs from older databases or alternate naming.
+static ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+    m.insert("claude-code", "claude");
+    m.insert("claude_code", "claude");
+    m.insert("codex-cli", "codex");
+    m.insert("gemini-cli", "gemini");
+    m
+});
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/// Resolve a provider alias to its canonical ID.
+///
+/// Returns `id` unchanged if it is not a known alias.
+pub fn resolve_provider_alias(id: &str) -> &'static str {
+    ALIASES.get(id).copied().unwrap_or_else(|| {
+        // If the id itself is a canonical key return the interned key, otherwise
+        // return a best-effort static ref. The caller should treat the return
+        // value as a lookup key only.
+        REGISTRY
+            .get_key_value(id)
+            .map(|(k, _)| *k)
+            .unwrap_or("") // unknown — get_provider will return None
+    })
+}
+
+/// Look up a provider by canonical ID or alias.
+///
+/// Returns `None` when the ID (and any resolved alias) does not match a known
+/// provider.
+pub fn get_provider(id: &str) -> Option<&'static ProviderConfig> {
+    // Direct lookup first.
+    if let Some(p) = REGISTRY.get(id) {
+        return Some(p);
+    }
+    // Fall back to alias resolution.
+    let canonical = ALIASES.get(id).copied()?;
+    REGISTRY.get(canonical).copied()
+}
+
+/// Return an iterator over all registered providers in insertion order.
+pub fn get_provider_list() -> impl Iterator<Item = &'static ProviderConfig> {
+    // Stable canonical order matches the TypeScript PROVIDERS object order.
+    static ORDER: &[&str] = &["claude", "codex", "gemini"];
+    ORDER.iter().filter_map(|id| REGISTRY.get(*id).copied())
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_ids_resolve() {
+        assert!(get_provider("claude").is_some());
+        assert!(get_provider("codex").is_some());
+        assert!(get_provider("gemini").is_some());
+    }
+
+    #[test]
+    fn aliases_resolve() {
+        assert_eq!(get_provider("claude-code").unwrap().id, "claude");
+        assert_eq!(get_provider("claude_code").unwrap().id, "claude");
+        assert_eq!(get_provider("codex-cli").unwrap().id, "codex");
+        assert_eq!(get_provider("gemini-cli").unwrap().id, "gemini");
+    }
+
+    #[test]
+    fn unknown_returns_none() {
+        assert!(get_provider("unknown-provider").is_none());
+    }
+
+    #[test]
+    fn provider_list_has_three_entries() {
+        assert_eq!(get_provider_list().count(), 3);
+    }
+
+    #[test]
+    fn claude_persistent_args_present() {
+        let p = get_provider("claude").unwrap();
+        assert!(p.persistent_launch_args.is_some());
+        assert_eq!(p.controller_type, ControllerType::Persistent);
+    }
+
+    #[test]
+    fn codex_resume_flag_is_none() {
+        let p = get_provider("codex").unwrap();
+        assert!(p.resume_flag.is_none());
+        assert_eq!(p.controller_type, ControllerType::Subprocess);
+    }
+
+    #[test]
+    fn gemini_auth_extra_env() {
+        let p = get_provider("gemini").unwrap();
+        assert!(p
+            .auth_extra_env
+            .iter()
+            .any(|(k, v)| *k == "GEMINI_FORCE_FILE_STORAGE" && *v == "true"));
+    }
+}

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -288,6 +288,15 @@ pub const COMMAND_IMPORT_FORGE_FROM_CLAW: &str = "importforgefromclaw";
 // Forge Seed
 pub const COMMAND_RESEED_FORGE_AGENTS: &str = "reseedforgeagents";
 
+// App API Tier 1 — agent lifecycle commands
+pub const COMMAND_AGENT_OPEN: &str = "agent.open";
+pub const COMMAND_AGENT_SEND: &str = "agent.send";
+pub const COMMAND_AGENT_STOP_API: &str = "agent.stop";
+pub const COMMAND_AGENT_STATUS: &str = "agent.status";
+pub const COMMAND_AGENT_LIST: &str = "agent.list";
+pub const COMMAND_AGENT_OUTPUT: &str = "agent.output";
+pub const COMMAND_AGENT_STREAM: &str = "agent.stream";
+
 // ---- Client type constants ----
 
 pub const CLIENT_TYPE_CONN_SERVER: &str = "connserver";
@@ -535,6 +544,132 @@ pub struct RunCliLoginResult {
     /// OAuth URL extracted from the CLI's output (open in browser)
     pub auth_url: Option<String>,
     pub raw_output: String,
+}
+
+// ---- App API Tier 1 — request/response types ----
+
+/// Request for agent.open — find or create an agent pane for the given agent_id.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentOpenData {
+    pub agent_id: String,
+    pub tab_id: Option<String>,
+    pub split_direction: Option<String>,
+    pub split_reference_block_id: Option<String>,
+    pub focus: Option<bool>,
+}
+
+/// Request for agent.send — send a message to an agent pane.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentSendData {
+    pub block_id: String,
+    pub message: String,
+}
+
+/// Request for agent.stop — stop a running agent subprocess.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentStopApiData {
+    pub block_id: String,
+    pub signal: Option<String>,
+}
+
+/// Request for agent.status — query status of an agent pane.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentStatusData {
+    pub block_id: String,
+}
+
+/// Request for agent.output — read buffered output lines from an agent pane.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentOutputData {
+    pub block_id: String,
+    pub after_line: Option<usize>,
+    pub max_lines: Option<usize>,
+}
+
+/// Request for agent.stream — subscribe to live output from an agent pane.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentStreamData {
+    pub block_id: String,
+}
+
+/// Response from agent.open.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentOpenResult {
+    pub block_id: String,
+    pub tab_id: String,
+    pub agent_id: String,
+    pub provider: String,
+    pub controller_type: String,
+    pub status: String,
+    pub created: bool,
+}
+
+/// Response from agent.send.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentSendResult {
+    pub block_id: String,
+    pub status: String,
+    pub session_id: Option<String>,
+}
+
+/// Response from agent.stop.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentStopResult {
+    pub block_id: String,
+    pub status: String,
+    pub exit_code: Option<i32>,
+}
+
+/// Response from agent.status.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentStatusResult {
+    pub block_id: String,
+    pub agent_id: String,
+    pub provider: String,
+    pub controller_type: String,
+    pub status: String,
+    pub session_id: Option<String>,
+    pub pid: Option<u32>,
+    pub exit_code: Option<i32>,
+}
+
+/// A single entry in the agent.list response.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentListEntry {
+    pub block_id: String,
+    pub tab_id: String,
+    pub agent_id: String,
+    pub provider: String,
+    pub status: String,
+    pub session_id: Option<String>,
+}
+
+/// Response from agent.list.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentListResult {
+    pub agents: Vec<AgentListEntry>,
+}
+
+/// Response from agent.output.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentOutputResult {
+    pub block_id: String,
+    pub lines: Vec<String>,
+    pub total_lines: usize,
+    pub has_more: bool,
 }
 
 /// Matches Go's `FileDataAt`

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1,0 +1,620 @@
+//! App API — high-level commands for programmatic control of AgentMux.
+//!
+//! These commands orchestrate multiple low-level operations (CreateBlock, SetMeta,
+//! ControllerResync) behind stable, intent-based interfaces. Callers express what
+//! they want ("open an agent pane with AgentX"), not how to do it.
+
+use std::sync::Arc;
+
+use base64::Engine;
+use serde_json::json;
+
+use crate::backend::blockcontroller;
+use crate::backend::obj::{self, Block, Tab, Workspace, MetaMapType};
+use crate::backend::providers;
+use crate::backend::rpc::engine::WshRpcEngine;
+use crate::backend::rpc_types::*;
+use crate::backend::storage::wstore::WaveStore;
+
+use super::AppState;
+
+/// Register all App API handlers on the RPC engine.
+pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    register_agent_open(engine, state);
+    register_agent_send(engine, state);
+    register_agent_stop(engine, state);
+    register_agent_status(engine, state);
+    register_agent_list(engine, state);
+    register_agent_output(engine, state);
+}
+
+// ---------------------------------------------------------------------------
+// agent.open
+// ---------------------------------------------------------------------------
+
+fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    let event_bus = state.event_bus.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_OPEN,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            let event_bus = event_bus.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentOpenData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.open: {e}"))?;
+
+                tracing::info!(agent_id = %cmd.agent_id, "agent.open");
+
+                // 1. Load the Forge agent (by id or name)
+                let agents = wstore.forge_list()
+                    .map_err(|e| format!("agent.open: {e}"))?;
+                let agent = agents.iter()
+                    .find(|a| a.id == cmd.agent_id || a.name.eq_ignore_ascii_case(&cmd.agent_id))
+                    .ok_or_else(|| format!("AGENT_NOT_FOUND: no forge agent with id '{}'", cmd.agent_id))?
+                    .clone();
+
+                // 2. Resolve provider
+                let provider = providers::get_provider(&agent.provider)
+                    .ok_or_else(|| format!("INVALID_PROVIDER: unknown provider '{}'", agent.provider))?;
+
+                // 3. Determine tab
+                let tab_id = resolve_tab_id(&wstore, cmd.tab_id.as_deref())?;
+
+                // 4. Check for existing agent pane in this tab (idempotent)
+                if let Some(existing) = find_agent_block(&wstore, &tab_id, &cmd.agent_id)? {
+                    let status = blockcontroller::get_block_controller_status(&existing.oid)
+                        .map(|s| s.shellprocstatus)
+                        .unwrap_or_else(|| "init".to_string());
+                    return Ok(Some(serde_json::to_value(&AgentOpenResult {
+                        block_id: existing.oid,
+                        tab_id,
+                        agent_id: cmd.agent_id,
+                        provider: agent.provider,
+                        controller_type: provider.controller_type_str().to_string(),
+                        status,
+                        created: false,
+                    }).unwrap()));
+                }
+
+                // 5. Resolve CLI path
+                let version = env!("CARGO_PKG_VERSION");
+                let home = std::env::var("HOME")
+                    .or_else(|_| std::env::var("USERPROFILE"))
+                    .map_err(|_| "cannot determine home directory".to_string())?;
+                let provider_dir = format!("{}/.agentmux/{}/cli/{}", home, version, provider.id);
+                let npm_bin = if cfg!(windows) {
+                    format!("{}/node_modules/.bin/{}.cmd", provider_dir, provider.cli_command)
+                } else {
+                    format!("{}/node_modules/.bin/{}", provider_dir, provider.cli_command)
+                };
+                if !std::path::Path::new(&npm_bin).exists() {
+                    return Err(format!(
+                        "CLI_NOT_AVAILABLE: {} not installed at {}. Open an agent pane in the UI to trigger installation.",
+                        provider.cli_command, npm_bin
+                    ));
+                }
+
+                // 6. Build metadata
+                let controller_type = provider.controller_type_str();
+                let is_persistent = controller_type == "persistent";
+                let cli_args: Vec<String> = if is_persistent {
+                    provider.persistent_launch_args
+                        .unwrap_or(provider.launch_args)
+                        .iter().map(|s| s.to_string()).collect()
+                } else {
+                    provider.launch_args.iter().map(|s| s.to_string()).collect()
+                };
+
+                let agent_slug = agent.name.to_lowercase()
+                    .chars().map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+                    .collect::<String>();
+                let work_dir = if agent.working_directory.is_empty() {
+                    format!("~/.agentmux/agents/{}", agent_slug)
+                } else {
+                    agent.working_directory.clone()
+                };
+
+                // Build env vars
+                let mut env_vars = serde_json::Map::new();
+                for key in provider.unset_env {
+                    env_vars.insert(key.to_string(), json!(""));
+                }
+                // Auth dir
+                let auth_dir = format!("{}/.agentmux/config/auth/{}", home, provider.auth_dir_name);
+                let _ = std::fs::create_dir_all(&auth_dir);
+                env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
+                for (k, v) in provider.auth_extra_env {
+                    env_vars.insert(k.to_string(), json!(v));
+                }
+                // Agent identity
+                env_vars.insert("GH_CONFIG_DIR".to_string(), json!(format!("~/.agentmux/config/gh-{}", agent_slug)));
+                env_vars.insert("AGENTMUX_AGENT_ID".to_string(), json!(&agent.name));
+                // Exit delay only for subprocess
+                if !is_persistent {
+                    env_vars.insert("CLAUDE_CODE_EXIT_AFTER_STOP_DELAY".to_string(), json!("30000"));
+                }
+
+                let mut meta = MetaMapType::new();
+                meta.insert("view".to_string(), json!("agent"));
+                meta.insert("agentId".to_string(), json!(&agent.id));
+                meta.insert("agentProvider".to_string(), json!(&agent.provider));
+                meta.insert("agentName".to_string(), json!(&agent.name));
+                meta.insert("agentIcon".to_string(), json!(if agent.icon.is_empty() { "sparkles" } else { &agent.icon }));
+                meta.insert("agentMode".to_string(), json!(if agent.agent_type.is_empty() { "host" } else { &agent.agent_type }));
+                // Derive output format from provider ID (matches frontend providers/index.ts)
+                let output_format = match provider.id {
+                    "claude" => "claude-stream-json",
+                    "codex" => "codex-json",
+                    "gemini" => "gemini-json",
+                    _ => "claude-stream-json",
+                };
+                meta.insert("agentOutputFormat".to_string(), json!(output_format));
+                meta.insert("controller".to_string(), json!(controller_type));
+                meta.insert("cmd".to_string(), json!(&npm_bin));
+                meta.insert("cmd:args".to_string(), json!(cli_args));
+                meta.insert("cmd:cwd".to_string(), json!(&work_dir));
+                meta.insert("cmd:env".to_string(), serde_json::Value::Object(env_vars));
+                meta.insert("agent:resume_flag".to_string(), json!(provider.resume_flag.unwrap_or("")));
+                meta.insert("agent:session_id_field".to_string(), json!(provider.session_id_field));
+
+                // 7. Create block
+                let block = crate::backend::wcore::create_block(&wstore, &tab_id, meta)
+                    .map_err(|e| format!("agent.open: create_block: {e}"))?;
+                let block_id = block.oid.clone();
+
+                tracing::info!(
+                    block_id = %block_id,
+                    agent_id = %cmd.agent_id,
+                    provider = %agent.provider,
+                    controller_type = %controller_type,
+                    "agent.open: block created"
+                );
+
+                // 8. Write agent config files
+                write_agent_config_files(&wstore, &agent, &agent_slug, &work_dir)?;
+
+                // 9. Register controller (resync)
+                let block_for_resync = wstore.must_get::<Block>(&block_id)
+                    .map_err(|e| format!("agent.open: reload block: {e}"))?;
+                blockcontroller::resync_controller(
+                    &block_for_resync,
+                    &tab_id,
+                    None,
+                    true,
+                    Some(broker.clone()),
+                    Some(event_bus.clone()),
+                    Some(wstore.clone()),
+                )?;
+
+                // 10. Broadcast block update
+                {
+                    let oref = format!("block:{}", block_id);
+                    if let Ok(updated) = wstore.must_get::<Block>(&block_id) {
+                        let update_data = serde_json::to_value(
+                            &obj::WaveObjUpdate {
+                                updatetype: "update".into(),
+                                otype: "block".into(),
+                                oid: block_id.clone(),
+                                obj: Some(obj::wave_obj_to_value(&updated)),
+                            },
+                        ).ok();
+                        event_bus.broadcast_event(
+                            &crate::backend::eventbus::WSEventType {
+                                eventtype: "waveobj:update".to_string(),
+                                oref,
+                                data: update_data,
+                            },
+                        );
+                    }
+                }
+
+                Ok(Some(serde_json::to_value(&AgentOpenResult {
+                    block_id,
+                    tab_id,
+                    agent_id: cmd.agent_id,
+                    provider: agent.provider,
+                    controller_type: controller_type.to_string(),
+                    status: "init".to_string(),
+                    created: true,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.send
+// ---------------------------------------------------------------------------
+
+fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_SEND,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentSendData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.send: {e}"))?;
+
+                tracing::info!(block_id = %cmd.block_id, "agent.send");
+
+                let ctrl = blockcontroller::get_controller(&cmd.block_id)
+                    .ok_or_else(|| format!("NOT_RUNNING: no controller for block {}", cmd.block_id))?;
+
+                // Re-read spawn config from block metadata (same pattern as agentinput)
+                let block: Block = wstore
+                    .get(&cmd.block_id)
+                    .map_err(|e| format!("agent.send: {e}"))?
+                    .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", cmd.block_id))?;
+
+                let cli_command = obj::meta_get_string(&block.meta, "cmd", "claude");
+                let cli_args: Vec<String> = match block.meta.get("cmd:args") {
+                    Some(serde_json::Value::Array(arr)) => arr
+                        .iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect(),
+                    _ => vec![],
+                };
+                let working_dir = obj::meta_get_string(&block.meta, "cmd:cwd", "");
+                let env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
+                    Some(serde_json::Value::Object(obj)) => obj
+                        .iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                        .collect(),
+                    _ => std::collections::HashMap::new(),
+                };
+                let session_id_field = obj::meta_get_string(
+                    &block.meta, "agent:session_id_field", "session_id",
+                );
+
+                // Dispatch to persistent or subprocess controller
+                let mut session_id = None;
+                if let Some(persistent_ctrl) = ctrl
+                    .as_any()
+                    .downcast_ref::<blockcontroller::persistent::PersistentSubprocessController>()
+                {
+                    let config = blockcontroller::persistent::PersistentSpawnConfig {
+                        cli_command,
+                        cli_args,
+                        working_dir,
+                        env_vars,
+                        session_id_field,
+                    };
+                    persistent_ctrl.send_message(cmd.message, config)?;
+                    session_id = persistent_ctrl.session_id();
+                } else if let Some(subprocess_ctrl) = ctrl
+                    .as_any()
+                    .downcast_ref::<blockcontroller::subprocess::SubprocessController>()
+                {
+                    let resume_flag = obj::meta_get_string(
+                        &block.meta, "agent:resume_flag", "--resume",
+                    );
+                    let config = blockcontroller::subprocess::SubprocessSpawnConfig {
+                        cli_command,
+                        cli_args,
+                        working_dir,
+                        env_vars,
+                        message: cmd.message,
+                        resume_flag,
+                        session_id_field,
+                    };
+                    subprocess_ctrl.spawn_turn(config)?;
+                } else {
+                    return Err("NOT_RUNNING: controller type not supported".to_string());
+                }
+
+                Ok(Some(serde_json::to_value(&AgentSendResult {
+                    block_id: cmd.block_id,
+                    status: "running".to_string(),
+                    session_id,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.stop
+// ---------------------------------------------------------------------------
+
+fn register_agent_stop(engine: &Arc<WshRpcEngine>, _state: &AppState) {
+    engine.register_handler(
+        COMMAND_AGENT_STOP_API,
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                let cmd: CommandAgentStopApiData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.stop: {e}"))?;
+
+                tracing::info!(block_id = %cmd.block_id, signal = ?cmd.signal, "agent.stop");
+
+                let ctrl = blockcontroller::get_controller(&cmd.block_id)
+                    .ok_or_else(|| format!("NOT_RUNNING: no controller for block {}", cmd.block_id))?;
+
+                let force = matches!(cmd.signal.as_deref(), Some("SIGKILL") | Some("SIGTERM"));
+                ctrl.stop(!force, blockcontroller::STATUS_DONE)?;
+
+                let exit_code = blockcontroller::get_block_controller_status(&cmd.block_id)
+                    .map(|s| s.shellprocexitcode);
+
+                Ok(Some(serde_json::to_value(&AgentStopResult {
+                    block_id: cmd.block_id,
+                    status: "done".to_string(),
+                    exit_code,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.status
+// ---------------------------------------------------------------------------
+
+fn register_agent_status(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_STATUS,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentStatusData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.status: {e}"))?;
+
+                let block: Block = wstore
+                    .get(&cmd.block_id)
+                    .map_err(|e| format!("agent.status: {e}"))?
+                    .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", cmd.block_id))?;
+
+                let agent_id = obj::meta_get_string(&block.meta, "agentId", "");
+                let provider = obj::meta_get_string(&block.meta, "agentProvider", "");
+                let controller_type = obj::meta_get_string(&block.meta, "controller", "");
+
+                let runtime = blockcontroller::get_block_controller_status(&cmd.block_id);
+                let status = runtime.as_ref()
+                    .map(|s| s.shellprocstatus.clone())
+                    .unwrap_or_else(|| "init".to_string());
+                let exit_code = runtime.as_ref().map(|s| s.shellprocexitcode);
+                let pid = None; // PID not currently exposed in status struct
+
+                // Get session ID from block meta
+                let session_id = block.meta.get("agent:sessionid")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                Ok(Some(serde_json::to_value(&AgentStatusResult {
+                    block_id: cmd.block_id,
+                    agent_id,
+                    provider,
+                    controller_type,
+                    status,
+                    session_id,
+                    pid,
+                    exit_code,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.list
+// ---------------------------------------------------------------------------
+
+fn register_agent_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_LIST,
+        Box::new(move |_data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let tabs: Vec<Tab> = wstore.get_all::<Tab>()
+                    .map_err(|e| format!("agent.list: {e}"))?;
+
+                let mut agents = Vec::new();
+                for tab in &tabs {
+                    for block_id in &tab.blockids {
+                        if let Ok(Some(block)) = wstore.get::<Block>(block_id) {
+                            let agent_id = obj::meta_get_string(&block.meta, "agentId", "");
+                            if agent_id.is_empty() {
+                                continue;
+                            }
+                            let provider = obj::meta_get_string(&block.meta, "agentProvider", "");
+                            let status = blockcontroller::get_block_controller_status(block_id)
+                                .map(|s| s.shellprocstatus)
+                                .unwrap_or_else(|| "init".to_string());
+                            let session_id = block.meta.get("agent:sessionid")
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string());
+
+                            agents.push(AgentListEntry {
+                                block_id: block_id.clone(),
+                                tab_id: tab.oid.clone(),
+                                agent_id,
+                                provider,
+                                status,
+                                session_id,
+                            });
+                        }
+                    }
+                }
+
+                Ok(Some(serde_json::to_value(&AgentListResult { agents }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.output
+// ---------------------------------------------------------------------------
+
+fn register_agent_output(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let broker = state.broker.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_OUTPUT,
+        Box::new(move |data, _ctx| {
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentOutputData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.output: {e}"))?;
+
+                let scope = format!("block:{}", cmd.block_id);
+                let max = cmd.max_lines.unwrap_or(1000);
+                let after = cmd.after_line.unwrap_or(0);
+
+                // Read persisted blockfile events from broker history
+                let mut all_lines: Vec<String> = Vec::new();
+                {
+                    let events = broker.read_event_history(
+                        crate::backend::wps::EVENT_BLOCK_FILE,
+                        &scope,
+                        max + after, // read enough to cover offset
+                    );
+                    for event in events {
+                        if let Some(ref data) = event.data {
+                            if let Some(data64) = data.get("data64").and_then(|v| v.as_str()) {
+                                if let Ok(bytes) = base64::engine::general_purpose::STANDARD
+                                    .decode(data64)
+                                {
+                                    let text = String::from_utf8_lossy(&bytes);
+                                    for line in text.lines() {
+                                        if !line.trim().is_empty() {
+                                            all_lines.push(line.to_string());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let total = all_lines.len();
+                let lines: Vec<String> = all_lines.into_iter()
+                    .skip(after)
+                    .take(max)
+                    .collect();
+                let has_more = after + lines.len() < total;
+
+                Ok(Some(serde_json::to_value(&AgentOutputResult {
+                    block_id: cmd.block_id,
+                    lines,
+                    total_lines: total,
+                    has_more,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a tab ID: use the provided one, or fall back to the first workspace's active tab.
+fn resolve_tab_id(wstore: &WaveStore, explicit: Option<&str>) -> Result<String, String> {
+    if let Some(tid) = explicit {
+        return Ok(tid.to_string());
+    }
+
+    // Fall back to first workspace's active tab
+    let workspaces: Vec<Workspace> = wstore.get_all::<Workspace>()
+        .map_err(|e| format!("agent.open: list workspaces: {e}"))?;
+
+    for ws in &workspaces {
+        if !ws.activetabid.is_empty() {
+            return Ok(ws.activetabid.clone());
+        }
+        if let Some(first_tab) = ws.tabids.first() {
+            return Ok(first_tab.clone());
+        }
+    }
+
+    Err("no tabs found in any workspace".to_string())
+}
+
+/// Find an existing agent block in a tab by agent ID.
+fn find_agent_block(wstore: &WaveStore, tab_id: &str, agent_id: &str) -> Result<Option<Block>, String> {
+    let tab: Tab = wstore.must_get(tab_id)
+        .map_err(|e| format!("TAB_NOT_FOUND: {e}"))?;
+
+    for block_id in &tab.blockids {
+        if let Ok(Some(block)) = wstore.get::<Block>(block_id) {
+            let block_agent_id = obj::meta_get_string(&block.meta, "agentId", "");
+            if block_agent_id == agent_id {
+                return Ok(Some(block));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the working directory.
+fn write_agent_config_files(
+    wstore: &WaveStore,
+    agent: &crate::backend::storage::ForgeAgent,
+    agent_slug: &str,
+    work_dir: &str,
+) -> Result<(), String> {
+    // Load forge contents and skills
+    let contents = wstore.forge_get_all_content(&agent.id)
+        .unwrap_or_default();
+    let skills = wstore.forge_list_skills(&agent.id)
+        .unwrap_or_default();
+
+    let mut content_map = std::collections::HashMap::new();
+    for fc in &contents {
+        content_map.insert(fc.content_type.clone(), fc.content.clone());
+    }
+
+    let config_files = crate::backend::agent_config::build_config_files(
+        &content_map,
+        &skills,
+        &agent.name,
+        &agent.id,
+    );
+
+    // Expand ~ in work_dir
+    let expanded_dir = if work_dir.starts_with("~/") || work_dir == "~" {
+        if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+            format!("{}/{}", home, work_dir.trim_start_matches("~/"))
+        } else {
+            work_dir.to_string()
+        }
+    } else {
+        work_dir.to_string()
+    };
+
+    let base_path = std::path::Path::new(&expanded_dir);
+    if !base_path.exists() {
+        std::fs::create_dir_all(base_path)
+            .map_err(|e| format!("failed to create working dir: {e}"))?;
+    }
+
+    for file in &config_files {
+        let file_path = base_path.join(&file.filename);
+        if let Some(parent) = file_path.parent() {
+            if !parent.exists() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+        }
+        std::fs::write(&file_path, &file.content)
+            .map_err(|e| format!("failed to write {}: {e}", file.filename))?;
+    }
+
+    tracing::info!(
+        agent_id = %agent.id,
+        work_dir = %expanded_dir,
+        file_count = config_files.len(),
+        "agent.open: wrote config files"
+    );
+
+    Ok(())
+}

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod cli_handlers;
 mod files;
+mod app_api;
 mod forge_handlers;
 mod messagebus;
 mod reactive;

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -933,6 +933,9 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
 
     // Forge handlers (agents, content, skills, history, import, reseed)
     super::forge_handlers::register_forge_handlers(engine, &state);
+
+    // App API handlers (agent.open, agent.send, agent.stop, agent.status, agent.list, agent.output)
+    super::app_api::register_app_api_handlers(engine, &state);
 }
 
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.85"
+version = "0.33.86"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.86"
+version = "0.33.87"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.82"
+version = "0.33.83"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.79"
+version = "0.33.80"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.84"
+version = "0.33.85"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.83"
+version = "0.33.84"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.80"
+version = "0.33.81"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.81"
+version = "0.33.82"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/docs/analysis/persistent-process-retro-2026-04-10.md
+++ b/docs/analysis/persistent-process-retro-2026-04-10.md
@@ -1,0 +1,105 @@
+# Persistent Process Mode — Debug Retro (2026-04-10)
+
+**Goal:** Replace per-turn subprocess with persistent long-running CLI process
+using `--input-format stream-json` for bidirectional communication.
+
+**Spec:** `docs/specs/persistent-process-mode.md`
+**Implementation:** `agentmux-srv/src/backend/blockcontroller/persistent.rs`
+
+---
+
+## Issues Found (chronological)
+
+### 1. System-scanning CLI resolver copies .exe as .cmd (PR #327, v0.33.77)
+- **Symptom:** Agent pane subprocess exits with code 1 immediately
+- **Root cause:** Resolver found `~/.local/bin/claude.exe` (Bun-bundled binary),
+  copied it to `bin/claude.cmd`. The `.cmd` parser (`parse_cmd_wrapper`) couldn't
+  parse a PE binary, fell back to `cmd.exe /C` which crashed.
+- **Fix:** Removed entire system-scanning copy path. All providers use npm install
+  exclusively to `node_modules/.bin/`.
+- **Lesson:** Never copy system binaries — version isolation requires independent installs.
+
+### 2. npm install gate on install_cmd string (PR #328, v0.33.78)
+- **Symptom:** "claude not found and npm install is not configured for this provider"
+- **Root cause:** Resolver checked `install_cmd.contains("npm install")`. Claude's
+  provider had an official installer string, not "npm install", so it skipped npm
+  entirely.
+- **Fix:** Gate on `npm_package` field instead — all providers with a package name
+  get npm installed.
+- **Lesson:** Don't branch on string matching of config values; use explicit type fields.
+
+### 3. persistent.rs used raw Command::new() instead of make_cli_cmd() (PR #329, v0.33.79)
+- **Symptom:** Process spawned as `cmd.exe` (pid visible in tasklist), no stdout
+  output, exits with code 1.
+- **Root cause:** `persistent.rs` used `Command::new(&config.cli_command)` which
+  on Windows spawns `cmd.exe /C claude.cmd`. `subprocess.rs` already used
+  `make_cli_cmd()` which parses `.cmd` → `node <script>`. Stdin/stdout piping
+  through `cmd.exe /C` doesn't reliably work for persistent processes.
+- **Fix:** One-line change: `Command::new()` → `make_cli_cmd()`.
+- **Lesson:** Any new controller that spawns CLI processes must use the shared
+  `make_cli_cmd()` helper, not raw `Command::new()`.
+
+### 4. Stale portables built before fix commits (v0.33.79, v0.33.80)
+- **Symptom:** Portable shows correct version but doesn't have the fix
+- **Root cause:** `task cef:package:portable` was run on the branch before the
+  fix commit was pushed. The version bump happened first, then the fix, but the
+  binary was compiled from pre-fix code.
+- **Fix:** Rebuild v0.33.80 from main after all PRs merged.
+- **Lesson:** Always verify the fix is in the built binary, not just in source.
+  `git log --oneline -1` before building.
+
+### 5. No stderr capture — blind to exit code 1 cause (v0.33.80)
+- **Symptom:** Process spawns, stdout reader finishes in ~40ms, exit code 1. No
+  error info because stderr was `Stdio::null()`.
+- **Root cause:** Original `persistent.rs` set `stderr(Stdio::null())` with a
+  comment about SIGPIPE/EPIPE. On Windows there's no SIGPIPE — the real effect
+  was hiding all error messages.
+- **Fix:** Changed to `Stdio::piped()` with a background tokio task draining
+  stderr lines to `tracing::warn!`.
+- **Lesson:** Never null stderr on a process you need to debug. Pipe + drain.
+
+### 6. Windows canonicalize() returns \\?\C:\... — Node.js can't parse it (v0.33.81)
+- **Symptom:** `Error: EISDIR: illegal operation on a directory, lstat 'C:'`
+- **Root cause:** `parse_cmd_wrapper` calls `resolved.canonicalize()` which on
+  Windows returns `\\?\C:\Users\...` (UNC extended-length path). Node.js
+  `realpathSync` in `run_main` can't handle the `\\?\` prefix and interprets
+  `C:` as a directory.
+- **Fix:** Strip `\\?\` prefix after `canonicalize()`:
+  `if path_str.starts_with(r"\\?\") { path_str = path_str[4..].to_string(); }`
+- **Lesson:** Always strip Windows UNC prefix when passing paths to external
+  programs (Node, Python, etc.). Rust's `canonicalize()` is the only stdlib
+  function that produces these paths.
+
+---
+
+## Architecture Decisions
+
+### Why npm install over system copy
+- Version isolation: each AgentMux version gets its own CLI install
+- No binary type confusion (.exe vs .cmd vs node script)
+- Reproducible: `npm install @anthropic-ai/claude-code@latest` always produces
+  a proper `node_modules/.bin/claude.cmd` wrapper
+
+### Why make_cli_cmd() over Command::new()
+- On Windows, npm `.cmd` wrappers must be parsed to extract the node entry script
+- `cmd.exe /C` drops arguments and breaks stdin/stdout piping for long-running processes
+- `make_cli_cmd()` centralizes this logic in `agentmux-common` for all crates
+
+### Why persistent over per-turn subprocess
+- No process startup latency per message
+- Session continuity without `--resume`
+- Mid-turn interruption (send while streaming)
+- Simpler state machine (no respawn logic)
+
+---
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `agentmux-srv/src/server/cli_handlers.rs` | Removed system scanner (-219 lines), npm gate fix |
+| `agentmux-srv/src/backend/blockcontroller/persistent.rs` | make_cli_cmd, stderr capture, args logging |
+| `agentmux-common/src/cli.rs` | Shared make_cli_cmd + .cmd parser |
+| `frontend/app/view/agent/providers/index.ts` | Claude → controllerType: "persistent" |
+| `frontend/app/view/agent/agent-model.ts` | persistentLaunchArgs routing |
+| `frontend/app/view/agent/agent-view.tsx` | Loading spinner clears on failure |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.85",
+  "version": "0.33.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.85",
+      "version": "0.33.86",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.86",
+  "version": "0.33.87",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.86",
+      "version": "0.33.87",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.79",
+  "version": "0.33.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.79",
+      "version": "0.33.80",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.83",
+  "version": "0.33.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.83",
+      "version": "0.33.84",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.84",
+  "version": "0.33.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.84",
+      "version": "0.33.85",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.80",
+  "version": "0.33.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.80",
+      "version": "0.33.81",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.81",
+  "version": "0.33.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.81",
+      "version": "0.33.82",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.82",
+  "version": "0.33.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.82",
+      "version": "0.33.83",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.82",
+  "version": "0.33.83",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.85",
+  "version": "0.33.86",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.80",
+  "version": "0.33.81",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.79",
+  "version": "0.33.80",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.84",
+  "version": "0.33.85",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.83",
+  "version": "0.33.84",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.81",
+  "version": "0.33.82",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.86",
+  "version": "0.33.87",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
High-level programmatic API for agent management. Callers express intent ("open an agent pane with AgentX"), not mechanics ("create block, set 14 metadata keys, resync controller").

**New commands (registered on WebSocket RPC):**
- `agent.open` — Create agent pane with Forge agent (idempotent — returns existing if already open)
- `agent.send` — Send message to persistent/subprocess controller (auto-spawns if needed)
- `agent.stop` — Stop agent process with optional signal
- `agent.status` — Get controller state, session ID, exit code
- `agent.list` — List all agent panes across all tabs
- `agent.output` — Read accumulated output from broker history

**New files (+1519 lines):**
- `agentmux-srv/src/backend/providers.rs` — Static Rust provider registry (claude, codex, gemini) with 7 unit tests
- `agentmux-srv/src/backend/agent_config.rs` — Config file builder (CLAUDE.md, .mcp.json, skills, hooks) with 9 unit tests
- `agentmux-srv/src/server/app_api.rs` — All 6 command handlers

**Spec:** `docs/specs/app-api-extension.md`

## Test plan
- [ ] `agent.open` with valid Forge agent ID → block created, controller registered
- [ ] `agent.open` twice with same ID → returns existing block (idempotent)
- [ ] `agent.send` → message delivered, response streams
- [ ] `agent.stop` → process terminates
- [ ] `agent.status` → returns correct state
- [ ] `agent.list` → lists all agent panes
- [ ] Invalid agent ID → AGENT_NOT_FOUND error
- [ ] Unit tests pass for providers.rs and agent_config.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)