### PR TITLE
feat: App API Tier 1 — programmatic agent lifecycle commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.82"
+version = "0.33.83"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.82"
+version = "0.33.83"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.82"
+version = "0.33.83"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.82"
+version = "0.33.83"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.82"
+version = "0.33.83"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -1,0 +1,464 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pure config-building logic for Forge agents.
+//!
+//! Ports the `buildConfigFiles`, `buildMcpConfig`, and `expandTemplate`
+//! functions from `frontend/app/view/agent/agent-model.ts`.
+//! All functions are pure — no I/O, no async.
+
+use std::collections::HashMap;
+
+use chrono::Utc;
+use serde_json::{json, Value};
+
+use crate::backend::storage::wstore::ForgeSkill;
+
+/// A single file to be written to the agent working directory.
+#[derive(Debug, Clone)]
+pub struct AgentConfigFile {
+    /// Path relative to the agent working directory (e.g. `"CLAUDE.md"`, `".mcp.json"`).
+    pub filename: String,
+    /// UTF-8 file content.
+    pub content: String,
+}
+
+/// Build the list of config files to write to the agent working directory.
+///
+/// Assembles `CLAUDE.md` from `soul` + `agentmd` + `memory` + skills index,
+/// writes each skill as a slash command under `.claude/commands/<trigger>.md`,
+/// writes `.claude/hooks.json` if a `hooks` content entry is present,
+/// auto-injects the AgentMux MCP server entry, and applies `{{VARIABLE}}`
+/// template substitution throughout.
+///
+/// Mirrors `buildConfigFiles()` in `frontend/app/view/agent/agent-model.ts`.
+pub fn build_config_files(
+    content_map: &HashMap<String, String>,
+    skills: &[ForgeSkill],
+    agent_name: &str,
+    agent_id: &str,
+) -> Vec<AgentConfigFile> {
+    let mut files: Vec<AgentConfigFile> = Vec::new();
+
+    // Template variables for {{}} substitution
+    let mut template_vars: HashMap<String, String> = HashMap::new();
+    template_vars.insert("AGENT".to_string(), agent_name.to_string());
+    template_vars.insert("AGENT_DISPLAY".to_string(), agent_name.to_string());
+    template_vars.insert("AGENT_ID".to_string(), agent_id.to_string());
+    // DATE in YYYY-MM-DD format, UTC
+    template_vars.insert("DATE".to_string(), Utc::now().format("%Y-%m-%d").to_string());
+    // WORKING_DIR is not available in this signature; leave it empty for callers
+    // that don't pass it — expansion will leave {{WORKING_DIR}} intact if absent.
+
+    // ----------------------------------------------------------------
+    // Build CLAUDE.md: Soul + AgentMD + Memory + Skills index
+    // ----------------------------------------------------------------
+    let mut claude_md_parts: Vec<String> = Vec::new();
+
+    if let Some(soul) = content_map.get("soul") {
+        claude_md_parts.push(expand_template(soul, &template_vars));
+    }
+    if let Some(agentmd) = content_map.get("agentmd") {
+        if !claude_md_parts.is_empty() {
+            claude_md_parts.push("\n---\n".to_string());
+        }
+        claude_md_parts.push(expand_template(agentmd, &template_vars));
+    }
+    if let Some(memory) = content_map.get("memory") {
+        claude_md_parts.push("\n# Memory\n".to_string());
+        claude_md_parts.push(memory.clone());
+    }
+
+    // Append skill index with trigger references
+    if !skills.is_empty() {
+        claude_md_parts.push("\n# Available Skills\n\n".to_string());
+        claude_md_parts.push("Use `/<trigger>` to invoke a skill.\n\n".to_string());
+        for skill in skills {
+            let trigger_part = if skill.trigger.is_empty() {
+                String::new()
+            } else {
+                format!(" (trigger: /{})", skill.trigger)
+            };
+            let desc_part = if skill.description.is_empty() {
+                String::new()
+            } else {
+                format!(" \u{2014} {}", skill.description)
+            };
+            claude_md_parts.push(format!("- **{}**{}{}\n", skill.name, trigger_part, desc_part));
+        }
+    }
+
+    if !claude_md_parts.is_empty() {
+        files.push(AgentConfigFile {
+            filename: "CLAUDE.md".to_string(),
+            content: claude_md_parts.join(""),
+        });
+    }
+
+    // ----------------------------------------------------------------
+    // Write each skill as a slash command: .claude/commands/{trigger}.md
+    // ----------------------------------------------------------------
+    for skill in skills {
+        if !skill.trigger.is_empty() && !skill.content.is_empty() {
+            let content = expand_template(&skill.content, &template_vars);
+            files.push(AgentConfigFile {
+                filename: format!(".claude/commands/{}.md", skill.trigger),
+                content,
+            });
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Write .claude/hooks.json if hooks content is present
+    // ----------------------------------------------------------------
+    if let Some(hooks) = content_map.get("hooks") {
+        files.push(AgentConfigFile {
+            filename: ".claude/hooks.json".to_string(),
+            content: hooks.clone(),
+        });
+    }
+
+    // ----------------------------------------------------------------
+    // Build .mcp.json with auto-injected AgentMux MCP server
+    // ----------------------------------------------------------------
+    // agent_bus_id is not in the function signature; callers that have it
+    // should call build_mcp_config directly and push the result themselves,
+    // or use the variant below.
+    let mcp_content = content_map.get("mcp").map(|s| s.as_str());
+    if let Some(mcp_json) = build_mcp_config(mcp_content, agent_name, "") {
+        files.push(AgentConfigFile {
+            filename: ".mcp.json".to_string(),
+            content: mcp_json,
+        });
+    }
+
+    files
+}
+
+/// Build the list of config files with a known `agent_bus_id`.
+///
+/// Same as [`build_config_files`] but also accepts an `agent_bus_id` so the
+/// MCP server entry can include `AGENTMUX_AGENT_BUS_ID`.  Prefer this overload
+/// when the caller has the full `ForgeAgent` available.
+pub fn build_config_files_with_bus(
+    content_map: &HashMap<String, String>,
+    skills: &[ForgeSkill],
+    agent_name: &str,
+    agent_id: &str,
+    agent_bus_id: &str,
+    working_directory: &str,
+) -> Vec<AgentConfigFile> {
+    let mut files: Vec<AgentConfigFile> = Vec::new();
+
+    let mut template_vars: HashMap<String, String> = HashMap::new();
+    template_vars.insert("AGENT".to_string(), agent_name.to_string());
+    template_vars.insert("AGENT_DISPLAY".to_string(), agent_name.to_string());
+    template_vars.insert("AGENT_ID".to_string(), agent_id.to_string());
+    template_vars.insert("WORKING_DIR".to_string(), working_directory.to_string());
+    template_vars.insert("DATE".to_string(), Utc::now().format("%Y-%m-%d").to_string());
+
+    // CLAUDE.md
+    let mut claude_md_parts: Vec<String> = Vec::new();
+    if let Some(soul) = content_map.get("soul") {
+        claude_md_parts.push(expand_template(soul, &template_vars));
+    }
+    if let Some(agentmd) = content_map.get("agentmd") {
+        if !claude_md_parts.is_empty() {
+            claude_md_parts.push("\n---\n".to_string());
+        }
+        claude_md_parts.push(expand_template(agentmd, &template_vars));
+    }
+    if let Some(memory) = content_map.get("memory") {
+        claude_md_parts.push("\n# Memory\n".to_string());
+        claude_md_parts.push(memory.clone());
+    }
+    if !skills.is_empty() {
+        claude_md_parts.push("\n# Available Skills\n\n".to_string());
+        claude_md_parts.push("Use `/<trigger>` to invoke a skill.\n\n".to_string());
+        for skill in skills {
+            let trigger_part = if skill.trigger.is_empty() {
+                String::new()
+            } else {
+                format!(" (trigger: /{})", skill.trigger)
+            };
+            let desc_part = if skill.description.is_empty() {
+                String::new()
+            } else {
+                format!(" \u{2014} {}", skill.description)
+            };
+            claude_md_parts.push(format!("- **{}**{}{}\n", skill.name, trigger_part, desc_part));
+        }
+    }
+    if !claude_md_parts.is_empty() {
+        files.push(AgentConfigFile {
+            filename: "CLAUDE.md".to_string(),
+            content: claude_md_parts.join(""),
+        });
+    }
+
+    // Skill slash commands
+    for skill in skills {
+        if !skill.trigger.is_empty() && !skill.content.is_empty() {
+            let content = expand_template(&skill.content, &template_vars);
+            files.push(AgentConfigFile {
+                filename: format!(".claude/commands/{}.md", skill.trigger),
+                content,
+            });
+        }
+    }
+
+    // Hooks
+    if let Some(hooks) = content_map.get("hooks") {
+        files.push(AgentConfigFile {
+            filename: ".claude/hooks.json".to_string(),
+            content: hooks.clone(),
+        });
+    }
+
+    // MCP — use full bus_id variant
+    let mcp_content = content_map.get("mcp").map(|s| s.as_str());
+    if let Some(mcp_json) = build_mcp_config(mcp_content, agent_name, agent_bus_id) {
+        files.push(AgentConfigFile {
+            filename: ".mcp.json".to_string(),
+            content: mcp_json,
+        });
+    }
+
+    files
+}
+
+/// Build `.mcp.json` content with the auto-injected AgentMux MCP server entry.
+///
+/// The AgentMux server is always present as `mcpServers.agentmux`.
+/// If `user_mcp_content` is `Some`, its `mcpServers` entries are merged on top
+/// (user entries win over the auto-injected entry if the key collides).
+/// If the user content is not valid JSON the auto-injected-only config is
+/// returned and no error is propagated (mirrors TS behavior).
+///
+/// Returns `None` only if serialization unexpectedly fails (should never happen).
+///
+/// Mirrors `buildMcpConfig()` in `frontend/app/view/agent/agent-model.ts`.
+pub fn build_mcp_config(
+    user_mcp_content: Option<&str>,
+    agent_name: &str,
+    agent_bus_id: &str,
+) -> Option<String> {
+    // Auto-injected AgentMux MCP server entry
+    let mut env_map = serde_json::Map::new();
+    if !agent_name.is_empty() {
+        env_map.insert("AGENTMUX_AGENT_ID".to_string(), json!(agent_name));
+    }
+    if !agent_bus_id.is_empty() {
+        env_map.insert("AGENTMUX_AGENT_BUS_ID".to_string(), json!(agent_bus_id));
+    }
+
+    let agentmux_server = json!({
+        "type": "stdio",
+        "command": "agentmux-mcp",
+        "args": [],
+        "env": Value::Object(env_map),
+    });
+
+    let mut mcp_servers = serde_json::Map::new();
+    mcp_servers.insert("agentmux".to_string(), agentmux_server);
+
+    // Merge user-provided MCP config if present
+    if let Some(raw) = user_mcp_content {
+        match serde_json::from_str::<Value>(raw) {
+            Ok(Value::Object(user_obj)) => {
+                if let Some(Value::Object(user_servers)) = user_obj.get("mcpServers") {
+                    for (k, v) in user_servers {
+                        mcp_servers.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+            Ok(_) => {
+                // User content parsed but isn't an object — skip merge silently
+            }
+            Err(_) => {
+                // Invalid JSON in forge content — keep auto-injected only (mirrors TS behavior)
+                tracing::error!("agent_config: invalid MCP JSON in forge content, using auto-injected only");
+            }
+        }
+    }
+
+    let result = json!({ "mcpServers": Value::Object(mcp_servers) });
+    match serde_json::to_string_pretty(&result) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            tracing::error!("agent_config: failed to serialize MCP config: {e}");
+            None
+        }
+    }
+}
+
+/// Replace `{{VARIABLE}}` placeholders in `content` with values from `vars`.
+///
+/// Placeholders that have no corresponding key in `vars` are left unchanged
+/// (the original `{{VARIABLE}}` text is preserved).
+///
+/// Mirrors `expandTemplate()` in `frontend/app/view/agent/agent-model.ts`.
+pub fn expand_template(content: &str, vars: &HashMap<String, String>) -> String {
+    // Hand-rolled replacement to avoid pulling in a regex dependency.
+    // Scans for `{{`, extracts the key name up to `}}`, and substitutes.
+    let mut result = String::with_capacity(content.len());
+    let bytes = content.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        // Look for '{{'
+        if i + 1 < len && bytes[i] == b'{' && bytes[i + 1] == b'{' {
+            // Find closing '}}'
+            if let Some(rel) = content[i + 2..].find("}}") {
+                let key = &content[i + 2..i + 2 + rel];
+                // Only substitute if key is a simple word (alphanumeric + underscore)
+                if key.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+                    if let Some(val) = vars.get(key) {
+                        result.push_str(val);
+                    } else {
+                        // No match — preserve the original placeholder
+                        result.push_str(&content[i..i + 2 + rel + 2]);
+                    }
+                    i += 2 + rel + 2; // skip past '}}'
+                    continue;
+                }
+            }
+        }
+        // Not a placeholder start — copy character verbatim
+        // Safety: i is always on a valid char boundary because we only advance
+        // by 1 when not inside a placeholder, and UTF-8 single-byte characters
+        // are the only ones we index directly.
+        let ch = content[i..].chars().next().unwrap();
+        result.push(ch);
+        i += ch.len_utf8();
+    }
+
+    result
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_skill(name: &str, trigger: &str, description: &str, content: &str) -> ForgeSkill {
+        ForgeSkill {
+            id: format!("skill-{}", trigger),
+            agent_id: "agent-1".to_string(),
+            name: name.to_string(),
+            trigger: trigger.to_string(),
+            skill_type: "prompt".to_string(),
+            description: description.to_string(),
+            content: content.to_string(),
+            created_at: 0,
+        }
+    }
+
+    #[test]
+    fn test_expand_template_basic() {
+        let mut vars = HashMap::new();
+        vars.insert("AGENT".to_string(), "Aria".to_string());
+        vars.insert("DATE".to_string(), "2026-04-10".to_string());
+
+        let out = expand_template("Hello {{AGENT}}, today is {{DATE}}.", &vars);
+        assert_eq!(out, "Hello Aria, today is 2026-04-10.");
+    }
+
+    #[test]
+    fn test_expand_template_unknown_placeholder_preserved() {
+        let vars = HashMap::new();
+        let out = expand_template("Value: {{UNKNOWN}}", &vars);
+        assert_eq!(out, "Value: {{UNKNOWN}}");
+    }
+
+    #[test]
+    fn test_expand_template_empty_vars() {
+        let vars = HashMap::new();
+        let out = expand_template("No placeholders here.", &vars);
+        assert_eq!(out, "No placeholders here.");
+    }
+
+    #[test]
+    fn test_build_mcp_config_no_user_content() {
+        let result = build_mcp_config(None, "Aria", "bus-42").unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let servers = &parsed["mcpServers"];
+        assert!(servers["agentmux"].is_object());
+        assert_eq!(servers["agentmux"]["command"], "agentmux-mcp");
+        assert_eq!(servers["agentmux"]["env"]["AGENTMUX_AGENT_ID"], "Aria");
+        assert_eq!(servers["agentmux"]["env"]["AGENTMUX_AGENT_BUS_ID"], "bus-42");
+    }
+
+    #[test]
+    fn test_build_mcp_config_merges_user_servers() {
+        let user_mcp = r#"{"mcpServers": {"mytool": {"type": "stdio", "command": "mytool"}}}"#;
+        let result = build_mcp_config(Some(user_mcp), "Aria", "").unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        let servers = &parsed["mcpServers"];
+        assert!(servers["agentmux"].is_object());
+        assert!(servers["mytool"].is_object());
+    }
+
+    #[test]
+    fn test_build_mcp_config_invalid_user_json_uses_auto_injected() {
+        let result = build_mcp_config(Some("not json {{"), "Aria", "").unwrap();
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert!(parsed["mcpServers"]["agentmux"].is_object());
+    }
+
+    #[test]
+    fn test_build_config_files_claude_md_assembled() {
+        let mut content_map = HashMap::new();
+        content_map.insert("soul".to_string(), "You are {{AGENT}}.".to_string());
+        content_map.insert("agentmd".to_string(), "## Instructions\nDo stuff.".to_string());
+
+        let files = build_config_files(&content_map, &[], "Aria", "agent-1");
+        let claude_md = files.iter().find(|f| f.filename == "CLAUDE.md").unwrap();
+        assert!(claude_md.content.contains("You are Aria."));
+        assert!(claude_md.content.contains("---"));
+        assert!(claude_md.content.contains("## Instructions"));
+    }
+
+    #[test]
+    fn test_build_config_files_skills_index_and_commands() {
+        let content_map = HashMap::new();
+        let skills = vec![
+            make_skill("Deploy", "deploy", "Deploy the app", "Run: deploy all"),
+            make_skill("Test", "test", "Run tests", "Run: test suite"),
+        ];
+
+        let files = build_config_files(&content_map, &skills, "Aria", "agent-1");
+
+        // CLAUDE.md should have the skills index
+        let claude_md = files.iter().find(|f| f.filename == "CLAUDE.md").unwrap();
+        assert!(claude_md.content.contains("Available Skills"));
+        assert!(claude_md.content.contains("/deploy"));
+        assert!(claude_md.content.contains("/test"));
+
+        // Individual skill command files
+        assert!(files.iter().any(|f| f.filename == ".claude/commands/deploy.md"));
+        assert!(files.iter().any(|f| f.filename == ".claude/commands/test.md"));
+    }
+
+    #[test]
+    fn test_build_config_files_hooks_written() {
+        let mut content_map = HashMap::new();
+        content_map.insert("hooks".to_string(), r#"{"hooks":[]}"#.to_string());
+
+        let files = build_config_files(&content_map, &[], "Aria", "agent-1");
+        assert!(files.iter().any(|f| f.filename == ".claude/hooks.json"));
+    }
+
+    #[test]
+    fn test_build_config_files_mcp_written() {
+        let content_map = HashMap::new();
+        let files = build_config_files(&content_map, &[], "Aria", "agent-1");
+        let mcp = files.iter().find(|f| f.filename == ".mcp.json").unwrap();
+        let parsed: Value = serde_json::from_str(&mcp.content).unwrap();
+        assert!(parsed["mcpServers"]["agentmux"].is_object());
+    }
+}

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -352,6 +352,11 @@ impl PersistentSubprocessController {
                 }
 
                 // Publish line as WPS blockfile event
+                tracing::info!(
+                    block_id = %block_id_read,
+                    line_len = line.len(),
+                    "persistent stdout → blockfile"
+                );
                 let line_with_newline = format!("{}\n", line);
                 if let Some(ref broker) = broker_read {
                     super::shell::handle_append_block_file(
@@ -360,6 +365,8 @@ impl PersistentSubprocessController {
                         PERSISTENT_OUTPUT_SUBJECT,
                         line_with_newline.as_bytes(),
                     );
+                } else {
+                    tracing::warn!(block_id = %block_id_read, "persistent stdout: no broker available");
                 }
             }
 

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
+pub mod agent_config;
 pub mod blockcontroller;
+pub mod providers;
 pub mod config_watcher_fs;
 pub mod ijson;
 pub mod docsite;

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -1,0 +1,287 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Static provider registry — Rust equivalent of
+//! `frontend/app/view/agent/providers/index.ts`.
+//!
+//! All string data is `&'static str` / `&'static [&'static str]` so lookups
+//! are zero-allocation.  The registry is initialised once via `LazyLock` and
+//! then read-only for the lifetime of the process.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+// ─── Controller type ─────────────────────────────────────────────────────────
+
+/// How the provider process is managed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControllerType {
+    /// A single long-running process; input is streamed to stdin.
+    Persistent,
+    /// A fresh subprocess is spawned for every turn; prior sessions are
+    /// resumed via `resume_flag`.
+    Subprocess,
+}
+
+// ─── ProviderConfig ──────────────────────────────────────────────────────────
+
+/// All configuration needed to launch, authenticate, and stream output from
+/// a provider CLI.
+#[derive(Debug)]
+pub struct ProviderConfig {
+    /// Canonical provider identifier (e.g. `"claude"`).
+    pub id: &'static str,
+    /// Human-readable name shown in the UI.
+    pub display_name: &'static str,
+    /// Executable name on PATH (e.g. `"claude"`).
+    pub cli_command: &'static str,
+    /// Whether the provider keeps a persistent subprocess or spawns per turn.
+    pub controller_type: ControllerType,
+    /// Complete CLI args for a single-turn (subprocess) invocation.
+    /// The user prompt is written to the process's stdin.
+    pub launch_args: &'static [&'static str],
+    /// CLI args for persistent (long-running) mode.
+    /// `None` when `controller_type` is `Subprocess`.
+    pub persistent_launch_args: Option<&'static [&'static str]>,
+    /// Flag passed to resume a prior session, e.g. `"--resume"`.
+    /// `None` when the provider does not support simple-flag resume.
+    pub resume_flag: Option<&'static str>,
+    /// JSON field name in the CLI's init event that carries the session /
+    /// thread ID, e.g. `"session_id"` or `"thread_id"`.
+    pub session_id_field: &'static str,
+    /// Output format produced by the CLI in styled / streaming mode.
+    pub styled_output_format: &'static str,
+    // ── Auth isolation ───────────────────────────────────────────────────────
+    /// Environment variable that redirects the provider's config / auth
+    /// directory, e.g. `"CLAUDE_CONFIG_DIR"`.
+    pub auth_config_dir_env_var: &'static str,
+    /// Sub-directory name under `{dataDir}/auth/`, e.g. `"claude"`.
+    pub auth_dir_name: &'static str,
+    /// Extra environment variables required for auth isolation.
+    /// Each entry is a `(key, value)` pair.
+    pub auth_extra_env: &'static [(&'static str, &'static str)],
+    /// Environment variables that must be *unset* before launching the CLI
+    /// (guards against nested-session issues, etc.).
+    pub unset_env: &'static [&'static str],
+    // ── npm install ──────────────────────────────────────────────────────────
+    /// npm package name used for local installation, e.g.
+    /// `"@anthropic-ai/claude-code"`.
+    pub npm_package: &'static str,
+    /// Version string passed to `npm install`, e.g. `"latest"` or `"0.116.0"`.
+    pub pinned_version: &'static str,
+    // ── Misc ─────────────────────────────────────────────────────────────────
+    /// Icon identifier used by the frontend.
+    pub icon: &'static str,
+    /// URL of the provider's documentation.
+    pub docs_url: &'static str,
+}
+
+impl ProviderConfig {
+    /// Return the controller type as the string used in block metadata.
+    pub fn controller_type_str(&self) -> &'static str {
+        match self.controller_type {
+            ControllerType::Persistent => "persistent",
+            ControllerType::Subprocess => "subprocess",
+        }
+    }
+}
+
+// ─── Provider definitions ────────────────────────────────────────────────────
+
+static CLAUDE: ProviderConfig = ProviderConfig {
+    id: "claude",
+    display_name: "Claude Code",
+    cli_command: "claude",
+    controller_type: ControllerType::Persistent,
+    launch_args: &[
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--dangerously-skip-permissions",
+    ],
+    persistent_launch_args: Some(&[
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--dangerously-skip-permissions",
+    ]),
+    resume_flag: Some("--resume"),
+    session_id_field: "session_id",
+    styled_output_format: "claude-stream-json",
+    auth_config_dir_env_var: "CLAUDE_CONFIG_DIR",
+    auth_dir_name: "claude",
+    auth_extra_env: &[],
+    unset_env: &["CLAUDECODE"],
+    npm_package: "@anthropic-ai/claude-code",
+    pinned_version: "latest",
+    icon: "sparkles",
+    docs_url: "https://docs.anthropic.com/claude-code",
+};
+
+static CODEX: ProviderConfig = ProviderConfig {
+    id: "codex",
+    display_name: "Codex CLI",
+    cli_command: "codex",
+    controller_type: ControllerType::Subprocess,
+    // exec subcommand runs non-interactively; --json emits NDJSON events; - reads prompt from stdin
+    launch_args: &[
+        "exec",
+        "--json",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "-",
+    ],
+    // Codex resume requires a subcommand change (exec resume <id>), not a simple flag.
+    // Multi-turn is handled by re-running exec; None disables automatic --resume append.
+    persistent_launch_args: None,
+    resume_flag: None,
+    session_id_field: "thread_id",
+    styled_output_format: "codex-json",
+    auth_config_dir_env_var: "CODEX_HOME",
+    auth_dir_name: "codex",
+    auth_extra_env: &[],
+    unset_env: &[],
+    npm_package: "@openai/codex",
+    pinned_version: "0.116.0",
+    icon: "robot",
+    docs_url: "https://platform.openai.com/docs/codex",
+};
+
+static GEMINI: ProviderConfig = ProviderConfig {
+    id: "gemini",
+    display_name: "Gemini CLI",
+    cli_command: "gemini",
+    controller_type: ControllerType::Subprocess,
+    // --output-format stream-json: NDJSON events; --yolo: auto-approve all tools;
+    // -p "": enable headless/non-interactive mode (prompt comes from stdin)
+    launch_args: &["--output-format", "stream-json", "--yolo", "-p", ""],
+    persistent_launch_args: None,
+    resume_flag: Some("-r"),
+    session_id_field: "session_id",
+    styled_output_format: "gemini-json",
+    auth_config_dir_env_var: "GEMINI_CLI_HOME",
+    auth_dir_name: "gemini",
+    auth_extra_env: &[("GEMINI_FORCE_FILE_STORAGE", "true")],
+    unset_env: &[],
+    npm_package: "@google/gemini-cli",
+    pinned_version: "0.32.1",
+    icon: "diamond",
+    docs_url: "https://ai.google.dev/gemini-cli",
+};
+
+// ─── Static registry ─────────────────────────────────────────────────────────
+
+static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+    m.insert(CLAUDE.id, &CLAUDE);
+    m.insert(CODEX.id, &CODEX);
+    m.insert(GEMINI.id, &GEMINI);
+    m
+});
+
+// Aliases for provider IDs from older databases or alternate naming.
+static ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+    m.insert("claude-code", "claude");
+    m.insert("claude_code", "claude");
+    m.insert("codex-cli", "codex");
+    m.insert("gemini-cli", "gemini");
+    m
+});
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+/// Resolve a provider alias to its canonical ID.
+///
+/// Returns `id` unchanged if it is not a known alias.
+pub fn resolve_provider_alias(id: &str) -> &'static str {
+    ALIASES.get(id).copied().unwrap_or_else(|| {
+        // If the id itself is a canonical key return the interned key, otherwise
+        // return a best-effort static ref. The caller should treat the return
+        // value as a lookup key only.
+        REGISTRY
+            .get_key_value(id)
+            .map(|(k, _)| *k)
+            .unwrap_or("") // unknown — get_provider will return None
+    })
+}
+
+/// Look up a provider by canonical ID or alias.
+///
+/// Returns `None` when the ID (and any resolved alias) does not match a known
+/// provider.
+pub fn get_provider(id: &str) -> Option<&'static ProviderConfig> {
+    // Direct lookup first.
+    if let Some(p) = REGISTRY.get(id) {
+        return Some(p);
+    }
+    // Fall back to alias resolution.
+    let canonical = ALIASES.get(id).copied()?;
+    REGISTRY.get(canonical).copied()
+}
+
+/// Return an iterator over all registered providers in insertion order.
+pub fn get_provider_list() -> impl Iterator<Item = &'static ProviderConfig> {
+    // Stable canonical order matches the TypeScript PROVIDERS object order.
+    static ORDER: &[&str] = &["claude", "codex", "gemini"];
+    ORDER.iter().filter_map(|id| REGISTRY.get(*id).copied())
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_ids_resolve() {
+        assert!(get_provider("claude").is_some());
+        assert!(get_provider("codex").is_some());
+        assert!(get_provider("gemini").is_some());
+    }
+
+    #[test]
+    fn aliases_resolve() {
+        assert_eq!(get_provider("claude-code").unwrap().id, "claude");
+        assert_eq!(get_provider("claude_code").unwrap().id, "claude");
+        assert_eq!(get_provider("codex-cli").unwrap().id, "codex");
+        assert_eq!(get_provider("gemini-cli").unwrap().id, "gemini");
+    }
+
+    #[test]
+    fn unknown_returns_none() {
+        assert!(get_provider("unknown-provider").is_none());
+    }
+
+    #[test]
+    fn provider_list_has_three_entries() {
+        assert_eq!(get_provider_list().count(), 3);
+    }
+
+    #[test]
+    fn claude_persistent_args_present() {
+        let p = get_provider("claude").unwrap();
+        assert!(p.persistent_launch_args.is_some());
+        assert_eq!(p.controller_type, ControllerType::Persistent);
+    }
+
+    #[test]
+    fn codex_resume_flag_is_none() {
+        let p = get_provider("codex").unwrap();
+        assert!(p.resume_flag.is_none());
+        assert_eq!(p.controller_type, ControllerType::Subprocess);
+    }
+
+    #[test]
+    fn gemini_auth_extra_env() {
+        let p = get_provider("gemini").unwrap();
+        assert!(p
+            .auth_extra_env
+            .iter()
+            .any(|(k, v)| *k == "GEMINI_FORCE_FILE_STORAGE" && *v == "true"));
+    }
+}

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -288,6 +288,15 @@ pub const COMMAND_IMPORT_FORGE_FROM_CLAW: &str = "importforgefromclaw";
 // Forge Seed
 pub const COMMAND_RESEED_FORGE_AGENTS: &str = "reseedforgeagents";
 
+// App API Tier 1 — agent lifecycle commands
+pub const COMMAND_AGENT_OPEN: &str = "agent.open";
+pub const COMMAND_AGENT_SEND: &str = "agent.send";
+pub const COMMAND_AGENT_STOP_API: &str = "agent.stop";
+pub const COMMAND_AGENT_STATUS: &str = "agent.status";
+pub const COMMAND_AGENT_LIST: &str = "agent.list";
+pub const COMMAND_AGENT_OUTPUT: &str = "agent.output";
+pub const COMMAND_AGENT_STREAM: &str = "agent.stream";
+
 // ---- Client type constants ----
 
 pub const CLIENT_TYPE_CONN_SERVER: &str = "connserver";
@@ -535,6 +544,132 @@ pub struct RunCliLoginResult {
     /// OAuth URL extracted from the CLI's output (open in browser)
     pub auth_url: Option<String>,
     pub raw_output: String,
+}
+
+// ---- App API Tier 1 — request/response types ----
+
+/// Request for agent.open — find or create an agent pane for the given agent_id.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentOpenData {
+    pub agent_id: String,
+    pub tab_id: Option<String>,
+    pub split_direction: Option<String>,
+    pub split_reference_block_id: Option<String>,
+    pub focus: Option<bool>,
+}
+
+/// Request for agent.send — send a message to an agent pane.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentSendData {
+    pub block_id: String,
+    pub message: String,
+}
+
+/// Request for agent.stop — stop a running agent subprocess.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentStopApiData {
+    pub block_id: String,
+    pub signal: Option<String>,
+}
+
+/// Request for agent.status — query status of an agent pane.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentStatusData {
+    pub block_id: String,
+}
+
+/// Request for agent.output — read buffered output lines from an agent pane.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentOutputData {
+    pub block_id: String,
+    pub after_line: Option<usize>,
+    pub max_lines: Option<usize>,
+}
+
+/// Request for agent.stream — subscribe to live output from an agent pane.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandAgentStreamData {
+    pub block_id: String,
+}
+
+/// Response from agent.open.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentOpenResult {
+    pub block_id: String,
+    pub tab_id: String,
+    pub agent_id: String,
+    pub provider: String,
+    pub controller_type: String,
+    pub status: String,
+    pub created: bool,
+}
+
+/// Response from agent.send.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentSendResult {
+    pub block_id: String,
+    pub status: String,
+    pub session_id: Option<String>,
+}
+
+/// Response from agent.stop.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentStopResult {
+    pub block_id: String,
+    pub status: String,
+    pub exit_code: Option<i32>,
+}
+
+/// Response from agent.status.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentStatusResult {
+    pub block_id: String,
+    pub agent_id: String,
+    pub provider: String,
+    pub controller_type: String,
+    pub status: String,
+    pub session_id: Option<String>,
+    pub pid: Option<u32>,
+    pub exit_code: Option<i32>,
+}
+
+/// A single entry in the agent.list response.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentListEntry {
+    pub block_id: String,
+    pub tab_id: String,
+    pub agent_id: String,
+    pub provider: String,
+    pub status: String,
+    pub session_id: Option<String>,
+}
+
+/// Response from agent.list.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentListResult {
+    pub agents: Vec<AgentListEntry>,
+}
+
+/// Response from agent.output.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AgentOutputResult {
+    pub block_id: String,
+    pub lines: Vec<String>,
+    pub total_lines: usize,
+    pub has_more: bool,
 }
 
 /// Matches Go's `FileDataAt`

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -166,45 +166,28 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .map_err(|e| format!("agent.open: create_block: {e}"))?;
                 let block_id = block.oid.clone();
 
-                // Insert layout node so the pane is visible in the UI
+                // Enqueue a layout insert action for the frontend to process.
+                // The frontend's LayoutModel watches pendingbackendactions on the
+                // LayoutState and applies them via treeReducer — same mechanism
+                // used by cross-window drag-and-drop (dnd.rs).
                 {
                     let tab: Tab = wstore.must_get(&tab_id)
                         .map_err(|e| format!("agent.open: reload tab: {e}"))?;
                     if let Ok(mut layout) = wstore.must_get::<obj::LayoutState>(&tab.layoutstate) {
-                        let node_id = uuid::Uuid::new_v4().to_string();
-
-                        if layout.rootnode.is_none() {
-                            layout.rootnode = Some(json!({
-                                "id": &node_id,
-                                "data": { "blockId": &block_id },
-                                "flexDirection": "row",
-                                "size": 10
-                            }));
-                            layout.leaforder = Some(vec![obj::LeafOrderEntry {
-                                nodeid: node_id,
-                                blockid: block_id.clone(),
-                            }]);
-                        } else {
-                            let new_leaf = json!({
-                                "id": &node_id,
-                                "data": { "blockId": &block_id },
-                                "flexDirection": "column",
-                                "size": 10
-                            });
-                            let old_root = layout.rootnode.take().unwrap();
-                            layout.rootnode = Some(json!({
-                                "id": uuid::Uuid::new_v4().to_string(),
-                                "flexDirection": "row",
-                                "size": 10,
-                                "children": [old_root, new_leaf]
-                            }));
-                            let mut leaforder = layout.leaforder.clone().unwrap_or_default();
-                            leaforder.push(obj::LeafOrderEntry {
-                                nodeid: node_id,
-                                blockid: block_id.clone(),
-                            });
-                            layout.leaforder = Some(leaforder);
-                        }
+                        let mut actions = layout.pendingbackendactions.take().unwrap_or_default();
+                        actions.push(obj::LayoutActionData {
+                            actiontype: "insert".to_string(),
+                            actionid: uuid::Uuid::new_v4().to_string(),
+                            blockid: block_id.clone(),
+                            nodesize: None,
+                            indexarr: None,
+                            focused: true,
+                            magnified: false,
+                            ephemeral: false,
+                            targetblockid: String::new(),
+                            position: String::new(),
+                        });
+                        layout.pendingbackendactions = Some(actions);
                         let _ = wstore.update(&mut layout);
                     }
                 }

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1,0 +1,682 @@
+//! App API — high-level commands for programmatic control of AgentMux.
+//!
+//! These commands orchestrate multiple low-level operations (CreateBlock, SetMeta,
+//! ControllerResync) behind stable, intent-based interfaces. Callers express what
+//! they want ("open an agent pane with AgentX"), not how to do it.
+
+use std::sync::Arc;
+
+use base64::Engine;
+use serde_json::json;
+
+use crate::backend::blockcontroller;
+use crate::backend::obj::{self, Block, Tab, Workspace, MetaMapType};
+use crate::backend::providers;
+use crate::backend::rpc::engine::WshRpcEngine;
+use crate::backend::rpc_types::*;
+use crate::backend::storage::wstore::WaveStore;
+
+use super::AppState;
+
+/// Register all App API handlers on the RPC engine.
+pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    register_agent_open(engine, state);
+    register_agent_send(engine, state);
+    register_agent_stop(engine, state);
+    register_agent_status(engine, state);
+    register_agent_list(engine, state);
+    register_agent_output(engine, state);
+}
+
+// ---------------------------------------------------------------------------
+// agent.open
+// ---------------------------------------------------------------------------
+
+fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    let event_bus = state.event_bus.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_OPEN,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            let event_bus = event_bus.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentOpenData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.open: {e}"))?;
+
+                tracing::info!(agent_id = %cmd.agent_id, "agent.open");
+
+                // 1. Load the Forge agent (by id or name)
+                let agents = wstore.forge_list()
+                    .map_err(|e| format!("agent.open: {e}"))?;
+                let agent = agents.iter()
+                    .find(|a| a.id == cmd.agent_id || a.name.eq_ignore_ascii_case(&cmd.agent_id))
+                    .ok_or_else(|| format!("AGENT_NOT_FOUND: no forge agent with id '{}'", cmd.agent_id))?
+                    .clone();
+
+                // 2. Resolve provider
+                let provider = providers::get_provider(&agent.provider)
+                    .ok_or_else(|| format!("INVALID_PROVIDER: unknown provider '{}'", agent.provider))?;
+
+                // 3. Determine tab
+                let tab_id = resolve_tab_id(&wstore, cmd.tab_id.as_deref())?;
+
+                // 4. Check for existing agent pane in this tab (idempotent)
+                if let Some(existing) = find_agent_block(&wstore, &tab_id, &cmd.agent_id)? {
+                    let status = blockcontroller::get_block_controller_status(&existing.oid)
+                        .map(|s| s.shellprocstatus)
+                        .unwrap_or_else(|| "init".to_string());
+                    return Ok(Some(serde_json::to_value(&AgentOpenResult {
+                        block_id: existing.oid,
+                        tab_id,
+                        agent_id: cmd.agent_id,
+                        provider: agent.provider,
+                        controller_type: provider.controller_type_str().to_string(),
+                        status,
+                        created: false,
+                    }).unwrap()));
+                }
+
+                // 5. Resolve CLI path
+                let version = env!("CARGO_PKG_VERSION");
+                let home = std::env::var("HOME")
+                    .or_else(|_| std::env::var("USERPROFILE"))
+                    .map_err(|_| "cannot determine home directory".to_string())?;
+                let provider_dir = format!("{}/.agentmux/{}/cli/{}", home, version, provider.id);
+                let npm_bin = if cfg!(windows) {
+                    format!("{}/node_modules/.bin/{}.cmd", provider_dir, provider.cli_command)
+                } else {
+                    format!("{}/node_modules/.bin/{}", provider_dir, provider.cli_command)
+                };
+                if !std::path::Path::new(&npm_bin).exists() {
+                    return Err(format!(
+                        "CLI_NOT_AVAILABLE: {} not installed at {}. Open an agent pane in the UI to trigger installation.",
+                        provider.cli_command, npm_bin
+                    ));
+                }
+
+                // 6. Build metadata
+                let controller_type = provider.controller_type_str();
+                let is_persistent = controller_type == "persistent";
+                let cli_args: Vec<String> = if is_persistent {
+                    provider.persistent_launch_args
+                        .unwrap_or(provider.launch_args)
+                        .iter().map(|s| s.to_string()).collect()
+                } else {
+                    provider.launch_args.iter().map(|s| s.to_string()).collect()
+                };
+
+                let agent_slug = agent.name.to_lowercase()
+                    .chars().map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
+                    .collect::<String>();
+                let work_dir = if agent.working_directory.is_empty() {
+                    format!("~/.agentmux/agents/{}", agent_slug)
+                } else {
+                    agent.working_directory.clone()
+                };
+
+                // Build env vars
+                let mut env_vars = serde_json::Map::new();
+                for key in provider.unset_env {
+                    env_vars.insert(key.to_string(), json!(""));
+                }
+                // Auth dir
+                let auth_dir = format!("{}/.agentmux/config/auth/{}", home, provider.auth_dir_name);
+                let _ = std::fs::create_dir_all(&auth_dir);
+                env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
+                for (k, v) in provider.auth_extra_env {
+                    env_vars.insert(k.to_string(), json!(v));
+                }
+                // Agent identity
+                env_vars.insert("GH_CONFIG_DIR".to_string(), json!(format!("~/.agentmux/config/gh-{}", agent_slug)));
+                env_vars.insert("AGENTMUX_AGENT_ID".to_string(), json!(&agent.name));
+                // Exit delay only for subprocess
+                if !is_persistent {
+                    env_vars.insert("CLAUDE_CODE_EXIT_AFTER_STOP_DELAY".to_string(), json!("30000"));
+                }
+
+                let mut meta = MetaMapType::new();
+                meta.insert("view".to_string(), json!("agent"));
+                meta.insert("agentId".to_string(), json!(&agent.id));
+                meta.insert("agentProvider".to_string(), json!(&agent.provider));
+                meta.insert("agentName".to_string(), json!(&agent.name));
+                meta.insert("agentIcon".to_string(), json!(if agent.icon.is_empty() { "sparkles" } else { &agent.icon }));
+                meta.insert("agentMode".to_string(), json!(if agent.agent_type.is_empty() { "host" } else { &agent.agent_type }));
+                // Derive output format from provider ID (matches frontend providers/index.ts)
+                let output_format = match provider.id {
+                    "claude" => "claude-stream-json",
+                    "codex" => "codex-json",
+                    "gemini" => "gemini-json",
+                    _ => "claude-stream-json",
+                };
+                meta.insert("agentOutputFormat".to_string(), json!(output_format));
+                meta.insert("controller".to_string(), json!(controller_type));
+                meta.insert("cmd".to_string(), json!(&npm_bin));
+                meta.insert("cmd:args".to_string(), json!(cli_args));
+                meta.insert("cmd:cwd".to_string(), json!(&work_dir));
+                meta.insert("cmd:env".to_string(), serde_json::Value::Object(env_vars));
+                meta.insert("agent:resume_flag".to_string(), json!(provider.resume_flag.unwrap_or("")));
+                meta.insert("agent:session_id_field".to_string(), json!(provider.session_id_field));
+
+                // 7. Create block + insert into layout tree
+                let block = crate::backend::wcore::create_block(&wstore, &tab_id, meta)
+                    .map_err(|e| format!("agent.open: create_block: {e}"))?;
+                let block_id = block.oid.clone();
+
+                // Insert layout node so the pane is visible in the UI
+                {
+                    let tab: Tab = wstore.must_get(&tab_id)
+                        .map_err(|e| format!("agent.open: reload tab: {e}"))?;
+                    if let Ok(mut layout) = wstore.must_get::<obj::LayoutState>(&tab.layoutstate) {
+                        let node_id = uuid::Uuid::new_v4().to_string();
+
+                        if layout.rootnode.is_none() {
+                            layout.rootnode = Some(json!({
+                                "id": &node_id,
+                                "data": { "blockId": &block_id },
+                                "flexDirection": "row",
+                                "size": 10
+                            }));
+                            layout.leaforder = Some(vec![obj::LeafOrderEntry {
+                                nodeid: node_id,
+                                blockid: block_id.clone(),
+                            }]);
+                        } else {
+                            let new_leaf = json!({
+                                "id": &node_id,
+                                "data": { "blockId": &block_id },
+                                "flexDirection": "column",
+                                "size": 10
+                            });
+                            let old_root = layout.rootnode.take().unwrap();
+                            layout.rootnode = Some(json!({
+                                "id": uuid::Uuid::new_v4().to_string(),
+                                "flexDirection": "row",
+                                "size": 10,
+                                "children": [old_root, new_leaf]
+                            }));
+                            let mut leaforder = layout.leaforder.clone().unwrap_or_default();
+                            leaforder.push(obj::LeafOrderEntry {
+                                nodeid: node_id,
+                                blockid: block_id.clone(),
+                            });
+                            layout.leaforder = Some(leaforder);
+                        }
+                        let _ = wstore.update(&mut layout);
+                    }
+                }
+
+                tracing::info!(
+                    block_id = %block_id,
+                    agent_id = %cmd.agent_id,
+                    provider = %agent.provider,
+                    controller_type = %controller_type,
+                    "agent.open: block created + layout updated"
+                );
+
+                // 8. Write agent config files
+                write_agent_config_files(&wstore, &agent, &agent_slug, &work_dir)?;
+
+                // 9. Register controller (resync)
+                let block_for_resync = wstore.must_get::<Block>(&block_id)
+                    .map_err(|e| format!("agent.open: reload block: {e}"))?;
+                blockcontroller::resync_controller(
+                    &block_for_resync,
+                    &tab_id,
+                    None,
+                    true,
+                    Some(broker.clone()),
+                    Some(event_bus.clone()),
+                    Some(wstore.clone()),
+                )?;
+
+                // 10. Broadcast block + tab + layout updates to frontend
+                {
+                    let mut updates = Vec::new();
+                    if let Ok(updated_block) = wstore.must_get::<Block>(&block_id) {
+                        updates.push(obj::WaveObjUpdate {
+                            updatetype: "update".into(),
+                            otype: "block".into(),
+                            oid: block_id.clone(),
+                            obj: Some(obj::wave_obj_to_value(&updated_block)),
+                        });
+                    }
+                    if let Ok(updated_tab) = wstore.must_get::<Tab>(&tab_id) {
+                        updates.push(obj::WaveObjUpdate {
+                            updatetype: "update".into(),
+                            otype: "tab".into(),
+                            oid: tab_id.clone(),
+                            obj: Some(obj::wave_obj_to_value(&updated_tab)),
+                        });
+                        if let Ok(updated_layout) = wstore.must_get::<obj::LayoutState>(&updated_tab.layoutstate) {
+                            updates.push(obj::WaveObjUpdate {
+                                updatetype: "update".into(),
+                                otype: "layout".into(),
+                                oid: updated_tab.layoutstate.clone(),
+                                obj: Some(obj::wave_obj_to_value(&updated_layout)),
+                            });
+                        }
+                    }
+                    for update in &updates {
+                        let oref = format!("{}:{}", update.otype, update.oid);
+                        if let Ok(data) = serde_json::to_value(update) {
+                            event_bus.broadcast_event(
+                                &crate::backend::eventbus::WSEventType {
+                                    eventtype: "waveobj:update".to_string(),
+                                    oref,
+                                    data: Some(data),
+                                },
+                            );
+                        }
+                    }
+                }
+
+                Ok(Some(serde_json::to_value(&AgentOpenResult {
+                    block_id,
+                    tab_id,
+                    agent_id: cmd.agent_id,
+                    provider: agent.provider,
+                    controller_type: controller_type.to_string(),
+                    status: "init".to_string(),
+                    created: true,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.send
+// ---------------------------------------------------------------------------
+
+fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_SEND,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentSendData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.send: {e}"))?;
+
+                tracing::info!(block_id = %cmd.block_id, "agent.send");
+
+                let ctrl = blockcontroller::get_controller(&cmd.block_id)
+                    .ok_or_else(|| format!("NOT_RUNNING: no controller for block {}", cmd.block_id))?;
+
+                // Re-read spawn config from block metadata (same pattern as agentinput)
+                let block: Block = wstore
+                    .get(&cmd.block_id)
+                    .map_err(|e| format!("agent.send: {e}"))?
+                    .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", cmd.block_id))?;
+
+                let cli_command = obj::meta_get_string(&block.meta, "cmd", "claude");
+                let cli_args: Vec<String> = match block.meta.get("cmd:args") {
+                    Some(serde_json::Value::Array(arr)) => arr
+                        .iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect(),
+                    _ => vec![],
+                };
+                let working_dir = obj::meta_get_string(&block.meta, "cmd:cwd", "");
+                let env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
+                    Some(serde_json::Value::Object(obj)) => obj
+                        .iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                        .collect(),
+                    _ => std::collections::HashMap::new(),
+                };
+                let session_id_field = obj::meta_get_string(
+                    &block.meta, "agent:session_id_field", "session_id",
+                );
+
+                // Dispatch to persistent or subprocess controller
+                let mut session_id = None;
+                if let Some(persistent_ctrl) = ctrl
+                    .as_any()
+                    .downcast_ref::<blockcontroller::persistent::PersistentSubprocessController>()
+                {
+                    let config = blockcontroller::persistent::PersistentSpawnConfig {
+                        cli_command,
+                        cli_args,
+                        working_dir,
+                        env_vars,
+                        session_id_field,
+                    };
+                    persistent_ctrl.send_message(cmd.message, config)?;
+                    session_id = persistent_ctrl.session_id();
+                } else if let Some(subprocess_ctrl) = ctrl
+                    .as_any()
+                    .downcast_ref::<blockcontroller::subprocess::SubprocessController>()
+                {
+                    let resume_flag = obj::meta_get_string(
+                        &block.meta, "agent:resume_flag", "--resume",
+                    );
+                    let config = blockcontroller::subprocess::SubprocessSpawnConfig {
+                        cli_command,
+                        cli_args,
+                        working_dir,
+                        env_vars,
+                        message: cmd.message,
+                        resume_flag,
+                        session_id_field,
+                    };
+                    subprocess_ctrl.spawn_turn(config)?;
+                } else {
+                    return Err("NOT_RUNNING: controller type not supported".to_string());
+                }
+
+                Ok(Some(serde_json::to_value(&AgentSendResult {
+                    block_id: cmd.block_id,
+                    status: "running".to_string(),
+                    session_id,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.stop
+// ---------------------------------------------------------------------------
+
+fn register_agent_stop(engine: &Arc<WshRpcEngine>, _state: &AppState) {
+    engine.register_handler(
+        COMMAND_AGENT_STOP_API,
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                let cmd: CommandAgentStopApiData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.stop: {e}"))?;
+
+                tracing::info!(block_id = %cmd.block_id, signal = ?cmd.signal, "agent.stop");
+
+                let ctrl = blockcontroller::get_controller(&cmd.block_id)
+                    .ok_or_else(|| format!("NOT_RUNNING: no controller for block {}", cmd.block_id))?;
+
+                let force = matches!(cmd.signal.as_deref(), Some("SIGKILL") | Some("SIGTERM"));
+                ctrl.stop(!force, blockcontroller::STATUS_DONE)?;
+
+                let exit_code = blockcontroller::get_block_controller_status(&cmd.block_id)
+                    .map(|s| s.shellprocexitcode);
+
+                Ok(Some(serde_json::to_value(&AgentStopResult {
+                    block_id: cmd.block_id,
+                    status: "done".to_string(),
+                    exit_code,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.status
+// ---------------------------------------------------------------------------
+
+fn register_agent_status(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_STATUS,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentStatusData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.status: {e}"))?;
+
+                let block: Block = wstore
+                    .get(&cmd.block_id)
+                    .map_err(|e| format!("agent.status: {e}"))?
+                    .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", cmd.block_id))?;
+
+                let agent_id = obj::meta_get_string(&block.meta, "agentId", "");
+                let provider = obj::meta_get_string(&block.meta, "agentProvider", "");
+                let controller_type = obj::meta_get_string(&block.meta, "controller", "");
+
+                let runtime = blockcontroller::get_block_controller_status(&cmd.block_id);
+                let status = runtime.as_ref()
+                    .map(|s| s.shellprocstatus.clone())
+                    .unwrap_or_else(|| "init".to_string());
+                let exit_code = runtime.as_ref().map(|s| s.shellprocexitcode);
+                let pid = None; // PID not currently exposed in status struct
+
+                // Get session ID from block meta
+                let session_id = block.meta.get("agent:sessionid")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                Ok(Some(serde_json::to_value(&AgentStatusResult {
+                    block_id: cmd.block_id,
+                    agent_id,
+                    provider,
+                    controller_type,
+                    status,
+                    session_id,
+                    pid,
+                    exit_code,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.list
+// ---------------------------------------------------------------------------
+
+fn register_agent_list(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_LIST,
+        Box::new(move |_data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let tabs: Vec<Tab> = wstore.get_all::<Tab>()
+                    .map_err(|e| format!("agent.list: {e}"))?;
+
+                let mut agents = Vec::new();
+                for tab in &tabs {
+                    for block_id in &tab.blockids {
+                        if let Ok(Some(block)) = wstore.get::<Block>(block_id) {
+                            let agent_id = obj::meta_get_string(&block.meta, "agentId", "");
+                            if agent_id.is_empty() {
+                                continue;
+                            }
+                            let provider = obj::meta_get_string(&block.meta, "agentProvider", "");
+                            let status = blockcontroller::get_block_controller_status(block_id)
+                                .map(|s| s.shellprocstatus)
+                                .unwrap_or_else(|| "init".to_string());
+                            let session_id = block.meta.get("agent:sessionid")
+                                .and_then(|v| v.as_str())
+                                .map(|s| s.to_string());
+
+                            agents.push(AgentListEntry {
+                                block_id: block_id.clone(),
+                                tab_id: tab.oid.clone(),
+                                agent_id,
+                                provider,
+                                status,
+                                session_id,
+                            });
+                        }
+                    }
+                }
+
+                Ok(Some(serde_json::to_value(&AgentListResult { agents }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.output
+// ---------------------------------------------------------------------------
+
+fn register_agent_output(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let broker = state.broker.clone();
+
+    engine.register_handler(
+        COMMAND_AGENT_OUTPUT,
+        Box::new(move |data, _ctx| {
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandAgentOutputData = serde_json::from_value(data)
+                    .map_err(|e| format!("agent.output: {e}"))?;
+
+                let scope = format!("block:{}", cmd.block_id);
+                let max = cmd.max_lines.unwrap_or(1000);
+                let after = cmd.after_line.unwrap_or(0);
+
+                // Read persisted blockfile events from broker history
+                let mut all_lines: Vec<String> = Vec::new();
+                {
+                    let events = broker.read_event_history(
+                        crate::backend::wps::EVENT_BLOCK_FILE,
+                        &scope,
+                        max + after, // read enough to cover offset
+                    );
+                    for event in events {
+                        if let Some(ref data) = event.data {
+                            if let Some(data64) = data.get("data64").and_then(|v| v.as_str()) {
+                                if let Ok(bytes) = base64::engine::general_purpose::STANDARD
+                                    .decode(data64)
+                                {
+                                    let text = String::from_utf8_lossy(&bytes);
+                                    for line in text.lines() {
+                                        if !line.trim().is_empty() {
+                                            all_lines.push(line.to_string());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let total = all_lines.len();
+                let lines: Vec<String> = all_lines.into_iter()
+                    .skip(after)
+                    .take(max)
+                    .collect();
+                let has_more = after + lines.len() < total;
+
+                Ok(Some(serde_json::to_value(&AgentOutputResult {
+                    block_id: cmd.block_id,
+                    lines,
+                    total_lines: total,
+                    has_more,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a tab ID: use the provided one, or fall back to the first workspace's active tab.
+fn resolve_tab_id(wstore: &WaveStore, explicit: Option<&str>) -> Result<String, String> {
+    if let Some(tid) = explicit {
+        return Ok(tid.to_string());
+    }
+
+    // Fall back to first workspace's active tab
+    let workspaces: Vec<Workspace> = wstore.get_all::<Workspace>()
+        .map_err(|e| format!("agent.open: list workspaces: {e}"))?;
+
+    for ws in &workspaces {
+        if !ws.activetabid.is_empty() {
+            return Ok(ws.activetabid.clone());
+        }
+        if let Some(first_tab) = ws.tabids.first() {
+            return Ok(first_tab.clone());
+        }
+    }
+
+    Err("no tabs found in any workspace".to_string())
+}
+
+/// Find an existing agent block in a tab by agent ID.
+fn find_agent_block(wstore: &WaveStore, tab_id: &str, agent_id: &str) -> Result<Option<Block>, String> {
+    let tab: Tab = wstore.must_get(tab_id)
+        .map_err(|e| format!("TAB_NOT_FOUND: {e}"))?;
+
+    for block_id in &tab.blockids {
+        if let Ok(Some(block)) = wstore.get::<Block>(block_id) {
+            let block_agent_id = obj::meta_get_string(&block.meta, "agentId", "");
+            if block_agent_id == agent_id {
+                return Ok(Some(block));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the working directory.
+fn write_agent_config_files(
+    wstore: &WaveStore,
+    agent: &crate::backend::storage::ForgeAgent,
+    agent_slug: &str,
+    work_dir: &str,
+) -> Result<(), String> {
+    // Load forge contents and skills
+    let contents = wstore.forge_get_all_content(&agent.id)
+        .unwrap_or_default();
+    let skills = wstore.forge_list_skills(&agent.id)
+        .unwrap_or_default();
+
+    let mut content_map = std::collections::HashMap::new();
+    for fc in &contents {
+        content_map.insert(fc.content_type.clone(), fc.content.clone());
+    }
+
+    let config_files = crate::backend::agent_config::build_config_files(
+        &content_map,
+        &skills,
+        &agent.name,
+        &agent.id,
+    );
+
+    // Expand ~ in work_dir
+    let expanded_dir = if work_dir.starts_with("~/") || work_dir == "~" {
+        if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+            format!("{}/{}", home, work_dir.trim_start_matches("~/"))
+        } else {
+            work_dir.to_string()
+        }
+    } else {
+        work_dir.to_string()
+    };
+
+    let base_path = std::path::Path::new(&expanded_dir);
+    if !base_path.exists() {
+        std::fs::create_dir_all(base_path)
+            .map_err(|e| format!("failed to create working dir: {e}"))?;
+    }
+
+    for file in &config_files {
+        let file_path = base_path.join(&file.filename);
+        if let Some(parent) = file_path.parent() {
+            if !parent.exists() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+        }
+        std::fs::write(&file_path, &file.content)
+            .map_err(|e| format!("failed to write {}: {e}", file.filename))?;
+    }
+
+    tracing::info!(
+        agent_id = %agent.id,
+        work_dir = %expanded_dir,
+        file_count = config_files.len(),
+        "agent.open: wrote config files"
+    );
+
+    Ok(())
+}

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -65,7 +65,8 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let tab_id = resolve_tab_id(&wstore, cmd.tab_id.as_deref())?;
 
                 // 4. Check for existing agent pane in this tab (idempotent)
-                if let Some(existing) = find_agent_block(&wstore, &tab_id, &cmd.agent_id)? {
+                // Use resolved agent.id (not raw user input which could be a name)
+                if let Some(existing) = find_agent_block(&wstore, &tab_id, &agent.id)? {
                     let status = blockcontroller::get_block_controller_status(&existing.oid)
                         .map(|s| s.shellprocstatus)
                         .unwrap_or_else(|| "init".to_string());
@@ -424,7 +425,8 @@ fn register_agent_status(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let status = runtime.as_ref()
                     .map(|s| s.shellprocstatus.clone())
                     .unwrap_or_else(|| "init".to_string());
-                let exit_code = runtime.as_ref().map(|s| s.shellprocexitcode);
+                let exit_code = runtime.as_ref()
+                    .and_then(|s| if s.shellprocstatus == "done" { Some(s.shellprocexitcode) } else { None });
                 let pid = None; // PID not currently exposed in status struct
 
                 // Get session ID from block meta

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod cli_handlers;
 mod files;
+mod app_api;
 mod forge_handlers;
 mod messagebus;
 mod reactive;

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -933,6 +933,9 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
 
     // Forge handlers (agents, content, skills, history, import, reseed)
     super::forge_handlers::register_forge_handlers(engine, &state);
+
+    // App API handlers (agent.open, agent.send, agent.stop, agent.status, agent.list, agent.output)
+    super::app_api::register_app_api_handlers(engine, &state);
 }
 
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.82"
+version = "0.33.83"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/docs/CEF-VERSION-REPORT-2026-04-03.md
+++ b/docs/CEF-VERSION-REPORT-2026-04-03.md
@@ -1,0 +1,24 @@
+# CEF & Chromium Version Report — 2026-04-03
+
+## Current AgentMux
+
+| Component | Version |
+|-----------|---------|
+| CEF Rust crate | `cef 146.4.0+146.0.9` (pinned `146` in Cargo.toml) |
+| CEF upstream | 146.0.9 (`146.0.9+g3ca6a87+chromium-146.0.7680.165`) |
+| Chromium (bundled) | 146.0.7680.165 |
+
+## Latest Available
+
+| Component | Version | Notes |
+|-----------|---------|-------|
+| CEF stable | **146.0.9** | Latest on Spotify CDN |
+| Chrome stable | **147.0.7727.49** | Released 2026-04-01 (early stable) |
+| CEF 147 branch | Not yet stable | No stable build on CDN yet |
+
+## Assessment
+
+- AgentMux is **on the latest stable CEF** (146.0.9 / Chromium 146)
+- One Chromium milestone behind Chrome stable (146 vs 147) — this is normal, CEF trails by ~1 milestone
+- No action needed until CEF 147 has a stable release on the Spotify CDN
+- When CEF 147 ships: update `cef` version pin in `agentmux-cef/Cargo.toml`, rebuild, and test

--- a/docs/CEF_ARCHITECTURE.md
+++ b/docs/CEF_ARCHITECTURE.md
@@ -1,0 +1,1188 @@
+# CEF (Chromium Embedded Framework) Architecture — Technical Reference
+
+## Table of Contents
+
+1. [CEF's Relationship to Chromium](#1-cefs-relationship-to-chromium)
+2. [Multi-Process Architecture](#2-multi-process-architecture)
+3. [The CEF C API Layer](#3-the-cef-c-api-layer)
+4. [Language Bindings Ecosystem](#4-language-bindings-ecosystem)
+5. [CEF Views vs Native Window](#5-cef-views-vs-native-window)
+6. [The Handler/Callback Model](#6-the-handlercallback-model)
+7. [IPC and Message Routing](#7-ipc-and-message-routing)
+8. [Content/Rendering Pipeline](#8-contentrendering-pipeline)
+9. [CEF Build System](#9-cef-build-system)
+10. [How CEF Differs from Electron](#10-how-cef-differs-from-electron)
+11. [Sandboxing](#11-sandboxing)
+12. [The GPU Process in Detail](#12-the-gpu-process-in-detail)
+
+---
+
+## 1. CEF's Relationship to Chromium
+
+### What CEF Is
+
+CEF is an open-source framework built on top of the Chromium project. While Chromium is a full browser application, CEF is a library for **embedding** a Chromium-based browser into other applications. It enables developers to use HTML, CSS, and JavaScript to create application UI without shipping an entire browser.
+
+CEF3 (the current generation) is built on the **Chromium Content API** — the same API layer that Chrome itself uses. The Content API provides the multi-process browser architecture, the Blink rendering engine, and the V8 JavaScript engine. CEF wraps this in a stable, documented API.
+
+### What CEF Exposes vs Hides
+
+CEF acts as a **stable abstraction layer** over Chromium's internal APIs:
+
+**Hides:**
+- Blink and Content API implementation details (which are unstable and change frequently)
+- The complexity of Chromium's multi-process management
+- Low-level threading and IPC plumbing
+- Chromium build system complexity
+
+**Exposes:**
+- Browser creation and lifecycle management
+- JavaScript execution and binding
+- Network layer (custom schemes, request interception, cookie management, auth handling)
+- Rendering control (on-screen, off-screen/windowless)
+- Custom plugins, protocols, JavaScript objects and extensions
+- DevTools remote debugging
+- Drag-and-drop, printing, downloads, context menus
+- Process-level callbacks (browser process, renderer process)
+
+The Blink and Content APIs are not stable and many features require additional implementation. CEF provides these implementations and hides the complexity behind a versioned API surface.
+
+### Version Mapping
+
+Since 2019, CEF uses the format:
+
+```
+X.Y.Z+gHHHHHHH+chromium-A.B.C.D
+```
+
+| Component | Meaning |
+|-----------|---------|
+| `X` | Major version = Chromium milestone (e.g., CEF 146 = Chromium 146) |
+| `Y` | Increments when C/C++ API changes; resets to 0 per branch |
+| `Z` | Bugfix counter; resets when Y increments |
+| `gHHHHHHH` | 7-character Git commit hash |
+| `A.B.C.D` | Full Chromium version |
+
+**Legacy format (pre-2019):** `X.YYYY.A.gHHHHHHH` where X was always 3, YYYY was the Chromium branch number, and A was the commit count.
+
+### Branch Versioning
+
+CEF maintains branches that track Chromium release milestones:
+
+- **Master branch** — Tracks Chromium master. Not for production.
+- **Release branches** — Created per Chromium milestone (MXX). Frozen APIs with only security/bug fixes. Example: Branch 7680 = Chromium 146 (Stable).
+- **LTS (Long-Term Support)** — Every 6th branch starting with M138 receives extended support (~8 additional months of security fixes after exiting stable).
+- **Legacy** — Old branches (back to 2704) available but unsupported.
+
+Current branch-to-Chromium mapping (as of early 2026):
+
+| Branch | Chromium | Channel |
+|--------|----------|---------|
+| 7727 | 147 | Beta |
+| 7680 | 146 | Stable |
+| 7204 | 138 | LTS |
+
+The `CHROMIUM_BUILD_COMPATIBILITY.txt` file in the CEF repo specifies the exact Chromium version for any given branch/commit. The generated `cef_version.h` header contains all version information at compile time.
+
+---
+
+## 2. Multi-Process Architecture
+
+CEF3 inherits Chromium's multi-process model. Each process type runs in an isolated OS process for security, stability, and parallelism.
+
+### Process Types
+
+```
++--------------------------------------------------------------------+
+|                        BROWSER PROCESS                              |
+|  (Host application main process)                                    |
+|                                                                     |
+|  - Window creation and management                                   |
+|  - UI thread (main event loop)                                      |
+|  - IO thread (IPC, network events)                                  |
+|  - FILE threads (filesystem operations)                             |
+|  - Network stack (via Network Service)                              |
+|  - Cookie management, auth, certificate handling                    |
+|  - CefApp::GetBrowserProcessHandler() callbacks                     |
+|  - CefClient handler callbacks                                      |
++--------------------------------------------------------------------+
+       |  IPC (Mojo / Legacy IPC)       |  IPC            |  IPC
+       v                                v                 v
++------------------+  +------------------+  +------------------+
+| RENDERER PROC 1  |  | RENDERER PROC 2  |  | RENDERER PROC N  |
+| (per origin)     |  | (per origin)     |  |                  |
+|                  |  |                  |  |                  |
+| - Blink (HTML/   |  | - Blink          |  | - Blink          |
+|   CSS layout)    |  |                  |  |                  |
+| - V8 (JavaScript)|  | - V8             |  | - V8             |
+| - DOM access     |  |                  |  |                  |
+| - JS bindings    |  |                  |  |                  |
+| - TID_RENDERER   |  |                  |  |                  |
+|   thread         |  |                  |  |                  |
++------------------+  +------------------+  +------------------+
+       |
+       | GPU command buffer (shared memory)
+       v
++--------------------------------------------------------------------+
+|                         GPU PROCESS                                 |
+|                                                                     |
+|  - Accelerated compositing (Viz display compositor)                 |
+|  - ANGLE (translates GL ES -> D3D/Vulkan/Metal)                    |
+|  - Rasterization of display lists into GPU texture tiles            |
+|  - Frame aggregation from all processes                             |
+|  - Final draw to screen                                             |
+|  - WebGL execution                                                  |
++--------------------------------------------------------------------+
+
++---------------------+  +---------------------+
+| UTILITY PROCESS(ES) |  | NETWORK SERVICE     |
+| - Short-lived tasks |  | - HTTP/HTTPS stack  |
+| - Data decoding     |  | - DNS resolution    |
+| - Audio service     |  | - Cookie storage    |
++---------------------+  +---------------------+
+```
+
+### What Runs Where
+
+**Browser Process (main):**
+- Window creation and native UI
+- All `CefClient` handler callbacks (DisplayHandler, LifeSpanHandler, RequestHandler, etc.)
+- `CefApp::GetBrowserProcessHandler()` callbacks
+- Network request management
+- `CefBrowserHost` operations
+- Threads: TID_UI (main), TID_IO (IPC/network), TID_FILE_* (filesystem)
+
+**Renderer Process(es):**
+- Blink rendering engine (HTML parsing, CSS layout, painting)
+- V8 JavaScript engine execution
+- DOM access and manipulation
+- Custom JavaScript bindings
+- `CefApp::GetRenderProcessHandler()` callbacks
+- One renderer per unique origin (scheme + domain) by default
+- Thread: TID_RENDERER (main thread; all Blink/V8 must run here)
+
+**GPU Process:**
+- Accelerated compositing via Viz display compositor
+- GPU rasterization via Skia/Ganesh
+- ANGLE translation (GL ES -> platform-native API)
+- WebGL rendering
+- Frame aggregation from all render processes + browser process
+- Final draw to screen
+
+**Utility Processes:**
+- Short-lived tasks (data decoding, file operations)
+- Audio service, storage service
+- Sandboxed for security
+
+### Subprocess Spawning
+
+CEF supports two models:
+
+**1. Single-executable model (Windows/Linux):**
+The main application executable is re-spawned with `--type=renderer`, `--type=gpu-process`, etc. The entry point detects this:
+
+```cpp
+int main(int argc, char* argv[]) {
+    CefMainArgs main_args(argc, argv);
+    
+    // If this is a subprocess, CefExecuteProcess blocks until exit
+    int exit_code = CefExecuteProcess(main_args, app.get(), nullptr);
+    if (exit_code >= 0)
+        return exit_code;  // Was a subprocess
+    
+    // This is the browser process
+    CefInitialize(main_args, settings, app.get(), nullptr);
+    CefRunMessageLoop();
+    CefShutdown();
+}
+```
+
+**2. Separate-executable model (all platforms, required on macOS):**
+A small helper binary handles subprocesses. Configured via `CefSettings.browser_subprocess_path`. The helper binary only calls `CefExecuteProcess()`. This is preferred when the main application is large or has long startup time.
+
+**Linux Zygote:**
+On Linux, Chromium uses a Zygote process (spawned at startup) that forks to create renderer processes. There are actually two zygotes — one sandboxed (for renderers), one unsandboxed (for processes needing system access). The Zygote is triggered by `--type=zygote`.
+
+### IPC Mechanisms
+
+Processes communicate via:
+
+1. **Mojo** — The modern IPC system. Uses Mojom IDL to define interfaces. Message pipes provide bidirectional, typed communication. ~3x faster than legacy IPC with 1/3 less context switching. Generates bindings for C++, Java, and JavaScript.
+
+2. **Legacy IPC** — Older system using `IPC::Channel`. Still present but being phased out in favor of Mojo.
+
+3. **Shared Memory** — Used for bulk data (textures, buffers, command buffers). The GPU command buffer is a shared-memory ring buffer.
+
+4. **CefProcessMessage** — CEF's high-level abstraction over IPC for application-level browser-to-renderer messaging.
+
+---
+
+## 3. The CEF C API Layer
+
+### Architecture
+
+CEF is C++ internally but exposes a C API through `libcef` (the shared library). A static C++ wrapper library (`libcef_dll_wrapper`) sits on top:
+
+```
++-------------------------------------------+
+|          Your Application (C++)           |
++-------------------------------------------+
+|       libcef_dll_wrapper (static lib)     |
+|  C++ classes: CefBrowser, CefClient, etc. |
+|  CefRefPtr<T> smart pointers              |
++-------------------------------------------+
+|          libcef C API (shared lib)        |
+|  C structs: cef_browser_t, cef_client_t   |
+|  cef_base_ref_counted_t reference counting|
+|  cef_string_t string types                |
++-------------------------------------------+
+|        Chromium Content API (C++)         |
+|        Blink, V8, cc, Viz, Mojo           |
++-------------------------------------------+
+```
+
+### Why the C API Exists
+
+Two critical reasons:
+
+1. **Memory Management Isolation** — `libcef` and the host application may use different C/C++ runtimes with different heap allocators. Objects (including strings) must be freed by the same runtime that allocated them. The C API boundary enforces this.
+
+2. **ABI Stability** — C++ has no stable ABI (name mangling, vtable layout, etc. vary by compiler). A C API provides a stable binary interface that any language can call. This enables the language bindings ecosystem.
+
+3. **String Type Flexibility** — `libcef` can be compiled with different underlying string types (UTF-8, UTF-16, or wide). The C API abstracts this away.
+
+### C++ to C Struct Mapping
+
+Every C++ class maps to a C struct with the same name pattern:
+
+| C++ Class | C Struct | Header |
+|-----------|----------|--------|
+| `CefBrowser` | `cef_browser_t` | `cef_browser_capi.h` |
+| `CefClient` | `cef_client_t` | `cef_client_capi.h` |
+| `CefApp` | `cef_app_t` | `cef_app_capi.h` |
+| `CefLifeSpanHandler` | `cef_life_span_handler_t` | `cef_life_span_handler_capi.h` |
+
+The translation between C++ and C is handled by an **auto-generated translator tool**. Most developers never touch the C API directly — they use the C++ wrapper.
+
+### Reference Counting: `cef_base_ref_counted_t`
+
+Every CEF C struct begins with a `cef_base_ref_counted_t` member:
+
+```c
+typedef struct _cef_base_ref_counted_t {
+    size_t size;
+    void (CEF_CALLBACK *add_ref)(struct _cef_base_ref_counted_t* self);
+    int  (CEF_CALLBACK *release)(struct _cef_base_ref_counted_t* self);
+    int  (CEF_CALLBACK *has_one_ref)(struct _cef_base_ref_counted_t* self);
+    int  (CEF_CALLBACK *has_at_least_one_ref)(struct _cef_base_ref_counted_t* self);
+} cef_base_ref_counted_t;
+```
+
+A callback struct (like `cef_client_t`) is laid out as:
+
+```c
+typedef struct _cef_client_t {
+    cef_base_ref_counted_t base;  // Must be first member
+    
+    // Vtable-style function pointers:
+    cef_life_span_handler_t* (CEF_CALLBACK *get_life_span_handler)(
+        struct _cef_client_t* self);
+    cef_display_handler_t* (CEF_CALLBACK *get_display_handler)(
+        struct _cef_client_t* self);
+    int (CEF_CALLBACK *on_process_message_received)(
+        struct _cef_client_t* self,
+        cef_browser_t* browser,
+        cef_frame_t* frame,
+        cef_process_id_t source_process,
+        cef_process_message_t* message);
+    // ... more handler getters
+} cef_client_t;
+```
+
+Because `base` is the first member, a `cef_client_t*` can be safely cast to `cef_base_ref_counted_t*`.
+
+In C++, the wrapper uses `CefRefPtr<T>` (similar to `std::shared_ptr`) which calls `AddRef()`/`Release()` automatically. The `IMPLEMENT_REFCOUNTING(ClassName)` macro provides the atomic ref-count implementation.
+
+### String Types: `cef_string_t`
+
+```c
+typedef struct _cef_string_utf16_t {
+    char16_t* str;
+    size_t length;
+    void (*dtor)(char16_t* str);  // Destructor for correct heap deallocation
+} cef_string_utf16_t;
+
+typedef cef_string_utf16_t cef_string_t;  // Default is UTF-16
+```
+
+The `dtor` function pointer ensures the string is freed by the correct runtime, even when strings cross the API boundary.
+
+---
+
+## 4. Language Bindings Ecosystem
+
+CEF's C API enables bindings in virtually any language that can call C functions.
+
+### C++ — Direct API (libcef_dll_wrapper)
+
+The "official" way to use CEF. The static library `libcef_dll_wrapper` wraps the C API in idiomatic C++ classes:
+
+```cpp
+class CefClient : public virtual CefBaseRefCounted {
+public:
+    virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() { return nullptr; }
+    virtual CefRefPtr<CefDisplayHandler> GetDisplayHandler() { return nullptr; }
+    virtual bool OnProcessMessageReceived(
+        CefRefPtr<CefBrowser> browser,
+        CefRefPtr<CefFrame> frame,
+        CefProcessId source_process,
+        CefRefPtr<CefProcessMessage> message) { return false; }
+};
+```
+
+Distributed as **source code** in the binary distribution. You compile it into your application. The sample applications (`cefsimple`, `cefclient`) demonstrate usage.
+
+### Rust — cef-rs / cef-ui
+
+Two-layer architecture:
+
+**`cef-dll-sys` (low-level):** Uses `rust-bindgen` to auto-generate raw FFI bindings from CEF's C API headers. The `build.rs` script downloads platform-specific CEF binaries, aggregates headers into `wrapper.h`, runs bindgen, and compiles `libcef_dll_wrapper` via CMake.
+
+**`cef` crate (safe wrapper):** Wraps raw FFI with safe, idiomatic Rust APIs.
+
+Key patterns:
+
+- **`RcImpl<T, I>`** — Dual-pointer struct containing the raw CEF C struct (`T`), a Rust trait implementation (`I`), and an `AtomicUsize` ref count. The CEF struct is positioned first so C code treats the pointer as a raw C struct, while Rust accesses the trait through the embedded implementation.
+
+- **Conversion traits** — `ConvertParam<T>` (Rust -> C), `ConvertReturnValue<T>` (C -> Rust), `WrapParamRef<T, P>` (handle mutable C pointers).
+
+- **`RefGuard<T>`** — RAII wrapper that calls `release()` on drop, preventing leaks.
+
+- **Reference counting** — `AtomicUsize` with relaxed ordering for increments, release ordering for decrements, acquire fence on reaching zero.
+
+- **Pattern recognition** — The binding generator detects C patterns like `(count: usize, ptr: *const T)` and converts them to safe `&[T]` slices.
+
+### Java — JCEF (Java CEF)
+
+Official Java bindings maintained at `github.com/chromiumembedded/java-cef`. Uses JNI to bridge Java classes to the CEF C++ API. Provides `CefApp`, `CefClient`, `CefBrowser` as Java classes. Used by JetBrains IDEs (IntelliJ IDEA, etc.) for their embedded browser.
+
+### C#/.NET — CefSharp and CefGlue
+
+**CefSharp:** ~30% C++/CLI, ~70% C#. Provides WPF and WinForms browser controls. Wraps the C++ API directly through C++/CLI interop. Most popular .NET CEF binding.
+
+**CefGlue:** Pure C# using P/Invoke against the C API directly. Provides Avalonia and WPF controls. No C++/CLI dependency, so it works on .NET Core/5+/6+ more naturally.
+
+### Python — cefpython
+
+Python bindings using Cython to wrap the CEF C++ API. Provides a Pythonic interface for embedding browsers in Python applications (e.g., with wxPython, PyQt, Tk).
+
+### Go — go-cef / cef2go / energy
+
+Multiple Go bindings exist:
+- `cef2go` (by CzarekTomczak) — CGo bindings to the C API
+- `energy` (by energye) — More complete Go framework wrapping CEF
+
+### Delphi — CEF4Delphi
+
+Comprehensive Delphi/Lazarus/FPC bindings. Provides VCL, FireMonkey (FMX), and Lazarus components. Supports Windows, Linux, and macOS.
+
+---
+
+## 5. CEF Views vs Native Window
+
+CEF provides two windowing modes for browser rendering.
+
+### Mode 1: Native Window (Parent HWND)
+
+You provide a native window handle (HWND on Windows, X11 window on Linux, NSView on macOS). CEF creates its browser widget as a child of your window.
+
+```cpp
+CefWindowInfo window_info;
+window_info.SetAsChild(parent_hwnd, rect);  // Your native window
+CefBrowserHost::CreateBrowser(window_info, client, url, settings, nullptr, nullptr);
+```
+
+**Pros:**
+- Full control over window chrome, title bar, frame
+- Easy integration with existing native UI frameworks
+- Can mix native widgets with embedded browser
+- Works on all platforms
+
+**Cons:**
+- You manage window lifecycle, sizing, DPI scaling
+- Must handle coordinate conversion (DIP vs device pixels) yourself
+- Frameless windows require platform-specific code (WS_POPUP on Windows, etc.)
+
+### Mode 2: CEF Views (Cross-Platform)
+
+CEF manages the window using its built-in Views/Aura framework (the same GUI framework Chromium uses on Windows and Linux).
+
+```cpp
+// Create browser view
+CefRefPtr<CefBrowserView> browser_view = CefBrowserView::CreateBrowserView(
+    client, url, settings, nullptr, nullptr, nullptr);
+
+// Create window containing the browser view
+CefWindow::CreateTopLevelWindow(new MyWindowDelegate(browser_view));
+```
+
+**Pros:**
+- Cross-platform window management (consistent behavior)
+- Built-in support for frameless windows (`CefWindowDelegate::IsFrameless()` returns true)
+- Integrated with CEF's bounds/resize callbacks
+- Simpler code for basic windowed browsers
+
+**Cons:**
+- Currently supported on **Windows and Linux only** (macOS support limited)
+- Less flexibility for complex native UI
+- Tied to CEF's window management semantics
+
+**Frameless in Views:** Return `true` from `CefWindowDelegate::IsFrameless()`. The `cefclient` sample demonstrates this with `--hide-frame`.
+
+### Mode 3: Off-Screen (Windowless) Rendering
+
+CEF renders to a pixel buffer that you paint yourself. No native window is created by CEF.
+
+```cpp
+CefWindowInfo window_info;
+window_info.SetAsWindowless(parent_hwnd);  // parent is optional
+CefBrowserHost::CreateBrowser(window_info, client, url, settings, nullptr, nullptr);
+```
+
+You implement `CefRenderHandler`:
+- `GetViewRect()` — Return desired view rectangle
+- `OnPaint()` — Receive invalidated regions + pixel buffer (BGRA format)
+- `GetScreenInfo()` — Configure DPI/screen info
+
+You forward input events via `CefBrowserHost::SendMouseClickEvent()`, `SendKeyEvent()`, etc.
+
+**Pros:**
+- Render browser content into any surface (game engines, custom compositors)
+- Full control over compositing
+- Works for headless/server-side rendering
+
+**Cons:**
+- No accelerated compositing (software rendering only) — performance impact
+- You handle all input forwarding manually
+- More complex integration
+
+### Coordinate Systems
+
+- **CEF Views APIs** — Use DIP (Density Independent Pixels) directly
+- **Windows APIs** — Expect device (pixel) coordinates; use `CefDisplay` for conversion
+- **Linux** — Root window pixel coordinates
+- **macOS Cocoa** — DIP with lower-left origin
+
+---
+
+## 6. The Handler/Callback Model
+
+CEF uses a handler/callback pattern where your application implements interfaces that CEF calls at specific lifecycle points. In the C API, these are vtable-style structs with function pointers.
+
+### CefApp — Application-Level Callbacks
+
+```
+CefApp
+  |-- OnBeforeCommandLineProcessing()    // Modify command-line args
+  |-- OnRegisterCustomSchemes()          // Register custom URI schemes
+  |-- GetBrowserProcessHandler()         // Return browser-process handler
+  |      |-- OnContextInitialized()      // CEF fully initialized
+  |      |-- OnBeforeChildProcessLaunch() // Before subprocess spawn
+  |-- GetRenderProcessHandler()          // Return renderer-process handler
+         |-- OnWebKitInitialized()       // WebKit initialized in renderer
+         |-- OnBrowserCreated()          // Browser created in renderer
+         |-- OnContextCreated()          // V8 context created (JS ready)
+         |-- OnContextReleased()         // V8 context destroyed
+         |-- OnProcessMessageReceived()  // IPC from browser process
+```
+
+### CefClient — Per-Browser Handler Hub
+
+A single `CefClient` can be shared among multiple browser instances. It returns sub-handlers:
+
+```
+CefClient
+  |-- GetDisplayHandler()       -> CefDisplayHandler
+  |     |-- OnTitleChange()
+  |     |-- OnAddressChange()
+  |     |-- OnConsoleMessage()
+  |
+  |-- GetLifeSpanHandler()      -> CefLifeSpanHandler
+  |     |-- OnBeforePopup()          // Intercept popup creation
+  |     |-- OnAfterCreated()         // Browser created (UI thread)
+  |     |-- DoClose()                // Close requested
+  |     |-- OnBeforeClose()          // Final cleanup
+  |
+  |-- GetLoadHandler()          -> CefLoadHandler
+  |     |-- OnLoadStart()
+  |     |-- OnLoadEnd()
+  |     |-- OnLoadError()
+  |
+  |-- GetRequestHandler()       -> CefRequestHandler
+  |     |-- OnBeforeBrowse()
+  |     |-- GetResourceHandler()     // Intercept arbitrary requests
+  |     |-- GetResourceResponseFilter() // Filter response data
+  |     |-- GetAuthCredentials()     // Proxy/HTTP auth
+  |     |-- OnCertificateError()
+  |
+  |-- GetDownloadHandler()      -> CefDownloadHandler
+  |-- GetDragHandler()          -> CefDragHandler
+  |-- GetFocusHandler()         -> CefFocusHandler
+  |-- GetKeyboardHandler()      -> CefKeyboardHandler
+  |-- GetContextMenuHandler()   -> CefContextMenuHandler
+  |-- GetDialogHandler()        -> CefDialogHandler
+  |-- GetRenderHandler()        -> CefRenderHandler (off-screen only)
+  |     |-- GetViewRect()
+  |     |-- OnPaint()
+  |     |-- GetScreenInfo()
+  |
+  |-- OnProcessMessageReceived()  // IPC from renderer process
+```
+
+### C API Vtable Pattern
+
+In the C API, each handler is a struct with function pointers (a C vtable):
+
+```c
+// You allocate and populate this struct
+cef_life_span_handler_t handler;
+handler.base.size = sizeof(cef_life_span_handler_t);
+handler.base.add_ref = my_add_ref;
+handler.base.release = my_release;
+handler.base.has_one_ref = my_has_one_ref;
+handler.on_after_created = my_on_after_created;
+handler.do_close = my_do_close;
+handler.on_before_close = my_on_before_close;
+```
+
+### Thread Safety — Which Callbacks Run Where
+
+This is critical to get right:
+
+| Callback | Thread | Process |
+|----------|--------|---------|
+| `OnAfterCreated()` | TID_UI | Browser |
+| `OnBeforeClose()` | TID_UI | Browser |
+| `OnContextInitialized()` | TID_UI | Browser |
+| `OnTitleChange()` | TID_UI | Browser |
+| `OnConsoleMessage()` | TID_UI | Browser |
+| `OnLoadStart/End/Error()` | TID_UI | Browser |
+| `GetAuthCredentials()` | TID_IO | Browser |
+| Network callbacks | TID_IO (varies) | Browser |
+| `OnContextCreated()` | TID_RENDERER | Renderer |
+| `OnProcessMessageReceived()` | TID_UI (browser) or TID_RENDERER (renderer) | Both |
+| `OnPaint()` | TID_UI | Browser |
+
+Use `CefCurrentlyOn(TID_UI)` to assert the expected thread:
+
+```cpp
+#define CEF_REQUIRE_UI_THREAD()       DCHECK(CefCurrentlyOn(TID_UI));
+#define CEF_REQUIRE_IO_THREAD()       DCHECK(CefCurrentlyOn(TID_IO));
+#define CEF_REQUIRE_RENDERER_THREAD() DCHECK(CefCurrentlyOn(TID_RENDERER));
+```
+
+Cross-thread work is dispatched via `CefPostTask()`:
+
+```cpp
+CefPostTask(TID_UI, base::BindOnce(&MyFunction, arg1, arg2));
+```
+
+---
+
+## 7. IPC and Message Routing
+
+### Process Startup Data
+
+When creating a browser, you can pass initialization data via the `extra_info` parameter (`CefDictionaryValue`) to `CefBrowserHost::CreateBrowser()`. This data is delivered to every renderer process associated with that browser via `CefRenderProcessHandler::OnBrowserCreated()`.
+
+### Runtime Process Messages (CefProcessMessage)
+
+The fundamental IPC primitive for application-level messaging:
+
+```
+Browser Process                          Renderer Process
+      |                                       |
+      |  CefProcessMessage("my_msg")          |
+      |-------------------------------------->|
+      |  browser->GetMainFrame()              |
+      |    ->SendProcessMessage(PID_RENDERER) |
+      |                                       |
+      |  Received in:                         |
+      |  CefRenderProcessHandler::            |
+      |    OnProcessMessageReceived()         |
+      |                                       |
+      |  CefProcessMessage("response")        |
+      |<--------------------------------------|
+      |  frame->SendProcessMessage(           |
+      |    PID_BROWSER)                       |
+      |                                       |
+      |  Received in:                         |
+      |  CefClient::                          |
+      |    OnProcessMessageReceived()         |
+```
+
+Messages carry a `CefListValue` argument list supporting strings, ints, doubles, booleans, binary data, dictionaries, and nested lists.
+
+### CefMessageRouter — High-Level JS-to-C++ Bridge
+
+CEF provides a built-in generic message router for asynchronous JavaScript-to-C++ communication.
+
+**Setup:**
+
+1. Create `CefMessageRouterBrowserSide` in the browser process with a `CefMessageRouterConfig`
+2. Create `CefMessageRouterRendererSide` in the renderer process with the **same** config
+3. Register application `Handler` instances with the browser-side router
+4. Wire router callbacks into `CefClient` and `CefRenderProcessHandler`
+
+**JavaScript API (injected into `window`):**
+
+```javascript
+// Send a query to C++
+var request_id = window.cefQuery({
+    request: 'my_request_data',
+    persistent: false,        // true = keep alive for multiple responses
+    onSuccess: function(response) {
+        console.log('Got response:', response);
+    },
+    onFailure: function(error_code, error_message) {
+        console.log('Error:', error_code, error_message);
+    }
+});
+
+// Cancel a pending query
+window.cefQueryCancel(request_id);
+```
+
+The function names (`cefQuery`, `cefQueryCancel`) are configurable via `CefMessageRouterConfig.js_query_function` and `js_cancel_function`.
+
+**C++ Handler:**
+
+```cpp
+class MyHandler : public CefMessageRouterBrowserSide::Handler {
+    bool OnQuery(CefRefPtr<CefBrowser> browser,
+                 CefRefPtr<CefFrame> frame,
+                 int64_t query_id,
+                 const CefString& request,
+                 bool persistent,
+                 CefRefPtr<Callback> callback) override {
+        if (request == "get_data") {
+            callback->Success("here is the data");
+            return true;  // Handled
+        }
+        return false;  // Pass to next handler
+    }
+    
+    void OnQueryCanceled(CefRefPtr<CefBrowser> browser,
+                         CefRefPtr<CefFrame> frame,
+                         int64_t query_id) override {
+        // Clean up resources for canceled query
+    }
+};
+```
+
+**Message flow:**
+
+```
+JavaScript: window.cefQuery({request, onSuccess, onFailure})
+  -> Renderer: CefMessageRouterRendererSide intercepts
+  -> IPC message to browser process
+  -> Browser: CefMessageRouterBrowserSide routes to Handler
+  -> Handler.OnQuery() executes, calls Callback.Success/Failure
+  -> IPC response to renderer
+  -> Renderer: invokes JS onSuccess/onFailure callback
+```
+
+Messages exceeding `CefMessageRouterConfig.message_size_threshold` bytes automatically route through shared memory regions for efficiency.
+
+### Custom V8 JavaScript Bindings
+
+For direct V8 integration (lower-level than CefMessageRouter):
+
+1. In `CefRenderProcessHandler::OnContextCreated()`, access the V8 context
+2. Create `CefV8Value` objects (functions, objects, arrays)
+3. Bind them to `window` or other global objects
+4. Implement `CefV8Handler::Execute()` for function callbacks
+
+This runs in the renderer process. To communicate with the browser process, send `CefProcessMessage` from the V8 handler callback.
+
+### Synchronous Requests
+
+Synchronous browser-renderer IPC is discouraged but possible via synchronous `XMLHttpRequest` from the renderer, which blocks the renderer until the browser's network layer responds. The request can be intercepted by `CefRequestHandler::GetResourceHandler()` in the browser process.
+
+---
+
+## 8. Content/Rendering Pipeline
+
+### From HTML to Pixels — The Full Pipeline
+
+The rendering pipeline has 12 stages, split across the main thread, compositor thread, and GPU process:
+
+```
+RENDERER PROCESS — Main Thread (TID_RENDERER)
++------------------------------------------------------------------+
+| 1. ANIMATE    — Apply CSS animations, modify property trees       |
+| 2. STYLE      — Resolve CSS -> computed styles per DOM node       |
+| 3. LAYOUT     — Compute positions and sizes -> fragment tree      |
+| 4. PRE-PAINT  — Build property trees, invalidate display lists    |
+| 5. SCROLL     — Update scroll offsets in property trees           |
+| 6. PAINT      — Generate display lists (SkPicture) for tiles      |
+| 7. COMMIT     — Copy property trees + display lists to compositor |
++------------------------------------------------------------------+
+         | (Commit blocks main thread briefly)
+         v
+RENDERER PROCESS — Compositor Thread
++------------------------------------------------------------------+
+| 8. LAYERIZE   — Break display lists into composited layer lists   |
+| 9. RASTER     — Convert display lists -> GPU texture tiles        |
+|    (via raster worker threads -> GPU process)                     |
+|10. ACTIVATE   — Create compositor frame (quads + render passes)   |
++------------------------------------------------------------------+
+         | (Submit compositor frame via CompositorFrameSink)
+         v
+GPU PROCESS (Viz)
++------------------------------------------------------------------+
+|11. AGGREGATE  — Combine frames from ALL render + browser processes|
+|12. DRAW       — Execute on GPU hardware -> pixels on screen       |
++------------------------------------------------------------------+
+```
+
+### Stage Details
+
+**DOM -> RenderObjects -> RenderLayers -> GraphicsLayers:**
+
+```
+DOM Tree                    1:1 visible nodes
+  |
+  v
+RenderObject Tree           Each visible DOM node gets a RenderObject
+  |                         (knows how to paint itself)
+  v
+RenderLayer Tree            Groups RenderObjects sharing coordinate space
+  |                         (preserves z-ordering)
+  v
+GraphicsLayer Tree          RenderLayers that get their own GPU texture:
+  |                         - 3D/perspective CSS transforms
+  |                         - <video> with accelerated decoding
+  |                         - <canvas> with WebGL/3D context
+  |                         - Animated opacity or transforms
+  |                         - Accelerated CSS filters
+  |                         - Overlapping composited layers
+  v
+cc Layer List               Chrome compositor's final representation
+```
+
+**Painting (Display List Recording):**
+Blink paints invalidated regions into `SkPicture`-backed `GraphicsContext`. This creates a **display list** (recording of draw commands), not actual pixels. The "interest area" around the viewport bounds what gets recorded.
+
+**Tiling:**
+Rather than rasterizing entire layers, the compositor breaks content into **tiles** and rasterizes per-tile. Tiles are prioritized by viewport proximity and estimated time-to-visibility. GPU memory is allocated to tiles based on priority.
+
+**Rasterization (Two Paths):**
+
+1. **Software rasterization** — SkPicture playback targets bitmaps in shared renderer-GPU memory. Occurs on compositor raster worker threads (parallel). Completed tiles upload to GPU as textures.
+
+2. **GPU rasterization (Ganesh/Graphite)** — SkPicture plays back via Skia's GPU backend, generating GL commands sent directly to the GPU process. Tiles become GPU textures in-place. No upload step needed.
+
+**Compositor Thread Independence:**
+The compositor thread can scroll and animate independently of the main thread. When the main thread is busy running JavaScript, the compositor continues producing frames. This is why CSS animations and scrolling remain smooth even during heavy JS execution.
+
+**The Commit:**
+When the main thread finishes a paint, it "commits" the updated layer trees and SkPicture recordings to the compositor thread. The main thread blocks briefly during commit. The compositor maintains two trees:
+- **Pending tree** — New content being rasterized
+- **Active tree** — Currently displayed content
+
+The pending tree activates only when visible high-resolution content is fully rasterized. If the user scrolls into unrecorded regions, a checkerboard pattern appears.
+
+**Drawing:**
+Drawing traverses the layer hierarchy depth-first, issuing GL commands to render each tile as a textured quad into the framebuffer. The compositor generates quads and render passes, which the Viz display compositor aggregates and executes.
+
+### Property Trees (Transform, Clip, Effect, Scroll)
+
+Instead of propagating transforms/clips down the layer tree, Chromium uses four separate **property trees** that layers reference by index:
+- **Transform tree** — Accumulated CSS transforms
+- **Clip tree** — Clip rectangles
+- **Effect tree** — Opacity, filters, blend modes
+- **Scroll tree** — Scroll offsets
+
+This allows efficient invalidation (changing a transform only updates the transform tree node, not all descendant layers).
+
+---
+
+## 9. CEF Build System
+
+### Building from Source
+
+CEF is built from Chromium source using the `automate-git.py` script:
+
+```bash
+# Build master branch
+python automate-git.py --download-dir=/path/to/download
+
+# Build a specific release branch
+python automate-git.py --download-dir=/path/to/download --branch=7680
+
+# 64-bit build
+python automate-git.py --download-dir=/path/to/download --branch=7680 --x64-build
+```
+
+The script performs:
+1. Downloads `depot_tools`, Chromium source, and CEF source
+2. Applies CEF patches to Chromium
+3. Generates build files using GN (required since branch 2840)
+4. Compiles Debug and Release builds using Ninja
+5. Runs `make_distrib` to create the binary distribution package
+
+**Requirements:**
+- Minimum 8GB RAM (16GB+ recommended)
+- ~100GB disk space for full Chromium source + build
+- Ninja build system
+- Clang compiler (default on all platforms; Windows since branch 3282)
+- Platform SDK (Windows SDK, Xcode, etc.)
+
+On subsequent runs, the script does the minimum work necessary. When switching branches, the existing `out` directory is moved to `out_(previousbranch)`.
+
+### Binary Distribution Contents
+
+The binary distribution is what most developers use (downloaded from `cef-builds.spotifycdn.com`):
+
+```
+cef_binary_<version>_<platform>/
+  |
+  |-- CMakeLists.txt              # Build the wrapper + samples
+  |-- README.txt                  # Build instructions
+  |
+  |-- include/                    # CEF C++ and C API headers
+  |     |-- cef_app.h, cef_browser.h, cef_client.h, ...
+  |     |-- capi/
+  |     |     |-- cef_app_capi.h, cef_browser_capi.h, ...
+  |     |-- views/
+  |     |     |-- cef_window.h, cef_browser_view.h, ...
+  |     |-- base/
+  |           |-- cef_ref_counted.h, cef_lock.h, ...
+  |
+  |-- libcef_dll/                 # libcef_dll_wrapper source code
+  |
+  |-- Release/                    # Release build binaries
+  |     |-- libcef.dll            # Core CEF library (Windows)
+  |     |   (or libcef.so on Linux, "Chromium Embedded Framework.framework" on macOS)
+  |     |-- libEGL.dll            # ANGLE EGL implementation
+  |     |-- libGLESv2.dll         # ANGLE GL ES implementation
+  |     |-- d3dcompiler_47.dll    # D3D shader compiler (Windows)
+  |     |-- vk_swiftshader.dll    # SwiftShader Vulkan (software GL)
+  |     |-- vulkan-1.dll          # Vulkan loader
+  |     |-- chrome_elf.dll        # Chrome crash reporting
+  |     |-- snapshot_blob.bin     # V8 snapshot data
+  |     |-- v8_context_snapshot.bin # V8 context snapshot
+  |     |-- icudtl.dat            # ICU Unicode data
+  |
+  |-- Resources/                  # (Windows/Linux only)
+  |     |-- chrome_100_percent.pak  # UI resources @1x
+  |     |-- chrome_200_percent.pak  # UI resources @2x
+  |     |-- resources.pak           # Non-localized resources
+  |     |-- locales/
+  |           |-- en-US.pak, fr.pak, de.pak, ...  # Per-locale strings
+  |
+  |-- Debug/                      # Debug build binaries (same files as Release)
+  |
+  |-- tests/
+        |-- cefsimple/            # Minimal browser sample
+        |-- cefclient/            # Full-featured sample
+        |-- ceftests/             # Unit tests
+```
+
+**Required at runtime:** `libcef.dll` (or equivalent), `icudtl.dat`, `v8_context_snapshot.bin`, `snapshot_blob.bin`, resource `.pak` files, at least `en-US.pak` locale.
+
+**Optional:** Only distribute locales you support. If none configured, `en-US` is the default.
+
+---
+
+## 10. How CEF Differs from Electron
+
+Both embed Chromium for desktop applications, but the architecture is fundamentally different.
+
+| Aspect | CEF | Electron |
+|--------|-----|----------|
+| **Core abstraction** | C API wrapping Chromium Content API | Node.js + Chromium merged |
+| **Runtime** | Native (C/C++/Rust/etc. host) | Node.js (JavaScript everywhere) |
+| **Chromium integration** | Via Content API (same as Chrome uses) | Builds Chromium as a library, patches it |
+| **Does NOT use CEF** | N/A | Correct — Electron wraps Chromium directly, not via CEF |
+| **Language support** | Any language with C FFI | JavaScript/TypeScript only |
+| **Primary use case** | Embed browser into existing native app | Build entire app in web technologies |
+| **Process model** | Chromium multi-process (browser, renderer, GPU) | Same multi-process + Node.js in main process |
+| **System access** | Via host application's native code | Via Node.js APIs in main process |
+| **API stability** | Stable C API with versioned branches | Electron API changes between major versions |
+| **Binary size** | Smaller (no Node.js) | Larger (Chromium + Node.js) |
+| **Resource usage** | Generally lower (no Node.js overhead) | Higher (Node.js event loop + Chromium) |
+| **Community** | Smaller but well-maintained | Large, extensive ecosystem (npm) |
+| **Examples** | Spotify (desktop), Steam, Unreal Engine, Adobe Premiere | VS Code, Discord, Slack, Notion |
+
+**Key architectural difference:** In Electron, the main process runs Node.js and communicates with renderer processes via Electron's `ipcMain`/`ipcRenderer`. In CEF, the main process is your native application, and communication uses CEF's `CefProcessMessage` or Mojo under the hood. CEF gives you lower-level control; Electron gives you developer productivity with web technologies.
+
+---
+
+## 11. Sandboxing
+
+CEF inherits Chromium's sandbox architecture, which restricts process privileges to minimize the impact of security vulnerabilities.
+
+### Sandbox by Process Type
+
+| Process | Sandbox Level | Notes |
+|---------|--------------|-------|
+| Browser | None | Main process, needs full system access |
+| Renderer | Maximum | Untrusted integrity level (S-1-16-0 on Windows). Cannot access filesystem, network, or most OS APIs directly |
+| GPU | Partial | Needs graphics driver access; runs at higher integrity than renderer |
+| Utility | Varies | Sandbox level depends on the utility task |
+| Network | Sandboxed | Isolated network operations |
+
+### Windows Sandbox Implementation
+
+On Windows, Chromium's sandbox:
+1. **Restricts the process token** — Removes privileges, lowers integrity level
+2. **Job objects** — Limits process resource usage
+3. **Alternate desktop** — Isolates window stations
+4. **Mitigation policies** — DEP, ASLR, CFG enforcement
+5. **Interception** — Hooks certain API calls to enforce policy
+
+Renderers get the most restrictive sandbox: Untrusted integrity level, minimal token privileges, no filesystem or registry access except through IPC to the browser process.
+
+### CEF Sandbox Configuration
+
+```cpp
+CefSettings settings;
+settings.no_sandbox = true;  // Disable sandbox entirely
+```
+
+Or via command line: `--no-sandbox`
+
+**When to disable:**
+- Development/debugging (easier process attachment)
+- Compatibility issues with certain drivers or environments
+- Docker/container environments where the sandbox conflicts with container isolation
+
+**macOS-specific:**
+- Uses `CefScopedSandboxContext` for helper processes
+- `CefScopedLibraryLoader` loads CEF framework at runtime (required by macOS sandbox)
+- Helper app has separate bundle and Info.plist (prevents dock icon, etc.)
+
+**Linux-specific:**
+- Zygote process handles sandboxed forking
+- Two zygotes: sandboxed (for renderers) and unsandboxed (for processes needing system access)
+- `--no-zygote` flag disables the zygote model
+
+### Security Implications
+
+Disabling the sandbox (`--no-sandbox`) means a compromised renderer process has the same privileges as the host application. This is a significant security risk for applications loading untrusted web content.
+
+---
+
+## 12. The GPU Process in Detail
+
+### Purpose
+
+The GPU process exists for two reasons:
+
+1. **Security** — Renderer processes run in a restrictive sandbox and cannot call OS graphics APIs (OpenGL, Direct3D, Vulkan) directly. The GPU process provides controlled access.
+
+2. **Stability** — GPU driver crashes don't crash the browser. The GPU process can crash and restart independently.
+
+### What It Does
+
+```
++-----------------------------------------------------------------------+
+|                          GPU PROCESS                                   |
+|                                                                        |
+|  +-------------------+    +-------------------+                        |
+|  | GPU Command Buffer|    | GPU Command Buffer|    (one per client)    |
+|  | Server (Renderer1)|    | Server (Renderer2)|                        |
+|  +--------+----------+    +--------+----------+                        |
+|           |                        |                                   |
+|           v                        v                                   |
+|  +------------------------------------------------+                   |
+|  |            ANGLE Translation Layer              |                   |
+|  |  GL ES 2.0/3.0 -> Platform Native API           |                   |
+|  |                                                  |                   |
+|  |  Windows: -> Direct3D 11 (default)               |                   |
+|  |           -> Direct3D 9 (fallback)               |                   |
+|  |           -> Vulkan (if available)               |                   |
+|  |  Linux:   -> Desktop OpenGL                      |                   |
+|  |           -> Vulkan                              |                   |
+|  |  macOS:   -> Metal (default)                     |                   |
+|  |           -> OpenGL (deprecated)                 |                   |
+|  +------------------------------------------------+                   |
+|                          |                                             |
+|  +------------------------------------------------+                   |
+|  |        Viz Display Compositor                   |                   |
+|  |  - Aggregates compositor frames from ALL        |                   |
+|  |    render processes + browser process           |                   |
+|  |  - Produces final composited frame              |                   |
+|  +------------------------------------------------+                   |
+|                          |                                             |
+|  +------------------------------------------------+                   |
+|  |        Skia/Ganesh (GPU Rasterization)          |                   |
+|  |  - Converts display lists to GPU textures       |                   |
+|  |  - Direct GL commands for tile rasterization    |                   |
+|  +------------------------------------------------+                   |
+|                          |                                             |
+|                    [ Screen Output ]                                   |
++-----------------------------------------------------------------------+
+```
+
+### GPU Command Buffer
+
+The command buffer is the core mechanism for cross-process GPU access:
+
+```
+RENDERER PROCESS                    GPU PROCESS
++------------------+               +------------------+
+| GLES2Implementation|             | GLES2DecoderImpl |
+| (client-side GL)   |             | (server-side)    |
+|                    |             |                    |
+| Serializes GL     |  Shared     | Reads commands,   |
+| calls into ring   |  Memory     | deserializes,     |
+| buffer            |  Ring       | executes real GL  |
+|                    |  Buffer    | via ANGLE         |
+| glClear() ->      |----------->| -> D3D11/GL call  |
+| glDrawArrays() -> |            |                    |
+| glTexImage2D() -> |            |                    |
++------------------+              +------------------+
+```
+
+**How it works:**
+1. The renderer's GL implementation (`GLES2Implementation`) serializes GL ES 2.0 commands into a shared-memory ring buffer
+2. The client writes commands at high speed with minimal IPC overhead
+3. Periodically, the client signals the GPU process that new commands are available
+4. The GPU process reads, validates, and executes commands via ANGLE
+5. Most GL calls have no return value, enabling asynchronous operation
+
+**Shared memory for bulk data:**
+Textures, vertex arrays, and bitmaps transfer via shared memory regions (not through the command buffer ring). The `gpu::TransferBuffer` manages alignment and position tracking.
+
+**Synchronization primitives:**
+- **Mailboxes** — Share textures between command buffers using string identifiers
+- **Sync tokens** — Ordered execution guarantees across command buffers (insert on A, wait on B ensures A's commands complete before B continues)
+
+### ANGLE (Almost Native Graphics Layer Engine)
+
+ANGLE translates OpenGL ES 2.0/3.0 API calls to platform-native graphics APIs:
+
+| Platform | Default Backend | Alternatives |
+|----------|----------------|-------------|
+| Windows | Direct3D 11 | Direct3D 9, Vulkan, OpenGL |
+| Linux | Desktop OpenGL | Vulkan |
+| macOS | Metal | OpenGL (deprecated) |
+| Android | Native GLES | Vulkan |
+
+This allows Chromium to use a single GL ES codebase everywhere while leveraging the best-supported graphics API per platform. On Windows, D3D11 is far more reliable than OpenGL drivers, making ANGLE essential.
+
+### SwiftShader (CPU-Based GL)
+
+SwiftShader is an open-source software implementation of Vulkan and OpenGL ES that runs entirely on the CPU. No GPU hardware required.
+
+**SwANGLE = ANGLE + SwiftShader Vulkan:**
+ANGLE uses SwiftShader's Vulkan implementation as its backend, providing a full GL ES -> Vulkan -> CPU software pipeline.
+
+**Use cases:**
+- Systems without GPUs (VMs, CI servers)
+- Blocklisted GPU drivers
+- WebGL fallback when hardware GL fails
+
+**Security warning:** SwiftShader uses JIT-compiled code in the GPU process, making it a high-security risk. Automatic WebGL fallback to SwiftShader has been deprecated. Explicit opt-in with `--enable-unsafe-swiftshader` is required.
+
+**Command-line control:**
+```
+--use-gl=angle --use-angle=swiftshader           # SwANGLE as GL ES driver
+--use-gl=angle --use-angle=swiftshader-webgl      # SwANGLE for WebGL only
+--use-vulkan=swiftshader                          # SwiftShader Vulkan directly
+```
+
+### GPU Fallback Stack
+
+When the GPU process crashes repeatedly, Chrome falls through a stack of increasingly degraded modes:
+
+```
+                        Normal startup
+                             |
+                             v
+                   +-------------------+
+                   | HARDWARE_VULKAN   |  <-- Try Vulkan first (Linux)
+                   +-------------------+
+                             |
+                        3 crashes
+                             v
+                   +-------------------+
+                   | HARDWARE_GL       |  <-- Fall back to OpenGL
+                   +-------------------+
+                             |
+                        3 crashes
+                             v
+                   +-------------------+
+                   | SWIFTSHADER       |  <-- Software GL (CPU)
+                   +-------------------+  <-- Hardware disabled,
+                             |                SwiftShader for WebGL
+                        3 crashes
+                             v
+                   +-------------------+
+                   | DISPLAY_COMPOSITOR|  <-- GPU process only does
+                   +-------------------+      display compositing
+                             |              No acceleration at all
+                        Crashes
+                             v
+                   +-------------------+
+                   | BROWSER CRASH     |  <-- Stack empty, give up
+                   +-------------------+
+```
+
+The fallback modes are stored as a stack in `GpuDataManagerImplPrivate::fallback_modes_`. Crash counting is tracked by `GpuProcessHost::RecordProcessCrash()`. Crashes are "forgiven" after elapsed time intervals (`GetForgiveMinutes()`). The crash limit is `kGpuFallbackCrashCount` (typically 3 in a short timeframe).
+
+Platform variations:
+- **Android** — Requires hardware acceleration; no SwiftShader/software fallback (except Chromecast audio-only)
+- **Fuchsia** — Always expects Vulkan; no GL fallback
+- **Windows/Linux** — Full fallback stack available
+
+### Context Virtualization
+
+The GPU process does not necessarily create a real driver-level GL context per client. It can share a single real context among multiple clients, saving and restoring GL state ("shadowed state") when switching between clients. This addresses:
+- Slow GL context switches on some drivers
+- Synchronization bugs with FBO rendering across contexts
+- Driver crashes with share groups
+
+Context virtualization is selectively enabled via the GPU blocklist based on known driver issues.
+
+### What Happens When the GPU Process Crashes
+
+1. Chromium detects the process handle signal
+2. Crash count increments in `GpuProcessHost`
+3. If under the limit: GPU process is restarted in the same mode
+4. If at the limit: next mode is popped from the fallback stack
+5. All renderer processes are notified of the context loss
+6. Renderers re-create their GL contexts and re-upload resources
+7. Compositing resumes with the new GPU process
+
+Web content receives a `webglcontextlost` event for WebGL canvases. Well-behaved applications listen for `webglcontextrestored` and re-initialize.
+
+---
+
+## Sources
+
+- [CEF General Usage Documentation](https://chromiumembedded.github.io/cef/general_usage.html)
+- [CEF Branches and Building](https://chromiumembedded.github.io/cef/branches_and_building.html)
+- [Chromium Multi-Process Architecture](https://www.chromium.org/developers/design-documents/multi-process-architecture/)
+- [GPU Accelerated Compositing in Chrome](https://www.chromium.org/developers/design-documents/gpu-accelerated-compositing-in-chrome/)
+- [RenderingNG Architecture (Chrome for Developers)](https://developer.chrome.com/docs/chromium/renderingng-architecture)
+- [Chromium Graphics Overview](https://www.chromium.org/developers/design-documents/chromium-graphics/)
+- [How cc Works](https://chromium.googlesource.com/chromium/src/+/lkgr/docs/how_cc_works.md)
+- [Viz README](https://chromium.googlesource.com/chromium/src/+/HEAD/components/viz/)
+- [Chromium Mojo README](https://chromium.googlesource.com/chromium/src/+/HEAD/mojo/README.md)
+- [SwiftShader in Chromium](https://chromium.googlesource.com/chromium/src/+/HEAD/docs/gpu/swiftshader.md)
+- [GPU Fallback Modes](https://chromium.googlesource.com/chromium/src/+/60b3c74b7f2ca17a28907fb0b40d9dabeaa48326/content/browser/gpu/fallback.md)
+- [CEF Message Router Header](https://github.com/chromiumembedded/cef/blob/master/include/wrapper/cef_message_router.h)
+- [cef-rs (Tauri Apps) DeepWiki](https://deepwiki.com/tauri-apps/cef-rs)
+- [cef-ui (Hytopia)](https://github.com/hytopiagg/cef-ui)
+- [CefSharp](https://github.com/cefsharp/CefSharp)
+- [CefGlue](https://github.com/OutSystems/CefGlue)
+- [CEF4Delphi](https://github.com/salvadordf/CEF4Delphi)
+- [cefcapi C API Example](https://github.com/cztomczak/cefcapi)
+- [CEF Wikipedia](https://en.wikipedia.org/wiki/Chromium_Embedded_Framework)
+- [Chromium Sandbox Diagnostics](https://www.chromium.org/Home/chromium-security/articles/chrome-sandbox-diagnostics-for-windows/)
+- [CEF Automated Builds](https://cef-builds.spotifycdn.com/index.html)
+- [Electron vs CEF Comparison (Oreate AI)](https://www.oreateai.com/blog/electron-vs-cef-navigating-the-chromium-landscape-for-desktop-apps/a339a8fc18c70c7b798df7805f075221)

--- a/docs/HANDOFF-2026-04-02.md
+++ b/docs/HANDOFF-2026-04-02.md
@@ -1,0 +1,84 @@
+# Handoff — 2026-04-02 Session
+
+## What Was Done
+
+### PRs Merged (8 total)
+| PR | Description | Status |
+|----|-------------|--------|
+| #268 | Eliminate white flash — native mode + cloak→show→uncloak | Merged |
+| #270 | Remove disable-gpu-compositing (not needed) | Merged |
+| #271 | Remove WS_THICKFRAME border flash | Merged |
+| #272 | **CEF Views deferred show** — the real fix. Don't call `window.show()` in `on_window_created`, show in `on_load_end` | Merged |
+| #273 | Secondary windows use CEF Views (resize works) | Merged |
+| #274 | Single-instance: double-click exe opens new window | Merged |
+| #275 | Opacity applies to all windows + removal works | Merged |
+| #269 | Closed — PowerShell packaging (unnecessary) | Closed |
+
+### PRs Open (awaiting merge)
+| PR | Description | Status |
+|----|-------------|--------|
+| #277 | Clipboard support for CEF (read/write via IPC) | Open, branch: `agenta/clipboard-cef` |
+| #278 | Fix echo delay — bypass RAF for small PTY writes | Open, branch: `agenta/fix-echo-delay` |
+
+### PRs To Take Over (from AgentX)
+| PR | Description | Action |
+|----|-------------|--------|
+| #267 | Win11 focus ring fix (4 changes bundled) | Split into 3 PRs — see `docs/analysis/pr-267-276-takeover.md` |
+| #276 | Echo delay fix | Cherry-picked into #278 (clean version). Close #276 after #278 merges. |
+
+## Current State
+
+- **Branch:** `agenta/fix-echo-delay` (PR #278)
+- **Main is clean** at PR #275 merge
+- **Desktop has:** `agentmux-cef-0.33.24-x64-portable` (echo delay build for testing)
+- **CEF testbed** at `~/Desktop/cef-testbed/` — useful for white flash regression testing
+
+## Key Findings (save time, don't repeat)
+
+### White Flash Root Cause
+`DwmExtendFrameIntoClientArea(-1)` resets the DWM composition surface to white. Removing it + using CEF Views deferred show eliminates the flash entirely. See `docs/analysis/cef-white-flash-retro.md`.
+
+### CEF Views Does NOT Auto-Show
+Contrary to earlier assumptions, CEF Views does not auto-show windows. The app's `on_window_created` delegate controls `Show()`. See `cefsimple/simple_app.cc` in the CEF repo for the pattern.
+
+### Secondary Windows Must Use CEF UI Thread
+`window_create_top_level` must run on the CEF UI thread. IPC handlers run on tokio threads. Use `post_task(ThreadId::UI, ...)` via `ui_tasks.rs::post_create_window()`.
+
+### Resize Requires CEF Views
+Native mode windows can't have edge resize because CEF's child window eats mouse events. `WM_NCHITTEST` on the parent never fires. CEF Views handles hit-testing internally.
+
+## What Needs Doing Next
+
+1. **Merge #277 (clipboard)** — reagent approved, tested, no perf impact
+2. **Merge #278 (echo delay)** — awaiting reagent review
+3. **Close #276** — superseded by #278
+4. **Split #267** into 3 PRs:
+   - CSS focus ring (`block.scss` + `blockframe.tsx`) — low risk
+   - DOM renderer default on Windows — needs perf testing
+   - Dragend safety net (`TileLayout.win32.tsx`) — separate concern
+5. **Opacity bug** — partially fixed (#275), but `set_window_transparency` still uses old `find_own_top_level_window()` on main (the multi-window fix in #275 uses `find_all_own_windows()`)
+6. **Vite config** — `build:frontend` uses `vite.config.tauri.ts`, should be renamed or CEF-specific config created
+
+## Build Command
+
+```bash
+bump patch -m "description" --commit
+task cef:package:portable
+```
+
+If version mismatch error: rebuild backend + CEF manually then repackage:
+```bash
+task build:backend
+cargo build -p agentmux-cef -p agentmux-launcher --release
+bash scripts/package-cef-portable.sh
+```
+
+## Important Files
+
+- `agentmux-cef/src/app.rs` — Window delegate, CEF Views setup, command line flags
+- `agentmux-cef/src/client.rs` — on_after_created, on_load_end (deferred show)
+- `agentmux-cef/src/ui_tasks.rs` — UI thread dispatch (CreateWindowTask)
+- `agentmux-cef/src/main.rs` — Singleton detection, port file, sidecar spawn
+- `agentmux-cef/src/commands/window.rs` — Opacity, new window, window management
+- `frontend/util/clipboard.ts` — Clipboard routing (CEF IPC)
+- `frontend/app/view/term/termwrap.ts` — RAF write, echo delay fix

--- a/docs/HANDOFF-2026-04-02T2230.md
+++ b/docs/HANDOFF-2026-04-02T2230.md
@@ -1,0 +1,65 @@
+# Handoff — 2026-04-02 22:30 UTC
+
+## What Was Done This Session
+
+### Merged
+| PR | Description |
+|----|-------------|
+| #277 | **Clipboard support for CEF host** — Win32 GlobalAlloc/Lock, macOS pbcopy/pbpaste, Linux wl-copy + xclip + xsel with WAYLAND_DISPLAY detection |
+| #278 | **Echo delay fix** — bypass RAF for small PTY writes (was merged before this session started) |
+
+### Closed
+| PR | Reason |
+|----|--------|
+| #276 | Superseded by #278 (AgentX's duplicate of echo delay fix) |
+
+### Review Fixes Applied to #277
+1. **Memory leak** — `GlobalFree(hmem)` on `GlobalLock` and `OpenClipboard` failure paths
+2. **Wayland clipboard** — added `wl-copy`/`wl-paste` with `WAYLAND_DISPLAY` env check so it doesn't swallow clipboard ops on X11 sessions where wl-utils are installed but non-functional
+3. **Version** — rebased on main, bumped correctly
+
+### Built
+- **v0.33.26** portable on Desktop (`agentmux-cef-0.33.26-x64-portable/`)
+- Includes clipboard (#277) + echo delay (#278) + all prior fixes
+
+## Current State
+
+- **Branch:** `main` at `156bfa6` (PR #277 merge)
+- **Local version:** 0.33.26 (bumped locally, not pushed — only build artifacts use it)
+- **Working tree:** clean (untracked docs/specs only)
+
+## Open PRs (need attention)
+
+| PR | Description | Action Needed |
+|----|-------------|---------------|
+| #267 | Win11 focus ring (AgentX, 4 changes bundled) | Split into 3 focused PRs — see `docs/analysis/pr-267-276-takeover.md` |
+| #256 | Drone pane Phase 1 (Agent1) | Review |
+| #249 | CLI exe copy fix (AgentA) | Stale — check if still relevant |
+| #234 | RAF guard + scroll flash retro (AgentA) | Stale — #278 may supersede parts |
+| #232 | Linux opacity + backend isolation (AgentX) | Review |
+| #228 | Linux zoom ghost-pixel fix (AgentX) | Review |
+| #224 | Tab drag cursor fix (AgentA) | Stale |
+| #209 | Docker attach delivery (AgentY) | Review |
+| #196 | Replace powershell with pwsh in Taskfile (AgentX) | Low priority |
+
+## Known Issues (from previous handoff, still open)
+
+1. **Opacity bug** — `set_window_transparency` in `commands/window.rs` still uses `find_own_top_level_window()` (single window). #275 fixed `find_all_own_windows()` for removal but the set path wasn't updated.
+2. **Vite config** — `build:frontend` uses `vite.config.tauri.ts`, should be renamed or CEF-specific config created.
+3. **PR #267 split** — needs 3 separate PRs: CSS focus ring, DOM renderer default, dragend safety net. Analysis in `docs/analysis/pr-267-276-takeover.md`.
+
+## Build Command
+
+```bash
+bump patch -m "description" --commit
+task build:backend
+cargo build -p agentmux-cef -p agentmux-launcher --release
+bash scripts/package-cef-portable.sh
+```
+
+## Key Files
+
+- `agentmux-cef/src/commands/clipboard.rs` — new, clipboard IPC (Win32/macOS/Linux)
+- `agentmux-cef/src/commands/window.rs` — opacity, new window management
+- `frontend/util/clipboard.ts` — frontend clipboard routing (CEF IPC)
+- `frontend/app/view/term/termwrap.ts` — RAF write, echo delay fix

--- a/docs/HANDOFF-2026-04-02T2245.md
+++ b/docs/HANDOFF-2026-04-02T2245.md
@@ -1,0 +1,82 @@
+# Handoff — 2026-04-02 22:45 UTC
+
+## What Was Done This Session
+
+### PRs Merged
+| PR | Description |
+|----|-------------|
+| #277 | **Clipboard support for CEF host** — Win32 GlobalAlloc/Lock, macOS pbcopy/pbpaste, Linux wl-copy/xclip/xsel with WAYLAND_DISPLAY env check |
+| #278 | **Echo delay fix** — bypass RAF for small PTY writes (merged before session) |
+
+### PRs Closed
+| PR | Reason |
+|----|--------|
+| #276 | Superseded by #278 (duplicate echo delay fix from AgentX) |
+
+### Review Fixes (applied to #277 before merge)
+- `GlobalFree(hmem)` on `GlobalLock` and `OpenClipboard` failure paths (memory leak)
+- Wayland: check `WAYLAND_DISPLAY` env before trying `wl-copy`/`wl-paste` — prevents silent failure on X11
+- Rebased on main, version bumped correctly
+
+### Built & Deployed
+- **v0.33.26** portable on Desktop (`agentmux-cef-0.33.26-x64-portable/`)
+- User is running this build now
+
+### Investigated: Instance Closed Unexpectedly
+- User reported 0.33.26 (or prior) instance closed on its own
+- No processes remained (`tasklist` empty), no WER crash dumps generated
+- No sidecar logs found in `~/.agentmux/log/`
+- **Conclusion:** clean exit, not a crash. Likely sidecar exited and `backend-terminated` handler closed the window, or user accidentally closed it. No action needed unless it reproduces.
+
+## Current State
+
+- **Branch:** `main` at `08ff00b` (bump to 0.33.26)
+- **Local version:** 0.33.26 (bump committed locally, not pushed to remote)
+- **Remote main:** `156bfa6` (PR #277 merge, version 0.33.25)
+- **Working tree:** clean (untracked docs/specs only)
+- **Desktop:** user running `agentmux-cef-0.33.26-x64-portable/`
+
+## What Needs Doing Next
+
+### Priority
+1. **Push local bump** — `git push origin main` to sync 0.33.26 to remote
+2. **Split PR #267** into 3 focused PRs (AgentX bundled 4 unrelated changes):
+   - CSS focus ring (`block.scss` + `blockframe.tsx`) — low risk
+   - DOM renderer default on Windows — needs perf testing
+   - Dragend safety net (`TileLayout.win32.tsx`) — separate concern
+   - Analysis: `docs/analysis/pr-267-276-takeover.md`
+3. **Opacity bug** — `set_window_transparency` in `commands/window.rs` still uses `find_own_top_level_window()` (single window). #275 fixed removal path with `find_all_own_windows()` but the set path wasn't updated.
+
+### Open PRs
+| PR | Owner | Description | Notes |
+|----|-------|-------------|-------|
+| #267 | AgentX | Win11 focus ring (bundled) | Split into 3 — see above |
+| #256 | Agent1 | Drone pane Phase 1 | Review |
+| #249 | AgentA | CLI exe copy fix | Stale — check relevance |
+| #234 | AgentA | RAF guard + scroll flash | Stale — #278 may supersede |
+| #232 | AgentX | Linux opacity + backend isolation | Review |
+| #228 | AgentX | Linux zoom ghost-pixel | Review |
+| #224 | AgentA | Tab drag cursor fix | Stale |
+| #209 | AgentY | Docker attach delivery | Review |
+| #196 | AgentX | pwsh in Taskfile | Low priority |
+
+### Low Priority
+- **Vite config** — `build:frontend` uses `vite.config.tauri.ts`, should rename for CEF
+- **Stale PR cleanup** — #234, #249, #224 may be obsolete after recent fixes
+
+## Build Command
+
+```bash
+bump patch -m "description" --commit
+task build:backend
+cargo build -p agentmux-cef -p agentmux-launcher --release
+bash scripts/package-cef-portable.sh
+```
+
+## Key Files
+- `agentmux-cef/src/commands/clipboard.rs` — clipboard IPC (new in #277)
+- `agentmux-cef/src/commands/window.rs` — opacity, window management
+- `agentmux-cef/src/sidecar.rs` — sidecar monitor, `backend-terminated` event
+- `frontend/app/store/ws.ts` — WS reconnect (infinite retry, visibility-based)
+- `frontend/app/view/term/termwrap.ts` — RAF write, echo delay bypass
+- `docs/analysis/pr-267-276-takeover.md` — plan for splitting #267

--- a/docs/HANDOFF-2026-04-03T2345.md
+++ b/docs/HANDOFF-2026-04-03T2345.md
@@ -1,0 +1,119 @@
+# Handoff — 2026-04-03 23:45 UTC
+
+## Session Summary
+
+Major codebase audit and cleanup session. 5 PRs merged, ~33,500 lines removed, codebase significantly cleaner.
+
+## PRs Merged This Session
+
+| PR | Description | Net Lines |
+|----|-------------|-----------|
+| #281 | **Delete src-tauri** — entire Tauri host, build infra, dead scripts, Taskfile tasks. Renamed `vite.config.tauri.ts` → `vite.config.ts` | -33,173 |
+| #282 | **parking_lot mutex safety** — replace `std::sync::Mutex` with `parking_lot::Mutex` in CEF host. Eliminates 63 `.lock().unwrap()` crash sites | -1 |
+| #283 | **Kill globalStore shim** — remove Jotai compatibility layer, fix direct `@tauri-apps/api/core` imports to use IPC abstraction | -167 |
+| #284 | **Consolidate dead_code allows** — replace 67 per-file `#![allow(dead_code)]` with single crate-level allow, fix 3 real warnings | -61 |
+| #285 | **Split websocket.rs** — extract CLI handlers (616 LOC) + forge handlers (539 LOC) into dedicated modules. websocket.rs: 2090 → 962 lines | +29 (net, split) |
+
+### Other PRs Merged (from earlier today)
+| PR | Description |
+|----|-------------|
+| #277 | Clipboard support for CEF host (Win32/macOS/Linux with Wayland detection) |
+| #278 | Echo delay fix — bypass RAF for small PTY writes |
+| #276 | Closed — superseded by #278 |
+
+## Current State
+
+- **Branch:** `main` at `eb65626`
+- **Version:** 0.33.35
+- **Desktop:** user running `agentmux-cef-0.33.34-x64-portable/` (tested, works)
+- **Working tree:** clean (untracked docs/specs only)
+
+## Open PRs
+
+| PR | Description | Status |
+|----|-------------|--------|
+| #279 | **Versioned binary names** (agentmux-srv, agentmux-wsh rename + versioned filenames) | Open — should land AFTER god module splits |
+| #280 | cef:package:portable auto-builds deps | Open |
+| #256 | Drone pane Phase 1 (Agent1) | Open |
+| #249 | CLI exe copy fix (AgentA) | Stale |
+| #234 | RAF guard + scroll flash (AgentA) | Stale — #278 may supersede |
+| #232 | Linux opacity + backend isolation (AgentX) | Open |
+| #228 | Linux zoom ghost-pixel (AgentX) | Open |
+| #224 | Tab drag cursor fix (AgentA) | Stale |
+| #209 | Docker attach delivery (AgentY) | Open |
+| #196 | pwsh in Taskfile (AgentX) | Low priority |
+
+## What Needs Doing Next
+
+### Priority 1: Continue P2-1 (Split God Modules)
+websocket.rs is done. Remaining god modules:
+- `agentmuxsrv-rs/src/backend/wcore.rs` (1419 lines) — workspace/window/block/layout ops
+- `agentmuxsrv-rs/src/backend/wconfig.rs` (1624 lines) — config + validation + schema
+- `agentmuxsrv-rs/src/backend/shell.rs` (1325 lines) — PTY, shell process, I/O loops (in blockcontroller/)
+- `frontend/app/store/global.ts` (917 lines) — atoms, services, utilities, counters mixed
+
+### Priority 2: Merge PR #279 (Binary Rename)
+After god modules are split, the rename has a cleaner target. Spec: `docs/specs/versioned-artifact-names.md`
+
+### Priority 3: Remaining Audit Items
+- P2-2: Rename legacy Wave modules (`wavebase.rs`, `waveobj.rs`, etc.) — 3h
+- P2-3: Define proper error types for string-error modules — 4h
+- P3-1: Replace 92 `any`/`as any` types in frontend — 4h
+- P3-2: Replace 52 `(window as any)` with type declarations — 2h
+- P3-3: Fix leaked `setInterval` in TermViewModel — 30min
+- P3-4: Add bounded channels in `rpc/router.rs` — 1h
+- P3-6: Structured key-value logging in Rust backend — 4h
+
+## Documents Written This Session
+
+### Audit & Analysis
+- `docs/analysis/full-codebase-audit-2026-04-03.md` — **Full codebase audit**: frontend, Rust backend, build system. Priority action plan P0→P3.
+- `docs/analysis/pty-duplicate-output-debug.md` — PTY duplicate output debug plan: root cause candidates, instrumentation plan for xterm write pipeline
+- `docs/CEF-VERSION-REPORT-2026-04-03.md` — CEF/Chromium version report: agentmux on latest stable CEF 146.0.9
+
+### Specs
+- `docs/specs/websocket-modularization.md` — websocket.rs split spec: target structure, coupling analysis, implementation order
+- `docs/specs/versioned-artifact-names.md` — Binary rename spec (pre-existing, referenced by PR #279)
+
+### Workspace
+- `C:/Systems/WORKSPACE-SPEC.md` — C:\Systems directory layout after cleanup (~63GB freed)
+
+### Handoff Docs
+- `docs/HANDOFF-2026-04-02.md` — Earlier session handoff
+- `docs/HANDOFF-2026-04-02T2230.md` — Mid-session handoff
+- `docs/HANDOFF-2026-04-02T2245.md` — End of Apr 2 session
+
+## Build Command
+
+```bash
+bump patch -m "description" --commit
+task cef:package:portable
+```
+
+## Key Architecture Changes
+
+### src-tauri is Gone
+- Deleted entirely in PR #281. CEF is the only host.
+- Frontend Tauri API shim (`tauri-bootstrap.ts`, `tauri-api.ts`) intentionally kept for test compat.
+- `vite.config.tauri.ts` renamed to `vite.config.ts`.
+- CLAUDE.md updated to reflect removal.
+
+### Mutex Safety (CEF Host)
+- All `std::sync::Mutex` → `parking_lot::Mutex` in agentmux-cef (PR #282)
+- `parking_lot::Mutex` has no poisoning — `lock()` returns guard directly, never panics
+- Exception: `ORIGINAL_WNDPROCS` static in `client.rs` stays as `std::sync::Mutex` (fully qualified, FFI context)
+
+### State Management (Frontend)
+- `globalStore` Jotai shim removed (PR #283)
+- `jotaiStore.ts` and `block-model.ts` deleted (dead code)
+- All signal reads/writes use direct SolidJS calls now
+- Vestigial `store: any` parameter removed from zoom functions
+
+### Backend Dead Code
+- 67 per-file `#![allow(dead_code)]` consolidated to single crate-level allow in `main.rs` (PR #284)
+- ~700 items from Go→Rust port not yet wired up — implementation backlog, not garbage
+
+### websocket.rs Split
+- `cli_handlers.rs` (616 LOC): resolvecli, checkcliauth, runclilogin
+- `forge_handlers.rs` (539 LOC): 15 forge CRUD handlers
+- `websocket.rs`: 2090 → 962 lines

--- a/docs/HANDOFF-2026-04-04.md
+++ b/docs/HANDOFF-2026-04-04.md
@@ -1,0 +1,104 @@
+# Handoff — 2026-04-04
+
+**From:** AgentA (Claude Code session on v0.33.43 → v0.33.44)
+**To:** Next AgentA session (running in v0.33.44 portable)
+**Branch:** `main` (PR #298 merged)
+
+---
+
+## What Was Done This Session
+
+### 1. GPU Crash Investigation
+
+Investigated a crash at ~11:02 AM today. Found in logs:
+- **Root cause:** CEF GPU process crash loop — ~80 GPU restarts in 6 seconds
+- **Error:** `kFatalFailure: Failed to create shared context for virtualization` (in `chrome_debug.log` for v0-33-34)
+- **Exit code:** `0x80000003` (`STATUS_BREAKPOINT`)
+- **Aftermath:** Shared memory allocation failures, display loss
+- **Backend was fine** — `agentmuxsrv` kept running, only warned about 3 dead PIDs at 18:07
+- **WER dumps:** `%LOCALAPPDATA%\CrashDumps\agentmux-cef.exe.24548.dmp` and `.36392.dmp`
+- **Logs location:** `%APPDATA%\ai.agentmux.cef.v0-33-34\chrome_debug.log` (lines 440-560)
+
+### 2. GPU Crash Recovery Spec (Written, Not Implemented)
+
+**File:** `docs/specs/gpu-crash-recovery.md`
+
+Four-phase design:
+1. **Persistent GPU health file** (`gpu-health.json`) — track crashes across sessions, auto-apply `--disable-gpu-compositing` or `--disable-gpu` on next launch
+2. **Watchdog launcher** — monitor exit codes, escalate GPU flags on relaunch
+3. **In-process monitor** — frontend heartbeat, CEF log hook, user banner
+4. **User settings** — Hardware Acceleration toggle (On/Off/Auto)
+
+**Key finding:** CEF has NO `OnGpuProcessCrashed` callback. GPU crash handling is internal to Chromium. We can only observe indirectly via `on_before_child_process_launch` (fires for all subprocesses including GPU — can detect rapid spawning = crash loop).
+
+The `cef` crate v146 Rust bindings DO expose `RequestHandler::on_render_process_terminated` (renderer only, not GPU) and `BrowserProcessHandler::on_before_child_process_launch` (all child processes at launch time).
+
+### 3. CEF Architecture Doc (Written)
+
+**File:** `docs/CEF_ARCHITECTURE.md` (1188 lines)
+
+Comprehensive doc covering all 12 sections of CEF internals — Chromium relationship, multi-process model, C API layer, language bindings, CEF Views, handler/callback model, IPC, rendering pipeline, build system, CEF vs Electron, sandboxing, GPU process detail.
+
+### 4. Versioned Process Names (Implemented, PR #298 Merged)
+
+**Problem:** Task Manager, WER crash dumps, and Event Viewer all showed bare `agentmux-cef` with no version.
+
+**Fix — two surfaces:**
+- **PE VERSIONINFO `FileDescription`** → controls Task Manager name → now shows "AgentMux CEF v0.33.44"
+- **Filename on disk** → controls WER dumps + Event Viewer → now `agentmux-cef-0.33.44.exe`
+
+**Files changed:**
+- `agentmux-cef/build.rs` — PE resources with version
+- `agentmux-launcher/build.rs` — PE resources with version
+- `agentmux-srv/build.rs` — NEW, PE resources with version
+- `agentmux-wsh/build.rs` — NEW, PE resources with version
+- `agentmux-launcher/src/main.rs` — `find_cef_binary()` discovers versioned exe, falls back to plain for dev
+- `agentmux-cef/src/sidecar.rs` — `find_wsh_source()` discovers versioned wsh
+- `scripts/package-cef-portable.sh` — copies agentmux-cef and wsh with versioned filenames
+- `docs/specs/versioned-process-names.md` — full spec
+
+**Portable layout after fix:**
+```
+agentmux.exe                                    (launcher — unversioned, user entry point)
+runtime/agentmux-cef-0.33.44.exe               (CEF host — versioned)
+runtime/agentmux-srv-0.33.44-windows.x64.exe   (backend — already versioned)
+runtime/wsh-0.33.44-windows.x64.exe            (shell — now versioned)
+```
+
+**Not yet done for Linux/macOS** — no packaging scripts exist yet for those platforms. The PE resource approach is Windows-only by nature. Filename versioning will carry over when platform packaging scripts are written.
+
+### 5. Memory Updated
+
+- Updated `project_cef_white_flash_fix.md` — corrected stale info about `--disable-gpu-compositing` (was removed in commit `ebc72b8`). Current fix is CEF Views deferred show, no GPU flags active.
+
+---
+
+## Open Work / Next Steps
+
+### GPU Crash Recovery (Priority: Medium)
+The spec is written but nothing is implemented. Phase 1 (persistent health file) is the highest-value, lowest-effort item. Consider implementing:
+1. Read/write `gpu-health.json` in `agentmux-cef/src/main.rs` before `CefInitialize`
+2. Implement `on_before_child_process_launch` to detect GPU subprocess churn
+3. Watchdog launcher is Phase 2 — the current launcher in `agentmux-launcher/src/main.rs` already spawns and waits, just needs crash-count + relaunch logic
+
+### Launcher as Watchdog (Priority: Medium)
+Related to GPU crash recovery. The launcher could also enable **state-preserving restart**: if CEF crashes but the backend sidecar survives, restarting CEF reconnects to the same backend. Key change: don't tie backend lifecycle to CEF via Job Object `KILL_ON_JOB_CLOSE`.
+
+### Stale Branch Cleanup
+Current branch is `agenta/versioned-process-names` (merged). The `agenta/fix-win11-focus-border` branch has an unmerged commit `a5f54dc` (bump to 0.33.44) that should be discarded or rebased — the real 0.33.44 bump is now on main via PR #298.
+
+---
+
+## Key Reference Locations
+
+| What | Where |
+|---|---|
+| GPU crash logs (today) | `%APPDATA%\ai.agentmux.cef.v0-33-34\chrome_debug.log` |
+| WER crash dumps | `%LOCALAPPDATA%\CrashDumps\` |
+| Backend logs | `%APPDATA%\ai.agentmux.cef.v0-33-*\logs\` |
+| GPU crash recovery spec | `docs/specs/gpu-crash-recovery.md` |
+| Versioned names spec | `docs/specs/versioned-process-names.md` |
+| CEF architecture doc | `docs/CEF_ARCHITECTURE.md` |
+| CEF launch args | `agentmux-cef/src/app.rs` ~line 190 |
+| CEF handler callbacks | `agentmux-cef/src/client.rs` |
+| CEF crate bindings | `~/.cargo/registry/src/.../cef-146.1.0+146.0.7/` |

--- a/docs/HANDOFF-2026-04-08.md
+++ b/docs/HANDOFF-2026-04-08.md
@@ -1,0 +1,85 @@
+# Handoff — 2026-04-08
+
+**From:** AgentA (Claude Code, this session)
+**PR:** #316 (`agenta/gpu-recovery-cef-init`) — **DO NOT MERGE** until user confirms soak test passes
+**Build:** v0.33.66 portable on Desktop
+
+---
+
+## What Was Done
+
+### 1. Node.js OOM resolved
+- Node v22.13.0 was crashing during `npm install` with V8 GC bug (`young object promotion failed`)
+- Reboot fixed it (was likely a stale page file or memory state)
+- Downloaded Node v22.22.2 MSI to Desktop but it wasn't installed yet — user may want to upgrade later
+
+### 2. PR #311 review fixes (merged branch: `agenta/memory-heartbeat-inprocess-gpu`)
+- Fixed heartbeat comment mismatch: "every 60 seconds" → "every 20 seconds"
+- Fixed startup burst: sleep before first log, not after
+- Pushed to branch, PR awaiting re-review
+
+### 3. White screen overnight investigation
+- All 3 portable instances (v0.33.62, v0.33.64, v0.33.73) went solid white after overnight idle
+- Processes alive (heartbeats ticking), no crashes, no OOM
+- **Root cause:** `webglcontextlost` event fired (confirmed in v0.33.64 logs at 17:16 UTC) while `--in-process-gpu` was active — zombie rendering state with no recovery
+- Machine and monitor never went to sleep — cause was likely Windows driver TDR, DXGI device removal, or GPU resource eviction with 3 instances sharing one GPU
+- Full analysis: `docs/analysis/white-screen-overnight-2026-04-08.md`
+
+### 4. PR #316 — GPU recovery + CEF init fix (v0.33.66)
+Based on `docs/specs/gpu-recovery-and-cef-init-fix.md`:
+
+| Change | File | What |
+|--------|------|------|
+| Remove `--in-process-gpu` | `agentmux-cef/src/app.rs` | Restore separate GPU process for crash recovery |
+| WebGL context loss handler | `frontend/tauri-bootstrap.ts` | Auto-reload page on `webglcontextlost` (safety net) |
+| `getApi()` diagnostic | `frontend/app/store/global.ts` | Logs stack trace when called before `window.api` exists |
+| `initBare()` defensive wait | `frontend/wave.ts` | Polls for `window.api` (max 5s) if not ready |
+
+---
+
+## What's Pending
+
+### Must verify before merging PR #316
+- [ ] Launch v0.33.66 portable — confirm GPU process visible in Task Manager (two `agentmux-cef-0.33.66.exe` entries)
+- [ ] Check host log for `getPlatform` error: `~/.agentmux/logs/agentmux-host-v0.33.66.log.*`
+- [ ] Overnight soak test — leave running 8+ hours, check for white screen in the morning
+- [ ] If soak passes → squash-merge PR #316
+
+### PR #311 still open
+- `agenta/memory-heartbeat-inprocess-gpu` — review fixes pushed, awaiting bot re-review
+- **Note:** PR #316 removes `--in-process-gpu` which PR #311 added. If #316 merges first, #311 will have a conflict in `app.rs`. Recommend merging #311 first (it has the heartbeat + renderer limit), then #316 on top.
+- Merge order: #311 → #316
+
+### Secondary bug: `getPlatform` race condition
+- The `getApi()` diagnostic guard in PR #316 will log a stack trace showing exactly which code calls `getApi()` before `window.api` is set
+- Check the host log after first launch for `[getApi] called before window.api exists` — the stack trace will point to the early caller
+- Fix that caller in a follow-up PR once identified
+
+### Pre-existing TS errors (not from our changes)
+```
+frontend/app/view/term/term.tsx(196,68): error TS2554: Expected 0 arguments, but got 1.
+frontend/app/view/term/term.tsx(197,68): error TS2554: Expected 0 arguments, but got 1.
+```
+Present on clean main — someone else's issue.
+
+---
+
+## Key File Locations
+
+| What | Path |
+|------|------|
+| Analysis report | `docs/analysis/white-screen-overnight-2026-04-08.md` |
+| Implementation spec | `docs/specs/gpu-recovery-and-cef-init-fix.md` |
+| Heartbeat status report | `docs/heartbeat-status-report.md` |
+| Host logs | `~/.agentmux/logs/agentmux-host-v*.log.*` |
+| Log pointer files | `~/.agentmux/logs/current-host-v*.path` |
+| Portable build | `~/Desktop/agentmux-cef-0.33.66-x64-portable/` |
+
+---
+
+## Session Context
+
+- All old AgentMux processes killed (confirmed zero remaining)
+- On branch `agenta/gpu-recovery-cef-init` based on latest main (`96efcb7`)
+- Node v22.13.0 still installed (v22.22.2 MSI on Desktop, not yet installed)
+- `node-v22.22.2-x64.msi` on Desktop can be deleted after upgrade or if not needed

--- a/docs/LOG_RESOLUTION_SPEC.md
+++ b/docs/LOG_RESOLUTION_SPEC.md
@@ -1,0 +1,477 @@
+# AgentMux Logging Stack — Analysis & Consolidation Spec
+
+**Date:** 2026-04-07 | **Version:** 0.33.62
+**Problem:** Logs are scattered across two unrelated directories, with version-stamped filenames and date suffixes. Every agent session burns 3-5 tool calls on a scavenger hunt. The spec must work identically across `task dev`, portable, and install modes.
+
+---
+
+## Part 1: Full Stack Analysis
+
+### Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  LAUNCHER (agentmux-launcher/src/main.rs)                    │
+│  • No logging today — eprintln! only (proposed: file log)    │
+│  • Windows: .status() — STAYS ALIVE for entire app lifetime  │
+│  • Unix: exec() — replaces self with CEF host process        │
+│  • Spawns CEF host, forwards exit code                       │
+└────────────────────────┬─────────────────────────────────────┘
+                         │ spawn (.status) / exec
+┌────────────────────────▼─────────────────────────────────────┐
+│  CEF HOST (agentmux-cef/src/main.rs)                         │
+│                                                              │
+│  init_logging() @ line 295                                   │
+│  ├─ Reads AGENTMUX_DATA_HOME (NOT SET YET at this point)    │
+│  ├─ Falls back to ~/.agentmux/logs/                          │
+│  ├─ File: agentmux-host-v{VER}.log.{DATE}                   │
+│  ├─ Format: JSON (file) + human-readable (stderr)            │
+│  └─ Filter: RUST_LOG or "info"                               │
+│                                                              │
+│  memory_heartbeat::start() @ line 257                        │
+│  ├─ Thread "mem-heartbeat", 20s interval                     │
+│  ├─ target: "mem_heartbeat"                                  │
+│  └─ → CEF host log file                                     │
+│                                                              │
+│  fe_log_structured (commands/backend.rs:70)                  │
+│  ├─ IPC: "fe_log_structured" via HTTP POST /ipc              │
+│  ├─ Receives console.log/warn/error/debug/info from frontend │
+│  ├─ Prefix: "[fe]"                                           │
+│  └─ → CEF host log file                                     │
+│                                                              │
+│  sidecar::spawn_backend() @ sidecar.rs:23                    │
+│  ├─ Sets AGENTMUX_DATA_HOME = {AppData/Roaming}/ai.agentmux │
+│  │   .cef.{dev|v{VER}}/                                     │
+│  └─ Spawns agentmux-srv with this env                        │
+└────────────────────────┬─────────────────────────────────────┘
+                         │ spawns
+┌────────────────────────▼─────────────────────────────────────┐
+│  SIDECAR (agentmux-srv/src/main.rs)                          │
+│                                                              │
+│  init_logging() @ line 530                                   │
+│  ├─ Reads AGENTMUX_DATA_HOME (SET by CEF host)              │
+│  ├─ → {AppData/Roaming}/ai.agentmux.cef.{id}/logs/          │
+│  ├─ File: agentmuxsrv-v{VER}.log.{DATE}                     │
+│  ├─ Format: JSON (file) + human-readable (stderr)            │
+│  └─ Filter: RUST_LOG or "agentmuxsrv=info,info"             │
+│                                                              │
+│  Shell spawn (blockcontroller/shell.rs:480)                  │
+│  ├─ Injects: AGENTMUX_VERSION, BLOCKID, TABID, LOCAL_URL    │
+│  └─ Does NOT inject any log-related env vars                 │
+└────────────────────────┬─────────────────────────────────────┘
+                         │ spawns PTY
+┌────────────────────────▼─────────────────────────────────────┐
+│  SHELL (bash/zsh/pwsh/fish)                                  │
+│  • Has AGENTMUX_VERSION but no log paths                     │
+│  • Shell integration scripts: OSC sequences only, no logging │
+│  • Agent CLIs: own stdout/stderr, not captured               │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│  WSH (agentmux-wsh/src/main.rs)                              │
+│  • No logging infrastructure (14-line entry point)           │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│  FRONTEND (browser context)                                  │
+│  • log-pipe.ts:17 — initLogPipe() monkey-patches console.*   │
+│  • Fire-and-forget IPC → fe_log_structured → CEF host log    │
+│  • Payload: { level, module: "console", message, data }      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### The Split: Where Logs Actually Land
+
+**Critical finding:** CEF host and sidecar logs are in completely different directories.
+
+| Component | Log Directory | Why |
+|-----------|--------------|-----|
+| CEF host | `~/.agentmux/logs/` | `init_logging()` runs BEFORE `AGENTMUX_DATA_HOME` is set; falls back to `~/.agentmux` |
+| Sidecar | `{AppData/Roaming}/ai.agentmux.cef.{id}/logs/` | Receives `AGENTMUX_DATA_HOME` from CEF host, points to versioned AppData dir |
+| Frontend | Same as CEF host | Piped via IPC |
+| Heartbeat | Same as CEF host | Same process |
+
+### Actual File Locations (verified on disk)
+
+```
+# CEF host log (+ frontend [fe] + heartbeat)
+~/.agentmux/logs/agentmux-host-v0.33.62.log.2026-04-07
+
+# Sidecar log (shell, blocks, RPC, config)
+C:\Users\area54\AppData\Roaming\ai.agentmux.cef.v0-33-62\logs\agentmuxsrv-v0.33.62.log.2026-04-07
+```
+
+### Per-Mode Behavior
+
+| Mode | AGENTMUX_DEV | AGENTMUX_DATA_HOME (sidecar) | CEF host log dir | Sidecar log dir |
+|------|-------------|------------------------------|------------------|-----------------|
+| `task dev` | `1` (Taskfile.yml:515) | `{Roaming}/ai.agentmux.cef.dev/` | `~/.agentmux/logs/` | `{Roaming}/ai.agentmux.cef.dev/logs/` |
+| Portable | unset | `{Roaming}/ai.agentmux.cef.v{VER}/` | `~/.agentmux/logs/` | `{Roaming}/ai.agentmux.cef.v{VER}/logs/` |
+| Install | unset | `{Roaming}/ai.agentmux.cef.v{VER}/` | `~/.agentmux/logs/` | `{Roaming}/ai.agentmux.cef.v{VER}/logs/` |
+
+**Key observation:** The CEF host log location is **always** `~/.agentmux/logs/` regardless of mode, because `init_logging()` at main.rs:299 runs before `AGENTMUX_DATA_HOME` is set. Only the sidecar's location varies.
+
+### Other Issues Found
+
+1. **No log cleanup** — logs accumulate forever. 46+ host log files in `~/.agentmux/logs/`, 100+ versioned AppData dirs
+2. **No log rotation** beyond daily rolling — a long session on one date produces a single growing file
+3. **Version mismatch possible** — sidecar.rs:30 uses the *CEF host's* `CARGO_PKG_VERSION` for the dir name, but the sidecar binary could be a different version (especially in dev mode where resolve_backend_binary has 4 fallback paths)
+
+---
+
+## Part 2: Consolidation Proposal
+
+### Goal
+
+An agent running in any mode should resolve any log file with one deterministic command — no globs, no version guessing, no directory hunting.
+
+### Option A: Consolidate All Logs to One Directory (recommended)
+
+**Move sidecar logs to `~/.agentmux/logs/`** so all logs land in one place.
+
+The sidecar already has `get_wave_data_dir()` in `base.rs:71` which resolves `AGENTMUX_DATA_HOME` → `~/.agentmux`. The issue is that `AGENTMUX_DATA_HOME` is set by the CEF host to the *versioned* AppData dir. The fix:
+
+**Change in `agentmux-srv/src/main.rs` init_logging():**
+```rust
+// Always log to ~/.agentmux/logs/ regardless of AGENTMUX_DATA_HOME,
+// so all logs land in one discoverable directory.
+let log_dir = dirs::home_dir()
+    .unwrap_or_default()
+    .join(".agentmux")
+    .join("logs");
+```
+
+This makes the log dir consistent across all modes and both components. `AGENTMUX_DATA_HOME` continues to control the sidecar's *data* directory (db, config, etc.) — just not logs.
+
+**Trade-off:** Sidecar logs are no longer isolated per-version in AppData. But they already have version in the filename (`agentmuxsrv-v0.33.62.log.{DATE}`), so multiple versions can coexist in the same directory.
+
+### Option B: Keep Split, Add Discovery Layer
+
+If consolidation is undesirable, add discovery env vars and pointer files to bridge the split.
+
+### Chosen: Option A + Discovery Layer
+
+Best of both worlds — consolidate for simplicity, add env vars for deterministic access.
+
+---
+
+## Part 3: Implementation
+
+### Change 1: Consolidate sidecar logs (P0)
+
+**File:** `agentmux-srv/src/main.rs` — `init_logging()` (~line 533)
+
+**Before:**
+```rust
+let log_dir = std::env::var("AGENTMUX_DATA_HOME")
+    .map(std::path::PathBuf::from)
+    .unwrap_or_else(|_| dirs::home_dir().unwrap_or_default().join(".agentmux"))
+    .join("logs");
+```
+
+**After:**
+```rust
+// Always log to ~/.agentmux/logs/ so all logs (host + sidecar) land in one
+// discoverable directory. AGENTMUX_DATA_HOME controls the data dir, not logs.
+let log_dir = dirs::home_dir()
+    .unwrap_or_default()
+    .join(".agentmux")
+    .join("logs");
+```
+
+**Risk:** Low — only changes log output location. Data, config, db all unaffected.
+**Verification:** After rebuild, check that `~/.agentmux/logs/agentmuxsrv-v*.log.*` exists.
+
+### Change 2: `AGENTMUX_LOG_DIR` env var (P0)
+
+**File:** `agentmux-srv/src/backend/blockcontroller/shell.rs` (~line 486)
+
+```rust
+// Inject log directory so agents can find logs without guessing.
+// Always ~/.agentmux/logs/ — matches both host and sidecar after consolidation.
+let log_dir = dirs::home_dir()
+    .unwrap_or_default()
+    .join(".agentmux")
+    .join("logs");
+c.env("AGENTMUX_LOG_DIR", log_dir.to_string_lossy().as_ref());
+```
+
+**Available in shell as:** `$AGENTMUX_LOG_DIR`
+
+### Change 3: Current-log pointer files (P0)
+
+Write a one-line text file containing the current log filename. Pointer files go in the same log dir.
+
+**File:** `agentmux-cef/src/main.rs` — after file appender creation (~line 306)
+
+```rust
+// Write pointer to current log file for agent discovery.
+// On Windows, symlinks require elevation, so use a plain text pointer.
+let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+let current_filename = format!("{}.{}", log_prefix, today);
+let _ = std::fs::write(log_dir.join("current-host.path"), &current_filename);
+```
+
+**File:** `agentmux-srv/src/main.rs` — after file appender creation (~line 544)
+
+```rust
+let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+let current_filename = format!("{}.{}", log_prefix, today);
+let _ = std::fs::write(log_dir.join("current-srv.path"), &current_filename);
+```
+
+**Result in `~/.agentmux/logs/`:**
+```
+current-host.path    → contains: "agentmux-host-v0.33.62.log.2026-04-07"
+current-srv.path     → contains: "agentmuxsrv-v0.33.62.log.2026-04-07"
+```
+
+### Change 4: Heartbeat refreshes pointers (P1)
+
+Piggyback on the existing 20s heartbeat loop to update the pointer file on date change.
+
+**File:** `agentmux-cef/src/memory_heartbeat.rs` — in the loop body
+
+```rust
+// Refresh log pointer in case of midnight rollover.
+// Cheap: one write every 20s, only changes on date boundary.
+let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+let current_filename = format!("agentmux-host-v{}.log.{}", env!("CARGO_PKG_VERSION"), today);
+let log_dir = dirs::home_dir()
+    .unwrap_or_default()
+    .join(".agentmux")
+    .join("logs");
+let _ = std::fs::write(log_dir.join("current-host.path"), &current_filename);
+```
+
+### Change 5: Launcher logging (P1)
+
+The launcher has zero logging today — only `eprintln!` for fatal errors. On Windows it stays alive for the **entire app lifetime** (`.status()` blocks until CEF host exits), so it's an invisible process that could mask startup failures, DLL resolution issues, or child process crashes.
+
+The launcher is intentionally minimal (no `tracing`, no `chrono`, no `dirs` crate — just `std` + `windows-sys`). Adding full tracing would bloat a 325 KB binary. Instead, use lightweight `std::fs` append-logging to the same consolidated log directory.
+
+**File:** `agentmux-launcher/src/main.rs`
+
+```rust
+use std::io::Write;
+
+/// Append a timestamped line to ~/.agentmux/logs/agentmux-launcher.log
+/// Best-effort — silently no-ops if the log dir doesn't exist yet.
+fn log(msg: &str) {
+    let log_dir = dirs_fallback_home().join(".agentmux").join("logs");
+    let _ = std::fs::create_dir_all(&log_dir);
+    let path = log_dir.join("agentmux-launcher.log");
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        // No chrono dep — use SystemTime for a rough timestamp
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let _ = writeln!(f, "[{}] v{} {}", secs, env!("CARGO_PKG_VERSION"), msg);
+    }
+}
+
+/// Home dir without the `dirs` crate (keep launcher zero-dep beyond windows-sys)
+fn dirs_fallback_home() -> std::path::PathBuf {
+    std::env::var("USERPROFILE")                          // Windows
+        .or_else(|_| std::env::var("HOME"))               // Unix
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from("."))
+}
+```
+
+**Log points to add in `main()`:**
+
+```rust
+fn main() {
+    let exe_path = std::env::current_exe().expect("cannot resolve exe path");
+    let exe_dir = exe_path.parent().expect("exe has no parent directory");
+    let runtime_dir = exe_dir.join("runtime");
+
+    log(&format!("starting — exe={} runtime={}", exe_path.display(), runtime_dir.display()));
+
+    // ... DLL search path setup ...
+    log("SetDllDirectoryW done");
+
+    let real_exe = find_cef_binary(&runtime_dir);
+    log(&format!("resolved CEF binary: {}", real_exe.display()));
+
+    if !real_exe.exists() {
+        log(&format!("FATAL: CEF binary not found at {}", real_exe.display()));
+        eprintln!("AgentMux runtime not found...");
+        std::process::exit(1);
+    }
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    log(&format!("spawning CEF host with {} args", args.len()));
+
+    // Windows: .status() blocks — launcher stays alive
+    let status = std::process::Command::new(&real_exe)
+        .args(&args)
+        .status();
+
+    match status {
+        Ok(s) => {
+            let code = s.code().unwrap_or(1);
+            log(&format!("CEF host exited with code {}", code));
+            std::process::exit(code);
+        }
+        Err(e) => {
+            log(&format!("FATAL: failed to spawn CEF host: {}", e));
+            eprintln!("Failed to launch AgentMux: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+```
+
+**Log file:** `~/.agentmux/logs/agentmux-launcher.log` (append-only, no rotation — file stays tiny since launcher only logs ~5 lines per session)
+
+**Format:** `[unix_epoch_secs] v0.33.62 message` — no deps needed, human-readable enough for diagnostics.
+
+**Why not tracing?** The launcher's job is to add zero overhead. Adding `tracing` + `tracing-subscriber` + `tracing-appender` + `chrono` would increase compile time and binary size for a component that logs 5 lines per lifetime. `std::fs::OpenOptions::append` is sufficient.
+
+**Cross-mode behavior:**
+- `task dev`: No launcher involved (runs `agentmux-cef` directly from `dist/cef-dev/`)
+- Portable: Launcher runs, logs to `~/.agentmux/logs/agentmux-launcher.log`
+- Install: Same as portable
+
+**Pointer file:** `current-launcher.path` is unnecessary — there's only one log file (no version/date suffix). Agents can access it directly: `cat "$AGENTMUX_LOG_DIR/agentmux-launcher.log"`.
+
+### Change 6: 7-day log retention (P2)
+
+Add a cleanup pass on startup in both `init_logging()` functions.
+
+```rust
+// Delete log files older than 7 days to prevent unbounded growth.
+if let Ok(entries) = std::fs::read_dir(&log_dir) {
+    let cutoff = std::time::SystemTime::now()
+        - std::time::Duration::from_secs(7 * 86400);
+    for entry in entries.flatten() {
+        let path = entry.path();
+        // Only touch log files, not pointer files
+        if !path.to_string_lossy().contains(".log.") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+        }
+    }
+}
+```
+
+### Change 7: `muxlog` shell helper (P2)
+
+**Files:** `agentmux-srv/src/backend/shellintegration/{bash.sh,zsh.sh}`
+
+```bash
+muxlog() {
+  local target="${1:-host}"
+  local ptr="$AGENTMUX_LOG_DIR/current-${target}.path"
+  if [ ! -f "$ptr" ]; then
+    echo "Unknown log target '$target'. Available:" >&2
+    ls "$AGENTMUX_LOG_DIR"/current-*.path 2>/dev/null \
+      | sed 's|.*/current-||;s|\.path||' >&2
+    return 1
+  fi
+  local logfile="$AGENTMUX_LOG_DIR/$(cat "$ptr")"
+  shift 2>/dev/null
+  case "${1:-tail}" in
+    tail) tail -f "$logfile" ;;
+    cat)  cat "$logfile" ;;
+    *)    grep "$1" "$logfile" ;;
+  esac
+}
+```
+
+**File:** `agentmux-srv/src/backend/shellintegration/pwsh.ps1`
+
+```powershell
+function muxlog {
+  param([string]$Target = "host", [string]$Action = "tail")
+  $ptr = "$env:AGENTMUX_LOG_DIR\current-$Target.path"
+  if (-not (Test-Path $ptr)) {
+    Write-Error "Unknown log target '$Target'"
+    return
+  }
+  $logfile = "$env:AGENTMUX_LOG_DIR\$(Get-Content $ptr)"
+  switch ($Action) {
+    "tail" { Get-Content $logfile -Wait -Tail 50 }
+    "cat"  { Get-Content $logfile }
+    default { Select-String $Action $logfile }
+  }
+}
+```
+
+---
+
+## Part 4: Cross-Mode Compatibility Matrix
+
+After all changes, the behavior should be identical across modes:
+
+| | `task dev` | Portable | Install |
+|-|-----------|----------|---------|
+| `$AGENTMUX_LOG_DIR` | `~/.agentmux/logs` | `~/.agentmux/logs` | `~/.agentmux/logs` |
+| Host log | `agentmux-host-v{V}.log.{D}` | same | same |
+| Sidecar log | `agentmuxsrv-v{V}.log.{D}` | same | same |
+| Launcher log | N/A (no launcher) | `agentmux-launcher.log` | `agentmux-launcher.log` |
+| `current-host.path` | points to host log | same | same |
+| `current-srv.path` | points to srv log | same | same |
+| `muxlog host` | tails host log | same | same |
+| `muxlog srv` | tails srv log | same | same |
+| Launcher log | N/A | `cat "$AGENTMUX_LOG_DIR/agentmux-launcher.log"` | same |
+
+**Multi-instance safety:** Multiple versions running simultaneously write to the same `~/.agentmux/logs/` directory but with different version-stamped filenames. Pointer files reflect whichever instance updated them last — acceptable since the agent is running inside a specific instance and `$AGENTMUX_VERSION` can disambiguate if needed.
+
+**Dev-mode edge case:** `AGENTMUX_DEV=1` no longer affects log location (it still affects CEF data dir for caches, cookies, etc.). This is intentional — dev logs belong with all other logs for easy discovery.
+
+---
+
+## Part 5: After Implementation — CLAUDE.md Update
+
+```markdown
+### Log Access (zero lookup)
+
+All logs land in `$AGENTMUX_LOG_DIR` (`~/.agentmux/logs/`). Pointer files resolve the current filename.
+
+| What | Command |
+|------|---------|
+| Current host log path | `cat "$AGENTMUX_LOG_DIR/current-host.path"` |
+| Current sidecar log path | `cat "$AGENTMUX_LOG_DIR/current-srv.path"` |
+| Tail host log | `muxlog host` or `tail -f "$AGENTMUX_LOG_DIR/$(cat "$AGENTMUX_LOG_DIR/current-host.path")"` |
+| Tail sidecar log | `muxlog srv` |
+| Frontend logs | `muxlog host '[fe]'` |
+| Memory heartbeat | `muxlog host mem_heartbeat` |
+| Dump full host log | `muxlog host cat` |
+| Launcher log (portable/install only) | `cat "$AGENTMUX_LOG_DIR/agentmux-launcher.log"` |
+
+Works identically across `task dev`, portable, and install builds.
+Never glob for log files. Never guess paths. Use the pointer files.
+```
+
+---
+
+## Summary of Changes
+
+| # | What | Files | Lines | Priority |
+|---|------|-------|-------|----------|
+| 1 | Consolidate sidecar logs to `~/.agentmux/logs/` | `agentmux-srv/src/main.rs:533` | 3 | P0 |
+| 2 | Inject `AGENTMUX_LOG_DIR` into shells | `shell.rs:486` | 5 | P0 |
+| 3 | Write `current-host.path` pointer | `agentmux-cef/src/main.rs:306` | 3 | P0 |
+| 4 | Write `current-srv.path` pointer | `agentmux-srv/src/main.rs:544` | 3 | P0 |
+| 5 | Launcher file logging | `agentmux-launcher/src/main.rs` | ~35 | P1 |
+| 6 | Heartbeat refreshes host pointer | `memory_heartbeat.rs:16` | 5 | P1 |
+| 7 | 7-day log retention on startup | Both `main.rs` init_logging | 15 | P2 |
+| 8 | `muxlog` shell helper | `shellintegration/{bash,zsh,pwsh,fish}` | ~20/script | P2 |
+| 9 | CLAUDE.md documentation | `CLAUDE.md` | 15 | P2 |
+
+**Total P0 effort:** ~14 lines of Rust across 3 files.
+**Total P1 effort:** ~40 lines (launcher logging + heartbeat pointer refresh).

--- a/docs/MEMORY_HEARTBEAT_SPEC.md
+++ b/docs/MEMORY_HEARTBEAT_SPEC.md
@@ -1,0 +1,96 @@
+# Memory Heartbeat Spec
+
+**PR:** #311 — `feat(cef): in-process GPU, renderer limit, memory heartbeat`
+**Version:** v0.33.62
+**Module:** `agentmux-cef/src/memory_heartbeat.rs`
+
+---
+
+## Purpose
+
+Forensic telemetry for diagnosing OOM and virtual address (VA) exhaustion crashes. Logs system-wide and per-process memory stats every 20 seconds to the `mem_heartbeat` tracing target. Designed to provide a timeline leading up to crashes that would otherwise leave no diagnostic trail.
+
+## Background
+
+Each CEF subprocess reserves ~100GB virtual address space (32GB GigaCage + 4x16GB PartitionAlloc pools + 4GB V8 pointer cage). On a 16GB machine with 87GB total VA, 3 subprocesses exhaust available VA. PR #311 reduces subprocess count (`--in-process-gpu`, `--renderer-process-limit=1`) and adds this heartbeat to catch remaining pressure.
+
+## Architecture
+
+```
+main.rs:257 → memory_heartbeat::start()
+                └── spawns "mem-heartbeat" thread (daemon, no shutdown signal)
+                    └── loop { sleep(20s); log_memory_stats(); }
+```
+
+- **Thread:** Named `mem-heartbeat`, spawned once at CEF startup, runs for process lifetime
+- **Interval:** 20 seconds (hardcoded)
+- **Target:** `tracing::info!(target: "mem_heartbeat", ...)`
+- **No shutdown:** Thread runs until process exits — no cancellation token needed for a desktop app
+
+## Metrics Logged
+
+### Windows (`cfg(target_os = "windows")`)
+
+**System memory** (via `GlobalMemoryStatusEx`):
+
+| Field | Unit | Description |
+|-------|------|-------------|
+| `load_pct` | % | Overall memory load percentage |
+| `total_phys_gb` | GB | Total physical RAM |
+| `avail_phys_gb` | GB | Available physical RAM |
+| `total_page_gb` | GB | Total commit limit (RAM + pagefile) |
+| `avail_page_gb` | GB | Available commit charge |
+| `total_virt_gb` | GB | Total user-mode VA space |
+| `avail_virt_gb` | GB | Available user-mode VA space |
+
+**Process memory** (via `GetProcessMemoryInfo`):
+
+| Field | Unit | Description |
+|-------|------|-------------|
+| `ws_mb` | MB | Current working set (physical pages mapped) |
+| `peak_ws_mb` | MB | Peak working set since process start |
+| `commit_mb` | MB | Current committed memory (pagefile-backed) |
+| `peak_commit_mb` | MB | Peak committed memory |
+| `page_faults` | count | Total page faults since start |
+
+### Linux/macOS (`cfg(not(target_os = "windows"))`)
+
+**Process** (from `/proc/self/status`): `VmRSS`, `VmSize`, `VmPeak`
+**System** (from `/proc/meminfo`): `MemTotal`, `MemAvailable`
+
+## Log Format
+
+Logs appear in the CEF host log file. Example output:
+
+```
+INFO mem_heartbeat: system memory load_pct=42 total_phys_gb=15.9 avail_phys_gb=9.2 total_page_gb=21.5 avail_page_gb=14.1 total_virt_gb=128.0 avail_virt_gb=87.3
+INFO mem_heartbeat: process memory ws_mb=312.4 peak_ws_mb=318.7 commit_mb=287.1 peak_commit_mb=290.5 page_faults=82341
+```
+
+## Companion Changes (PR #311)
+
+| Switch | Effect | Why |
+|--------|--------|-----|
+| `--in-process-gpu` | Merges GPU process into browser process | Eliminates one ~100GB VA reservation |
+| `--renderer-process-limit=1` | Caps renderer subprocesses to 1 | Prevents DevTools popups spawning additional renderers |
+
+Both switches are appended in `app.rs` via `cmd.append_switch()` during `on_before_command_line_processing`.
+
+## Diagnostic Workflow
+
+When investigating a crash:
+
+1. Find the host log file (see `reference_log_paths.md` for locations)
+2. Grep for `mem_heartbeat` entries in the minutes before the crash
+3. Look for:
+   - `avail_virt_gb` trending toward 0 → VA exhaustion
+   - `avail_phys_gb` near 0 with high `load_pct` → physical OOM
+   - `ws_mb` growing monotonically → memory leak in browser process
+   - `page_faults` spiking → thrashing
+
+## Future Considerations
+
+- Threshold-based warnings (e.g., log at WARN when `avail_virt_gb < 5`)
+- Expose metrics to frontend for a sysinfo widget
+- Configurable interval via settings
+- Child process memory (renderer, utility) — currently only reports browser process

--- a/docs/NEXT-2026-04-04.md
+++ b/docs/NEXT-2026-04-04.md
@@ -1,0 +1,89 @@
+# Next Steps — 2026-04-04
+
+## Immediate: Continue God Module Splits (P2-1)
+
+### 1. Split `wcore.rs` (1419 lines)
+**File:** `agentmuxsrv-rs/src/backend/wcore.rs`
+**Contains:** workspace creation/deletion, window management, block/tab operations, layout logic
+**Target:**
+```
+agentmuxsrv-rs/src/backend/
+├── wcore.rs         → mod orchestrator (re-exports, <200 LOC)
+├── workspace.rs     → workspace CRUD
+├── window.rs        → window lifecycle
+├── block.rs         → block/tab operations
+├── layout.rs        → layout tree manipulation
+```
+**Approach:** Same pattern as websocket.rs — extract functions into modules, verify `cargo check` after each.
+
+### 2. Split `wconfig.rs` (1624 lines)
+**File:** `agentmuxsrv-rs/src/backend/wconfig.rs`
+**Contains:** config loading, validation, schema generation, defaults
+**Target:**
+```
+├── wconfig.rs       → mod orchestrator (<200 LOC)
+├── config/
+│   ├── mod.rs       → re-exports
+│   ├── loader.rs    → config file loading + migration
+│   ├── validate.rs  → validation rules
+│   ├── schema.rs    → JSON schema generation
+│   └── defaults.rs  → default values
+```
+
+### 3. Split `shell.rs` (1325 lines)
+**File:** `agentmuxsrv-rs/src/backend/blockcontroller/shell.rs`
+**Contains:** PTY creation, shell process lifecycle, I/O read/write loops, resize handling
+**Target:**
+```
+├── blockcontroller/
+│   ├── shell.rs     → mod orchestrator (<300 LOC)
+│   ├── shell/
+│   │   ├── mod.rs
+│   │   ├── pty.rs       → PTY creation + platform detection
+│   │   ├── io_loop.rs   → read/write loops
+│   │   └── lifecycle.rs → start/stop/resize
+```
+
+### 4. Split `global.ts` (917 lines)
+**File:** `frontend/app/store/global.ts`
+**Contains:** 104+ exports — atoms, services, utilities, counters, notifications
+**Target:**
+```
+frontend/app/store/
+├── global.ts        → re-exports only (<50 LOC)
+├── atoms.ts         → all SolidJS signals/atoms
+├── services.ts      → RPC wrapper functions
+├── counters.ts      → dev tooling counters
+├── notifications.ts → alert/notification system
+```
+
+## After Splits: Merge PR #279 (Binary Rename)
+Spec: `docs/specs/versioned-artifact-names.md`
+- Rename `agentmuxsrv-rs/` → `agentmux-srv/`, `wsh-rs/` → `agentmux-wsh/`
+- Version every binary filename (visible in Task Manager)
+- ~600 line changes across ~90 files — much cleaner after god modules are split
+
+## Other Open Items
+| Priority | Item | Effort |
+|----------|------|--------|
+| P2-2 | Rename legacy Wave modules (`wavebase.rs` → `base.rs`, etc.) | 3h |
+| P2-3 | Define proper error types for string-error modules | 4h |
+| P3-1 | Replace 92 `any`/`as any` types in frontend | 4h |
+| P3-2 | Replace 52 `(window as any)` with type declarations | 2h |
+| P3-3 | Fix leaked `setInterval` in TermViewModel | 30min |
+| P3-4 | Add bounded channels in `rpc/router.rs` | 1h |
+| P3-6 | Structured key-value logging in Rust backend | 4h |
+
+## Open PRs to Address
+| PR | Action |
+|----|--------|
+| #279 | Merge after god module splits |
+| #280 | Review and merge (auto-build deps) |
+| #234, #249, #224 | Triage — likely stale, close or rebase |
+
+## Reference Docs
+- `docs/analysis/full-codebase-audit-2026-04-03.md` — full audit with priority plan
+- `docs/specs/websocket-modularization.md` — websocket split spec (completed)
+- `docs/specs/versioned-artifact-names.md` — binary rename spec (PR #279)
+- `docs/analysis/pty-duplicate-output-debug.md` — PTY debug instrumentation plan
+- `docs/HANDOFF-2026-04-03T2345.md` — session handoff with all context

--- a/docs/REPORT-2026-04-03-status.md
+++ b/docs/REPORT-2026-04-03-status.md
@@ -1,0 +1,86 @@
+# AgentMux Status Report — 2026-04-03
+
+## Current State
+
+| Field | Value |
+|-------|-------|
+| **Local version** | 0.33.26 |
+| **Remote version** | 0.33.25 (1 local commit not pushed) |
+| **Branch** | `main` at `08ff00b` |
+| **Working tree** | Clean (untracked docs/specs only) |
+| **Running build** | v0.33.25 portable on Desktop |
+
+---
+
+## Unpushed Commit
+
+```
+08ff00b chore: bump version to 0.33.26
+```
+
+Remote `main` is at `156bfa6` (PR #277 merge). A `git push origin main` will sync.
+
+---
+
+## Recently Merged PRs (last 48h)
+
+| PR | Description | Merged |
+|----|-------------|--------|
+| #278 | Echo delay fix — bypass RAF for small PTY writes | Apr 2 16:44 |
+| #277 | Clipboard support for CEF host (Win32/macOS/Linux) | Apr 2 15:00 |
+| #275 | Opacity applies to all windows + removal fix | Apr 2 08:16 |
+| #274 | Single-instance new window on re-launch | Apr 2 06:18 |
+| #273 | Secondary windows use CEF Views (resize + no flash) | Apr 2 05:54 |
+| #272 | CEF Views deferred show — no flash, resize works | Apr 2 04:34 |
+| #271 | Remove WS_THICKFRAME to eliminate white border flash | Apr 2 03:07 |
+| #270 | Remove disable-gpu-compositing flag | Apr 2 02:53 |
+| #268 | Eliminate white flash on startup | Apr 1 21:29 |
+| #266 | Per-version cache dir + DWM only on secondary windows | Apr 1 03:21 |
+
+**10 PRs merged in ~36 hours** — major CEF host stabilization push.
+
+---
+
+## Open PRs (9)
+
+### Needs Splitting
+| PR | Owner | Description | Action |
+|----|-------|-------------|--------|
+| #267 | AgentX | Win11 focus ring (bundled 4 changes) | Split into 3 focused PRs |
+
+### Needs Review
+| PR | Owner | Description | Age |
+|----|-------|-------------|-----|
+| #256 | Agent1 | Drone pane Phase 1 (node-graph canvas) | 4 days |
+| #232 | AgentX | Linux opacity + backend isolation | 9 days |
+| #228 | AgentX | Linux zoom ghost-pixel fix | 9 days |
+| #209 | AgentY | Docker attach delivery | 12 days |
+| #196 | AgentX | pwsh in Taskfile | 13 days |
+
+### Likely Stale
+| PR | Owner | Description | Why |
+|----|-------|-------------|-----|
+| #249 | AgentA | CLI exe copy fix | 6 days — check if still relevant |
+| #234 | AgentA | RAF guard + scroll flash | 8 days — #278 may supersede |
+| #224 | AgentA | Tab drag cursor fix | 9 days — stale |
+
+---
+
+## Priority Actions
+
+1. **Push local bump** — `git push origin main` (syncs 0.33.26)
+2. **Split PR #267** — 3 PRs: CSS focus ring, DOM renderer default, dragend safety net (analysis in `docs/analysis/pr-267-276-takeover.md`)
+3. **Opacity bug** — `set_window_transparency` in `commands/window.rs` still uses single-window lookup; #275 only fixed removal path
+4. **Stale PR triage** — close or rebase #234, #249, #224
+5. **Review queue** — #256, #232, #228, #209
+
+---
+
+## Untracked Files (not committed)
+
+Docs/specs/analysis files accumulated across sessions:
+- 4 handoff docs, 1 prior report
+- 10 analysis/spec docs in `docs/`
+- Leftover temp dirs: `46316runtimeDir/`, `4648runtimeDir/`, `cef-testbed/`
+
+Consider: commit the docs, `.gitignore` or delete the temp dirs.

--- a/docs/REPORT-agent-pane-architecture-2026-04-09.md
+++ b/docs/REPORT-agent-pane-architecture-2026-04-09.md
@@ -1,0 +1,281 @@
+# Agent Pane — Comprehensive Architecture Breakdown
+
+**Date:** 2026-04-09
+**Purpose:** Refactoring planning document
+
+---
+
+## 1. Frontend Components
+
+### 1.1 File Structure
+
+**Location:** `frontend/app/view/agent/`
+
+| File | Purpose |
+|------|---------|
+| `agent-model.ts` | ViewModel: launch orchestration, block metadata, RPC coordination |
+| `agent-view.tsx` | Top-level component: AgentPicker + AgentPresentationView + runLaunchFlow() |
+| `state.ts` | SolidJS signal factory: createAgentAtoms() |
+| `types.ts` | TypeScript types: DocumentNode, StreamEvent, ToolNode, ProviderDefinition |
+| `stream-parser.ts` | NDJSON parser: stream events -> DocumentNodes |
+| `useAgentStream.ts` | SolidJS hook: subscribes to WPS blockfile, translates, parses |
+| `index.ts` | Re-exports |
+| `init-monitor.ts` | Initialization state tracking |
+
+### 1.2 Components Subdirectory
+
+**Location:** `frontend/app/view/agent/components/`
+
+| Component | Responsibility |
+|-----------|----------------|
+| `AgentDocumentView.tsx` | Renders document: log lines at top, then DocumentNode list. Auto-scroll, collapse/expand |
+| `AgentFooter.tsx` | Textarea input + Enter/Shift+Enter handling + loading spinner |
+| `ToolBlock.tsx` | Tool execution display: Bash, Edit (diff), Read, Write, Grep/Glob. 50KB truncation |
+| `AgentMessageBlock.tsx` | Agent-to-agent message display (mux vs ject) |
+| `MarkdownBlock.tsx` | Markdown rendering with streaming support |
+| `SubagentLinkBlock.tsx` | Clickable link to spawn/open subagent pane |
+| `BashOutputViewer.tsx` | Specialized bash stdout/stderr rendering |
+| `DiffViewer.tsx` | Side-by-side diff for Edit tool |
+
+### 1.3 AgentViewModel (`agent-model.ts`)
+
+**Key Atoms** (via `createAgentAtoms()`):
+- `documentAtom` — rendered DocumentNode[]
+- `documentStateAtom` — collapsed nodes, scroll, selection, filters
+- `streamingStateAtom` — active, bufferSize, lastEventTime
+- `processAtom` — pid, status (idle/running/paused/failed), canRestart
+- `authAtom`, `sessionIdAtom`, `rawOutputAtom`
+
+**Key Methods:**
+- `launchAgent(agentId)` — simple provider launch: validate Node.js, build CLI args, set block metadata, ControllerResync
+- `launchForgeAgent(agent)` — full forge setup: load content blobs, build CLAUDE.md, write skill commands, inject MCP server, per-agent GitHub/auth isolation
+
+---
+
+## 2. Launch Flow (Detailed Step-by-Step)
+
+**Location:** `agent-view.tsx` L168-372 — `runLaunchFlow()`
+
+### Phase 0: Container Runtime Check (if applicable)
+- If `agentMode === "container"`, call `ResolveCliCommand` with provider_id="docker"
+
+### Phase 1: CLI Resolution / Installation
+- **RPC:** `ResolveCliCommand(TabRpcClient, {...})` — 5min timeout
+- Input: provider_id, cli_command, npm_package, pinned_version, install_command
+- Output: `ResolveCliResult { cli_path, version, source }`
+- Subscribe to `install_progress` events for npm output streaming
+- Block metadata `cmd` updated with resolved path
+
+### Phase 2: Auth Check -> Auto-login if Needed
+- **RPC:** `CheckCliAuthCommand(TabRpcClient, { cli_path, auth_check_args, auth_env })`
+- Claude fast path: reads `~/.claude/.credentials.json` directly (no subprocess)
+- If not authenticated:
+  - `getApi().runCliLogin(cli_path, login_args, authEnv)` — spawns browser
+  - Polling loop: `CheckCliAuthCommand` every 2s, 5min deadline
+  - Cancel via `getApi().cancelCliLogin()`
+  - On timeout: return "auth_failed", show Retry button
+
+### Phase 3: Controller Registration
+- **RPC:** `ControllerResyncCommand(TabRpcClient, { tabid, blockid, forcerestart: false })`
+- Creates SubprocessController on backend
+- `agentReady` signal set to true
+
+### Signals During Flow:
+- `flowRunning` — true during entire flow
+- `agentReady` — true after successful completion
+- `loginWaiting` — true during auth polling (shows Cancel button)
+- `canRetry` — true after auth_failed (shows Retry button)
+- `authUrl` — OAuth URL string (shown with copy button)
+- `isLoading()` — derived: `flowRunning() || !agentReady()`
+
+---
+
+## 3. Provider System
+
+**Location:** `frontend/app/view/agent/providers/index.ts`
+
+### ProviderDefinition Interface
+```
+id, displayName, cliCommand, launchArgs, outputFormat,
+authType, authCheckCommand, authLoginCommand,
+npmPackage, pinnedVersion,
+authConfigDirEnvVar, authDirName, authExtraEnv,
+resumeFlag, sessionIdField
+```
+
+### Provider Configs
+
+| Field | Claude | Codex | Gemini |
+|-------|--------|-------|--------|
+| CLI | claude | codex | gemini |
+| Auth | OAuth | OAuth | OAuth |
+| npm | @anthropic-ai/claude-code | @openai/codex | @google/gemini-cli |
+| Version | latest | 0.116.0 | 0.32.1 |
+| Resume | --resume | null | -r |
+| Session field | session_id | thread_id | session_id |
+| Launch args | -p --output-format stream-json --verbose --include-partial-messages --dangerously-skip-permissions | exec --json --dangerously-bypass-approvals-and-sandbox - | --output-format stream-json --yolo -p "" |
+
+---
+
+## 4. Subprocess Controller (Backend)
+
+**File:** `agentmux-srv/src/backend/blockcontroller/subprocess.rs`
+
+### Architecture
+- **Per-turn model:** Fresh `claude -p` per user message
+- **Multi-turn:** Session ID captured from init event, `--resume <sid>` on next turn
+- **State machine:** INIT -> RUNNING -> DONE -> RUNNING (re-spawn)
+- **I/O:** Two async tasks per turn: stdout_reader + process_waiter
+
+### spawn_turn() Steps (L189-515)
+1. Lock check (prevent concurrent spawns)
+2. Resume flag handling (append --resume + session_id if available)
+3. Status update -> RUNNING, publish via WPS
+4. Build Command via `make_cli_cmd()` (handles .cmd wrappers)
+5. Set args, working dir (~expansion), env vars, piped stdio
+6. Spawn process, store PID
+7. **stdin writer task:** write message bytes, close stdin
+8. **stdout_reader task:** line-by-line NDJSON, session ID capture, health monitoring, WPS blockfile publication
+9. **stderr_reader task:** non-blocking logging
+10. **Health watchdog:** every 5s timeout check
+11. **process_waiter:** select on exit OR kill signal, update status to DONE
+
+### Session Resumption
+1. First turn: CLI emits init event with session_id
+2. Extract and store in inner state + block metadata
+3. Next turn: append `--resume <sid>` to CLI args
+
+---
+
+## 5. CLI Handlers (Backend)
+
+**File:** `agentmux-srv/src/server/cli_handlers.rs`
+
+### ResolveCliCommand (L18-429)
+Resolution order:
+1. Check versioned dir: `~/.agentmux/<version>/cli/<provider>/`
+2. System scan: known paths + where/which
+3. Copy from system to versioned dir (fast, no network)
+4. npm install: `npm install --prefix <dir> <pkg>@<version>` (with Windows raw_arg handling)
+5. Official installer: PowerShell/bash with 120s timeout
+
+### CheckCliAuthCommand (L432-564)
+- Claude fast path: read .credentials.json (isolated dir -> global fallback)
+- Others: run CLI auth check command (25s timeout)
+
+### RunCliLogin (L566-595)
+- Spawn login process with null stdio (browser opens)
+- Return immediately, frontend polls
+
+### make_cli_cmd (agentmux-common crate)
+- Parse .cmd wrapper, extract %dp0% relative JS path
+- Invoke `node <script>` directly, bypass cmd.exe /C
+
+---
+
+## 6. Data Flow
+
+### User Message -> CLI stdin
+```
+AgentFooter textarea
+  -> handleSendMessage(message)
+    -> RpcApi.AgentInputCommand(TabRpcClient, { blockid, message })
+      -> WebSocket -> RPC router -> AgentInputCommand handler (websocket.rs L714)
+        -> Load block metadata (cmd, args, env, cwd)
+        -> Create SubprocessSpawnConfig
+        -> subprocess_ctrl.spawn_turn(config)
+          -> Spawn process, write message to stdin as JSON
+```
+
+### CLI stdout -> Frontend
+```
+Subprocess stdout (NDJSON lines)
+  -> stdout_reader task (line-by-line BufReader)
+    -> WPS blockfile publication: handle_append_block_file(broker, blockid, "output", line)
+      -> Frontend subscription: getFileSubject(blockId, "output")
+        -> Decode base64 -> lineBuffer -> split on \n
+          -> JSON.parse each line
+            -> Provider translator: rawEvent -> StreamEvent[]
+              -> Stream parser: StreamEvent -> DocumentNode[]
+                -> Update documentAtom signal
+```
+
+### WPS Event Types
+- `install_progress` — npm install output lines
+- `blockfile` — subprocess stdout streaming (subject: "output")
+- `controllerstatus` — state changes (init/running/done + exit code)
+- `subagent:spawned` / `subagent:completed` — inter-agent events
+
+---
+
+## 7. Block/Layout Integration
+
+### Block Metadata Fields (Agent Pane)
+```
+view: "agent"
+controller: "subprocess"
+agentId: "claude"
+agentProvider: "claude"
+agentName: "My Agent"
+agentOutputFormat: "claude-stream-json"
+cmd: "/path/to/claude"
+cmd:args: ["-p", "--output-format", "stream-json", ...]
+cmd:cwd: "~/.agentmux/agents/my-agent"
+cmd:env: { CLAUDE_CONFIG_DIR, GH_CONFIG_DIR, AGENTMUX_AGENT_ID, ... }
+agent:resume_flag: "--resume"
+agent:session_id_field: "session_id"
+agent:sessionid: "abc123"  (captured from CLI init event)
+```
+
+### Creation Flow
+```
+AgentPicker -> click card
+  -> model.launchAgent(agentId)
+    -> Set block metadata via RpcApi.SetMetaCommand()
+    -> Create controller via RpcApi.ControllerResyncCommand()
+    -> AgentViewWrapper switches to AgentPresentationView
+```
+
+---
+
+## 8. Known Issues & State
+
+### Working End-to-End
+- Claude Code: resolve, auth, launch, single-turn, streaming, tool rendering
+- Forge agents: content loading, skill injection, CLAUDE.md assembly, MCP auto-inject
+- Multi-turn: session ID capture, --resume appending
+- Subagent linking: event subscription, click-to-open
+
+### Incomplete / Issues
+- **Codex & Gemini:** Provider definitions exist, NOT tested end-to-end
+- **Container agents:** Docker detection code present, NOT tested
+- **Loading spinner:** Shows during launch but flow completes in ~560ms (barely visible)
+- **API key auth:** No UI for Codex/Gemini API key entry
+- **System scanner in resolver:** Still falls back to `where`/`which` + copies system binaries (should be npm-only)
+
+### Recent Fixes (PR #318, branch `agenta/fix-cmd-wrapper-node-resolve`)
+- .cmd wrapper -> node resolution (agentmux-common shared crate)
+- Auth check fallback to global ~/.claude/.credentials.json
+- Layout self-healing on startup + delete (prune orphaned block nodes)
+- Loading spinner in agent footer (agentReady signal)
+
+---
+
+## Key Files Reference
+
+| File | Lines | Role |
+|------|-------|------|
+| `frontend/app/view/agent/agent-model.ts` | L13-412 | ViewModel |
+| `frontend/app/view/agent/agent-view.tsx` | L59-675 | Wrapper + Picker + Presentation |
+| `frontend/app/view/agent/state.ts` | L46-87 | Atoms factory |
+| `frontend/app/view/agent/types.ts` | L14-347 | Type definitions |
+| `frontend/app/view/agent/stream-parser.ts` | L27-200+ | NDJSON parser |
+| `frontend/app/view/agent/useAgentStream.ts` | L31-184 | Stream hook |
+| `frontend/app/view/agent/providers/index.ts` | L4-134 | Provider configs |
+| `frontend/app/view/agent/components/AgentDocumentView.tsx` | L32-200 | Document renderer |
+| `frontend/app/view/agent/components/AgentFooter.tsx` | L16-57 | Input + spinner |
+| `frontend/app/view/agent/components/ToolBlock.tsx` | L23-163 | Tool rendering |
+| `agentmux-srv/src/backend/blockcontroller/subprocess.rs` | L1-530+ | Subprocess controller |
+| `agentmux-srv/src/server/cli_handlers.rs` | L12-596 | CLI resolution, auth, login |
+| `agentmux-srv/src/server/websocket.rs` | L714-783 | AgentInput RPC handler |
+| `agentmux-common/src/cli.rs` | L1-55 | Shared .cmd wrapper parser |

--- a/docs/REPORT-cli-wrappers-2026-04-08.md
+++ b/docs/REPORT-cli-wrappers-2026-04-08.md
@@ -1,0 +1,116 @@
+# CLI Wrapper Resolution — Status Report
+
+**Date:** 2026-04-08
+**Issue:** agentmuxai/agentmux#314
+**Related branches:** `agenta/codex-gemini-fixes-v2`, `agenta/fix-cli-exe-cmd-windows`
+**Session:** `a912e4d7` (v0.33.73 instance, Apr 8 04:18–10:15 UTC)
+
+---
+
+## Background
+
+AgentMux installs AI CLIs (Claude Code, Codex, Gemini) into per-version isolated directories (`~/.agentmux/<version>/cli/<provider>/`) via npm. On Windows, npm produces `.cmd` batch wrappers (e.g., `claude.cmd`) that call `node cli.js %*`. These wrappers are invoked from Rust via `std::process::Command`.
+
+## The Problem: `cmd.exe /C .cmd` Is Broken
+
+When Rust spawns `.cmd` files, it wraps them with `cmd.exe /C <path>.cmd <args>`. This pattern is **fundamentally broken** when combined with piped stdio:
+
+1. **Arguments get dropped** — `cmd.exe /C claude.cmd --version` prints the Windows banner instead of the version. The `--version` arg is silently lost.
+2. **No output captured** — with `Stdio::piped()`, `cmd.exe` captures its own banner but the actual CLI never runs.
+3. **Browser doesn't open** — `claude auth login` never executes, so the OAuth flow never starts.
+4. **`CREATE_NO_WINDOW` + `Stdio::null()` double-blocks** — the CLI process can't produce any visible output.
+
+## Work Done in Session `a912e4d7`
+
+The agent (running in v0.33.73 portable) made significant progress across versions v0.33.66 through v0.33.73:
+
+### Phase 1: CLI Resolver Rewrite (v0.33.66–67)
+- **Removed the system-scanning anti-pattern** — previously the resolver would scan system PATH, find CLIs, and copy them to the versioned dir. This defeated isolation and produced version-mismatched binaries.
+- **All providers now use npm-only install** — `npm install --prefix <versioned_dir> @anthropic-ai/claude-code@latest` (or `@openai/codex@latest`, etc.)
+- **Removed `windowsInstallCommand` and `installCommand` from provider configs** — no more provider-specific install scripts
+- **Removed `bin/` candidate path** — only `node_modules/.bin/` is checked now, eliminating stale artifacts from the old copy era
+- **Net: -356 lines, +106 lines** in `cli_handlers.rs`
+
+### Phase 2: `.cmd` Wrapper Fix (v0.33.68–70)
+- **Auth login**: Resolved `.cmd` → `node cli.js` directly in `platform.rs` (CEF host auth handler), bypassing `cmd.exe /C` entirely
+- **Version detection**: Fixed `get_cli_version()` to pass args correctly for `.cmd` files
+- **Browser open**: Added `start <url>` (Windows) / `xdg-open` (Linux) fallback when CLI can't open browser itself
+- **Auth URL capture**: Changed from stderr to stdout capture (Claude prints URL to stdout)
+- **Frontend**: Auth URL now displayed in agent view log with clickable link
+
+### Phase 3: UI Polish (v0.33.71)
+- **Processing indicator**: Added pulsing dot/bar in agent view footer when the agent is thinking (tracks `controllerstatus` events)
+- **Codex/Gemini readiness**: Provider configs verified complete, same npm resolver works for all three
+
+### Filed: Issue #314
+Documents the full `cmd.exe /C` problem, all affected code paths, and the proposed centralized fix via a `make_cli_cmd` rewrite.
+
+## Current State: INCOMPLETE
+
+### What Works
+- CLI resolution via npm install to versioned dir
+- Claude Code version detection (via `node cli.js --version` bypass)
+- Auth login browser open + URL display (for Claude, via `node cli.js` bypass)
+- Processing indicator in agent view
+
+### What's Still Broken (Issue #314)
+- **`make_cli_cmd` in `cli_handlers.rs` (sidecar)** still uses `cmd.exe /C` for `.cmd` files — this affects the **subprocess launch** path (not just auth). The agent pane spawns the CLI via the sidecar's `ControllerResync`, which calls `make_cli_cmd`. If the `.cmd` wrapper doesn't pass args correctly, the agent session itself may not work.
+- **Fix is only applied in two spots** (CEF host auth login + version detection). The sidecar's `make_cli_cmd` needs the same treatment — resolve `.cmd` → `node <entry_script>` centrally.
+- **Codex and Gemini untested** — the npm install path should work, but the `.cmd` launch path hasn't been verified for these providers.
+
+### Proposed Centralized Fix (from Issue #314)
+Rewrite `make_cli_cmd` to detect `.cmd` wrappers and resolve to the underlying `node cli.js` invocation:
+
+```rust
+fn make_cli_cmd(cli_path: &str) -> Command {
+    if cli_path.ends_with(".cmd") {
+        // Parse the .cmd file to find the node entry script
+        // e.g., claude.cmd contains: @node "cli.js" %*
+        // Spawn: node <dir>/cli.js <args>
+        let entry = parse_cmd_wrapper(cli_path);
+        let mut cmd = Command::new("node");
+        cmd.arg(entry);
+        cmd
+    } else {
+        Command::new(cli_path)
+    }
+}
+```
+
+## Branch Status
+
+| Branch | Base | Status | Contains |
+|--------|------|--------|----------|
+| `agenta/codex-gemini-fixes-v2` | v0.32.92 | **Stale** — based on old main, do not merge | Early Codex/Gemini work |
+| `agenta/fix-cli-exe-cmd-windows` | v0.32.104 | **Stale** — based on old main, do not merge | Auth URL display, exe/cmd fix |
+| (session work) | v0.33.65 main | **Not on a named branch** — changes are in dev builds v0.33.66–73 | Full rewrite |
+
+**Important:** The session's work (v0.33.66–73) was done via `task dev` hot-reload iterations. The commits exist locally but may not be on a pushed branch. The agent built incrementally (v0.33.66 → 67 → 68 → 69 → 70 → 71 → 73) with each version fixing issues found in the previous one.
+
+### To recover the work:
+```bash
+# Check which local branches have the latest commits
+git log --all --oneline --since="2026-04-08T04:00:00" | head -20
+
+# Or check the reflog for the session's commits
+git reflog --since="2026-04-08T04:00:00" | head -30
+```
+
+## Recommendations
+
+1. **Recover the session's commits** — find the final state (v0.33.73) on whatever local branch the agent left it on, or cherry-pick from reflog
+2. **Rebase onto current main** (v0.33.65) — the CLI resolver rewrite is the big win
+3. **Implement the centralized `make_cli_cmd` fix** per Issue #314 — one function, all paths fixed
+4. **Test all three providers end-to-end** — Claude, Codex, Gemini: install → auth → launch → send message → receive response
+5. **PR the work** once the centralized fix is in and all three providers pass
+
+## Related Files
+
+| File | Role |
+|------|------|
+| `agentmux-srv/src/backend/cli_handlers.rs` | CLI resolution, npm install, `make_cli_cmd`, version detection |
+| `agentmux-cef/src/platform.rs` | CEF host auth login handler (`.cmd` → `node cli.js` bypass) |
+| `frontend/app/view/agent/agent-view.tsx` | Launch flow UI, auth URL display, processing indicator |
+| `frontend/app/view/agent/agent-model.ts` | Agent model, CLI path computation |
+| `frontend/util/cef-api.ts` | IPC bridge for `run_cli_login`, `resolve_cli_command` |
+| `frontend/app/store/providers.ts` | Provider definitions (npm packages, args, env vars) |

--- a/docs/REPORT-v0.33.26.md
+++ b/docs/REPORT-v0.33.26.md
@@ -1,0 +1,65 @@
+# v0.33.26 Release Report
+
+**Date:** 2026-04-02
+**Base:** v0.33.24 → v0.33.26 (2 version bumps, 2 PRs merged, 1 PR closed)
+**Built:** Portable ZIP deployed to Desktop
+
+---
+
+## Changes from v0.33.24
+
+### PR #277 — Clipboard Support for CEF Host
+**Files:** `agentmux-cef/src/commands/clipboard.rs` (new), `commands/mod.rs`, `ipc.rs`, `frontend/util/clipboard.ts`
+
+Native clipboard implementation replacing the deprecated Tauri clipboard API:
+
+- **Windows:** Win32 `GlobalAlloc`/`GlobalLock`/`OpenClipboard`/`SetClipboardData` — direct system clipboard access
+- **macOS:** Shells out to `pbcopy` (write) and `pbpaste` (read)
+- **Linux:** Environment-aware fallback chain:
+  - Wayland: `wl-copy`/`wl-paste` (only attempted when `WAYLAND_DISPLAY` is set)
+  - X11 fallback: `xclip -selection clipboard`, then `xsel --clipboard`
+- **Frontend:** `frontend/util/clipboard.ts` updated to route through CEF IPC (`read_clipboard`/`write_clipboard` commands) instead of Tauri API
+- **Review fixes applied before merge:**
+  - `GlobalFree(hmem)` on `GlobalLock` and `OpenClipboard` failure paths (memory leak fix)
+  - Wayland detection via `WAYLAND_DISPLAY` env check — prevents silent `wl-copy` failure on X11 sessions
+
+### PR #278 — Terminal Echo Delay Fix
+**Files:** `frontend/app/view/term/termwrap.ts`
+
+- Small PTY writes (typical of character echo) bypass `requestAnimationFrame` batching and write directly to xterm.js
+- Eliminates visible keystroke delay in fast-typing scenarios
+- Guard added against out-of-order writes when RAF bypass and queued RAF writes interleave
+
+### PR #276 — Closed
+- Duplicate echo delay fix submitted by AgentX, superseded by #278
+
+---
+
+## Files Changed (v0.33.24 → v0.33.26)
+
+| File | Lines | Description |
+|------|-------|-------------|
+| `agentmux-cef/src/commands/clipboard.rs` | +177 | New — native clipboard for Win/Mac/Linux |
+| `agentmux-cef/src/commands/mod.rs` | +1 | Register clipboard module |
+| `agentmux-cef/src/ipc.rs` | +4 | Route `read_clipboard`/`write_clipboard` IPC |
+| `agentmux-cef/src/sidecar.rs` | +1/-1 | Minor (unrelated) |
+| `frontend/app/store/ws.ts` | +13/-34 | Simplify WebSocket reconnect |
+| `frontend/app/view/agent/components/AgentDocumentView.tsx` | +1/-1 | Minor |
+| `frontend/app/view/term/termwrap.ts` | +14/-4 | RAF bypass for echo delay |
+| `frontend/util/clipboard.ts` | +6/-6 | Route clipboard to CEF IPC |
+| Version files (×7) | +13/-13 | 0.33.24 → 0.33.26 |
+
+**Total:** 15 files, +227 / -55
+
+---
+
+## Current State
+
+- **Local main:** `08ff00b` (v0.33.26 bump — **not yet pushed to remote**)
+- **Remote main:** `156bfa6` (v0.33.25, PR #277 merge commit)
+- **Working tree:** Clean
+- **Desktop build:** `agentmux-cef-0.33.26-x64-portable/` — running
+
+## Pending Action
+
+- `git push origin main` to sync the v0.33.26 bump to remote

--- a/docs/SPEC-VA-REDUCTION.md
+++ b/docs/SPEC-VA-REDUCTION.md
@@ -1,0 +1,197 @@
+# Spec: Virtual Address Space Reduction for CEF Subprocesses
+
+**Status:** Draft (empirically validated)
+**Date:** 2026-04-07
+**Author:** AgentA
+**Affects:** `agentmux-cef` (CEF host), `main.rs`, `app.rs`
+
+---
+
+## Problem Statement
+
+Each CEF subprocess reserves ~100GB of virtual address space (VA) on Windows. A single AgentMux instance (v0.33.58) spawns 4 subprocesses, consuming **401.7GB VA total** while using only **63.4MB committed memory**. The system has 87.7GB total VA ceiling (32GB RAM + 56GB page file), with only **2.9GB free VA** during normal operation — one more subprocess or a second instance will trigger OOM crashes (`0xe0000008`).
+
+---
+
+## Empirical Measurements (2026-04-07)
+
+### Per-Process VA Breakdown
+
+Measured on running AgentMux v0.33.58 portable instance:
+
+| PID   | Process Type      | Virtual (GB) | Committed (MB) | Working Set (MB) |
+|-------|-------------------|-------------|-----------------|-------------------|
+| 22440 | browser (main)    | 100.56      | 38.3            | 100.9             |
+| 33052 | gpu-process       | 100.38      | 7.9             | 23.1              |
+| 25052 | utility (network) | 100.40      | 9.2             | 28.1              |
+| 2412  | utility (storage) | 100.39      | 8.0             | 17.9              |
+| 27500 | agentmux-srv      | 4.17        | 23.7            | 34.2              |
+| **Total** | | **405.9 GB** | **87.1 MB** | **204.2 MB** |
+
+**No renderer process is present** — the frontend runs in the browser process (Alloy mode). The 100GB reservation appears in ALL Chromium processes regardless of type.
+
+### System VA Budget
+
+| Metric | Value |
+|--------|-------|
+| Physical RAM | 31.9 GB |
+| Page file | 55.8 GB (system-managed) |
+| Total VA ceiling | 87.7 GB |
+| Free VA | 2.9 GB |
+| CEF VA consumption | 401.7 GB |
+
+The 401.7GB VA exceeds the 87.7GB ceiling by 4.6x. Windows allows this because `MEM_RESERVE` does not count against commit charge — only `MEM_COMMIT` does. The system works until committed memory approaches the ceiling, at which point new reservations or commits fail with OOM.
+
+### VA Memory Map (per subprocess)
+
+Every CEF subprocess shows the **identical** reservation pattern:
+
+```
+Region                Size     State    Type
+0x????????????0000    32.00 GB RESERVE  PRIVATE   ← PartitionAlloc GigaCage
+0x????????????0000    16.00 GB RESERVE  PRIVATE   ← PartitionAlloc regular pool
+0x????????????0000    16.00 GB RESERVE  PRIVATE   ← PartitionAlloc BRP pool
+0x????????????0000    16.00 GB RESERVE  PRIVATE   ← PartitionAlloc configurable pool
+0x????????????0000    16.00 GB RESERVE  PRIVATE   ← PartitionAlloc thread-isolated pool
+0x7FF4????????0000     4.00 GB RESERVE  PRIVATE   ← V8 pointer compression cage
+0x7FFCA6801000         0.21 GB COMMIT   IMAGE     ← libcef.dll (250 MB)
+                     --------
+Total:              ~100.2 GB reserved + 0.3 GB committed
+```
+
+### What Each Reservation Is
+
+1. **32 GB — PartitionAlloc GigaCage**: The umbrella address space region that houses all PA pools. Reserves 32GB contiguous VA for address masking (fast "is this pointer from PA?" checks via single bitwise AND).
+
+2. **4x 16 GB — PartitionAlloc Pools**: Each pool is a separate VA region:
+   - **Regular pool**: General allocations not protected by BackupRefPtr
+   - **BRP pool**: Allocations protected by BackupRefPtr (use-after-free mitigation)
+   - **Configurable pool**: Used by V8 Sandbox when enabled; still reserved when disabled
+   - **Thread-isolated pool**: Per-thread memory with pkey isolation (x64 only)
+
+3. **4 GB — V8 Pointer Compression Cage**: V8 uses pointer compression (storing 32-bit offsets instead of 64-bit pointers). This requires a 4GB region where all V8 heap objects live, so any object can be addressed as `base + 32bit_offset`.
+
+4. **0.21 GB — libcef.dll**: The CEF/Chromium binary itself, memory-mapped.
+
+**Total: 32 + 64 + 4 + 0.21 = ~100.2 GB per subprocess**
+
+### Critical Finding: V8 Sandbox Is Already DISABLED
+
+Despite the earlier hypothesis, the V8 Sandbox (1TB memory cage) is **not the cause** of the 100GB reservation. Evidence:
+
+1. **CEF disables V8 Sandbox since M103**: CEF set `v8_enable_sandbox=false` starting in Chromium 103 because the sandbox broke `CefV8Value::CreateArrayBuffer` (external memory can't be passed into the cage). Source: [CEF issue #3332](https://bitbucket.org/chromiumembedded/cef/issues/3332).
+
+2. **No 1TB region observed**: If the V8 sandbox were enabled, we'd see a single ~1TB `MEM_RESERVE` region. We don't — the largest single region is 32GB.
+
+3. **Non-renderer processes have the same 100GB**: The GPU process and utility processes (which don't run V8/JS at all) also reserve 100GB. This proves the reservation comes from **PartitionAlloc**, which is used by ALL Chromium processes, not from V8.
+
+4. **The `v8-sandbox` string in libcef.dll** is just code/symbol references (the feature detection code exists regardless of whether the feature is compiled in). It does NOT prove the sandbox is enabled.
+
+**The "100GB → 4GB by disabling V8 sandbox" claim from the earlier conversation was wrong.** The V8 sandbox is already disabled. The 100GB comes from PartitionAlloc's pool architecture, which cannot be disabled without rebuilding Chromium with a different allocator.
+
+---
+
+## What Actually Matters
+
+Since the 100GB is from PartitionAlloc (not V8), the mitigation options are different:
+
+### Option 1: `--in-process-gpu` — Eliminate GPU subprocess (saves 100GB)
+
+Merges the GPU process into the browser process. One fewer 100GB subprocess.
+
+```rust
+// In app.rs on_before_command_line_processing:
+let key = CefString::from("in-process-gpu");
+cmd.append_switch(Some(&key));
+```
+
+**Impact:** 4 → 3 subprocesses = ~300GB instead of ~400GB.
+**Risk:** GPU driver crash kills the whole app instead of just restarting the GPU process. Low risk for a local desktop app.
+
+### Option 2: `--renderer-process-limit=1` — Cap renderer processes
+
+Even though we currently have 0 renderers (Alloy mode), DevTools and popups can spawn them. Capping to 1 prevents runaway renderer spawning.
+
+```rust
+let key = CefString::from("renderer-process-limit");
+let val = CefString::from("1");
+cmd.append_switch_with_value(Some(&key), Some(&val));
+```
+
+**Impact:** Prevents future surprise 100GB subprocesses when opening DevTools.
+**Risk:** None for single-origin app.
+
+### Option 3: Increase page file (system setting)
+
+**Current:** 56GB page file → 87.7GB VA ceiling
+**Target:** 120GB page file → ~152GB VA ceiling
+
+This doesn't reduce per-process VA but raises the ceiling. With `--in-process-gpu` (300GB VA, only ~60MB committed), the system runs comfortably below the commit charge limit.
+
+### Option 4: Custom Chromium/CEF build with reduced PA pool sizes
+
+PartitionAlloc pool sizes are compile-time constants in `partition_alloc_constants.h`. The 16GB per pool and 32GB GigaCage are hardcoded. Reducing them (e.g., to 4GB per pool) would require:
+- Building CEF from source (~8 hours on fast hardware)
+- Patching PartitionAlloc constants
+- Regression testing (PA uses pool size for address masking — smaller pools may break fast-path checks)
+
+**This is the nuclear option.** Not recommended unless Options 1-3 are insufficient.
+
+### Option 5: `--no-untrusted-code-mitigations` — Free performance (no VA impact)
+
+Disables V8 Spectre JIT mitigations. Up to 15% perf improvement for compute-heavy JS. No VA impact, but a free win for trusted content.
+
+```rust
+let key = CefString::from("no-untrusted-code-mitigations");
+cmd.append_switch(Some(&key));
+```
+
+---
+
+## Recommended Plan
+
+1. **Apply Options 1, 2, 5** in `app.rs:225` (4 lines of code total)
+2. **Bump, build, measure:** Expected result: 3 subprocesses × 100GB = ~300GB VA, ~50MB committed
+3. **Increase page file** to 120GB (system setting) for headroom
+4. **Validate:** Run two instances for 4+ hours, monitor VA
+
+**Expected final state:** Two instances = ~600GB VA reserved, ~100MB committed, against a ~152GB commit charge ceiling. Since `MEM_RESERVE` doesn't count against commit charge, this should run indefinitely without OOM.
+
+---
+
+## Verification Script
+
+```powershell
+# Check VA per AgentMux subprocess
+Get-Process | Where-Object { $_.ProcessName -like '*agentmux*' } |
+  Select-Object Id, ProcessName,
+    @{N='VA_GB';E={[math]::Round($_.VirtualMemorySize64/1GB,1)}},
+    @{N='Commit_MB';E={[math]::Round($_.PrivateMemorySize64/1MB,1)}},
+    @{N='WS_MB';E={[math]::Round($_.WorkingSet64/1MB,1)}} |
+  Format-Table -AutoSize
+
+# Check system VA headroom
+$os = Get-CimInstance Win32_OperatingSystem
+"Free VA: {0:F1} GB / {1:F1} GB total" -f ($os.FreeVirtualMemory/1MB), ($os.TotalVirtualMemorySize/1MB)
+```
+
+**Success criteria:**
+- Single instance: 3 subprocesses (not 4), ~300GB VA, no GPU process
+- Two instances: ~600GB VA, > 5GB free VA remaining
+- No OOM crashes after 4+ hours
+
+---
+
+## References
+
+- [V8 Sandbox](https://v8.dev/blog/sandbox) — 1TB VA cage (NOT the cause here — disabled in CEF since M103)
+- [CEF Issue #3332](https://bitbucket.org/chromiumembedded/cef/issues/3332) — CEF disabled V8 sandbox for ArrayBuffer compatibility
+- [VSCode 1TB VA](https://afana.me/archive/2023/06/15/vscode-high-virtual-memory/) — Electron (with V8 sandbox enabled) shows 1TB; CEF does not
+- [PartitionAlloc Design](https://chromium.googlesource.com/chromium/src/+/master/base/allocator/partition_allocator/PartitionAlloc.md) — Pool architecture, GigaCage
+- [PartitionAlloc Glossary](https://chromium.googlesource.com/chromium/src/+/HEAD/base/allocator/partition_allocator/glossary.md) — Pool types: regular, BRP, configurable, thread-isolated
+- [GigaCage Implementation](https://issues.chromium.org/issues/40132577) — Original Chromium issue for GigaCage
+- [Chromium OOM Investigation](https://chromium.googlesource.com/chromium/src/+/refs/tags/134.0.6960.0/docs/memory/oom.md) — PartitionAlloc VA overcounting
+- [V8 Untrusted Code Mitigations](https://v8.dev/docs/untrusted-code-mitigations) — Spectre JIT mitigations (separate from sandbox)
+- [CEF Forum: renderer-process-limit](https://magpcss.org/ceforum/viewtopic.php?p=44500) — Limiting renderer processes
+- [CEF Forum: GPU Process](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=11953) — in-process-gpu switch
+- [Chromium Command Line Switches](https://peter.sh/experiments/chromium-command-line-switches/) — Full switch reference

--- a/docs/analysis/blank-panes-orphaned-layout-nodes.md
+++ b/docs/analysis/blank-panes-orphaned-layout-nodes.md
@@ -1,0 +1,77 @@
+# Blank Panes: Orphaned Layout Nodes
+
+**Date:** 2026-04-09
+**Instance:** v0.33.69 dev (db at `%APPDATA%/ai.agentmux.cef.v0-33-69/db/wave.db`)
+
+## Symptom
+
+Two blank/dark pane areas in the layout. No content renders; the pane frame exists but is empty.
+
+## Root Cause
+
+The layout tree (`db_layout`) contains leaf nodes that reference blocks which no longer exist in `db_block`. When a block is deleted, its entry is removed from:
+- `db_block` (the block row is deleted)
+- `db_tab.blockids` (the block ID is removed from the tab's block list)
+
+But the layout tree (`db_layout.rootnode.children[]` and `db_layout.leaforder[]`) is **not pruned** — the deleted block's node remains in the flex tree, occupying space but rendering nothing.
+
+## Evidence
+
+```
+Layout 354837d7 has 3 leaf nodes:
+  1. blockid: d525dd68  -> NOT IN db_block (orphaned)
+  2. blockid: 34128bdc  -> NOT IN db_block (orphaned)
+  3. blockid: 1d9a8231  -> EXISTS (agent view)
+
+Tab blockids: [1d9a8231]  (only 1 block, but layout has 3 slots)
+```
+
+## Affected Code Path
+
+Block deletion flows through `DeleteBlock` in the service layer:
+- `agentmux-srv/src/server/service.rs` — handles the HTTP `object.DeleteBlock` call
+- Deletes from `db_block` and removes the ID from `db_tab.blockids`
+- Does NOT prune the corresponding node from `db_layout.rootnode`
+
+The frontend's `onNodeDelete` callback (in `tabcontent.tsx`) attempts to remove the node from the layout model, but if the frontend is out of sync or the delete races with a layout update, the orphaned node persists in the database.
+
+## Proposed Fix: Layout Self-Healing
+
+Instead of relying on the delete path to be perfect, add a **layout validation pass** that runs:
+
+1. **On tab load** (when a tab becomes active):
+   - Walk `rootnode.children` recursively
+   - For each leaf node with a `blockId`, check if the block exists in `db_block`
+   - If not, remove that leaf node from the tree and update `leaforder`
+   - Save the pruned layout back to the database
+
+2. **After any `DeleteBlock` call** (belt-and-suspenders):
+   - Same validation: prune any leaf nodes referencing the deleted block ID
+   - This handles the case where the frontend's layout update was lost
+
+3. **Frontend fallback** (defense in depth):
+   - In the pane renderer, if a block ID has no corresponding block data, render nothing and trigger a layout prune via RPC
+   - Prevents blank rectangles from ever being visible to the user
+
+### Key Principle
+
+The layout tree should be treated as a **derived structure** from the block list — if a block doesn't exist, its layout node must not exist. This invariant should be enforced on read (self-healing), not just on write (delete path).
+
+## Quick Fix (manual, for the current session)
+
+```sql
+-- Remove orphaned leaf nodes from the layout
+-- Run against: %APPDATA%/ai.agentmux.cef.v0-33-69/db/wave.db
+-- (requires app restart after)
+```
+
+Or: close the blank panes via the UI (click X on the pane header), which should trigger `onNodeDelete` and prune them.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `agentmux-srv/src/server/service.rs` | Add layout pruning after `DeleteBlock` |
+| `agentmux-srv/src/backend/wcore/tab.rs` | Add `validate_layout()` called on tab activation |
+| `agentmux-srv/src/backend/obj.rs` | Helper: `prune_orphaned_layout_nodes(layout, valid_block_ids)` |
+| `frontend/app/tab/tabcontent.tsx` | Render empty placeholder + trigger prune RPC for missing blocks |

--- a/docs/analysis/blank-tab-contextmenu-bug.md
+++ b/docs/analysis/blank-tab-contextmenu-bug.md
@@ -1,0 +1,116 @@
+# Bug: Right-click context menu stops working on empty tab after closing all panes
+
+**Date:** 2026-04-09
+**Severity:** UX bug — blocks discoverability of widget launcher
+
+## Symptom
+
+1. Fresh startup with no panes → right-click on blank background → widget menu appears (works)
+2. Open a terminal (or any pane) → close it → back to blank background
+3. Right-click on blank background → nothing happens (broken)
+
+## Root Cause
+
+The TileLayout's `.display-container` div is `position: absolute; width: 100%; height: 100%` with a z-index, creating a full-size invisible overlay that intercepts the `contextmenu` event.
+
+### Why it works on first startup
+
+On first startup, the `TileLayout` component mounts but the `.display-container` has no content. The right-click event propagates from the empty `.display-container` through to the parent div (in `tabcontent.tsx:94`) because there are no child elements to consume it.
+
+**Actually, the real reason it works initially:** On first launch, the tab may not exist yet (Show gate at `tabcontent.tsx:97` returns false), so TileLayout never mounts. The parent div receives the click directly.
+
+### Why it breaks after closing panes
+
+After opening and closing panes:
+1. The tab exists (`tabData() != null` → Show gate stays true)
+2. TileLayout stays mounted with an empty `.display-container`
+3. The `.display-container` is a 100% × 100% absolutely-positioned div
+4. It sits **above** the parent div in z-order
+5. The `contextmenu` event fires on `.display-container`, not on the parent div
+6. Nothing handles it on `.display-container` → event is consumed with no effect
+
+The parent div's `onContextMenu` handler (tabcontent.tsx:94) never fires because the event target is the `.display-container`, and the event doesn't bubble to the parent div's handler since `.display-container` is a child of `.tile-layout`, which IS inside the parent div — so bubbling should work.
+
+**Wait — bubbling SHOULD work.** The parent div contains `.tile-layout` which contains `.display-container`. A `contextmenu` event on `.display-container` should bubble up to the parent div.
+
+### Revised diagnosis: the handler's guard clause
+
+Looking more carefully at the handler:
+
+```typescript
+const handleContextMenu = (e: MouseEvent) => {
+    const tab = tabData();
+    if (!tab || (tab.blockids?.length ?? 0) > 0) return;  // LINE 82
+    ...
+};
+```
+
+The guard checks `tab.blockids?.length`. After closing the last pane:
+- `DeleteBlock` removes the block from `tab.blockids` on the backend
+- But the frontend's reactive `tabData()` atom may not have updated yet
+- If `tabData()` still shows the old `blockids` with the deleted block ID, `length > 0` → handler returns early
+
+**This is a race condition:** The `DeleteBlock` RPC completes and the block is removed from the DB, but the frontend's WaveObj atom for the tab hasn't received the update event yet. During this window, the context menu handler sees stale `blockids` and bails out.
+
+After the atom updates, subsequent right-clicks should work — but by then the user has already concluded it's broken.
+
+**Alternative theory:** The blockids array IS updated, but there's another issue. The `onNodeDelete` callback in the TileLayout triggers `DeleteBlock`, which updates the tab's blockids. The layout tree's rootnode becomes undefined, but the tab atom updates reactively. The handler should see `blockids.length === 0` on the next right-click.
+
+Let me reconsider: **Does the tab get a new blockids update when the last block is deleted?**
+
+In `block.rs:delete_block()`:
+```rust
+tab.blockids.retain(|id| id != block_id);
+store.update(&mut tab)?;
+```
+
+The tab IS updated in the DB. The frontend receives a WaveObjUpdate for the tab via WPS. So `tabData().blockids` should eventually become `[]`.
+
+### Most likely cause: event target and pointer-events
+
+The `.display-container` has `pointer-events: auto` by default. Even when empty, it captures mouse events. The `contextmenu` event fires on `.display-container` and bubbles up to the parent div — **this should work**.
+
+Unless: the TileLayout's `.tile-layout` div or the `.display-container` has an `onContextMenu` handler that calls `stopPropagation()`.
+
+**Check for stopPropagation on display-container or tile-layout.**
+
+## Proposed Fix
+
+Regardless of the exact cause, the fix is straightforward — add the context menu handler directly to the TileLayout's display-container (or the tile-layout div), so it works whether or not events bubble correctly:
+
+### Option A: Forward context menu from TileLayout (cleanest)
+
+Add an `onContextMenu` prop to TileLayout that fires when clicking empty space:
+
+```typescript
+// In TileLayout.win32.tsx — on the display-container div:
+onContextMenu={(e) => {
+    // Only fire if clicking empty space (no leaf node under cursor)
+    if (e.target === displayContainerRef.current) {
+        props.contents.onEmptyContextMenu?.(e);
+    }
+}}
+```
+
+### Option B: Add handler in tabcontent.tsx on the tile-layout wrapper
+
+Wrap TileLayout in a div that handles contextmenu and doesn't rely on bubbling.
+
+### Option C: Use pointer-events: none on empty display-container
+
+```scss
+.display-container:empty {
+    pointer-events: none;
+}
+```
+
+This lets clicks pass through to the parent when the container has no children. But `:empty` might not work if there are whitespace text nodes.
+
+## Files
+
+| File | Line | Role |
+|------|------|------|
+| `frontend/app/tab/tabcontent.tsx` | 80-94 | Context menu handler + guard clause |
+| `frontend/layout/lib/TileLayout.win32.tsx` | 129-151 | Display container that may intercept events |
+| `frontend/layout/lib/tilelayout.scss` | 12-27 | Absolute positioning + z-index on display-container |
+| `agentmux-srv/src/backend/wcore/block.rs` | 36-46 | Backend delete_block removes from tab.blockids |

--- a/docs/analysis/cef-white-flash-on-startup.md
+++ b/docs/analysis/cef-white-flash-on-startup.md
@@ -1,0 +1,420 @@
+# CEF White Flash on Startup - Analysis & Solutions
+
+**Date:** 2026-03-31
+**Platform:** Windows 10/11, Rust CEF host (cef-rs)
+**Problem:** Brief white screen visible before CEF renders dark-themed content
+
+---
+
+## Root Cause Analysis
+
+The white flash has **three independent sources**, all of which contribute to the visible artifact. Fixing only one may reduce but not eliminate the flash.
+
+### Source 1: DWM Default Window Background (Win32 layer)
+
+When a Win32 window is first created, the Desktop Window Manager (DWM) allocates a
+**default white background surface** for it. This is the surface DWM composites before
+your application or any child window has painted anything. This white surface is visible
+from the moment `ShowWindow` is called until the first successful
+`WM_PAINT`/`WM_ERASEBKGND` cycle completes.
+
+Even if you set `hbrBackground` in your `WNDCLASSEX` to a dark brush, there is a race:
+DWM shows its default surface before your window procedure receives `WM_ERASEBKGND`.
+
+### Source 2: Chromium's Internal White Default (Blink/Renderer layer)
+
+Chromium's `RenderWidgetHostViewBase::background_color_` defaults to **white**. The
+first frame the compositor produces uses this color. The `background_color` field in
+`CefSettings` and `CefBrowserSettings` instructs CEF to override this default, but the
+override only takes effect **after** the renderer process has initialized and the
+`RenderWidgetHost` has been created. There is a window of time (tens to hundreds of
+milliseconds) where the browser HWND exists but the renderer hasn't applied the
+background color yet.
+
+Additionally, in certain CEF versions (notably 129-131 era), `background_color` had
+regressions where it stopped working entirely, though this was later determined to be
+related to pages that set their own CSS background overriding the setting.
+
+### Source 3: CEF Views Framework Hardcoded White (Views layer)
+
+When using CEF Views mode (`CefBrowserView` + `CefWindow`), the underlying Chromium
+Views framework initializes `view_view.h` with a **hardcoded white background**. The
+`CefBrowserViewImpl::SetBackgroundColor()` method only changes the
+`resizeBackgroundColor` (used during window resize), not the initial composition
+background. This means the Views layer paints white independently of what the renderer
+will eventually produce.
+
+### Timeline of a typical launch (without fixes)
+
+```
+t=0ms    CreateWindowEx() called
+         DWM shows default white surface
+t=1ms    WM_ERASEBKGND received (if hbrBackground is set, paints dark here)
+t=2ms    CEF child HWND created inside parent
+         Child also has DWM white default
+t=5ms    ShowWindow(SW_SHOW) on parent
+         USER SEES WHITE (from DWM default and/or child background)
+t=20ms   CEF renderer process initializes
+t=50ms   Renderer creates RenderWidgetHost, applies background_color
+t=80ms   First compositor frame with dark background arrives
+         White flash ends
+```
+
+---
+
+## Solutions (Ranked by Reliability)
+
+### 1. DWM Cloaking Technique (BEST - eliminates flash entirely)
+
+**Reliability: Highest**
+**Complexity: Medium**
+**Works in: Native mode and CEF Views mode**
+
+This is the technique that Chromium itself (Chrome/Edge) adopted in 2025 to fix the
+identical problem in dark mode. It completely eliminates the white flash by hiding the
+window from DWM until you have painted the correct background.
+
+#### How it works
+
+1. After `CreateWindowEx`, **cloak** the window using `DwmSetWindowAttribute` with `DWMWA_CLOAK = TRUE`. The window exists but is invisible to the user -- DWM does not composite it.
+2. Call `ShowWindow(SW_SHOW)` -- the window is "shown" in Win32 terms but still invisible because it's cloaked.
+3. Use GDI to `FillRect` the entire client area with your dark background color.
+4. **Uncloak** the window with `DWMWA_CLOAK = FALSE`. The user now sees the dark-painted window immediately.
+
+#### Code example (Rust, using windows-sys)
+
+```rust
+use windows_sys::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_CLOAK};
+use windows_sys::Win32::Graphics::Gdi::{
+    CreateSolidBrush, FillRect, GetDC, ReleaseDC, DeleteObject,
+};
+use windows_sys::Win32::UI::WindowsAndMessaging::GetClientRect;
+use windows_sys::Win32::Foundation::{BOOL, TRUE, FALSE, RECT};
+
+/// Call this AFTER CreateWindowEx but BEFORE the window is visible to the user.
+/// `hwnd` is your top-level application window handle.
+unsafe fn prevent_white_flash(hwnd: isize, r: u8, g: u8, b: u8) {
+    // Step 1: Cloak the window (hide from DWM compositor)
+    let cloak: BOOL = TRUE;
+    DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_CLOAK,
+        &cloak as *const _ as *const _,
+        std::mem::size_of::<BOOL>() as u32,
+    );
+
+    // Step 2: Show the window (Win32 state, but user can't see it yet)
+    windows_sys::Win32::UI::WindowsAndMessaging::ShowWindow(
+        hwnd,
+        windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOW,
+    );
+
+    // Step 3: Paint the client area with the desired dark color
+    let hdc = GetDC(hwnd);
+    if hdc != 0 {
+        let brush = CreateSolidBrush(r as u32 | (g as u32) << 8 | (b as u32) << 16);
+        let mut rect: RECT = std::mem::zeroed();
+        GetClientRect(hwnd, &mut rect);
+        FillRect(hdc, &rect, brush);
+        ReleaseDC(hwnd, hdc);
+        DeleteObject(brush as _);
+    }
+
+    // Step 4: Uncloak -- window becomes visible with dark background
+    let uncloak: BOOL = FALSE;
+    DwmSetWindowAttribute(
+        hwnd,
+        DWMWA_CLOAK,
+        &uncloak as *const _ as *const _,
+        std::mem::size_of::<BOOL>() as u32,
+    );
+}
+```
+
+#### Notes
+
+- `DWMWA_CLOAK` has value `13` and is available on Windows 8+.
+- This addresses **Source 1** (DWM default). The CEF child HWND still has its own
+  DWM surface, but if the parent is painted dark and CEF's `background_color` is set
+  correctly, the child's brief white is masked by the parent's dark fill.
+- The Chromium commit implementing this lives in `ui/views/win/hwnd_message_handler.cc`.
+
+---
+
+### 2. Win32 Window Class Background Brush + WM_ERASEBKGND (Good baseline)
+
+**Reliability: High for parent window, partial for CEF child**
+**Complexity: Low**
+**Works in: Native mode and CEF Views mode**
+
+This ensures your parent Win32 window never shows white, even without cloaking.
+
+#### Implementation
+
+**A) Set the window class background brush at registration time:**
+
+```rust
+use windows_sys::Win32::Graphics::Gdi::CreateSolidBrush;
+
+let dark_brush = CreateSolidBrush(0x00222222); // RGB(34, 34, 34) in COLORREF format
+
+let wc = WNDCLASSEXW {
+    cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+    hbrBackground: dark_brush,
+    // ... other fields ...
+};
+RegisterClassExW(&wc);
+```
+
+**B) Override WM_ERASEBKGND on the CEF child's parent:**
+
+```rust
+// In your window procedure (wndproc)
+match msg {
+    WM_ERASEBKGND => {
+        let hdc = wparam as isize;
+        let mut rect: RECT = std::mem::zeroed();
+        GetClientRect(hwnd, &mut rect);
+        let brush = CreateSolidBrush(0x00222222);
+        FillRect(hdc, &rect, brush);
+        DeleteObject(brush as _);
+        return 1; // We handled it, no further erasing needed
+    }
+    // ...
+}
+```
+
+**C) Change the CEF browser child window's class brush after creation:**
+
+```rust
+use windows_sys::Win32::UI::WindowsAndMessaging::{SetClassLongPtrW, GCLP_HBRBACKGROUND};
+
+// After CefBrowserHost::CreateBrowser returns and you have the browser HWND:
+let browser_hwnd = browser.get_host().get_window_handle();
+let dark_brush = CreateSolidBrush(0x00222222);
+SetClassLongPtrW(browser_hwnd, GCLP_HBRBACKGROUND, dark_brush as isize);
+```
+
+#### Limitations
+
+- This only addresses **Source 1** (Win32/DWM layer). The Chromium renderer's initial
+  white frame (**Source 2**) will still briefly appear inside the CEF child area.
+- `SetClassLongPtrW` changes the brush for ALL windows of that class, which may affect
+  other CEF browser instances if you need different colors.
+
+---
+
+### 3. CefSettings.background_color + CefBrowserSettings.background_color (Essential but insufficient alone)
+
+**Reliability: Medium (addresses Source 2 only)**
+**Complexity: Low**
+**Works in: Both modes**
+
+This is what you already have. It is necessary but not sufficient because it only
+controls the renderer's default background -- it does not affect the Win32/DWM layer
+or the Views framework layer.
+
+```rust
+// In your CEF initialization:
+let mut settings = cef::Settings::default();
+settings.background_color = 0xFF222222; // ARGB: fully opaque, rgb(34,34,34)
+
+// When creating each browser:
+let mut browser_settings = cef::BrowserSettings::default();
+browser_settings.background_color = 0xFF222222;
+```
+
+#### Important details
+
+- Alpha must be `0xFF` (fully opaque) or `0x00` (fully transparent). No partial alpha.
+- If alpha is `0x00` for a windowed browser, it falls back to `CefSettings.background_color`.
+- The page's own CSS `background-color` will override this once loaded.
+- The `--background-color` command-line switch (`cefclient --background-color=green`)
+  is an alternative way to set the same value.
+
+---
+
+### 4. Create Window Hidden, Show After First Paint (Eliminates flash visually)
+
+**Reliability: High**
+**Complexity: Medium**
+**Works in: Both modes (different implementation)**
+
+Instead of trying to paint the right color before the user sees the window, hide the
+window entirely until CEF has rendered its first frame.
+
+#### Native mode (Alloy style)
+
+```rust
+// Option A: Use WindowInfo.hidden field
+window_info.hidden = 1; // Create browser view initially hidden
+
+// Option B: Create parent window without WS_VISIBLE
+let hwnd = CreateWindowExW(
+    0,
+    class_name,
+    window_title,
+    WS_OVERLAPPEDWINDOW, // Note: no WS_VISIBLE
+    // ...
+);
+
+// In your CefLoadHandler::OnLoadingStateChange implementation:
+fn on_loading_state_change(&self, browser: &Browser, is_loading: bool, ...) {
+    if !is_loading {
+        // Page finished loading -- safe to show
+        let hwnd = browser.get_host().get_window_handle();
+        ShowWindow(hwnd, SW_SHOW);
+    }
+}
+```
+
+#### CEF Views mode
+
+```rust
+// In CefWindowDelegate::GetInitialShowState, return hidden:
+fn get_initial_show_state(&self, window: &CefWindow) -> cef_show_state_t {
+    CEF_SHOW_STATE_HIDDEN
+}
+
+// In CefLoadHandler::OnLoadingStateChange:
+fn on_loading_state_change(&self, browser: &Browser, is_loading: bool, ...) {
+    if !is_loading {
+        // Get the CefWindow and show it
+        if let Some(view) = browser.get_host().get_browser_view() {
+            if let Some(window) = view.get_window() {
+                window.show();
+            }
+        }
+    }
+}
+```
+
+#### Limitations
+
+- **Perceived startup time increases.** The user sees nothing until the page loads,
+  which may feel slower than seeing a dark window appear instantly.
+- **Splash screen needed?** Some apps show a native splash window (painted dark) while
+  CEF loads, then swap to the CEF window.
+- **CEF issue #3638 warning:** On Windows, changing visibility during startup can trigger
+  native window occlusion tracking bugs that result in permanently blank browser content.
+  Avoid `Show()` -> `Hide()` -> `Show()` patterns. Show exactly once.
+
+---
+
+### 5. DWM Dark Mode Title Bar (Cosmetic improvement for title bar only)
+
+**Reliability: High (for title bar area)**
+**Complexity: Very low**
+**Works in: Both modes**
+
+This does not fix the client area flash but prevents the title bar from being bright
+white on dark-themed apps.
+
+```rust
+use windows_sys::Win32::Graphics::Dwm::{DwmSetWindowAttribute, DWMWA_USE_IMMERSIVE_DARK_MODE};
+
+let use_dark: BOOL = TRUE;
+DwmSetWindowAttribute(
+    hwnd,
+    DWMWA_USE_IMMERSIVE_DARK_MODE, // value = 20
+    &use_dark as *const _ as *const _,
+    std::mem::size_of::<BOOL>() as u32,
+);
+```
+
+---
+
+### 6. Custom User Stylesheet Injection (Legacy workaround)
+
+**Reliability: Low**
+**Complexity: Low**
+**Works in: Both modes**
+
+Older CEF versions supported `user_style_sheet_location` to inject a CSS rule like
+`body { background-color: #222 !important; }` as a base64 data URL. This made Blink
+apply the dark background before the page's own CSS loaded.
+
+**This approach is deprecated** in modern CEF. The `user_style_sheet_location` setting
+was removed. If needed, the same effect can be achieved via `CefRequestHandler` by
+injecting a `<style>` tag into the response, but this is fragile and not recommended.
+
+---
+
+## Recommended Fix (Combined Approach)
+
+For the best result, combine solutions **1 + 2 + 3**:
+
+```
+Startup sequence:
+1. Register WNDCLASSEX with dark hbrBackground (Solution 2A)
+2. CreateWindowEx (window exists but is white in DWM)
+3. Cloak the window with DWMWA_CLOAK (Solution 1)
+4. ShowWindow(SW_SHOW) -- cloaked, user sees nothing
+5. FillRect entire client area with dark brush (Solution 1)
+6. Uncloak -- user sees dark window instantly (Solution 1)
+7. CefBrowserHost::CreateBrowser with background_color=0xFF222222 (Solution 3)
+8. CEF renderer initializes and paints first frame
+   (brief moment where dark GDI paint is visible, then CEF content appears)
+```
+
+This eliminates the white flash from all three sources:
+- **DWM layer:** Cloaking prevents the default white from ever being visible
+- **Win32 layer:** Dark brush ensures WM_ERASEBKGND paints dark
+- **Renderer layer:** `background_color` ensures CEF's first frame is dark
+
+### What about CEF Views mode specifically?
+
+In CEF Views mode, you don't directly control the Win32 window creation. However:
+- `CefSettings.background_color` still applies (Solution 3)
+- You can get the native HWND from `CefWindow::GetWindowHandle()` in
+  `OnWindowCreated` and apply the cloaking + brush techniques at that point
+- The `GetInitialShowState` returning `CEF_SHOW_STATE_HIDDEN` approach (Solution 4)
+  is an alternative if cloaking is too complex
+
+---
+
+## CEF Version Notes
+
+| CEF Version | background_color works? | Notes |
+|-------------|------------------------|-------|
+| < 3202      | Partially              | White flash common, Views layer hardcoded white |
+| 3202+       | Yes                    | Fix for Views background color propagation |
+| 111         | Yes                    | Confirmed working |
+| 129-131     | Yes*                   | Works, but pages with own CSS background override it |
+| 132+        | Yes                    | `--background-color` CLI flag confirmed working |
+
+*The issue #3841 reports of "not working" in 129-131 were user error -- the loaded
+HTML had explicit CSS background that overrode the setting.
+
+---
+
+## How Other Apps Handle This
+
+| App | Technique |
+|-----|-----------|
+| **Chrome/Edge** | DWM cloaking (DWMWA_CLOAK) since 2025 -- paint dark while cloaked, then uncloak |
+| **Electron** | `backgroundColor` option on BrowserWindow + `ready-to-show` event to delay display |
+| **Spotify** | CEF-based; users report white flash still occurs on startup (not fully solved) |
+| **Discord** | Electron; uses `backgroundColor: '#2f3136'` + delayed show |
+| **VS Code** | Electron; `backgroundColor` from theme + splash/loading indicator |
+
+---
+
+## References
+
+- [CEF Forum: Initial black browser background color](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=11044)
+- [CEF Forum: Customize browser_background_color causes white flash](https://magpcss.org/ceforum/viewtopic.php?f=7&t=15337)
+- [CEF Forum: Don't show window until browser loaded](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=13544)
+- [CEF Forum: Create CefBrowserWindow in initial hidden state](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=17001)
+- [CEF Issue #3841: background_color not working v129-131](https://github.com/chromiumembedded/cef/issues/3841)
+- [CEF Issue #3610: Runtime theme switching](https://github.com/chromiumembedded/cef/issues/3610)
+- [CEF Issue #3638: Window visibility during startup](https://github.com/chromiumembedded/cef/issues/3638)
+- [Chromium: hwnd_message_handler.cc DWMWA_CLOAK implementation](https://chromium.googlesource.com/chromium/src/+/bde885b4e8cf11db7ba2af6c70a6580830a52e7a/ui/views/win/hwnd_message_handler.cc)
+- [Microsoft fixing Chrome/Edge white flash in dark mode](https://www.windowslatest.com/2025/01/08/microsoft-finally-fixing-chrome-edges-white-flash-in-dark-mode-on-windows-11-windows-10/)
+- [Electron Issue #2172: Flash of white when window shown](https://github.com/electron/electron/issues/2172)
+- [CefSharp Issue #1923: Initial background of chromium browser](https://github.com/cefsharp/CefSharp/issues/1923)
+- [cef_settings_t docs (Spotify CDN)](https://cef-builds.spotifycdn.com/docs/118.7/structcef__settings__t.html)
+- [cef_window_info_t docs](https://cef-builds.spotifycdn.com/docs/131.0/structcef__window__info__t.html)
+- [Win32: DwmSetWindowAttribute / DWMWA_CLOAK](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute)
+- [Win32: SetClassLongPtrW / GCLP_HBRBACKGROUND](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setclasslongptrw)
+- [Win32: WM_ERASEBKGND handling](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-erasebkgnd)

--- a/docs/analysis/cef-white-flash-retro.md
+++ b/docs/analysis/cef-white-flash-retro.md
@@ -1,0 +1,115 @@
+# CEF White Flash on Startup — Retro & Research
+
+**Date:** 2026-04-01
+**Status:** Close to solved — testbed confirms zero-flash with the right sequence
+**Blocker level:** Cosmetic (app works, UX issue)
+
+## Problem
+
+When AgentMux launches, a white rectangle flashes briefly before the frontend (dark-themed HTML) paints. This was not present in the Tauri host because Tauri creates windows hidden and shows them only after WebView2's `NavigationCompleted` event.
+
+## Root Cause (confirmed via testbed)
+
+Three independent factors combine to cause the flash:
+
+1. **GPU compositing startup delay** — CEF's GPU process takes time to initialize. During this gap, the window surface is white. **Fix:** `--disable-gpu-compositing` forces software compositing which respects `background_color` from the first frame.
+
+2. **CEF Views auto-show** — CEF Views calls `ShowWindow` based on `initial_show_state` before content is ready. No way to prevent it. **Fix:** Use native window mode (`browser_host_create_browser` with `WindowInfo`) where we control `WS_VISIBLE`.
+
+3. **`DwmExtendFrameIntoClientArea(-1)`** — This call resets the DWM composition surface, causing a white frame even on a cloaked window. **Fix:** Call it while the window is still hidden (before ShowWindow), not after.
+
+## The Working Recipe (testbed variant 12)
+
+Confirmed zero-flash in `cef-testbed` with heavy DOM (2000 blocks + 5000 rows) over HTTP:
+
+```
+Startup sequence:
+1. Create native window WITHOUT WS_VISIBLE (hidden)
+2. on_after_created: DwmExtendFrameIntoClientArea(-1) on HIDDEN window (safe, not visible)
+3. on_after_created: install_frameless_resize_hook
+4. Content loads...
+5. on_load_end:
+   a. DWMWA_CLOAK = TRUE (hide from DWM)
+   b. GDI FillRect dark (#222222)
+   c. ShowWindow(SW_SHOW) — still invisible (cloaked)
+   d. DWMWA_CLOAK = FALSE — first visible frame is dark
+   e. SetForegroundWindow
+
+Command-line flags:
+  --disable-gpu-compositing
+  --disable-features=CalculateNativeWinOcclusion
+  --background-color=ff222222
+```
+
+## Testbed Results Matrix
+
+| Variant | Description | Flash? |
+|---------|------------|--------|
+| 1 | Baseline: CEF Views, no settings | YES - full white |
+| 2 | + background_color 0xFF222222 | YES |
+| 3 | + dark class brush before show | YES |
+| 7 | + --disable-gpu | NO (but disables all GPU) |
+| 8 | + --disable-gpu-compositing | Barely visible |
+| 9 | disable-gpu-comp + CEF Views deferred show | YES (CEF Views auto-shows) |
+| 10 | disable-gpu-comp + MINIMIZED + restore | YES |
+| 11 | **Native window (no WS_VISIBLE) + disable-gpu-comp** | **NO** |
+| 12 | Native + disable-gpu-comp + DWMWA_CLOAK | **NO** |
+| 12+DWM in on_after_created (on visible window) | YES (DWM surface reset) |
+| 12+DWM in cloak sequence | YES (cloak doesn't protect) |
+| 12+DWM on hidden window, cloak→show in on_load_end | **TESTING** |
+
+## Key Findings
+
+### `--disable-gpu-compositing` is essential
+Without it, the GPU process startup delay always causes white frames. Software compositing uses `background_color` from frame 1.
+
+### CEF Views cannot prevent the flash
+`initial_show_state` has no HIDDEN option on Windows. CEF Views auto-shows the window. Native window mode (`browser_host_create_browser`) is required.
+
+### `DwmExtendFrameIntoClientArea(-1)` causes white surface reset
+Even inside a DWMWA_CLOAK, calling this triggers a DWM surface reallocation that paints white. Must be called while the window is hidden (no WS_VISIBLE), before any show.
+
+### DWMWA_CLOAK IS settable (value 13)
+Despite some docs suggesting read-only, `DwmSetWindowAttribute(hwnd, 13, &1, 4)` works on Windows 10. It hides the window from DWM while keeping it composed. Combined with GDI dark paint + ShowWindow, the first visible frame is dark.
+
+### `on_load_end` is the right timing hook
+Fires when main frame HTML is loaded. The inline CSS `background: #222` has already been parsed. Combined with software compositing, the surface is dark at this point.
+
+## AgentMux Versions Tested
+
+| Version | Changes | Result |
+|---------|---------|--------|
+| 0.33.13 | Baseline (main) | Works, white flash |
+| 0.33.26 | Revert to main | Works, white flash |
+| 0.33.27 | Native window mode (inverted condition) | Still CEF Views |
+| 0.33.28 | Fix condition + frameless hook on main | Shorter flash |
+| 0.33.29-30 | Various approaches | Broke CEF init |
+| 0.33.31 | Revert to main | Works, white flash |
+| 0.33.32 | + disable-gpu-compositing | Slightly better |
+| 0.33.33 | + background_color + dark brush | Still flash |
+| 0.33.34 | Native + disable-gpu-comp + show on_load_end | Fast flash |
+| 0.33.35 | + 50ms delay before show | Still flash |
+| 0.33.36 | + 150ms delay | Still flash |
+| 0.33.37 | + DWMWA_CLOAK sequence | Still flash |
+| 0.33.38 | + DWM frameless inside cloak | Still flash |
+
+## Performance Impact of `--disable-gpu-compositing`
+
+Software compositing means the compositor runs on CPU instead of GPU. For AgentMux's use case (terminals, text, simple UI), this should have minimal impact. WebGL-dependent content (e.g., mermaid diagrams) may render slower. Monitor this.
+
+## Next Steps
+
+1. Confirm testbed variant 12 works with DWM frameless on hidden window
+2. Port exact sequence to AgentMux
+3. Ensure all three pieces are in the right order:
+   - `DwmExtendFrameIntoClientArea` BEFORE any ShowWindow (on hidden window)
+   - `DWMWA_CLOAK` in on_load_end wrapping ShowWindow
+   - `--disable-gpu-compositing` in command line
+
+## References
+
+- [Microsoft fixing Chrome/Edge white flash (Jan 2025)](https://www.windowslatest.com/2025/01/08/microsoft-finally-fixing-chrome-edges-white-flash-in-dark-mode-on-windows-11-windows-10/)
+- [Chromium hwnd_message_handler.cc](https://github.com/chromium/chromium/blob/master/ui/views/win/hwnd_message_handler.cc)
+- [CEF #3638: Changing window visibility during startup](https://github.com/chromiumembedded/cef/issues/3638)
+- [CEF Bitbucket #1161: Background color on resize](https://bitbucket.org/chromiumembedded/cef/issues/1161)
+- [DWMWINDOWATTRIBUTE docs](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute)

--- a/docs/analysis/clipboard-load-time.md
+++ b/docs/analysis/clipboard-load-time.md
@@ -1,0 +1,58 @@
+# Clipboard Branch Load Time Analysis
+
+**Date:** 2026-04-02
+**Conclusion:** No load time difference — perceived slowness was from CEF cache state
+
+## Investigation
+
+User reported clipboard branch (0.33.23) felt slower than main. Deep dive:
+
+### Bundle Comparison
+
+| Metric | Main (0.33.24) | Clipboard (0.33.23) |
+|--------|---------------|-------------------|
+| Main bundle | 2,166,847 bytes | 2,166,838 bytes |
+| JS chunks | 51 | 51 |
+| Binary size | 2,591,744 bytes | 2,595,840 bytes |
+
+**9 bytes difference** in JS bundle. 4KB in binary (clipboard Win32 code). Negligible.
+
+### Startup Timeline (cold cache, both builds)
+
+| Event | Clipboard | Main |
+|-------|-----------|------|
+| IPC server start | +4ms | +8ms |
+| Backend ready | +80ms | +102ms |
+| CEF initialized | +192ms | +274ms |
+| Frontend injected | +510ms | +591ms |
+| setupCefApi | +526ms | +607ms |
+| fonts-ready | +696ms | +777ms |
+| window-show | +782ms | +866ms |
+
+**Clipboard is actually slightly faster** in this run. Both are within normal variance.
+
+### Why It Felt Slower
+
+The clipboard branch portable (0.33.23) was tested after clearing all CEF caches (`rm -rf $APPDATA/ai.agentmux.cef.v0-33-*`). The main build (0.33.24) was tested with warm caches from the benchmark runs. CEF's cold start includes:
+- First-time browser profile creation
+- GPU process initialization
+- Chrome feature flag evaluation
+- First-time font enumeration
+
+This adds 200-500ms to the first launch after cache clear.
+
+### Clipboard Code Path at Runtime
+
+The clipboard module (`clipboard.rs`) adds zero startup cost:
+- No init code — just two functions (`read_clipboard`, `write_clipboard`)
+- Only called on user action (Ctrl+C/V)
+- IPC route registration is a hashmap insert (nanoseconds)
+
+The frontend `clipboard.ts` change:
+- Replaced static Tauri import with direct `invokeCommand` call
+- No dynamic import, no lazy loading, no startup code
+- Smaller than before (removed Tauri detection logic)
+
+## Verdict
+
+No performance regression from the clipboard change. Safe to merge.

--- a/docs/analysis/cross-window-drag-wiring.md
+++ b/docs/analysis/cross-window-drag-wiring.md
@@ -1,0 +1,202 @@
+# Cross-Window Drag: Wiring Analysis
+
+**Date:** 2026-03-30
+**Status:** Backend complete, frontend needs 4 targeted fixes
+
+---
+
+## Architecture Overview
+
+Cross-window drag lets users drag a pane or tab out of one AgentMux window to create a new window (tear-off) or drop it into an existing window.
+
+```
+User drags pane outside window
+  → CrossWindowDragMonitor detects dragend (or OLE fallback timer)
+  → startCrossDrag() → backend creates DragSession
+  → updateCrossDrag() → backend hit-tests all windows via Win32 GetWindowRect
+  → backend broadcasts "cross-drag-update" to all windows
+  → target window's DragOverlay shows drop indicator
+  → user releases mouse
+  → completeCrossDrag() → backend broadcasts "cross-drag-end"
+  → target handles drop (MoveBlockToTab) or tear-off (TearOffBlock + openWindowAtPosition)
+```
+
+---
+
+## Backend (CEF Host) — FULLY IMPLEMENTED
+
+All 10 commands are routed in `agentmux-cef/src/ipc.rs:235-245` and implemented in `agentmux-cef/src/commands/drag.rs`:
+
+| Command | Implementation | Status |
+|---------|---------------|--------|
+| `start_cross_drag` | UUID session, stores in `AppState.active_drag`, broadcasts `cross-drag-start` | Done |
+| `update_cross_drag` | Hit-tests all browser HWNDs via `GetWindowRect`, broadcasts `cross-drag-update` | Done |
+| `complete_cross_drag` | Takes session, broadcasts `cross-drag-end` with result=drop/tearoff | Done |
+| `cancel_cross_drag` | Clears session, broadcasts `cross-drag-end` with result=cancel | Done |
+| `get_cursor_point` | Win32 `GetCursorPos` | Done |
+| `get_mouse_button_state` | Win32 `GetAsyncKeyState(VK_LBUTTON)` | Done |
+| `set_drag_cursor` | `SetSystemCursor` — replaces no-drop with crosshair | Done |
+| `restore_drag_cursor` | `SystemParametersInfoW(SPI_SETCURSORS)` | Done |
+| `release_drag_capture` | `ReleaseCapture` + `WM_CANCELMODE` on all child windows | Done |
+| `open_window_at_position` | Creates new CEF browser at screen coords with IPC creds + workspaceId in URL | Done |
+| `set_js_drag_active` | No-op on Windows (Linux GTK guard) | Done |
+
+State tracking: `DragSession` struct in `agentmux-cef/src/state.rs` with drag_id, drag_type (Pane|Tab), source info, payload.
+
+Hit-testing: `hit_test_windows()` iterates `AppState.browsers` HashMap, gets HWND from each `browser.host()`, checks `GetWindowRect` bounds.
+
+Event broadcasting: `events::emit_event_all_windows()` calls `execute_javascript()` on every browser instance, dispatching a `CustomEvent` on `window`.
+
+---
+
+## Frontend CEF API (`frontend/util/cef-api.ts`) — PARTIALLY WIRED
+
+### Duplicate keys in the API object
+
+The `createCefApi()` function returns an object with **two sets** of drag methods:
+
+**First set (lines 423-433) — STUBS (no-ops):**
+```typescript
+setJsDragActive: async (_active: boolean) => {},
+startCrossDrag: async () => "",
+updateCrossDrag: async () => null as string | null,
+completeCrossDrag: async () => {},
+cancelCrossDrag: async (_dragId: string) => {},
+openWindowAtPosition: async () => "",
+setDragCursor: async () => {},
+restoreDragCursor: async () => {},
+releaseDragCapture: async () => {},
+getMouseButtonState: async () => false,          // ← NO OVERRIDE
+```
+
+**Second set (lines 540-579) — REAL implementations via invokeCommand():**
+```typescript
+startCrossDrag: async (dragType, sourceWindow, ...) => invokeCommand("start_cross_drag", {...}),
+updateCrossDrag: async (dragId, screenX, screenY) => invokeCommand("update_cross_drag", {...}),
+completeCrossDrag: async (dragId, targetWindow, ...) => invokeCommand("complete_cross_drag", {...}),
+cancelCrossDrag: async (dragId) => invokeCommand("cancel_cross_drag", {...}),
+openWindowAtPosition: async (screenX, screenY, workspaceId?) => invokeCommand("open_window_at_position", {...}),
+setDragCursor: async () => invokeCommand("set_drag_cursor"),
+restoreDragCursor: async () => invokeCommand("restore_drag_cursor"),
+releaseDragCapture: async () => invokeCommand("release_drag_capture"),
+```
+
+In JS, **last duplicate key wins**. So the real implementations override the stubs for everything **except `getMouseButtonState`**, which has no second definition.
+
+### Missing from CEF API
+
+| Method | Status | Needed By |
+|--------|--------|-----------|
+| `getMouseButtonState` | **Stub only** (returns `false`) | `CrossWindowDragMonitor.win32.tsx:70` |
+| `getCursorPoint` | **Not in API at all** | `CrossWindowDragMonitor.win32.tsx:148` |
+
+---
+
+## Frontend CrossWindowDragMonitor (`frontend/app/drag/CrossWindowDragMonitor.win32.tsx`) — BROKEN ON CEF
+
+The monitor imports directly from `@tauri-apps/api/core` instead of using `getApi()`:
+
+### Problem 1: `get_mouse_button_state` (line 70-71)
+```typescript
+const { invoke } = await import("@tauri-apps/api/core");
+isButtonPressed = await invoke<boolean>("get_mouse_button_state");
+```
+**Fails on CEF:** `@tauri-apps/api/core` is not available. Should use `getApi().getMouseButtonState()`.
+
+### Problem 2: `get_cursor_point` (line 147-149)
+```typescript
+const { invoke } = await import("@tauri-apps/api/core");
+cursorPoint = await invoke<{ x: number; y: number }>("get_cursor_point");
+```
+**Fails on CEF:** Same issue. Should use `getApi().getCursorPoint()`.
+
+### DragOverlay (`frontend/app/drag/DragOverlay.tsx`) — WORKS
+
+Already uses `getApi().listen()` for all event subscriptions. No Tauri-specific imports. Will work on both hosts.
+
+---
+
+## Required Changes
+
+### Fix 1: Add `getMouseButtonState` real implementation to `cef-api.ts`
+
+```typescript
+// Replace stub at line 433 or add override in the second block (~line 578)
+getMouseButtonState: async () => {
+    return await invokeCommand<boolean>("get_mouse_button_state");
+},
+```
+
+### Fix 2: Add `getCursorPoint` to `cef-api.ts`
+
+```typescript
+getCursorPoint: async () => {
+    return await invokeCommand<{ x: number; y: number }>("get_cursor_point");
+},
+```
+
+Also add to `tauri-api.ts` if not present (should wrap `invoke("get_cursor_point")`).
+
+### Fix 3: Update `CrossWindowDragMonitor.win32.tsx` to use `getApi()`
+
+Replace direct Tauri imports:
+
+```typescript
+// BEFORE (line 68-73):
+const { invoke } = await import("@tauri-apps/api/core");
+isButtonPressed = await invoke<boolean>("get_mouse_button_state");
+
+// AFTER:
+isButtonPressed = await getApi().getMouseButtonState();
+```
+
+```typescript
+// BEFORE (line 146-149):
+const { invoke } = await import("@tauri-apps/api/core");
+cursorPoint = await invoke<{ x: number; y: number }>("get_cursor_point");
+
+// AFTER:
+cursorPoint = await getApi().getCursorPoint();
+```
+
+### Fix 4: Clean up dead stubs in `cef-api.ts`
+
+Remove lines 423-433 (the first set of stub definitions). They're all overwritten by the real implementations at lines 540-579, except `getMouseButtonState` which should be added there instead.
+
+---
+
+## Files to Change
+
+| File | Change | Risk |
+|------|--------|------|
+| `frontend/util/cef-api.ts:423-433` | Remove stubs, add `getMouseButtonState` + `getCursorPoint` to real block | Low |
+| `frontend/util/tauri-api.ts` | Add `getCursorPoint` + `getMouseButtonState` if missing | Low |
+| `frontend/app/drag/CrossWindowDragMonitor.win32.tsx:68-75` | Replace `import("@tauri-apps/api/core")` with `getApi()` | Low |
+| `frontend/app/drag/CrossWindowDragMonitor.win32.tsx:146-149` | Replace `import("@tauri-apps/api/core")` with `getApi()` | Low |
+| `frontend/types/custom.d.ts` | Add `getCursorPoint` + `getMouseButtonState` to `AppApi` interface | Low |
+
+---
+
+## Testing Plan
+
+1. `task dev` — launch CEF host
+2. Open a terminal pane, drag it out of the window
+3. Expect: new window appears at cursor position with the terminal pane (scrollback preserved, PTY continues)
+4. Open two windows, drag a pane from one to the other
+5. Expect: pane moves to target window, DragOverlay shows during hover
+6. Drag a tab out of a window
+7. Expect: new window with that tab's full layout
+
+### Fallback timer test (Windows-specific)
+1. Drag a pane outside the window and release over Explorer (not another AgentMux window)
+2. Wait 800ms — OLE fallback should fire
+3. Expect: `get_mouse_button_state` returns false → tear-off triggers
+
+---
+
+## Related Specs
+
+- `docs/specs/cef-drag-window-management.md` — full 5-system analysis
+- `specs/pane-popout-to-new-window.md` — pop-out button design (magnify → popout)
+- `docs/specs/pane-dnd-fix-spec.md` — Pragmatic DnD migration
+- `docs/retros/2026-03-20-secondary-window-dnd-regression.md` — WebView2 DnD fix history

--- a/docs/analysis/frontend-build-tauri-config.md
+++ b/docs/analysis/frontend-build-tauri-config.md
@@ -1,0 +1,29 @@
+# Frontend Build Uses Tauri Vite Config
+
+**Date:** 2026-04-02
+**Status:** Known issue — not causing immediate breakage but worth addressing
+**Discovered during:** Clipboard CEF implementation
+
+## Finding
+
+The `build:frontend` task in `Taskfile.yml` uses `vite.config.tauri.ts`:
+```yaml
+build:frontend:
+    cmd: npx vite build --mode production --config vite.config.tauri.ts
+```
+
+There is only one vite config — no CEF-specific variant exists. Since the Tauri host is deprecated and CEF is the primary host, the frontend is being built with a config designed for a different runtime.
+
+## Impact
+
+- Tauri plugin imports (e.g., `@tauri-apps/plugin-clipboard-manager`, `@tauri-apps/plugin-fs`) are bundled but only used via dynamic `import()` with CEF fallbacks
+- Tauri-specific Vite plugins may add unnecessary overhead
+- No functional breakage — CEF mode is detected at runtime via `__AGENTMUX_IPC_PORT__`
+
+## Recommendation
+
+Either:
+1. Rename `vite.config.tauri.ts` → `vite.config.ts` (it's the only config)
+2. Or create a `vite.config.cef.ts` that strips Tauri plugins and update Taskfile
+
+Low priority — works as-is.

--- a/docs/analysis/full-codebase-audit-2026-04-03.md
+++ b/docs/analysis/full-codebase-audit-2026-04-03.md
@@ -1,0 +1,235 @@
+# AgentMux Full Codebase Audit — 2026-04-03
+
+## Executive Summary
+
+The codebase is **solid but carries significant technical debt** from the Tauri→CEF migration and the Go→Rust port. Three systemic issues dominate:
+
+1. **Tauri is still in the workspace** — `src-tauri/` is 31MB of dead code still compiled by `cargo check`, referenced by `.bump.json`, and the `package` task literally calls `npx tauri build` instead of CEF
+2. **Dual state management** — Frontend runs Jotai atoms, a globalStore shim, AND SolidJS signals simultaneously across 11+ files
+3. **God modules** — `wcore.rs` (1419 lines), `wconfig.rs` (1624 lines), `shell.rs` (1325 lines), `global.ts` (917 lines) each bundle unrelated concerns
+
+---
+
+## Part 1: Should We Delete src-tauri/?
+
+### YES — Immediately
+
+**It is completely dead:**
+- Not imported by any active crate (agentmux-cef, agentmux-srv, agentmux-wsh)
+- Not built by any active task (`task dev`, `task cef:package:portable`)
+- Last real code change: March 7, 2026
+- Only touched since by automated version bumps via `.bump.json`
+
+**It actively causes problems:**
+- Still in workspace `Cargo.toml` members → `cargo check` compiles it
+- `.bump.json` bumps `src-tauri/Cargo.toml` and `src-tauri/tauri.conf.json` on every version bump — wasted git noise
+- The `package`, `package:macos`, `package:portable:linux` Taskfile tasks call `npx tauri build` — **they're broken and would produce wrong output if anyone ran them**
+
+**What to keep:**
+- `frontend/tauri-*.ts` files — runtime compatibility shim (checks `__TAURI_INTERNALS__` at runtime, no-ops on CEF)
+- `@tauri-apps/*` npm deps — used by the frontend shim and test infrastructure
+- Test helpers (`wdio.conf.cjs`, `test/helpers/tauri-helpers.js`) — still reference Tauri mocks
+
+**Deletion order:**
+1. Remove `src-tauri` from `Cargo.toml` workspace members
+2. Remove `src-tauri/Cargo.toml` and `src-tauri/tauri.conf.json` targets from `.bump.json`
+3. Delete deprecated Taskfile tasks: `dev:tauri`, `tauri:dev`, `tauri:build`, `tauri:copy-sidecars`, `start`, `quickdev`, `sync:dev:binaries:*`
+4. Fix `package`/`package:macos`/`package:portable:linux` to use CEF build pipeline
+5. Delete scripts: `sync-version.sh`, `update-tauri.sh`, `verify-tauri-versions.sh`, `build-release.ps1`
+6. Delete entire `src-tauri/` directory
+7. Clean `.gitignore` entries for `src-tauri/`
+8. Update BUILD.md, CONTRIBUTING.md
+
+**Files outside src-tauri/ that reference it (must update):**
+- `Cargo.toml` (workspace members)
+- `.bump.json` (version targets)
+- `Taskfile.yml` (52 lines in 7+ tasks)
+- `vite.config.tauri.ts` (watch ignore — harmless but confusing name)
+- `.gitignore`
+- `scripts/sync-version.sh`, `scripts/update-tauri.sh`, `scripts/verify-tauri-versions.sh`
+- `scripts/benchmarks/measure-performance.{ps1,sh}`, `scripts/build-appimage.sh`, `scripts/package-msix.ps1`
+- `wdio.conf.cjs` (test config)
+- `BUILD.md`, `CONTRIBUTING.md`
+
+---
+
+## Part 2: Frontend Audit
+
+### CRITICAL
+
+| Issue | File(s) | Details |
+|-------|---------|---------|
+| **Dead Jotai in BlockModel** | `frontend/app/block/block-model.ts:4-5, 14-32` | Still imports and uses `jotai.atom()` despite migration to SolidJS signals. Creates unmaintained dual-state system |
+| **Direct Tauri imports in active code** | `frontend/app/drag/CrossWindowDragMonitor.linux.tsx:14`, `darwin.tsx:61`, `frontend/app/view/term/term.tsx:274` | Hardcoded `import { invoke } from "@tauri-apps/api/core"` instead of using platform IPC abstraction — breaks on CEF |
+
+### HIGH
+
+| Issue | File(s) | Details |
+|-------|---------|---------|
+| **God file: global.ts** | `frontend/app/store/global.ts` (917 lines) | 104+ exports mixing atoms, services, utilities, counters, notifications. Split into focused modules |
+| **globalStore shim used in 11 files** | `blockframe.tsx`, `termwrap.ts`, `keymodel.ts`, `agent-model.ts`, `term.tsx`, etc. | Jotai compatibility shim obscures incomplete migration to SolidJS signals |
+| **Dual state management** | Across frontend | Code uses SolidJS signals + globalStore shim + raw Jotai atoms + window globals simultaneously |
+
+### MEDIUM
+
+| Issue | File(s) | Details |
+|-------|---------|---------|
+| **52 `any` types** | Throughout frontend | `global.ts:889`, `wos.ts:67,94`, `wshclient.ts:50,75`, `blockutil.tsx:56,88` — loses type safety |
+| **40+ `as any` casts** | `block.tsx:41-50`, `blockframe.tsx:91,100`, `global.ts:180` | All ViewModels cast as `any` in block registry |
+| **52 `(window as any)` casts** | `wave.ts` (19 occurrences), `ipc.ts`, `cef-api.ts`, `tauri-api.ts` | Should use proper type declarations for window globals |
+| **Tauri-only features silently broken on CEF** | `frontend/util/notification.ts:56-71` — `sendNativeNotification()` no-ops on CEF; `frontend/wave.ts:68-106` — instance ID title no-ops on CEF | Features that work on Tauri but silently fail on CEF |
+| **Dead Tauri bootstrap files** | `frontend/tauri-bootstrap.ts` (210 lines), `frontend/tauri-init.ts` (31 lines) | Conditional on `__TAURI_INTERNALS__` — never active on CEF, but add weight |
+| **Leaked setInterval in TermViewModel** | `frontend/app/view/term/termViewModel.ts:32-33` | Global `setInterval(() => ..., 60_000)` never cleaned up — accumulates on re-creation |
+| **Global mutable state in drag handlers** | `CrossWindowDragMonitor.linux.tsx:23`, `darwin.tsx:22-30` | Module-level `let _currentDragPayload` — concurrent drags overwrite each other |
+| **Unbounded OSC buffer** | `frontend/app/view/term/termosc.ts:45-100` | No size limit on JSON parsing from terminal escape sequences |
+
+### LOW
+
+| Issue | File(s) | Details |
+|-------|---------|---------|
+| Duplicate platform detection logic | `ipc.ts:19-27`, `wave.ts:57-65` | Same `isTauri()`/`isCef()` check in multiple places |
+| `setTimeout(fn, 0)` anti-pattern | 18 files | Should use `queueMicrotask()` or `requestAnimationFrame()` |
+| Import path inconsistencies | Various | Mix of `@/app/store/global` and `@/store/global` |
+| TODO comments without owners | `wave.ts:439,551,650` | Stale technical debt markers |
+| Commented-out tests | `autotitle.test.ts:181` | Disabled but not removed |
+
+---
+
+## Part 3: Rust Backend Audit
+
+### CRITICAL
+
+| Issue | File(s) | Details |
+|-------|---------|---------|
+| **Blocking std::sync::Mutex in async code** | `agentmux-srv/src/backend/ai/tools.rs:210,225,249,276,293,299` | `.lock().unwrap()` on `std::sync::Mutex` inside async functions blocks the tokio executor thread. Replace with `tokio::sync::Mutex` |
+| **Panic on lock poisoning** | `agentmux-cef/src/ipc.rs:191`, `main.rs:174,186`, `sidecar.rs:58,59,80,131`, `client.rs:75,130,334` | `.lock().unwrap()` on mutexes — if any thread panics while holding the lock, ALL subsequent lock attempts crash. Use `parking_lot::Mutex` (no poisoning) or handle the error |
+| **Path traversal in home dir expansion** | `agentmux-srv/src/backend/wavebase.rs:250-261` | `expand_home_dir()` rejects `~user/` but accepts bare paths like `../../../root` without canonical validation |
+
+### HIGH
+
+| Issue | File(s) | Details |
+|-------|---------|---------|
+| **36+ files with blanket `#![allow(dead_code)]`** | `wavebase.rs:7`, `waveobj.rs:7`, `wavefileutil.rs:10`, and 33 more | Masks actually-unused code. Examples: `migrate_legacy_data_dir()`, `validate_wsh_supported_arch()`, entire `parse_wave_file_path()` |
+| **String-based errors instead of typed enums** | `wavebase.rs:104-120`, `shell.rs`, many older modules | `Result<T, String>` loses error context. Storage layer has proper `StoreError` but legacy modules don't |
+| **.expect() in CEF UI thread callbacks** | `agentmux-cef/src/client.rs:69,126,224` | `browser.expect("Browser is None")` in CEF callbacks — panicking here crashes CEF. Should return gracefully |
+| **God modules** | `wconfig.rs` (1624 lines), `wcore.rs` (1419 lines), `shell.rs` (1325 lines), `wstore.rs` (1166 lines) | Bundle unrelated concerns. `wcore.rs` has workspace creation, window management, block operations, and layout logic in one file |
+
+### MEDIUM
+
+| Issue | File(s) | Details |
+|-------|---------|---------|
+| **Legacy Wave naming throughout** | `wavebase.rs`, `waveobj.rs`, `wavefileutil.rs`, `wconfig.rs`, `wcore.rs`, `wps.rs` | Go-era "Wave" prefix still everywhere. Constants like `WAVE_LOCK_FILE`, `wave.sock` coexist with `REMOTE_WAVE_HOME_DIR_NAME: &str = ".agentmux"` |
+| **Blocking on async in main()** | `agentmux-cef/src/main.rs:173,182` | `runtime.block_on(ipc::start_ipc_server(...))` and `runtime.block_on(sidecar::spawn_backend(...))` — blocks UI thread during startup |
+| **Mixed logging: eprintln + tracing** | Throughout | Some paths use `eprintln!`, others use `tracing::warn!`. No structured key-value logging |
+| **IPC token in plaintext HTTP** | `agentmux-cef/src/main.rs:150-154` | Auth token sent in HTTP request to localhost — acceptable for local IPC but could use Unix domain sockets on Linux/macOS |
+| **Unbounded channels** | `agentmux-srv/src/backend/rpc/router.rs:84-93` | `mpsc::unbounded_channel()` for RPC messages — no flow control under load |
+
+### LOW
+
+| Issue | File(s) | Details |
+|-------|---------|---------|
+| Clone abuse in merge_meta | `waveobj.rs:67-99` | Clones entire map upfront even for no-op merges |
+| No graceful shutdown of watchdog | `blockcontroller/watchdog.rs` | `tokio::spawn()` with no cancellation token |
+| Raw libc calls without nix crate | `agentmux-srv/src/main.rs:30-141` | Parent process monitoring uses raw `libc::` calls — `nix` crate would be safer |
+
+### Rust Strengths (no changes needed)
+- No SQL injection (parameterized queries throughout)
+- No command injection (args passed as arrays, not shell-concatenated)
+- No unsafe code in core logic (only in platform-specific FFI)
+- Proper trait-based abstractions (`Controller`, `ConnInterface`, `RpcClient`)
+- Strong typing with `Uuid`, enums, newtype patterns
+
+---
+
+## Part 4: Build System Audit
+
+### Dead Taskfile Tasks
+| Task | Status | Action |
+|------|--------|--------|
+| `dev:tauri` | Deprecated, marked in desc | Delete |
+| `tauri:dev` | Unused | Delete |
+| `tauri:build` | Unused | Delete |
+| `tauri:copy-sidecars` | Only used by deprecated tasks | Delete |
+| `start` | Unused (`cd src-tauri && cargo run`) | Delete |
+| `quickdev` | Unused (`tauri dev --config ...`) | Delete |
+| `sync:dev:binaries:*` | Only dep of `dev:tauri` | Delete |
+| `package` | **BROKEN** — calls `npx tauri build` | Rewrite for CEF |
+| `package:macos` | **BROKEN** — calls `npx tauri build` | Rewrite for CEF |
+| `package:portable:linux` | **BROKEN** — calls `npx tauri build` | Rewrite for CEF |
+| `artifacts:upload` | References non-existent `src-tauri/target/release/bundle/` | Delete or rewrite |
+
+### Dead Scripts
+| Script | Action |
+|--------|--------|
+| `scripts/sync-version.sh` | Delete (`.bump.json` handles this) |
+| `scripts/update-tauri.sh` | Delete |
+| `scripts/verify-tauri-versions.sh` | Delete |
+| `scripts/build-release.ps1` | Delete (unused, not called by any task) |
+| `scripts/build-appimage.sh` | Rewrite for CEF or delete |
+| `scripts/package-msix.ps1` | Rewrite for CEF or delete |
+| `scripts/benchmarks/measure-performance.{ps1,sh}` | Update paths from src-tauri to target/release |
+
+### Stale dist/ Artifacts
+| Artifact | Action |
+|----------|--------|
+| `dist/agentmux-0.32.106-x64-portable.zip` | Delete |
+| `dist/agentmux-cef-portable/` | Delete |
+| `dist/cef-release/` | Delete |
+| Old wsh binaries (40+ versioned copies) | Delete all except current version |
+
+### Configuration Issues
+| File | Issue | Action |
+|------|-------|--------|
+| `.bump.json` | Targets `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json` | Remove both |
+| `vite.config.tauri.ts` | Name implies Tauri-only but CEF uses it too | Rename to `vite.config.ts` |
+| `Cargo.toml` | `src-tauri` in workspace members | Remove |
+| `.gitignore` | `src-tauri/target/`, `src-tauri/binaries/`, `src-tauri/gen/schemas/` | Remove |
+
+---
+
+## Part 5: Priority Action Plan
+
+### P0 — Do Now (blocks other work)
+1. **Delete src-tauri/** and clean all references (see Part 1 deletion order)
+2. **Replace `std::sync::Mutex` with `tokio::sync::Mutex`** in `ai/tools.rs` — prevents executor thread starvation
+3. **Fix `.lock().unwrap()` in CEF callbacks** — use `parking_lot::Mutex` or handle poison errors
+
+### P1 — This Week
+4. **Remove globalStore shim** — convert remaining 11 files to SolidJS signals, delete `jotaiStore.ts`
+5. **Fix direct Tauri imports** in `CrossWindowDragMonitor.linux.tsx`, `darwin.tsx`, `term.tsx` — route through platform IPC abstraction
+6. **Add canonical path validation** in `expand_home_dir()`
+7. **Remove blanket `#![allow(dead_code)]`** — audit and delete truly dead functions
+8. **Delete dead Taskfile tasks and scripts** (see tables above)
+
+### P2 — This Sprint
+9. **Split god modules**: `wcore.rs` → `workspace.rs` + `window.rs` + `block.rs` + `layout.rs`; `global.ts` → `atoms.ts` + `services.ts` + `counters.ts` + `notifications.ts`
+10. **Rename legacy Wave modules**: `wavebase.rs` → `base.rs`, `waveobj.rs` → `object.rs`, etc. Update `WAVE_LOCK_FILE` → `AGENTMUX_LOCK_FILE`
+11. **Define proper error types** for `wavebase`, `shell`, and other string-error modules
+12. **Fix `package` Taskfile tasks** to use CEF build pipeline
+13. **Clean stale dist/ artifacts**
+14. **Rename `vite.config.tauri.ts`** → `vite.config.ts`
+
+### P3 — Backlog
+15. Replace `any` types (52 occurrences) with proper generics
+16. Replace `(window as any)` (52 occurrences) with type declarations
+17. Fix leaked `setInterval` in `TermViewModel`
+18. Add bounded channels in `rpc/router.rs`
+19. Use `nix` crate instead of raw `libc::` calls
+20. Add structured key-value logging throughout Rust backend
+
+---
+
+## Metrics
+
+| Category | Count |
+|----------|-------|
+| Dead Tauri code (files) | 109+ (src-tauri/) + 5 frontend + 7 scripts |
+| `any` / `as any` types | 92 |
+| `(window as any)` casts | 52 |
+| `.lock().unwrap()` in production | 20+ |
+| `#![allow(dead_code)]` blankets | 36 files |
+| God modules (>1000 lines) | 4 Rust + 1 TypeScript |
+| Dead Taskfile tasks | 11 |
+| Dead scripts | 6 |
+| Legacy "Wave" naming | 8 module files + 10+ constants |
+| Estimated cleanup effort | ~40-60 hours total |

--- a/docs/analysis/opacity-inconsistency.md
+++ b/docs/analysis/opacity-inconsistency.md
@@ -1,0 +1,173 @@
+# Window Opacity Inconsistency — Investigation Report
+
+**Date:** 2026-04-02
+**Status:** Root causes identified, fix spec below
+**Severity:** UX bug — opacity sometimes doesn't apply, worse with multiple windows
+
+## Symptoms
+
+1. Switching between opacity levels doesn't always take effect
+2. Multiple windows: some get new opacity, others don't
+3. May need to toggle multiple times for it to stick
+
+## Code Audit
+
+### Frontend → Host flow
+
+1. `app.tsx:141` — `AppSettingsUpdater` effect reacts to settings changes:
+   ```ts
+   getApi().setWindowTransparency(isTransparentOrBlur, isBlur, opacity);
+   ```
+2. `cef-api.ts:391` — sends IPC:
+   ```ts
+   invokeCommand("set_window_transparency", { transparent, blur, opacity })
+   ```
+3. `ipc.rs` routes to `commands::window::set_window_transparency()`
+
+### Host-side: `set_window_transparency()` (window.rs:179)
+
+```rust
+pub fn set_window_transparency(state, args) {
+    let transparent = args["transparent"];  // bool
+    let blur = args["blur"];               // bool
+    let _opacity = args["opacity"];         // f64 (0.0-1.0)
+
+    let hwnd = find_own_top_level_window();  // ← BUG 1: only finds ONE window
+    if blur {
+        apply_window_effects(hwnd, true, true);  // DWM backdrop
+    }
+    if transparent {
+        apply_window_opacity(hwnd, _opacity);    // WS_EX_LAYERED + alpha
+    }
+    // ← BUG 2: no "else" to REMOVE opacity when transparent=false
+}
+```
+
+### `find_own_top_level_window()` (window.rs:212)
+
+```rust
+EnumWindows(callback, ...);
+// callback: find first visible window with our PID → return it, stop enum
+```
+
+Returns the **first** visible window it finds. In multi-window, this is arbitrary — could be any window.
+
+### `apply_window_opacity()` (window.rs:292)
+
+```rust
+// Adds WS_EX_LAYERED + SetLayeredWindowAttributes(alpha)
+let ex_style = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex_style | WS_EX_LAYERED);
+SetLayeredWindowAttributes(hwnd, 0, alpha, LWA_ALPHA);
+```
+
+## Root Causes
+
+### Bug 1: Only targets one window
+
+`find_own_top_level_window()` returns a single HWND — the first visible window in enum order. With multiple windows, only one gets the opacity change. Which one is non-deterministic (depends on Z-order).
+
+**Fix:** Iterate `state.browsers` and apply to every window's HWND.
+
+### Bug 2: No opacity removal path
+
+When `transparent` is `false`, the function does nothing — it doesn't remove `WS_EX_LAYERED` or reset alpha to 255. So once opacity is set, it can only be changed to a different value, never fully removed.
+
+```rust
+if transparent {
+    apply_window_opacity(hwnd, _opacity);  // sets opacity
+}
+// Missing: else { remove_window_opacity(hwnd); }
+```
+
+**Fix:** When `transparent=false`, remove `WS_EX_LAYERED` from the extended style.
+
+### Bug 3: DWM backdrop not removed
+
+Same issue with `blur` — `apply_window_effects` is only called when `blur=true`. When `blur=false`, the DWM backdrop (Mica/Acrylic) is never reset to `DWMSBT_NONE`.
+
+Actually — looking more carefully, `apply_window_effects` DOES handle the `!transparent && !blur` case at line 247:
+```rust
+if !transparent && !blur {
+    let backdrop_type: i32 = 1; // DWMSBT_NONE
+    DwmSetWindowAttribute(...);
+    return;
+}
+```
+
+But this is only reached when BOTH are false. If only blur changes from true to false while transparent stays true, the backdrop isn't cleared.
+
+**Fix:** Always call `apply_window_effects` with the current state, not conditionally.
+
+### Bug 4: CEF Views HWND mismatch
+
+`find_own_top_level_window()` enumerates by process ID and returns the first visible HWND. In CEF Views mode, the window hierarchy is:
+```
+CefWindow (top-level, our target)
+  └── BrowserView
+       └── Chrome_WidgetWin_0 (CEF internal)
+```
+
+The enum might return the Chrome_WidgetWin child instead of the CefWindow parent. Setting `WS_EX_LAYERED` on the wrong HWND has no effect.
+
+**Fix:** Use `state.browsers` → `browser.host().window_handle()` → `GetAncestor(GA_ROOT)` to find the correct top-level HWND for each window.
+
+### Bug 5: Each window's frontend calls independently
+
+Each window runs its own `AppSettingsUpdater`. When settings change, ALL windows send `set_window_transparency` — but the handler only applies to one HWND. The first IPC call works; subsequent calls from other windows target the same HWND (the first one found).
+
+**Fix:** The IPC call should include the `windowLabel` so the handler can target the correct window. Or: apply to all windows unconditionally.
+
+## Proposed Fix
+
+### Option A: Apply to all windows (simplest)
+
+```rust
+pub fn set_window_transparency(state, args) {
+    let transparent = args["transparent"];
+    let blur = args["blur"];
+    let opacity = args["opacity"];
+
+    #[cfg(target_os = "windows")]
+    {
+        let browsers = state.browsers.lock().unwrap();
+        for (label, browser) in browsers.iter() {
+            if let Some(host) = browser.host() {
+                let hwnd = host.window_handle();
+                if !hwnd.0.is_null() {
+                    let top = GetAncestor(hwnd.0 as _, GA_ROOT);
+                    let target = if !top.is_null() { top } else { hwnd.0 as _ };
+                    unsafe {
+                        apply_window_effects(target, transparent, blur);
+                        if transparent {
+                            apply_window_opacity(target, opacity);
+                        } else {
+                            remove_window_opacity(target);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+unsafe fn remove_window_opacity(hwnd: *mut c_void) {
+    let ex = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+    SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex & !(WS_EX_LAYERED as isize));
+}
+```
+
+### Option B: Per-window targeting (cleaner)
+
+Pass `windowLabel` from frontend, look up the specific browser in `state.browsers`. Requires frontend change to include the label.
+
+**Recommendation:** Option A for now — fixes all bugs with minimal changes. Option B for follow-up if per-window opacity is desired.
+
+## Files to Change
+
+1. `agentmux-cef/src/commands/window.rs` — rewrite `set_window_transparency` to iterate all browsers, add `remove_window_opacity`, fix `apply_window_effects` to always set backdrop type
+2. No frontend changes needed for Option A
+
+## Estimated Complexity
+
+Low — ~30 lines changed in one file.

--- a/docs/analysis/pane-tearoff-not-rendering.md
+++ b/docs/analysis/pane-tearoff-not-rendering.md
@@ -1,0 +1,79 @@
+# Pane Tear-Off: Root Cause — CEF Shared Renderer Process
+
+**Date:** 2026-03-31
+**Status:** ROOT CAUSE CONFIRMED
+
+---
+
+## Root Cause
+
+**CEF Alloy mode shares the renderer process across browser windows created by `browser_host_create_browser`.** This means:
+
+1. **Module-level state is shared** — `savedInitOpts` in `wave.ts` is set by the main window, so the tear-off window's `initWaveWrap` may call `reinitWave()` instead of `initWave()`
+2. **`document` may reference the wrong DOM** — if the renderer process is shared, `document.getElementById("main")` returns the main window's element, not the tear-off window's
+3. **SolidJS render tree exists only once** — `render(App, elem)` in the main window creates the SolidJS tree; the tear-off window either skips render or renders into the wrong DOM
+
+### Evidence
+
+From trace logging in `initWave`:
+- Main window: all 7 trace steps fire, `render()` produces 1 child, `AppInner` mounts ✅
+- Tear-off window: "Init Wave" log fires (line 593), then **ZERO trace logs** — not even the very next `sendLog` at line 594
+
+This is impossible if the JS context is truly isolated. The only explanation: the tear-off window either:
+- Shares the renderer process and `initWave` operates on stale/wrong state
+- OR the tear-off window never actually runs `initWave` — the "Init Wave" log is from the main window reacting to WPS updates
+
+### The `sendLog` routing problem
+
+All CEF browser windows share the same IPC HTTP server. `sendLog` calls go to the same endpoint with no window identifier. We cannot distinguish which window produced which log line. The "Init Wave" at timestamp `.994` might actually be from the main window (re-initializing after the source layout changes from `TearOffBlock`).
+
+---
+
+## Fix: Separate renderer processes per window
+
+### Option A: Use `--renderer-process-per-site` CEF flag
+
+Force each browser to use its own renderer process. Each window gets isolated JS, isolated `document`, isolated module state.
+
+In `app.rs` or wherever CEF settings are configured:
+```rust
+settings.renderer_process_per_site = true;
+// OR use the command-line switch:
+// --renderer-process-per-site
+```
+
+### Option B: Use CEF `request_context` per browser
+
+Create a new `CefRequestContext` for each browser window in `open_window_at_position`. Each request context gets its own renderer process.
+
+### Option C: Use separate-process window creation
+
+Instead of `browser_host_create_browser` (in-process), spawn a new `agentmux-cef.exe` process for each window (like the portable launcher does). Each process has fully isolated CEF.
+
+### Option D: Frontend-side workaround (quickest)
+
+Make the frontend robust to shared-renderer mode:
+- Pass `windowLabel` to `initWave` and use it to scope all DOM operations
+- Never rely on module-level singletons — use per-window state maps
+- Key SolidJS render trees by window label
+
+This is the most work but doesn't require CEF changes.
+
+---
+
+## Recommended Fix
+
+**Option A** is simplest. One line in CEF settings forces process isolation per site (which in our case = per window since they all load from `localhost:5173`). Each window gets its own V8 isolate, its own `document`, its own module state.
+
+If that flag doesn't isolate per-window (since they're same-origin), try `--site-per-process` or create distinct request contexts (Option B).
+
+---
+
+## Files Involved
+
+| File | Role |
+|------|------|
+| `agentmux-cef/src/app.rs` | CEF settings — add renderer isolation |
+| `agentmux-cef/src/commands/drag.rs:337` | `browser_host_create_browser` — may need `request_context` |
+| `frontend/wave.ts:515` | `initWaveWrap` — `savedInitOpts` shared across windows |
+| `frontend/wave.ts:585` | `initWave` — `render(App, elem)` targets wrong DOM |

--- a/docs/analysis/persistent-process-retro-2026-04-10.md
+++ b/docs/analysis/persistent-process-retro-2026-04-10.md
@@ -70,6 +70,50 @@ using `--input-format stream-json` for bidirectional communication.
   programs (Node, Python, etc.). Rust's `canonicalize()` is the only stdlib
   function that produces these paths.
 
+### 9. Stale instances stacking up — port file collisions (v0.33.86-91)
+- **Symptom:** "Sent new-window request to existing instance" — new versions
+  refuse to launch, or open windows in a broken older instance.
+- **Root cause:** Test instances (.86, .87, .88, .89) were never closed between
+  builds. Each version left an `ipc-port` file in its data dir. New launches
+  connected to the stale port and delegated, or opened a window in a broken
+  instance whose frontend was from a different branch.
+- **Fix:** Discipline — always kill the previous test instance before launching
+  the next. Only `.78` (our running instance) and ONE test instance at a time.
+- **Lesson:** `tasklist | grep agentmux | grep -v "0.33.78"` before every launch.
+  Clean up stale port files. Never let instances stack up.
+
+### 10. "Failed to load AgentMux frontend" — stale instance windows (v0.33.86-91)
+- **Symptom:** Multiple windows show "Failed to load AgentMux frontend" with
+  `ERR_CONNECTION_REFUSED` to `localhost:5173`.
+- **Root cause:** These were windows from stale .86/.89 instances that were never
+  closed. The "Sent new-window request to existing instance" mechanism opened
+  new windows in these broken instances. The frontend couldn't load because
+  `frontend/index.html` wasn't found relative to the exe in those builds
+  (branch mismatch or build artifact issue).
+- **Fix:** Killed all stale instances. The .88 build that was properly launched
+  worked fine — frontend loaded correctly.
+- **Lesson:** "Failed to load" errors during testing are usually stale instances,
+  not build bugs. Close everything and retry with a clean state.
+
+### 11. agent.open creates block but pane not visible in UI (v0.33.88-89)
+- **Symptom:** `agent.open` returns success, `agent.list` shows the agent, but
+  no pane appears in the UI.
+- **Root cause:** `create_block` only adds the block to the tab's `blockids` and
+  stores it in the database. The layout tree (`LayoutState.rootnode`) is a
+  separate data structure that defines what the frontend renders. Without a
+  layout node, the block is invisible.
+- **Fix:** After `create_block`, insert a layout node into the tab's `LayoutState`:
+  - Empty tab: set as sole root node
+  - Existing panes: wrap old root + new leaf in a row container
+  - Update `leaforder` array
+  - Broadcast layout + tab + block updates via event bus
+- **Lesson:** The layout tree is the source of truth for what's visible. Creating
+  a block without a layout node is like adding a row to a database table without
+  updating the UI's data source. The frontend's `createBlock()` uses
+  `layoutModel.treeReducer(InsertNode)` which handles all the edge cases
+  (splitting, focusing, flex sizing). The backend layout manipulation is simpler
+  but functional.
+
 ---
 
 ## Architecture Decisions

--- a/docs/analysis/pr-267-276-takeover.md
+++ b/docs/analysis/pr-267-276-takeover.md
@@ -1,0 +1,88 @@
+# PR #267 + #276 Takeover Report
+
+**Date:** 2026-04-02
+**Author:** AgentA (taking over from AgentX)
+
+## PR #267: fix(win11): pane focus ring — DOM renderer + backdrop-filter
+
+**Status:** Approved by reagent, needs splitting
+**Branch:** `agentx/fix-win11-pane-focus-highlight`
+
+### What it does (4 changes bundled together)
+
+1. **Default to DOM renderer on Windows** (`term.tsx`, `termwrap.ts`)
+   - WebGL canvases on Win11 get promoted to DWM hardware overlay planes
+   - CSS borders can't paint above hardware overlays → focus ring invisible
+   - DOM renderer not promoted → focus ring visible
+   - Opt-in to WebGL via `term:disablewebgl=false`
+
+2. **`backdrop-filter: blur(0.1px)` on `.block-mask`** (`block.scss`)
+   - Forces compositor to render the mask above all sampled layers
+   - Guarantees focus ring renders above xterm's scroll layer
+
+3. **Remove `z-index` from `.block-focused`** (`block.scss`)
+   - `z-index` creates stacking context that isolates xterm's GPU layer
+   - Without it, `.block-mask` at `z-index:50` composites correctly
+
+4. **Win11 `dragend` safety net** (`TileLayout.win32.tsx`)
+   - Prevents `activeDrag` from sticking after snap-layout interruption
+   - **Separate concern — should be its own PR**
+
+### Concerns
+
+- **DOM renderer default degrades terminal performance.** DOM is significantly slower for fast-scrolling output (e.g., `cat` large file, build logs). Most users won't know to opt-in to WebGL.
+- **`backdrop-filter` hack is fragile** — relies on Chromium compositor behavior.
+- **No version bump** — has bump commits but they conflict with current main.
+
+### Plan: Split into 2 PRs
+
+**PR A:** CSS focus ring fix (block.scss + blockframe.tsx)
+- `backdrop-filter: blur(0.1px)` on `.block-mask`
+- Remove `z-index` from `.block-focused`
+- Move `BlockMask` to last in DOM
+- Low risk, pure CSS
+
+**PR B:** DOM renderer default on Windows (term.tsx + termwrap.ts)
+- Needs perf testing before merging
+- Consider: is `backdrop-filter` alone sufficient without switching renderers?
+
+**PR C:** Win11 dragend safety net (TileLayout.win32.tsx)
+- Separate concern, separate PR
+
+---
+
+## PR #276: fix(term): eliminate character echo delay
+
+**Status:** Changes requested by reagent (hardcoded path in package-portable.ps1)
+**Branch:** `agentx/fix-keyboard-echo-delay`
+
+### What it does
+
+- Small PTY writes (≤512 bytes) bypass `requestAnimationFrame` and write directly to xterm.js
+- Eliminates 16-32ms latency on character echo during PTY output
+- Removes noisy `console.log` from RAF write path
+
+### Root cause
+
+`scheduleRafWrite` (scroll-flicker fix) added RAF latency to ALL PTY output including single-byte echoes. When a write was in flight, new data waited for the full current write + another RAF cycle = 24ms+ delay per keystroke during output.
+
+### Concerns
+
+- **Has unrelated files:** `scripts/package-portable.ps1` with hardcoded user path, `CLAUDE.md` changes, bump commits
+- **Core fix is sound:** 512-byte threshold is reasonable, xterm.js serializes writes internally
+
+### Plan: Cherry-pick the termwrap.ts change only
+
+The actual fix is a single file change in `termwrap.ts`. Everything else is noise from the other agent's session.
+
+---
+
+## Execution Plan
+
+1. Close PR #267 and #276 (from agentx branch, too much noise)
+2. Cherry-pick the good changes onto clean branches from main:
+   - `agenta/focus-ring-css` — block.scss + blockframe.tsx changes
+   - `agenta/dom-renderer-windows` — term.tsx + termwrap.ts renderer change (needs perf test)
+   - `agenta/dragend-safety` — TileLayout.win32.tsx
+   - `agenta/fix-echo-delay` — termwrap.ts RAF bypass
+3. PR each separately with reagent review

--- a/docs/analysis/process-grouping-retro-2026-04-07.md
+++ b/docs/analysis/process-grouping-retro-2026-04-07.md
@@ -1,0 +1,69 @@
+# Process Grouping Retro — 2026-04-07
+
+**Session:** AgentA  
+**Trigger:** User reported "processes not grouped under AgentMux CEF in Task Manager"  
+**Resolution:** False alarm — grouping was working correctly in v0.33.57
+
+---
+
+## What Happened
+
+User reported that AgentMux processes were not grouped in Task Manager. The earlier analysis doc (`docs/analysis/process-tree-grouping.md`, written 2026-04-05) had already modelled this as a real bug caused by the launcher architecture.
+
+I immediately moved to implement the recommended fix (Option A — DETACHED_PROCESS spawn in the launcher). Before the build completed, the user opened v0.33.57 and confirmed grouping was working fine.
+
+Reverted the launcher change before it was committed or built.
+
+---
+
+## Root Cause of the False Alarm
+
+The prior analysis doc (2026-04-05) described a real scenario where processes scatter, but got the Task Manager grouping mechanism wrong.
+
+**What the doc assumed:**  
+Task Manager groups sub-processes under their OS-level parent process (by PID parent-child relationship). Since the launcher has no visible window, it lands in "Background processes", and the CEF host (its child) would scatter too.
+
+**What Task Manager actually does:**  
+Task Manager groups sub-processes under the process that **owns visible top-level windows**, regardless of parent PID. Since `agentmux-cef.exe` creates the CEF windows, Task Manager treats it as the "App" owner. All of its child processes (renderer, GPU, utility, backend sidecar) nest under it correctly — even though the launcher is technically the OS-level parent and is sitting in "Background processes".
+
+So the launcher + `.status()` (wait for exit) pattern is correct and does NOT break grouping. The launcher remains a background entry, the CEF host appears in "Apps", and everything groups properly.
+
+---
+
+## Why the Prior Analysis Was Wrong
+
+The 2026-04-05 analysis was written during the launcher architecture investigation (PR #298). It was based on the theoretical behavior of Task Manager's parent-PID grouping. It was never validated empirically against a live build that showed the actual behavior. PR #302's test plan item "Process grouping under agentmux-cef.exe in Task Manager is preserved" was added based on the assumption that grouping was already broken and needed to be preserved — but the grouping was fine.
+
+---
+
+## Correct Mental Model
+
+```
+Task Manager (Processes tab)
+
+[Apps]
+  AgentMux CEF v0.33.57                    ← agentmux-cef-0.33.57.exe, owns CEF windows
+    agentmux-cef-0.33.57.exe (renderer)    ← child of CEF host
+    agentmux-cef-0.33.57.exe (gpu)         ← child of CEF host
+    agentmux-cef-0.33.57.exe (utility)     ← child of CEF host
+    agentmux-srv-0.33.57-windows.x64.exe   ← spawned by CEF host (Job Object tied)
+      pwsh.exe                              ← shell pane 1
+      pwsh.exe                              ← shell pane 2
+
+[Background processes]
+  agentmux.exe                             ← launcher, no window, waiting for CEF to exit
+```
+
+The launcher is an orphan entry in Background processes — that is expected and harmless.
+
+---
+
+## What Was NOT Reverted
+
+The launcher source was edited and immediately reverted before any commit. No build was produced. The `docs/analysis/process-tree-grouping.md` file remains as historical context but its Option A recommendation is no longer needed and should not be acted on without fresh evidence that grouping is actually broken.
+
+---
+
+## Lesson
+
+Before implementing a fix for a reported regression, verify the regression is actually present in the current build. A 30-second test run would have saved the investigation entirely.

--- a/docs/analysis/process-tree-grouping.md
+++ b/docs/analysis/process-tree-grouping.md
@@ -1,0 +1,145 @@
+# Process Tree Grouping Analysis
+
+**Date:** 2026-04-05
+**Issue:** AgentMux processes appear as independent background processes in Task Manager instead of grouped under one app entry.
+
+---
+
+## Findings
+
+### How Task Manager Groups Processes
+
+Task Manager's "Processes" tab has two sections:
+- **"Apps"** — processes that own a **visible top-level window**
+- **"Background processes"** — everything else
+
+Child processes appear nested under their parent **only if the parent itself is in the "Apps" section** (owns a visible window). If the parent is invisible, its children appear as independent entries.
+
+### The Process Tree
+
+```
+agentmux.exe (launcher)                    ← windows_subsystem = "windows", NO visible window
+  └─ agentmux-cef-0.33.45.exe (browser)   ← creates CEF windows, SHOULD be an "App"
+       ├─ agentmux-cef-0.33.45.exe --type=gpu-process
+       ├─ agentmux-cef-0.33.45.exe --type=renderer
+       ├─ agentmux-cef-0.33.45.exe --type=utility
+       └─ agentmux-srv-0.33.45-windows.x64.exe (backend sidecar)
+            ├─ pwsh.exe (terminal pane 1)
+            ├─ pwsh.exe (terminal pane 2)
+            └─ bash.exe (terminal pane 3)
+```
+
+### Evidence: What Controls the Grouping
+
+| File | Line | Code | Effect |
+|---|---|---|---|
+| `agentmux-launcher/src/main.rs` | 12-15 | `windows_subsystem = "windows"` | Launcher has NO console, NO visible window |
+| `agentmux-launcher/src/main.rs` | 56-58 | `Command::new(&real_exe).args(&args).status()` | Spawns CEF as child, no special flags |
+| `agentmux-cef/src/main.rs` | 18-22 | `windows_subsystem = "windows"` | CEF host also no console |
+| `agentmux-cef/src/sidecar.rs` | 120 | `cmd.creation_flags(0x08000000)` | Backend spawned with `CREATE_NO_WINDOW` |
+| `agentmux-cef/src/sidecar.rs` | 134-153 | Job Object `KILL_ON_JOB_CLOSE` | Ties backend lifecycle to CEF, does NOT affect TM grouping |
+
+### The Problem
+
+The launcher (`agentmux.exe`) is the process tree root but has `windows_subsystem = "windows"` and never creates a visible window. It just spawns the CEF host and calls `.status()` to wait.
+
+Task Manager sees:
+1. `agentmux.exe` — no window → "Background processes"
+2. `agentmux-cef-0.33.45.exe` — has CEF windows → should be "Apps", BUT its parent is a background process
+3. Backend + shells — no windows → "Background processes"
+
+The result: everything scatters across "Background processes" instead of grouping under one "Apps" entry.
+
+### When Did This Break?
+
+**This is NOT caused by the v0.33.44 versioned names change.** The launcher architecture was introduced earlier. Before the launcher existed, `agentmux-cef.exe` was run directly — it owned the windows and appeared under "Apps" with all its children grouped.
+
+The launcher added an invisible wrapper that broke the grouping because Task Manager doesn't group children under an invisible parent.
+
+### Previous Behavior (Pre-Launcher)
+
+```
+[Apps]
+  AgentMux CEF                              ← agentmux-cef.exe owned the windows directly
+    ├─ agentmux-cef.exe (gpu)
+    ├─ agentmux-cef.exe (renderer)
+    └─ agentmux-srv-... (backend)
+         ├─ pwsh.exe
+         └─ bash.exe
+```
+
+### Current Behavior (With Launcher)
+
+```
+[Background processes]
+  agentmux.exe                              ← invisible launcher
+  AgentMux CEF v0.33.45                     ← CEF host, has windows but parent is invisible
+  agentmux-cef-0.33.45.exe                  ← GPU subprocess
+  agentmux-cef-0.33.45.exe                  ← renderer subprocess  
+  agentmux-srv-0.33.45-windows.x64.exe      ← backend
+  pwsh.exe                                   ← shell 1
+  pwsh.exe                                   ← shell 2
+```
+
+---
+
+## Solution Options
+
+### Option A: Launcher Exits After Spawn (Recommended)
+
+Make the launcher exec-replace itself with the CEF host on Windows. Since Windows has no `execvp()`, the launcher can:
+1. Spawn the CEF host as a **detached** process (not a child)
+2. Exit immediately
+
+The CEF host becomes a top-level process that owns windows → appears under "Apps". The launcher is gone.
+
+**Downside:** Launcher can't monitor exit codes for watchdog/restart logic. But that's Phase 2 anyway.
+
+**Implementation:**
+```rust
+// agentmux-launcher/src/main.rs
+#[cfg(target_os = "windows")]
+{
+    use std::os::windows::process::CommandExt;
+    // DETACHED_PROCESS = 0x00000008
+    // CREATE_NEW_PROCESS_GROUP = 0x00000200
+    let child = std::process::Command::new(&real_exe)
+        .args(&args)
+        .creation_flags(0x00000008) // DETACHED_PROCESS
+        .spawn();
+    match child {
+        Ok(_) => std::process::exit(0), // launcher exits, CEF is now top-level
+        Err(e) => {
+            eprintln!("Failed to launch AgentMux: {}", e);
+            std::process::exit(1);
+        }
+    }
+}
+```
+
+### Option B: Launcher Creates a Hidden HWND
+
+The launcher creates an invisible window (size 0x0 or off-screen) so Task Manager recognizes it as an "App". Its children then group under it.
+
+**Downside:** More code, hacky, and the launcher's invisible window could interfere with focus/activation.
+
+### Option C: Move DLL Path Setup Into CEF Host
+
+The only reason the launcher exists is to call `SetDllDirectoryW` before the CEF host's load-time dependency on `libcef.dll` is resolved. If we can solve the DLL search path differently, the launcher is unnecessary:
+- Use a `.local` file (DLL redirection)
+- Use an application manifest with `<probing>` element
+- Delay-load `libcef.dll`
+
+**Downside:** Significant rearchitecture, may not be feasible with CEF's load-time linking.
+
+### Option D: Accept Current Behavior
+
+Multiple background process entries is technically correct. The grouping is cosmetic.
+
+---
+
+## Recommendation
+
+**Option A** is the simplest fix. The launcher spawns the CEF host as a detached process and exits. The CEF host becomes the top-level process owner, Task Manager groups everything under it.
+
+The only thing lost is the launcher's ability to monitor the CEF host's exit code (for future watchdog logic). That can be addressed separately when implementing the GPU crash recovery watchdog — the watchdog would be a separate persistent process, not the launcher.

--- a/docs/analysis/pty-duplicate-output-debug.md
+++ b/docs/analysis/pty-duplicate-output-debug.md
@@ -1,0 +1,172 @@
+# PTY Duplicate Output & Color Offset Debug — 2026-04-03
+
+## Symptom
+- Duplicate characters in xterm output (some chars duplicated, others dropped)
+- Color highlighting at wrong offsets
+- Observed with Claude Code CLI running inside AgentMux 0.33.27
+
+## Root Cause Candidates
+
+### 1. ptyOffset double-counting (most likely for duplicate/drop)
+
+`doTerminalWrite()` in `termwrap.ts:381` tracks `ptyOffset` by adding `data.length` (byte count of the raw base64-decoded chunk). This is the **byte offset into the backend file**.
+
+The load path in `loadInitialTerminalData()` does:
+1. Fetch cache file → `doTerminalWrite(cacheData, ptyOffset)` — sets `ptyOffset` to the cache's stored value
+2. Fetch main file from `ptyOffset` — appends only bytes after the cache
+
+If there's a race or overlap between:
+- `loadInitialTerminalData()` (initial load, uses `doTerminalWrite` with explicit `setPtyOffset`)
+- `handleNewFileSubjectData()` (live WS events, uses `scheduleRafWrite` → `doTerminalWrite` with `setPtyOffset=null`)
+
+…then live events that arrive **during** the load get written twice: once from the file fetch and once from the WS stream. Or they get dropped if the ptyOffset overshoots.
+
+### 2. RAF bypass race (duplicate for small chunks)
+
+`scheduleRafWrite()` at line 338-347:
+```ts
+if (data.length <= 512 && this.rafBuffer.length === 0 && !this.writeInFlight) {
+    this.doTerminalWrite(data, null);  // direct write, bypasses RAF
+    return;
+}
+this.rafBuffer.push(data);
+```
+
+If `writeInFlight=true` but `rafBuffer` is empty when a small chunk arrives, it falls through to `rafBuffer.push`. When the in-flight write finishes and drains the buffer, that chunk gets written. But if ANOTHER small chunk arrives before `writeInFlight` clears, the check `rafBuffer.length === 0` is false — it queues instead of bypasses. This is correct behavior, but it means ordering depends on the exact timing of `writeInFlight` transitions.
+
+The guard added in PR #278 (`bf78e71`) protects against out-of-order small chunks, but a subtle case exists: if `doTerminalWrite` is called directly (bypass path) while a RAF flush is mid-`terminal.write()` callback, xterm.js may process them out of order internally since `terminal.write()` is async.
+
+### 3. Wrong offsets for color (ANSI escape sequence split across chunks)
+
+ANSI escape sequences (color codes) are multi-byte: `\x1b[38;2;R;G;Bm`. If a chunk boundary lands **inside** an escape sequence, xterm.js will:
+- Process the partial sequence as literal characters → duplicate/garbage output
+- When the continuation arrives, try to interpret it as a new sequence → wrong color offsets
+
+Claude Code uses Ink which emits heavy ANSI: cursor positioning, RGB colors, cursor-up sequences. These can easily be split across WebSocket messages.
+
+The RAF batching (PR #273) was specifically designed to coalesce these — but the bypass path for small chunks (≤512 bytes) can re-introduce splits if a continuation chunk is small and bypasses while the first chunk is in-flight.
+
+### 4. `ptyOffset` uses `data.length` (bytes) but xterm uses character positions
+
+`ptyOffset += data.length` counts **raw bytes** (the base64-decoded wire bytes). This is the correct unit for the backend file offset. However, if the offset drifts (e.g. due to the race in candidate #1), subsequent fetches request data from the wrong position → partial writes or overlap → duplicates or drops.
+
+---
+
+## Debug Instrumentation Plan
+
+### A. Log every write with sequence number + offset tracking
+
+In `doTerminalWrite()`, add a sequence counter and log before and after:
+
+```ts
+private writeSeq = 0;
+
+doTerminalWrite(data: string | Uint8Array, setPtyOffset?: number): Promise<void> {
+    const seq = ++this.writeSeq;
+    const byteLen = typeof data === "string" ? data.length : data.length;
+    const offsetBefore = this.ptyOffset;
+    console.log(`[tw] write#${seq} bytes=${byteLen} ptyOffset=${offsetBefore} setPtyOffset=${setPtyOffset ?? "null"} src=${new Error().stack?.split('\n')[2]?.trim()}`);
+    // ... existing code ...
+    this.terminal.write(data, () => {
+        console.log(`[tw] write#${seq} DONE ptyOffset=${this.ptyOffset} elapsed=${...}ms`);
+        resolve();
+    });
+}
+```
+
+This tells you:
+- Sequence of writes
+- Whether offset is advancing correctly
+- Whether any writes fire out of order (seq gaps)
+- Call site (RAF flush vs direct bypass vs initial load)
+
+### B. Tag the source of each write
+
+Three paths feed `doTerminalWrite`:
+1. `loadInitialTerminalData` (cache replay)
+2. `loadInitialTerminalData` (main file fetch)
+3. `scheduleRafWrite` → RAF flush
+4. `scheduleRafWrite` → direct bypass
+
+Add a `source` tag:
+
+```ts
+doTerminalWrite(data: string | Uint8Array, setPtyOffset?: number, source = "unknown"): Promise<void> {
+    console.log(`[tw:${source}] seq=${++this.writeSeq} bytes=${data.length} ptyOffset=${this.ptyOffset}`);
+```
+
+Call sites:
+- `doTerminalWrite(cacheData, ptyOffset, "cache")` 
+- `doTerminalWrite(mainData, null, "main-file")`
+- `doTerminalWrite(data, null, "raf-bypass")`
+- `doTerminalWrite(merged, null, "raf-flush")`
+
+### C. Detect chunk boundary ANSI splits
+
+Check if a chunk ends mid-escape-sequence:
+
+```ts
+function endsInPartialEscape(data: Uint8Array): boolean {
+    // Check last 8 bytes for \x1b or partial CSI
+    const tail = data.slice(-8);
+    for (let i = tail.length - 1; i >= 0; i--) {
+        if (tail[i] === 0x1b) return true; // ESC not followed by complete sequence
+    }
+    return false;
+}
+```
+
+Log a warning in `scheduleRafWrite` when a bypassed chunk ends in a partial escape — that's a guaranteed color offset bug.
+
+### D. WS message arrival timestamps
+
+In `handleNewFileSubjectData`, log arrival time and chunk size:
+
+```ts
+handleNewFileSubjectData(msg: WSFileEventData) {
+    const now = performance.now();
+    if (msg.fileop === "append") {
+        const decoded = base64ToArray(msg.data64);
+        console.log(`[tw:ws] fileop=append bytes=${decoded.length} t=${now.toFixed(1)}ms loaded=${this.loaded}`);
+        // Check for ANSI split
+        if (endsInPartialEscape(decoded)) {
+            console.warn(`[tw:ws] WARN: chunk ends in partial escape — color split likely bytes=${decoded.length}`);
+        }
+```
+
+This catches the key case: chunks arriving before `loaded=true` go into `heldData` — if they overlap with `loadInitialTerminalData`'s file fetch, you'll see duplicates.
+
+### E. Log `loaded` transition
+
+```ts
+// Where this.loaded is set to true (in initTerminal):
+console.log(`[tw] loaded=true, flushing ${this.heldData.length} held chunks`);
+```
+
+---
+
+## Where to Look First
+
+Given the "duplicating some, dropping others" behavior specifically with Claude Code output:
+
+1. **Check the `loaded` flag race** — Claude Code streams output continuously. If WS events arrive before `loadInitialTerminalData` completes AND the file fetch already includes those bytes, you'll see exact duplicates of the tail of the output.
+
+2. **Check `ptyOffset` after load** — add `console.log('[tw] initial load complete, ptyOffset=', this.ptyOffset)`. If it doesn't match the actual file size, every subsequent live write will be off.
+
+3. **Check RAF bypass during high-throughput** — Claude Code's Ink UI emits many small cursor-positioning sequences. Some will hit the bypass path while larger content chunks are in-flight → potential ordering issue.
+
+---
+
+## Files to Modify
+
+| File | What |
+|------|------|
+| `frontend/app/view/term/termwrap.ts` | Add debug logging in `doTerminalWrite`, `scheduleRafWrite`, `handleNewFileSubjectData`, `loadInitialTerminalData` |
+
+All logs appear in the `task dev` terminal output tagged `[fe]` — **not in browser DevTools** (log pipe forwards all console output to the backend).
+
+## Build & Test
+```bash
+npm run build:dev   # or task dev for hot reload
+```
+Look for `[fe] [tw:*]` entries in the sidecar log output.

--- a/docs/analysis/test-infrastructure-audit-2026-04-04.md
+++ b/docs/analysis/test-infrastructure-audit-2026-04-04.md
@@ -1,0 +1,212 @@
+# Test Infrastructure Audit — 2026-04-04
+
+## Executive Summary
+
+AgentMux has a **distributed test infrastructure** spanning three platforms:
+- **Rust backend** (agentmux-srv): 907+ unit/integration tests
+- **Frontend** (TypeScript/SolidJS): 10 vitest files testing UI and layout
+- **E2E**: 2 Playwright tests — **stale**, written for removed Tauri host
+- **No CI/CD**: No GitHub Actions workflows — tests only run manually
+
+---
+
+## What Works Today
+
+| Component | Framework | Command | Tests |
+|-----------|-----------|---------|-------|
+| Rust unit tests | cargo test | `cargo test -p agentmux-srv` | 857 `#[test]` + 50 `#[tokio::test]` |
+| Rust integration | cargo test | `cargo test -p agentmux-srv --test integration_test` | 4 tests |
+| Frontend unit | Vitest 3.0.9 | `npm test` | 10 test files |
+| Layout engine | Vitest | `npm test` | 4 test files (689 lines) |
+| Coverage | Istanbul | `npm run coverage` | LCOV output to `./coverage/` |
+| CDK infra | Jest | `cd infra/cdk && npm test` | 2 test files |
+
+## What's Broken / Stale
+
+| Component | Issue |
+|-----------|-------|
+| E2E Playwright tests | Written for Tauri — reference `_electron`, `tauri-driver`, removed paths |
+| WebdriverIO configs | `wdio.conf.cjs` + `wdio.macos.conf.cjs` — target dead Tauri architecture |
+| npm E2E scripts | `test:e2e`, `test:e2e:macos`, `test:e2e:debug` — all broken |
+| CI/CD | No `.github/workflows/` — zero automated test runs on push/PR |
+| Shell copytests | 48 bash scripts in `tests/copytests/cases/` — not integrated into any runner |
+
+---
+
+## Rust Test Breakdown (907+ tests)
+
+### By Module (top files)
+
+| File | Tests | Notes |
+|------|-------|-------|
+| `backend/ijson.rs` | 33 | JSON manipulation |
+| `backend/dbutil.rs` | 26 | SQLite helpers |
+| `backend/fileutil.rs` | 26 | File operations |
+| `backend/base.rs` | 21 | Base utilities |
+| `backend/envutil.rs` | 18 | Environment/path |
+| `backend/wcore/mod.rs` | 18 | Core CRUD operations |
+| `backend/ai/tools.rs` | 17+4 | AI tool use |
+| `backend/ai/mod.rs` | 15 | AI routing |
+| `backend/blockcontroller/shell.rs` | 16 | Shell controller lifecycle |
+| `backend/blockcontroller/mod.rs` | 14 | Controller registry |
+| `backend/wconfig/mod.rs` | 31 | Config parsing/serde |
+
+### Integration Test (`agentmux-srv/tests/integration_test.rs`)
+
+4 tests that spawn the real backend binary:
+1. `health_returns_200` — HTTP health check
+2. `auth_rejects_missing_key` — 401 on missing auth
+3. `auth_accepts_valid_header` — 200 with valid auth
+4. `sigterm_exits_process` — graceful shutdown
+
+**Note:** Integration tests don't compile currently — `server/tests.rs` has pre-existing struct field mismatches.
+
+### Untested Crates
+
+- `agentmux-cef` — no tests (CEF host, IPC bridge)
+- `agentmux-wsh` — no tests (shell integration CLI)
+- `agentmux-launcher` — no tests (tiny DLL path launcher)
+
+---
+
+## Frontend Test Breakdown (10 files)
+
+### Vitest Config (`vitest.config.ts`)
+- Reporter: verbose + JUnit XML
+- Coverage: Istanbul → LCOV
+- No coverage thresholds defined
+
+### Test Files
+
+| File | Purpose |
+|------|---------|
+| `app/block/autotitle.test.ts` | Auto-title from workspace paths |
+| `app/store/backendStatus.test.ts` | Backend connectivity state |
+| `app/tab/tabbar-dnd.test.ts` | Tab bar drag-and-drop |
+| `app/view/agent/providers/index.test.ts` | AI provider selection |
+| `app/view/agent/state.test.ts` | Agent state management |
+| `app/view/agent/stream-parser.test.ts` | Stream response parsing |
+| `layout/tests/layoutModel.test.ts` | Layout model (196 lines) |
+| `layout/tests/layoutNode.test.ts` | Layout nodes (301 lines) |
+| `layout/tests/layoutTree.test.ts` | Layout tree (84 lines) |
+| `layout/tests/utils.test.ts` | Layout utilities (108 lines) |
+
+### Untested Frontend Areas
+- Terminal view (`app/view/term/`) — no tests
+- Forge view (`app/view/forge/`) — no tests
+- Store layer (`app/store/wos.ts`, `global.ts`) — minimal coverage
+- IPC layer (`app/platform/ipc.ts`) — no tests
+- Most UI components — no tests
+
+---
+
+## E2E Tests (Stale)
+
+### Files
+- `e2e/close-button.test.ts` (112 lines) — Playwright + Electron API
+- `e2e/widget-click.test.ts` (134 lines) — Playwright + CDP on port 9333
+- `e2e/debug-launch.ts`, `test-agent-debug.ts`, `test-close-button.ts` — helper scripts
+
+### Why Stale
+- Reference `_electron as electron` API (Electron host removed)
+- Reference `make/win-unpacked/AgentMux.exe` (Tauri build path, deleted)
+- WebdriverIO configs target `tauri-driver` (removed)
+- Port 9333 CDP was WebView2 debugging — CEF uses different mechanism
+
+### Configs (all stale)
+- `playwright.config.ts` — timeout 120s, workers 1, HTML reporter
+- `wdio.conf.cjs` — targets `src-tauri/target/release/agentmux`
+- `wdio.macos.conf.cjs` — mocks `window.__TAURI_INTERNALS__`
+
+---
+
+## Shell Integration Tests
+
+48 bash scripts in `tests/copytests/cases/` (test000.sh through test047.sh).
+
+Test `wsh file copy` operations with various scenarios. Not integrated into any standard test runner — must be run manually.
+
+---
+
+## Test Commands Reference
+
+```bash
+# Frontend unit tests
+npm test                                    # vitest (watch mode)
+npm run coverage                            # vitest + istanbul coverage
+
+# Rust tests
+cargo test -p agentmux-srv                  # all unit + integration
+cargo test -p agentmux-srv --lib            # unit tests only
+cargo test -p agentmux-srv -- wcore         # filter by name
+
+# CDK tests
+cd infra/cdk && npm test                    # jest
+
+# E2E (STALE — do not run)
+# npm run test:e2e                          # broken (Tauri)
+# npm run test:e2e:macos                    # broken (Tauri)
+```
+
+---
+
+## File Tree
+
+```
+agentmux/
+├── vitest.config.ts                    # Frontend test config
+├── playwright.config.ts                # E2E config (stale)
+├── wdio.conf.cjs                       # WebdriverIO (stale)
+├── wdio.macos.conf.cjs                 # WebdriverIO macOS (stale)
+│
+├── e2e/                                # E2E tests (stale)
+│   ├── close-button.test.ts
+│   └── widget-click.test.ts
+│
+├── frontend/
+│   ├── app/
+│   │   ├── block/autotitle.test.ts
+│   │   ├── store/backendStatus.test.ts
+│   │   ├── tab/tabbar-dnd.test.ts
+│   │   └── view/agent/
+│   │       ├── providers/index.test.ts
+│   │       ├── state.test.ts
+│   │       └── stream-parser.test.ts
+│   └── layout/tests/
+│       ├── layoutModel.test.ts
+│       ├── layoutNode.test.ts
+│       ├── layoutTree.test.ts
+│       └── utils.test.ts
+│
+├── agentmux-srv/
+│   ├── src/                            # 63 modules with #[cfg(test)]
+│   │   └── (857 #[test] + 50 #[tokio::test])
+│   └── tests/
+│       └── integration_test.rs         # 4 integration tests
+│
+├── infra/cdk/test/
+│   ├── agentmux-webhook-stack.test.ts
+│   └── integration.test.ts
+│
+└── tests/copytests/cases/
+    └── test000.sh .. test047.sh        # 48 shell scripts
+```
+
+---
+
+## Critical Gaps
+
+1. **No CI/CD** — zero automated test runs on push/PR
+2. **E2E tests stale** — written for removed Tauri host, need CEF rewrite
+3. **No coverage enforcement** — thresholds not set
+4. **Integration tests broken** — `server/tests.rs` has pre-existing compile errors
+5. **agentmux-cef/wsh untested** — lightweight but no test coverage at all
+6. **48 shell copytests orphaned** — not in any runner
+
+## Recommendations
+
+1. **GitHub Actions**: `cargo test` on Rust changes, `npm test` on frontend changes
+2. **Fix integration tests**: Update `server/tests.rs` struct fields
+3. **Delete or rewrite E2E**: Remove stale Tauri tests, write CEF equivalents if needed
+4. **Coverage gates**: Set 70% floor on frontend, enforce in CI
+5. **Integrate copytests**: Either wrap in cargo test harness or remove

--- a/docs/analysis/websocket-robustness-cef.md
+++ b/docs/analysis/websocket-robustness-cef.md
@@ -1,0 +1,77 @@
+# WebSocket Robustness in CEF
+
+**Date:** 2026-04-02
+**Trigger:** UI freeze during testing — WebSocket disconnected, frontend went unresponsive
+
+## Current State
+
+The WebSocket layer (`frontend/app/store/ws.ts`) has reconnect logic from the Tauri era:
+
+### What exists (PR #233, #223)
+- `WSControl.reconnect()` — exponential backoff up to 60s, max 20 attempts then gives up
+- `WSControl.changeEndpoint()` — reconnects to new port after backend restart
+- `backendStatus.ts` — listens for `backend-terminated` / `backend-ready` events
+- Ping/pong heartbeat every 5 seconds
+- Message queue for offline buffering
+
+### What works
+- Reconnects after clean close
+- Reconnects after backend restart (new port)
+- Detects backend crash via `backend-terminated` event
+
+### What doesn't work (CEF-specific gaps)
+
+#### 1. No `backend-terminated` event in CEF
+The `backend-terminated` event is emitted by the Tauri host when the sidecar dies. In CEF, the host (`main.rs`) spawns the sidecar via `std::process::Child` with a Windows Job Object (KILL_ON_JOB_CLOSE). If the sidecar crashes:
+- The Job Object kills it
+- But there's no event emitted to the frontend
+- `backendStatusAtom` stays "running" while WS is dead
+- UI becomes unresponsive
+
+**Fix needed:** CEF host should monitor the sidecar process and emit `backend-terminated` event when it exits.
+
+#### 2. Gives up after 20 reconnect attempts
+`reconnectTimes > 20` → stops trying. If the sidecar is slow to restart or the port changes, the frontend permanently gives up.
+
+**Fix needed:** Never fully give up — switch to longer intervals (e.g., 60s) but keep trying. Show a reconnecting indicator to the user.
+
+#### 3. No visibility-based reconnect
+When the window regains focus after being backgrounded, the WS might be dead but the reconnect timer hasn't fired yet.
+
+**Fix needed:** On `visibilitychange` or `focus`, check WS state and reconnect immediately.
+
+#### 4. WS URL hardcoded at init time
+The WS URL is set during `initGlobalWS()` from the backend endpoints. If the sidecar restarts with a different port, only the `backend-ready` event path updates it. If that event is missed (race condition), the WS reconnects to the old port forever.
+
+**Fix needed:** On reconnect failure, re-query the backend endpoints via IPC before retrying.
+
+## What Caused Today's Freeze
+
+The sidecar log shows two WebSocket disconnects at 14:59:18 and 14:59:21. After that, no reconnection — the frontend was frozen.
+
+Likely sequence:
+1. Something caused the WebSocket connection to drop (possibly a large terminal write, or the sidecar briefly stalled)
+2. The `onclose` handler fired → `reconnect()` called
+3. Reconnect may have failed (sidecar port changed, or 20 attempts exhausted from previous disconnects)
+4. Frontend stuck with no WS — all RPC calls hang, UI becomes unresponsive
+
+## Priority Fixes
+
+### P0: Emit backend-terminated in CEF host
+Monitor sidecar process in a background thread. On exit, emit event to all browsers via JS injection.
+
+### P1: Never give up reconnecting
+Change `reconnectTimes > 20` to slower intervals instead of giving up.
+
+### P2: Re-query endpoints on reconnect failure
+If WS connect fails, call `get_backend_endpoints` IPC to get current port.
+
+### P3: Frontend reconnect indicator
+Show a banner when WS is disconnected so the user knows the UI is stale.
+
+## References
+- PR #233: `fix(ws): reconnect to new backend endpoint after restart`
+- PR #223: `feat: sidecar modularization + backend crash recovery`
+- `frontend/app/store/ws.ts` — WSControl class
+- `frontend/app/store/backendStatus.ts` — backend status signals
+- `agentmux-cef/src/sidecar.rs` — sidecar spawning

--- a/docs/analysis/white-screen-overnight-2026-04-08.md
+++ b/docs/analysis/white-screen-overnight-2026-04-08.md
@@ -1,0 +1,146 @@
+# White Screen Overnight — 2026-04-08
+
+**Reporter:** User (area54)
+**Investigator:** AgentA
+**Instances affected:** v0.33.62, v0.33.64, v0.33.73 (all 3 running portable instances)
+**Symptom:** All instances showed solid white screen after overnight idle. Processes still running, heartbeats still ticking.
+
+---
+
+## Evidence from Logs
+
+### Smoking gun: `webglcontextlost` in v0.33.64
+
+```
+2026-04-08T17:16:30.331Z  [fe] webglcontextlost event received
+2026-04-08T17:16:30.408Z  WebSocket client disconnected conn_id=b02380e9...
+```
+
+The frontend received a `webglcontextlost` event, then the WebSocket disconnected. No crash, no error, no OOM — the process continued running but the rendering surface was gone.
+
+### Timeline per instance
+
+| Instance | Last real [fe] activity | webglcontextlost? | Heartbeat still running? |
+|----------|------------------------|-------------------|-------------------------|
+| v0.33.62 | 16:07 (idle timeout save) | Not logged (may have fired before log-pipe was ready, or xterm canvas lost context silently) | Yes, 18:08 |
+| v0.33.64 | 10:41 (focus event), then 17:16 (context lost) | **Yes** — 17:16:30 UTC | Yes, 18:08 |
+| v0.33.73 | 10:13 (startup + initial render) | Not logged | Yes, 18:08 |
+
+### Memory at time of white screen (all healthy)
+
+| Instance | Working Set | Peak WS | Commit | System Avail |
+|----------|------------|---------|--------|-------------|
+| v0.33.62 | 158 MB | 213 MB | 203 MB | 19.3 GB |
+| v0.33.64 | 170 MB | 177 MB | 225 MB | 19.3 GB |
+| v0.33.73 | 148 MB | 148 MB | 152 MB | 19.3 GB |
+
+No OOM. No memory pressure. System load was 39% with 19+ GB available.
+
+### Other errors (benign, unrelated)
+
+All 3 instances logged on startup:
+```
+[UNHANDLED-REJECTION] Cannot read properties of undefined (reading 'getPlatform')
+```
+This is a race condition during CEF API initialization — the platform bridge isn't ready when the frontend first tries to call it. Separate bug, not the cause of white screen.
+
+---
+
+## Root Cause Analysis
+
+### What happened
+
+Windows performed a display driver reset overnight (TDR — Timeout Detection and Recovery, or monitor sleep/wake power state change). This invalidated all GPU contexts system-wide.
+
+### Why it caused white screen
+
+PR #311 added `--in-process-gpu` to merge the GPU process into the CEF browser process. This has a known tradeoff documented in the code:
+
+> Tradeoff: GPU driver crash kills the app instead of just restarting the GPU process — acceptable for a local desktop app.
+> — `agentmux-cef/src/app.rs:252`
+
+However, the actual behavior is **worse than documented**. A GPU context loss with `--in-process-gpu` doesn't crash the app — it leaves the app in a **zombie rendering state**:
+- Process alive (heartbeat ticking)
+- Backend alive (websocket was connected until context loss)
+- Frontend JavaScript alive (can still log)
+- But the rendering surface (WebGL/compositor context) is gone
+- Result: solid white screen with no way to recover
+
+### With vs without `--in-process-gpu`
+
+| Scenario | Separate GPU process | In-process GPU |
+|----------|---------------------|----------------|
+| GPU context lost | GPU process crashes, Chromium restarts it, page re-composits | Rendering surface gone, no recovery path |
+| Driver TDR reset | GPU process restarts transparently | White screen zombie state |
+| App crash risk | GPU crash isolated | GPU crash can kill entire app |
+| Memory overhead | +100GB VA (virtual, not physical) | Eliminated |
+
+### Online research confirms this
+
+- **Electron issue [#11934](https://github.com/electron/electron/issues/11934)**: `webglcontextrestored` event does NOT fire after GPU process respawn — Chromium bug, still open
+- **Electron issue [#31625](https://github.com/electron/electron/issues/31625)**: WebGL context lost on screen minimize — same class of bug
+- **Electron issue [#8517](https://github.com/electron/electron/issues/8517)**: Context lost when switching displays with dual GPU
+- **CEF Forum [thread](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=17386)**: CEF crash after Windows wake up — GPU context loss after sleep, "Lost UI shared context" errors
+- **Chromium design doc on [GPU compositing](https://www.chromium.org/developers/design-documents/gpu-accelerated-compositing-in-chrome/)**: GPU process exists for crash isolation; in-process mode removes that isolation
+- **Microsoft TechCommunity [bug report](https://techcommunity.microsoft.com/discussions/windows11/bug-applications-can-crash-after-sleephibernation-if-uses-dedicated-graphics/4024966)**: Applications crash after sleep/hibernation when using dedicated graphics — GPU disabled during sleep, app can't find device on wake
+- **Khronos WebGL wiki on [handling context loss](https://khronos.org/webgl/wiki/HandlingContextLost)**: Must call `event.preventDefault()` on `webglcontextlost` and re-init on `webglcontextrestored`
+
+---
+
+## Fix Options
+
+### Option 1: Remove `--in-process-gpu` (recommended)
+
+**Restore the separate GPU process.** Let Chromium's built-in crash recovery handle driver resets.
+
+- **Pro:** Battle-tested recovery path, no code changes needed beyond removing the flag
+- **Con:** Adds one process (~100GB virtual address space, ~20-50MB physical RAM)
+- **The 100GB VA concern from PR #311 was about PartitionAlloc pools** — this is virtual address space, not physical memory. On a 64-bit system with 128TB VA space, 100GB is 0.07%. It's free.
+
+```rust
+// Remove these lines from app.rs:249-255:
+// let gpu_key = CefString::from("in-process-gpu");
+// cmd.append_switch(Some(&gpu_key));
+```
+
+### Option 2: Add `webglcontextlost` handler with page reload
+
+Listen for context loss in the frontend, reload the page to re-establish the rendering surface.
+
+```javascript
+// In frontend init:
+document.addEventListener('webglcontextlost', (event) => {
+    event.preventDefault();
+    console.error('[recovery] WebGL context lost — reloading page');
+    setTimeout(() => window.location.reload(), 500);
+}, true);
+```
+
+- **Pro:** Works with or without `--in-process-gpu`, preserves memory savings
+- **Con:** User sees a page flash/reload; terminal state may be lost mid-session; `contextrestored` doesn't reliably fire in Chromium ([electron#11934](https://github.com/electron/electron/issues/11934)) so reload is the only reliable recovery
+- **Risk:** If the driver is permanently gone (not just a TDR), this creates a reload loop
+
+### Option 3: Both (belt and suspenders)
+
+Remove `--in-process-gpu` AND add the `webglcontextlost` handler. The handler becomes a safety net for edge cases where even the separate GPU process can't recover.
+
+---
+
+## Recommendation
+
+**Option 1 (remove `--in-process-gpu`)** for the immediate fix. The VA overhead is negligible and the separate GPU process is Chromium's designed recovery path.
+
+**Option 2 as a follow-up** regardless — `webglcontextlost` can happen even with a separate GPU process in rare cases, and a reload handler is cheap insurance.
+
+The `--renderer-process-limit=1` and memory heartbeat from PR #311 are still valuable and should be kept.
+
+---
+
+## Secondary Bug: `getPlatform` UNHANDLED-REJECTION
+
+All 3 instances log on startup:
+```
+[UNHANDLED-REJECTION] Cannot read properties of undefined (reading 'getPlatform')
+```
+
+This is a race condition where the frontend calls `getPlatform()` before the CEF API bridge (`window.__AGENTMUX_CEF__` or similar) is injected. Not related to the white screen but should be fixed separately — likely needs a ready-state gate or retry in the CEF API initialization path.

--- a/docs/analysis/window-process-coupling.md
+++ b/docs/analysis/window-process-coupling.md
@@ -1,0 +1,221 @@
+# Window-Process Coupling Analysis
+
+**Date:** 2026-04-05
+
+---
+
+## Background
+
+AgentMux is a CEF-based desktop terminal app. The process tree looks like:
+
+```
+agentmux.exe (launcher, windows_subsystem="windows", no visible window)
+  └─ agentmux-cef-0.33.46.exe (CEF browser host — owns windows → appears in Task Manager "Apps")
+       ├─ agentmux-cef-0.33.46.exe --type=gpu-process
+       ├─ agentmux-cef-0.33.46.exe --type=renderer (per window)
+       └─ agentmux-srv-0.33.46-windows.x64.exe (backend, Job Object KILL_ON_JOB_CLOSE)
+            ├─ pwsh.exe (terminal panes, children of agentmux-srv)
+            └─ pwsh.exe
+```
+
+Task Manager groups processes by parent PID. Shells appear under `agentmux-srv` which appears under `agentmux-cef`. This grouping is only maintained while `agentmux-cef` has a visible window — otherwise everything falls into "Background processes."
+
+---
+
+## The Two Requirements That Keep Conflicting
+
+**Requirement A (Shell Cleanup):** When a secondary window closes, all shell processes (pwsh, bash, cmd) for that window's tabs/panes must exit. Without cleanup, they become resource-wasting orphans.
+
+**Requirement B (Task Manager Grouping):** Shell processes must remain visually grouped under `agentmux-cef` in Task Manager while alive. They must not appear as independent "Background processes."
+
+---
+
+## Why These Requirements Conflict
+
+Task Manager grouping is based on **live process tree** (parent-child PID relationships). A process appears "independent" in Background processes if:
+
+1. It has no parent with a visible window, OR
+2. It died while its parent was still alive (the act of dying is seen as "detaching")
+
+Both requirements involve the same event: a secondary window close. The conflict is about **when** shells die relative to the CEF process being alive:
+
+- **Kill shells while CEF is alive** → they die independently → briefly appear as ungrouped before disappearing from Task Manager
+- **Kill shells after CEF exits** → too late for secondary window close (CEF only fully exits when ALL windows close via Job Object)
+
+The true fix requires killing shells in a window narrow enough that Task Manager does not register them as independent: either before the window is visible (impossible) or after the CEF renderer for that window is already gone.
+
+---
+
+## Three Attempts and Why Each Failed
+
+### Attempt 1: No Cleanup (before PR #299, through v0.33.44)
+
+No code to kill shells on window close.
+
+**Result:**
+- Shell cleanup: shells stay alive as orphans indefinitely
+- Grouping: shells stay alive and remain grouped under `agentmux-cef`
+
+### Attempt 2: PR #299 + `beforeunload` Handler (v0.33.45)
+
+Code added to `frontend/wave.ts`:
+
+```typescript
+window.addEventListener("beforeunload", () => {
+    const wid = windowId();
+    if (wid && windowCountAtom() > 1) {
+        WindowService.CloseWindow(wid).catch(() => {});
+    }
+});
+```
+
+`beforeunload` fires before the CEF window is destroyed. The `fetch()` to `agentmux-srv` goes out, and the backend kills shells via `delete_controller()`. The shells die while `agentmux-cef.exe` and `agentmux-srv.exe` are still running.
+
+**Additional bug:** `windowCountAtom` was a SolidJS signal set via `setWindowCountAtom`. When a secondary window closed, the CEF host emitted `"window-instances-changed"` only on OPEN (in `open_new_window`), never on close. So the main window's `windowCountAtom` stayed at 2 even after the secondary closed. This caused the main window's `beforeunload` to also call `CloseWindow` unnecessarily.
+
+**Result:**
+- Shell cleanup: shells die when window closes (`fetch` completes because `beforeunload` has a brief synchronous window in Chromium)
+- Grouping: shells die while CEF is alive → they appear as independent background processes momentarily before disappearing
+
+**User observation:** "i see the processes exit now, but before they were listed under the main CEF process, now they are independent in the background processes"
+
+### Attempt 3: `on_before_close` Rust Hook (v0.33.46)
+
+**Design:**
+
+1. Frontend calls `registerBackendWindow(label, windowId)` IPC after `initWave()` completes, storing `window_label → backend_window_id` in `AppState.window_id_map`
+2. CEF Rust `on_before_close` hook: looks up the closing browser's label → looks up backend window ID → spawns thread → raw TCP call to `agentmux-srv /wave/service?method=CloseWindow`
+3. Also emits `"window-instances-changed"` to remaining windows (fixes the `windowCountAtom` stale count bug from Attempt 2)
+
+**Result:**
+- Grouping: fixed (user confirmed "i see they all stay together now")
+- Tab close: fixed (`delete_tab_inner` calls `delete_controller` from PR #299)
+- Shell cleanup on window close: broken again — shells do not exit when a secondary window closes
+
+---
+
+## Root Cause Analysis: v0.33.46 Window Close Failure
+
+The `on_before_close` Rust hook spawns a thread that calls `backend_close_window()`. This function makes a raw TCP connection to `agentmux-srv` and sends an HTTP POST to `/wave/service`.
+
+Three possible failure points have been identified.
+
+### Failure Point A: `window_id_map` Is Empty for the Closing Browser
+
+`backend_window_id` is looked up via:
+
+```rust
+self.state.window_id_map.lock().remove(lbl)
+```
+
+Where `lbl` comes from:
+
+```rust
+browsers.iter()
+    .find(|(_, b)| b.is_same(Some(&mut browser)) != 0)
+    .map(|(k, _)| k.clone())
+```
+
+If `b.is_same()` returns 0 for all browsers (identity comparison broken across CEF Rust binding clones), `label` = None → `backend_window_id` = None → only a warning is logged, no cleanup.
+
+Alternatively, if the `register_backend_window` IPC call failed silently (`.catch(() => {})`), the entry was never added to `window_id_map`.
+
+### Failure Point B: TCP Call Reaches Backend but Wrong Request Format
+
+The raw HTTP body sent is:
+
+```json
+{"service":"window","method":"CloseWindow","args":["<window-id>"],"uicontext":null}
+```
+
+`agentmux-srv`'s `handle_service` at `server/service.rs:18` does `serde_json::from_slice(&body)` into `WebCallType`. Then `dispatch_service` does `service::get_arg(args, 0)` for the window ID, reading `args[0]` as the window UUID string. Deserialization as `String` should succeed.
+
+Auth: the raw TCP request includes `?authkey={auth_key}` which matches what `auth_middleware` checks. This path is not the failure point.
+
+### Failure Point C: Thread Timing
+
+This is not the failure point. Axum processes the request before writing the response. The server-side processing (killing shells) happens regardless of whether the client reads the response.
+
+---
+
+## The Fundamental Design Tension
+
+**CEF's process management model:** CEF is designed around browsers. Browser lifecycle events (`on_before_close`, `do_close`) are the canonical hooks for cleanup. But these hooks run while the CEF process is still alive, meaning any shells killed here die independently (not via CEF process exit), which is visible in Task Manager.
+
+**Windows Task Manager's grouping model:** Task Manager groups by live parent-child PID relationships. Once a process dies, it's gone. If it dies while its parent chain is alive, there is a brief moment where Task Manager shows it as "detaching." With rapid kills (< 50ms from window close to shell exit), this flash is imperceptible. With slower kills (> 500ms), the user may briefly see shells in "Background processes" before they disappear.
+
+**The actual conflict is timing, not architecture:**
+
+- `beforeunload` kills shells while the window is still open (still showing on screen) → 500–2000ms while visible → noticeable ungrouped flash
+- `on_before_close` Rust hook fires AFTER the window begins destroying → the shell kill happens after the window is visually gone → the ungrouped flash is imperceptible or zero
+
+The `on_before_close` Rust approach is architecturally correct. The grouping problem with `beforeunload` arose because kills happened while the window was still visible. The v0.33.46 approach kills shells after the window is already gone — the issue is only that the lookup or TCP call is silently failing.
+
+---
+
+## Diagnosis Steps for v0.33.46
+
+### Step 1: Add Visible Logging
+
+In `client.rs` `on_before_close`, add an explicit log for the window ID lookup result:
+
+```rust
+tracing::info!(
+    "[on_before_close] secondary window close: label={:?} backend_window_id={:?}",
+    label,
+    backend_window_id
+);
+```
+
+### Step 2: Verify `register_backend_window` Is Being Called
+
+In `commands/window.rs` `register_backend_window`, check CEF log for lines like:
+
+```
+[window] registered backend window ID label=window-{uuid} window_id={uuid}
+```
+
+If these lines are absent, the IPC call is not completing and `window_id_map` is never populated.
+
+### Step 3: Verify Browser Identity Comparison
+
+Add a debug log inside the `find` closure to count how many browsers are checked and whether any match. This will confirm whether `is_same` is returning 0 for all entries.
+
+### Step 4: Alternative — Use Browser Identifier Directly
+
+Instead of using `is_same` to find the browser label (which requires cloning the CEF browser object across the binding layer), store a `browser_id → label` map in `AppState` and populate it in `on_after_created`. CEF browsers have a unique integer ID accessible via `browser.identifier()`. This avoids the `is_same` cloning issue entirely:
+
+```rust
+// in on_after_created:
+let id = browser.identifier();
+self.state.browser_label_map.lock().insert(id, label);
+
+// in on_before_close:
+let id = browser.identifier();
+let label = self.state.browser_label_map.lock().remove(&id);
+```
+
+---
+
+## Definitive Solution
+
+The definitive solution that achieves both requirements simultaneously:
+
+1. **Keep the v0.33.46 Rust `on_before_close` approach.** This is architecturally correct. Shells killed here die after the window is visually gone, so Task Manager never registers them as independent background processes.
+
+2. **Fix the `window_id_map` lookup by keying on `browser.identifier()` (integer ID) instead of label string.** This eliminates ambiguity from `is_same` comparisons across cloned CEF Rust binding objects.
+
+3. **Keep `register_backend_window` but map by browser ID.** Have the frontend register `(windowLabel, backendWindowId)`. In Rust, map `browser_id → (label, backendWindowId)`, populated in `on_after_created` where the browser object is first available and unambiguous.
+
+**Expected outcome:** Shells die after the window is visually gone. Task Manager never shows them as independent. Grouping is preserved until the moment of death. Both Requirement A and Requirement B are satisfied.
+
+---
+
+## Summary Table
+
+| Version | Mechanism | Shell Cleanup | Task Manager Grouping |
+|---|---|---|---|
+| v0.33.44 and before | None | No | Yes |
+| v0.33.45 (PR #299) | `beforeunload` fetch | Yes | No (brief ungrouped flash) |
+| v0.33.46 | `on_before_close` Rust hook | No (lookup failure) | Yes |
+| Target fix | `on_before_close` + `browser.identifier()` key | Yes | Yes |

--- a/docs/analysis/window-resize-handlers.md
+++ b/docs/analysis/window-resize-handlers.md
@@ -1,0 +1,107 @@
+# Window Edge Resize Handlers — Analysis
+
+**Date:** 2026-04-02
+**Status:** Not working — windows cannot be resized by dragging edges
+**Pane resize:** Works (internal SolidJS drag handles)
+
+## Problem
+
+After the white flash fix (PR #268, #271), window edge resize no longer works. Users cannot drag the window edges or corners to resize. Pane resize (internal dividers) still works — this is purely a Win32 window-level issue.
+
+## What Changed Across PRs #268, #270, #271
+
+**Before (CEF Views mode):** The main window used CEF Views framework (`window_create_top_level`). Resize was handled by CEF internally via the `WindowDelegate::can_resize() -> 1` callback. No Win32 styles needed — CEF managed everything.
+
+**PR #268:** Switched main window from CEF Views to native Win32 mode (`browser_host_create_browser` with `WindowInfo`). This gave us control over `WS_VISIBLE` to fix the white flash. But it also meant resize now depends on Win32 styles (`WS_THICKFRAME`) instead of CEF's internal delegate.
+
+**PR #270:** Removed `--disable-gpu-compositing` (unrelated to resize).
+
+**PR #271:** Removed `WS_THICKFRAME` from window creation (caused white L-shaped border flash). Moved it to `on_load_end` via `SetWindowLongPtrW` + `SWP_FRAMECHANGED`. Also removed `DwmExtendFrameIntoClientArea` from all windows and `setup_native_frameless` from secondary windows.
+
+**Net effect:** Both resize mechanisms are gone:
+- CEF Views `can_resize` delegate → no longer used (native mode)
+- Win32 `WS_THICKFRAME` at creation → removed (causes flash)
+- Win32 `WS_THICKFRAME` post-show → added but not working (see analysis below)
+- `DwmExtendFrameIntoClientArea` + `WS_THICKFRAME` combo → removed (causes flash)
+
+## Root Cause
+
+`WS_THICKFRAME` is required for Windows to process `WM_NCHITTEST` hit-test results (HTLEFT, HTRIGHT, etc.) as resize actions. Without it, returning HTLEFT from WM_NCHITTEST is ignored by the window manager.
+
+### Timeline
+
+1. **Original (CEF Views):** CEF Views handled resize internally — no Win32 style needed
+2. **PR #268:** Switched to native window mode. Added `WS_THICKFRAME` at creation for resize
+3. **PR #271:** Removed `WS_THICKFRAME` from creation (caused white border flash). Added it back in `on_load_end` via `SetWindowLongPtrW` + `SetWindowPos(SWP_FRAMECHANGED)`
+
+### Why Post-Show WS_THICKFRAME Doesn't Work
+
+Adding `WS_THICKFRAME` after the window is visible via `SetWindowLongPtrW` + `SWP_FRAMECHANGED` should theoretically work. Possible reasons it doesn't:
+
+1. **CEF intercepts WM_NCHITTEST** — CEF's browser HWND may be handling hit-testing internally and not forwarding to the parent window's `WM_NCHITTEST` handler
+2. **WndProc hook order** — Our `install_frameless_resize_hook` replaces the WndProc BEFORE `WS_THICKFRAME` is added. The hook returns HTLEFT/etc but Windows may need the thick frame style present when the hook is installed
+3. **Child window covers entire client area** — CEF creates a child window (Chrome_WidgetWin) that fills the entire client area. Mouse events go to the child, not the parent. The child doesn't forward `WM_NCHITTEST` to the parent
+4. **SWP_FRAMECHANGED timing** — The `SetWindowPos` call may need to happen on the UI thread at a specific point in the message loop
+
+## WndProc Hook Implementation
+
+Current hook in `client.rs` (`install_frameless_resize_hook`):
+
+```rust
+WM_NCCALCSIZE if wparam == 1 => return 0;  // Remove non-client area
+WM_NCACTIVATE => return 1;                  // Suppress DWM border
+WM_NCHITTEST => {
+    // Check cursor against window rect edges (6px border)
+    // Return HTLEFT, HTRIGHT, HTTOP, HTBOTTOM, or corner variants
+    // Falls through to original WndProc if not on edge
+}
+```
+
+This hook is installed on the **browser HWND** (from `host.window_handle()`), which in native mode IS the top-level window. The hook should work — the question is whether `WM_NCHITTEST` messages reach it.
+
+## Possible Fixes
+
+### Option A: Verify WS_THICKFRAME is actually applied
+
+Add logging after `SetWindowLongPtrW` to confirm the style was set:
+```rust
+let new_style = GetWindowLongPtrW(target, GWL_STYLE);
+tracing::info!("WS_THICKFRAME set: {}", (new_style & WS_THICKFRAME as isize) != 0);
+```
+
+### Option B: Re-install WndProc hook after WS_THICKFRAME
+
+The hook may need to be installed AFTER `WS_THICKFRAME` is added. Currently:
+1. `on_after_created`: install hook (no WS_THICKFRAME yet)
+2. `on_load_end`: add WS_THICKFRAME
+
+Try reversing: add `WS_THICKFRAME` first, then re-install the hook.
+
+### Option C: Handle resize via WM_SYSCOMMAND
+
+Instead of relying on `WM_NCHITTEST` + `WS_THICKFRAME`, manually initiate resize:
+```rust
+WM_LBUTTONDOWN => {
+    // If cursor near edge, send WM_SYSCOMMAND with SC_SIZE + direction
+    SendMessageW(hwnd, WM_SYSCOMMAND, SC_SIZE | direction, 0);
+}
+```
+This doesn't require `WS_THICKFRAME` at all.
+
+### Option D: Transparent resize border overlay
+
+Create a separate transparent layered window around the main window that handles resize. This is what some apps (e.g., Spotify) do for frameless windows.
+
+### Option E: Move WS_THICKFRAME to creation, use DWMWA_CLOAK for border
+
+Create with `WS_THICKFRAME` (border exists but window is cloaked). The cloak hides both the content flash AND the border. Uncloak after `WM_NCCALCSIZE` has already hidden the border via the hook.
+
+## Recommended Next Step
+
+Start with **Option A** (verify the style is set) then **Option B** (re-install hook after style). If neither works, **Option C** (WM_SYSCOMMAND) is the most reliable — it doesn't depend on window styles at all.
+
+## References
+
+- [WM_NCHITTEST docs](https://learn.microsoft.com/en-us/windows/win32/inputdev/wm-nchittest)
+- [Custom Window Frame Using DWM](https://learn.microsoft.com/en-us/windows/win32/dwm/customframe)
+- [Frameless window resize without WS_THICKFRAME](https://www.tutorialpedia.org/blog/create-window-without-titlebar-with-resizable-border-and-without-bogus-6px-white-stripe/)

--- a/docs/heartbeat-status-report.md
+++ b/docs/heartbeat-status-report.md
@@ -1,0 +1,93 @@
+# Memory Heartbeat Status Report — v0.33.60
+
+**Date:** 2026-04-07
+**PR:** #311 (`agenta/memory-heartbeat-inprocess-gpu`)
+**Build:** v0.33.60 portable
+
+---
+
+## What Was Added (PR #311)
+
+1. **`--in-process-gpu`** — merges GPU process into browser, eliminates one ~100GB VA reservation
+2. **`--renderer-process-limit=1`** — caps renderer subprocess spawns
+3. **`memory_heartbeat` module** — logs system + process memory every 20s
+
+## Heartbeat Implementation
+
+**File:** `agentmux-cef/src/memory_heartbeat.rs` (121 lines)
+
+- Spawns background thread named `mem-heartbeat`
+- Sleeps 20s between logs (sleeps before first log to avoid startup burst)
+- Uses Win32 APIs: `GlobalMemoryStatusEx()` + `GetProcessMemoryInfo()`
+- Emits two `tracing::info!` entries per cycle to target `mem_heartbeat`:
+  - **System memory:** load%, total/available phys RAM, page file, virtual memory
+  - **Process memory:** working set, peak WS, commit, peak commit, page faults
+
+## Current Status: NOT OBSERVABLE IN PORTABLE MODE
+
+### The Problem
+
+The CEF host initializes tracing to write to **stderr only** (`main.rs:58-64`):
+
+```rust
+tracing_subscriber::fmt()
+    .with_env_filter(...)
+    .with_writer(std::io::stderr)
+    .init();
+```
+
+In portable mode, the launcher spawns `agentmux-cef-0.33.60.exe` as a GUI process. **stderr is not captured anywhere.** The heartbeat thread is running and logging, but the output goes to `/dev/null`.
+
+### Evidence
+
+- No log file exists for v0.33.60 in `~/.agentmux/logs/`
+- Last host log: `agentmux-host-v0.33.1.log.2026-03-30`
+- No `.log` files in the portable directory
+- The sidecar (`agentmux-srv`) writes its own log files to `~/.agentmux/logs/` but the CEF host does not
+
+### Where It DOES Work
+
+- `task dev` — stderr is visible in the terminal
+- Any launch where stderr is redirected: `agentmux.exe 2>heartbeat.log`
+
+## Recommendation: Add File Logging to CEF Host
+
+The heartbeat's entire purpose is forensic crash analysis — the data must persist on disk to be useful. Two options:
+
+### Option A: File appender in CEF host (recommended)
+
+Add `tracing-appender` to write to `~/.agentmux/logs/agentmux-host-v{VERSION}.log.{DATE}`:
+
+```rust
+use tracing_appender::rolling;
+let file_appender = rolling::daily(&log_dir, format!("agentmux-host-v{}.log", version));
+let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+
+tracing_subscriber::fmt()
+    .with_env_filter(...)
+    .with_writer(non_blocking)  // file instead of stderr
+    .init();
+```
+
+This matches what the sidecar already does and would restore the `agentmux-host-v*.log.*` files that stopped appearing after v0.33.1.
+
+### Option B: Launcher captures stderr
+
+Have `agentmux-launcher` redirect the child's stderr to a log file. Simpler but less flexible.
+
+## Other Heartbeat Systems (for context)
+
+The codebase has additional health monitoring unrelated to the memory heartbeat:
+
+| System | Location | Purpose |
+|--------|----------|---------|
+| Agent Health Monitor | `agentmux-srv/.../health.rs` | Tracks agent subprocess state (Healthy→Degraded→Stalled→Dead) |
+| Parent Process Watcher | `agentmux-srv/src/main.rs` | Detects frontend death, shuts down backend |
+| Process Watchdog | `agentmux-srv/.../watchdog.rs` | Kills panes exceeding max-runtime/idle limits |
+| IPC Health Endpoint | `agentmux-cef/src/ipc.rs` | `GET /health` → `{"status":"ok","version":"..."}` |
+
+These all function independently. Only the memory heartbeat has the stderr-sink issue.
+
+---
+
+**Bottom line:** The heartbeat code is correct and running, but its output is invisible in portable builds. Adding a file appender is a ~10 line fix that makes the forensic data actually available for crash analysis.

--- a/docs/memory-retro-report.md
+++ b/docs/memory-retro-report.md
@@ -1,0 +1,124 @@
+# AgentMux Memory Retrospective — From v0.12 to v0.33.62
+
+**Date:** 2026-04-07
+**Author:** AgentA (Claude Opus 4.6)
+
+---
+
+## The Journey
+
+### Phase 1: Electron Era (v0.12.x — Oct 2025)
+- **Stack:** Electron + Go backend + Node.js
+- **Memory profile:** Electron's multi-process model (main + renderer + GPU + utility)
+- **Binary size:** ~25 MB Go backend alone
+- **Pain points:** electron-builder packaging bugs, hardware acceleration crashes on RDP/Sandbox
+- **Notable:** v0.14.0 disabled hardware acceleration entirely for Windows Sandbox/RDP compatibility
+
+### Phase 2: Tauri Migration (v0.15.x–v0.27.x — Jan–Feb 2026)
+- **Stack:** Tauri (WebView2) + Go backend → transitioning to Rust
+- **Memory profile:** WebView2 shared renderer, lighter than Electron
+- **Pain points:**
+  - `custom-protocol` feature gate bug: webview always loaded production bundle even in dev mode (fixed PR #6)
+  - System WebView2 version inconsistency across machines
+  - CGO signal faults on macOS (systray crash, v0.27.14)
+
+### Phase 3: Go → 100% Rust (v0.29–v0.31 — Feb 2026)
+- **Stack:** Tauri + 100% Rust backend
+- **Binary size:** 5.5 MB total (agentmuxsrv 4.4 MB + wsh 1.1 MB) — **78% smaller** than Go
+- **Memory:** 3.6x lower baseline than Go backend (measured at v0.29.0)
+- **Notable:** Deleted all Go source code. Rewrote wsh in Rust (1.1 MB vs 11 MB, 90% reduction)
+
+### Phase 4: CEF Migration (v0.32.x–v0.33.x — Mar–Apr 2026)
+- **Stack:** CEF (Chromium Embedded Framework) + Rust backend
+- **Why:** Pinned Chromium version eliminates system WebView2 version lottery
+- **Memory profile:** CEF's PartitionAlloc reserves massive virtual address space per subprocess:
+  - **32 GB GigaCage** per process
+  - **4 x 16 GB pools** per process
+  - **4 GB V8 pointer cage** per process
+  - Total: **~100 GB VA** per CEF subprocess
+  - On a 16 GB machine with 87 GB total user-mode VA, 3 subprocesses left <3 GB free
+
+---
+
+## The Crashes
+
+### OOM #1: FileStore Cache Leak (v0.32.77, fixed v0.32.78 — PR #222)
+- **Symptom:** Sidecar crash `0xC0000409` after 4+ hours of multi-agent usage
+- **Root cause:** `flush_cache()` was a complete no-op — nothing ever set `dirty=true`, so the cache grew forever. Plus `write_file()` duplicated all data into `data_entries` that was never read.
+- **Growth rate:** ~4 MB/hour under multi-agent workloads
+- **Fix:** Added LRU eviction with 60s TTL, stopped caching write data
+- **Lesson:** WER crash dumps configured (`%LOCALAPPDATA%\CrashDumps\`) for future forensics
+
+### OOM #2: VA Exhaustion from CEF Subprocesses (v0.33.57, mitigated v0.33.58 — PR #311)
+- **Symptom:** Potential VA exhaustion on machines with limited address space
+- **Root cause:** Each CEF subprocess (browser, GPU, renderer) reserves ~100 GB VA. DevTools popups could spawn additional renderers.
+- **Fix (PR #311):**
+  - `--in-process-gpu` — merges GPU process into browser, eliminates one ~100 GB reservation
+  - `--renderer-process-limit=1` — caps renderer spawns
+  - Added `memory_heartbeat` module for forensic telemetry
+
+### Logging Gap: Heartbeat Writing to /dev/null (v0.33.58–v0.33.61)
+- **Problem:** CEF host tracing went to stderr only. In portable/GUI mode, stderr is not captured.
+- **Effect:** Heartbeat was running but output was lost — defeating its forensic purpose
+- **Fix (v0.33.62):** Added `tracing-appender` with rolling daily log file to `~/.agentmux/logs/`
+
+---
+
+## Where We Are Now (v0.33.62)
+
+### Live Heartbeat Data (first ~2 minutes of runtime)
+
+**System:**
+| Metric | Value |
+|--------|-------|
+| Physical RAM | 31.9 GB total, 22.6 GB available |
+| Memory load | 29% |
+| Page file | 76.5 GB total, 63.9 GB available |
+| Virtual address space | 131 TB total, 130.9 TB available |
+
+**CEF Host Process:**
+| Metric | First Beat (T+20s) | Latest (T+100s) | Delta |
+|--------|---------------------|------------------|-------|
+| Working set | 179.6 MB | 168.1 MB | -11.5 MB (settled) |
+| Peak working set | 182.2 MB | 182.2 MB | stable |
+| Commit | 252.0 MB | 163.6 MB | -88.4 MB (GC/decommit) |
+| Peak commit | 255.6 MB | 255.6 MB | stable |
+| Page faults | 118,608 | 120,210 | +1,602 (normal) |
+
+### Process Count (with --in-process-gpu)
+- **Browser process** (includes GPU) — 1 process
+- **Renderer** — 1 process (capped by --renderer-process-limit=1)
+- **Total VA reserved:** ~200 GB (2 processes x ~100 GB) vs ~300 GB before (3 processes)
+- **VA headroom:** 130.9 TB available — not a concern on this 64-bit machine
+
+### Binary Sizes (current)
+| Component | Size |
+|-----------|------|
+| agentmux-launcher (agentmux.exe) | 325 KB |
+| agentmux-cef | ~5 MB |
+| agentmux-srv | ~4.4 MB |
+| wsh | ~1.1 MB |
+| CEF runtime (DLLs + resources) | ~300 MB |
+| **Portable ZIP** | **152 MB** |
+
+---
+
+## Timeline Summary
+
+| Version | Date | Stack | Backend Binary | Baseline Memory | Key Event |
+|---------|------|-------|----------------|-----------------|-----------|
+| v0.12.x | Oct 2025 | Electron + Go | 25 MB | High | Initial fork |
+| v0.15.x | Jan 2026 | Tauri + Go | 25 MB | Medium | Agent colors, reactive messaging |
+| v0.29.0 | Feb 2026 | Tauri + Rust | 5.5 MB | 3.6x lower than Go | Go deleted, 100% Rust |
+| v0.32.78 | Mar 2026 | CEF + Rust | 5.5 MB | Stable (leak fixed) | FileStore OOM fix |
+| v0.33.58 | Apr 2026 | CEF + Rust | 5.5 MB | ~180 MB WS | --in-process-gpu, heartbeat added |
+| v0.33.62 | Apr 2026 | CEF + Rust | 5.5 MB | ~168 MB WS | File logging, heartbeat visible |
+
+---
+
+## What's Left
+
+1. **Long-running stability:** The FileStore leak is fixed, but the heartbeat is new — need 24+ hour soak tests to confirm no new leaks
+2. **Heartbeat alerting:** Currently log-only. Could add threshold-based warnings (e.g., >80% memory load)
+3. **VA on 32-bit / low-VA machines:** Not a concern on this 64-bit dev machine (131 TB VA), but `--in-process-gpu` is insurance for constrained environments
+4. **CEF multi-window:** Each new window could spawn additional renderer processes — monitor with heartbeat

--- a/docs/specs/app-api-extension.md
+++ b/docs/specs/app-api-extension.md
@@ -1,0 +1,689 @@
+# App API Extension Spec
+
+**Status:** Proposed
+**Date:** 2026-04-10
+**Motivation:** CEF webview content is inaccessible to external automation tools
+(Windows MCP, AppleScript, etc.). The only reliable way to programmatically
+control AgentMux is through its own API surface.
+
+---
+
+## Problem
+
+AgentMux exposes ~65 CEF IPC commands and 100+ backend RPC commands, but they're
+low-level primitives (SetMeta, CreateBlock, ControllerResync). Common high-level
+operations require orchestrating 3-5 calls in the correct order with the correct
+metadata keys. This makes external automation fragile and tightly coupled to
+internal implementation details.
+
+**Example — opening an agent pane today requires:**
+1. `CreateBlock` with `{ view: "agent" }`
+2. `SetMeta` with agentId, provider, controller, cmd, cmd:args, cmd:env, cmd:cwd, ...
+3. `ControllerResync` with forcerestart
+4. Wait for CLI resolution + auth check
+5. `AgentInput` with the first message
+
+Any change to metadata keys, env var names, or launch flow breaks all callers.
+
+---
+
+## Design Principles
+
+1. **High-level intent, not low-level mechanics.** Callers express what they want
+   ("open an agent pane with AgentX"), not how to do it ("create block, set 14
+   metadata keys, resync controller").
+
+2. **Stable contract.** Internal metadata keys, env vars, and controller types
+   can change without breaking the API. The API translates intent to internals.
+
+3. **Idempotent where possible.** `openAgent` with the same agent ID returns the
+   existing pane if one is already open. `sendAgentMessage` auto-spawns if needed.
+
+4. **Observable.** Every action returns enough state to know what happened.
+   Streaming endpoints for real-time output.
+
+5. **Transport-agnostic.** Same commands work over CEF IPC (in-process), WebSocket
+   RPC (cross-process), and HTTP REST (external tools). Implementation is one
+   function called from all three transports.
+
+---
+
+## New Commands
+
+### Tier 1 — Agent Lifecycle (needed now)
+
+#### `agent.open`
+Open an agent pane with a registered Forge agent, or return existing pane.
+
+```typescript
+// Request
+{
+  agentId: string;           // Forge agent ID (e.g., "agentx")
+  tabId?: string;            // Tab to open in (default: current tab)
+  splitDirection?: "horizontal" | "vertical";  // Split existing pane
+  splitReferenceBlockId?: string;              // Pane to split from
+  focus?: boolean;           // Focus the new pane (default: true)
+}
+
+// Response
+{
+  blockId: string;           // Block ID of the agent pane
+  tabId: string;             // Tab containing the pane
+  agentId: string;           // Confirmed agent ID
+  provider: string;          // Provider (claude, codex, gemini)
+  controllerType: string;    // "persistent" | "subprocess"
+  status: string;            // "init" | "running" | "done"
+  created: boolean;          // true if new pane, false if existing
+}
+```
+
+#### `agent.send`
+Send a message to an agent pane. Auto-spawns the process if not running.
+
+```typescript
+// Request
+{
+  blockId: string;           // Target block ID
+  message: string;           // User message text
+}
+
+// Response
+{
+  blockId: string;
+  status: string;            // "running" | "queued"
+  sessionId?: string;        // CLI session ID if available
+}
+```
+
+#### `agent.stop`
+Stop the agent's running process.
+
+```typescript
+// Request
+{
+  blockId: string;
+  signal?: "SIGINT" | "SIGTERM" | "SIGKILL";  // Default: SIGTERM
+}
+
+// Response
+{
+  blockId: string;
+  status: string;            // "done"
+  exitCode?: number;
+}
+```
+
+#### `agent.status`
+Get the current state of an agent pane.
+
+```typescript
+// Request
+{
+  blockId: string;
+}
+
+// Response
+{
+  blockId: string;
+  agentId: string;
+  provider: string;
+  controllerType: string;
+  status: string;            // "init" | "running" | "done" | "crashed"
+  sessionId?: string;
+  pid?: number;
+  exitCode?: number;
+  uptime_ms?: number;
+}
+```
+
+#### `agent.list`
+List all active agent panes across all tabs.
+
+```typescript
+// Request
+{}
+
+// Response
+{
+  agents: Array<{
+    blockId: string;
+    tabId: string;
+    agentId: string;
+    provider: string;
+    status: string;
+    sessionId?: string;
+  }>;
+}
+```
+
+#### `agent.output`
+Read the accumulated output of an agent pane (non-streaming).
+
+```typescript
+// Request
+{
+  blockId: string;
+  afterLine?: number;        // Only return lines after this index
+  maxLines?: number;         // Limit (default: 1000)
+}
+
+// Response
+{
+  blockId: string;
+  lines: string[];           // Raw NDJSON lines from the CLI
+  totalLines: number;
+  hasMore: boolean;
+}
+```
+
+#### `agent.stream`
+Subscribe to real-time output from an agent pane (streaming RPC).
+
+```typescript
+// Request
+{
+  blockId: string;
+}
+
+// Stream Response (one per stdout line)
+{
+  blockId: string;
+  line: string;              // Raw NDJSON line
+  lineIndex: number;
+}
+```
+
+---
+
+### Tier 2 — Pane & Layout Management (needed soon)
+
+#### `pane.open`
+Open a new pane with any widget type.
+
+```typescript
+// Request
+{
+  widget: string;            // Widget key: "agent", "term", "sysinfo", etc.
+  tabId?: string;            // Default: current tab
+  splitDirection?: "horizontal" | "vertical";
+  splitReferenceBlockId?: string;
+  focus?: boolean;
+  meta?: Record<string, any>;  // Initial block metadata
+}
+
+// Response
+{
+  blockId: string;
+  tabId: string;
+  widget: string;
+}
+```
+
+#### `pane.close`
+Close a pane by block ID.
+
+```typescript
+// Request
+{
+  blockId: string;
+}
+
+// Response
+{
+  closed: boolean;
+}
+```
+
+#### `pane.focus`
+Focus a specific pane.
+
+```typescript
+// Request
+{
+  blockId: string;
+}
+
+// Response
+{
+  focused: boolean;
+}
+```
+
+#### `pane.list`
+List all panes in a tab (or all tabs).
+
+```typescript
+// Request
+{
+  tabId?: string;            // Omit for all tabs
+}
+
+// Response
+{
+  panes: Array<{
+    blockId: string;
+    tabId: string;
+    view: string;            // "agent", "term", "sysinfo", etc.
+    focused: boolean;
+    meta: Record<string, any>;
+  }>;
+}
+```
+
+#### `pane.resize`
+Resize a pane within its layout.
+
+```typescript
+// Request
+{
+  blockId: string;
+  size: number;              // Flex size (relative to siblings)
+}
+
+// Response
+{
+  blockId: string;
+  size: number;
+}
+```
+
+---
+
+### Tier 3 — Tab & Window Management (needed for multi-window workflows)
+
+#### `tab.create`
+Create a new tab.
+
+```typescript
+// Request
+{
+  name?: string;
+  windowId?: string;         // Default: current window
+  activate?: boolean;        // Switch to new tab (default: true)
+}
+
+// Response
+{
+  tabId: string;
+  name: string;
+}
+```
+
+#### `tab.close`
+Close a tab.
+
+```typescript
+// Request
+{
+  tabId: string;
+}
+
+// Response
+{
+  closed: boolean;
+}
+```
+
+#### `tab.list`
+List all tabs.
+
+```typescript
+// Request
+{
+  windowId?: string;
+}
+
+// Response
+{
+  tabs: Array<{
+    tabId: string;
+    name: string;
+    active: boolean;
+    paneCount: number;
+  }>;
+}
+```
+
+#### `tab.activate`
+Switch to a tab.
+
+```typescript
+// Request
+{
+  tabId: string;
+}
+
+// Response
+{
+  activated: boolean;
+}
+```
+
+#### `window.list`
+List all windows.
+
+```typescript
+// Response
+{
+  windows: Array<{
+    windowId: string;
+    label: string;
+    focused: boolean;
+    tabCount: number;
+    position: { x: number; y: number };
+    size: { width: number; height: number };
+  }>;
+}
+```
+
+---
+
+### Tier 4 — Terminal Interaction (needed for automation)
+
+#### `terminal.open`
+Open a terminal pane.
+
+```typescript
+// Request
+{
+  tabId?: string;
+  shell?: string;            // "bash", "pwsh", "cmd" (default: auto-detect)
+  cwd?: string;              // Working directory
+  env?: Record<string, string>;
+  splitDirection?: "horizontal" | "vertical";
+  splitReferenceBlockId?: string;
+}
+
+// Response
+{
+  blockId: string;
+  tabId: string;
+  shell: string;
+}
+```
+
+#### `terminal.input`
+Send text to a terminal.
+
+```typescript
+// Request
+{
+  blockId: string;
+  text: string;
+  sendEnter?: boolean;       // Append \n (default: true)
+}
+
+// Response
+{
+  sent: boolean;
+}
+```
+
+#### `terminal.signal`
+Send a signal to the terminal process.
+
+```typescript
+// Request
+{
+  blockId: string;
+  signal: "SIGINT" | "SIGTERM" | "SIGKILL";
+}
+
+// Response
+{
+  sent: boolean;
+}
+```
+
+---
+
+### Tier 5 — Workspace & Config (needed for setup automation)
+
+#### `workspace.info`
+Get workspace metadata.
+
+```typescript
+// Response
+{
+  version: string;           // AgentMux version
+  dataDir: string;
+  configDir: string;
+  platform: string;
+  windowCount: number;
+  tabCount: number;
+  paneCount: number;
+  agentCount: number;        // Running agent panes
+}
+```
+
+#### `forge.list`
+List registered Forge agents (not running panes — agent configs).
+
+```typescript
+// Response
+{
+  agents: Array<{
+    id: string;
+    name: string;
+    provider: string;
+    icon: string;
+    workingDir: string;
+    agentType: string;       // "host" | "worker"
+  }>;
+}
+```
+
+#### `forge.create`
+Create a new Forge agent.
+
+```typescript
+// Request
+{
+  name: string;
+  provider: string;          // "claude" | "codex" | "gemini"
+  workingDir?: string;
+  icon?: string;
+  agentType?: string;
+  providerFlags?: string;
+}
+
+// Response
+{
+  id: string;
+  name: string;
+  provider: string;
+}
+```
+
+---
+
+## Implementation Plan
+
+### Phase 1 — Backend Command Handlers (Rust)
+
+**New file:** `agentmux-srv/src/server/app_api.rs`
+
+Single module that registers all `agent.*`, `pane.*`, `tab.*`, `terminal.*`,
+`workspace.*`, and `forge.*` commands with the RPC engine. Each handler
+orchestrates the low-level operations (CreateBlock, SetMeta, ControllerResync)
+internally.
+
+```rust
+pub fn register_app_api_handlers(engine: &mut WshRpcEngine) {
+    // agent.*
+    engine.register_handler("agent.open", ...);
+    engine.register_handler("agent.send", ...);
+    engine.register_handler("agent.stop", ...);
+    engine.register_handler("agent.status", ...);
+    engine.register_handler("agent.list", ...);
+    engine.register_handler("agent.output", ...);
+    engine.register_stream_handler("agent.stream", ...);
+
+    // pane.*
+    engine.register_handler("pane.open", ...);
+    engine.register_handler("pane.close", ...);
+    engine.register_handler("pane.focus", ...);
+    engine.register_handler("pane.list", ...);
+
+    // tab.*, terminal.*, workspace.*, forge.*
+    ...
+}
+```
+
+### Phase 2 — CEF IPC Bridge
+
+Expose the same commands via CEF IPC so `getApi()` can call them:
+
+```typescript
+// frontend/util/cef-api.ts additions
+agentOpen(opts: AgentOpenRequest): Promise<AgentOpenResponse>;
+agentSend(opts: AgentSendRequest): Promise<AgentSendResponse>;
+agentStop(opts: AgentStopRequest): Promise<AgentStopResponse>;
+agentStatus(opts: AgentStatusRequest): Promise<AgentStatusResponse>;
+agentList(): Promise<AgentListResponse>;
+paneOpen(opts: PaneOpenRequest): Promise<PaneOpenResponse>;
+paneClose(opts: PaneCloseRequest): Promise<PaneCloseResponse>;
+paneList(opts?: PaneListRequest): Promise<PaneListResponse>;
+tabCreate(opts?: TabCreateRequest): Promise<TabCreateResponse>;
+tabList(opts?: TabListRequest): Promise<TabListResponse>;
+workspaceInfo(): Promise<WorkspaceInfoResponse>;
+forgeList(): Promise<ForgeListResponse>;
+```
+
+### Phase 3 — HTTP REST Gateway (external access)
+
+**New file:** `agentmux-srv/src/server/rest_api.rs`
+
+Optional HTTP REST endpoints for external tools (curl, MCP servers, scripts):
+
+```
+POST /api/v1/agent/open     → agent.open
+POST /api/v1/agent/send     → agent.send
+POST /api/v1/agent/stop     → agent.stop
+GET  /api/v1/agent/status   → agent.status
+GET  /api/v1/agent/list     → agent.list
+GET  /api/v1/agent/output   → agent.output
+WS   /api/v1/agent/stream   → agent.stream
+
+POST /api/v1/pane/open      → pane.open
+POST /api/v1/pane/close     → pane.close
+GET  /api/v1/pane/list      → pane.list
+
+POST /api/v1/tab/create     → tab.create
+GET  /api/v1/tab/list       → tab.list
+
+GET  /api/v1/workspace/info → workspace.info
+GET  /api/v1/forge/list     → forge.list
+```
+
+Auth: Bearer token from `AGENTMUX_AUTH_KEY` env var (same as WSH auth).
+
+### Phase 4 — MCP Server Integration
+
+Expose App API commands as MCP tools in the `agentmux` MCP server so agents
+can programmatically manage their own workspace:
+
+```json
+{
+  "tools": [
+    { "name": "open_agent_pane", "inputSchema": { "agentId": "string", ... } },
+    { "name": "send_agent_message", "inputSchema": { "blockId": "string", "message": "string" } },
+    { "name": "open_terminal", "inputSchema": { "cwd": "string", ... } },
+    { "name": "terminal_input", "inputSchema": { "blockId": "string", "text": "string" } },
+    { "name": "list_panes", "inputSchema": {} },
+    { "name": "workspace_info", "inputSchema": {} }
+  ]
+}
+```
+
+---
+
+## Error Handling
+
+All commands return structured errors:
+
+```typescript
+{
+  error: {
+    code: string;            // Machine-readable: "AGENT_NOT_FOUND", "BLOCK_NOT_FOUND", etc.
+    message: string;         // Human-readable description
+    details?: any;           // Optional context
+  }
+}
+```
+
+**Standard error codes:**
+
+| Code | Meaning |
+|------|---------|
+| `AGENT_NOT_FOUND` | Forge agent ID doesn't exist |
+| `BLOCK_NOT_FOUND` | Block ID doesn't exist |
+| `TAB_NOT_FOUND` | Tab ID doesn't exist |
+| `ALREADY_RUNNING` | Agent process already active |
+| `NOT_RUNNING` | Agent process not active (can't send/stop) |
+| `CLI_NOT_AVAILABLE` | CLI binary not installed |
+| `AUTH_REQUIRED` | CLI not authenticated |
+| `INVALID_WIDGET` | Unknown widget type |
+| `INVALID_PROVIDER` | Unknown provider |
+
+---
+
+## Versioning
+
+- API version in URL path: `/api/v1/...`
+- Version header: `X-AgentMux-API-Version: 1`
+- Breaking changes increment version; old versions supported for 2 major releases
+- Non-breaking additions (new fields, new commands) don't bump version
+
+---
+
+## Security
+
+- HTTP REST endpoints require Bearer token authentication
+- Token source: `AGENTMUX_AUTH_KEY` (same as WebSocket auth)
+- Bind to `127.0.0.1` only (no network exposure)
+- Rate limiting: 100 req/s per endpoint (prevent accidental loops)
+- `agent.send` and `terminal.input` are write operations — logged with caller ID
+
+---
+
+## Observability
+
+Every command logs:
+- Command name, caller, timestamp
+- Execution time
+- Success/error status
+- For mutations: before/after state
+
+Format: `[app-api] agent.open agentId=agentx blockId=abc123 created=true 12ms`
+
+---
+
+## Migration Path
+
+1. **Phase 1:** Ship `agent.*` commands (Tier 1) — unblocks persistent process testing
+2. **Phase 2:** Ship `pane.*` + `tab.*` (Tiers 2-3) — unblocks automation workflows
+3. **Phase 3:** Ship HTTP REST gateway — unblocks external tools (curl, scripts)
+4. **Phase 4:** Ship MCP integration — unblocks agent self-management
+
+Existing low-level commands (`CreateBlock`, `SetMeta`, etc.) remain available.
+The App API is a convenience layer, not a replacement.
+
+---
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `agentmux-srv/src/server/app_api.rs` | All command handlers |
+| `agentmux-srv/src/server/rest_api.rs` | HTTP REST gateway (Phase 3) |
+| `frontend/types/app-api.d.ts` | TypeScript types for all requests/responses |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `agentmux-srv/src/server/mod.rs` | Register app_api module |
+| `agentmux-srv/src/server/websocket.rs` | Call `register_app_api_handlers()` |
+| `frontend/util/cef-api.ts` | Add `agentOpen()`, `agentSend()`, etc. |
+| `agentmux-cef/src/ipc.rs` | Route new IPC commands to backend RPC |

--- a/docs/specs/app-api-status.md
+++ b/docs/specs/app-api-status.md
@@ -1,0 +1,143 @@
+# App API — Implementation Status
+
+**Date:** 2026-04-11
+**Spec:** `docs/specs/app-api-extension.md`
+**Retro:** `docs/analysis/persistent-process-retro-2026-04-10.md`
+
+---
+
+## What's Working (Verified End-to-End)
+
+### Backend RPC Commands (WebSocket)
+
+All Tier 1 commands register on the WSH RPC engine and respond correctly:
+
+| Command | Status | Verified |
+|---------|--------|----------|
+| `agent.open` | Working | Creates block, sets metadata, writes config files, registers controller, inserts layout node |
+| `agent.send` | Working | Sends message via persistent stdin or subprocess spawn |
+| `agent.stop` | Working | Stops controller process |
+| `agent.status` | Working | Returns agent state, session ID, exit code |
+| `agent.list` | Working | Lists all agent panes across tabs |
+| `agent.output` | Implemented | Reads broker event history (needs persist > 0 for blockfile events) |
+
+### WebSocket Protocol
+
+Commands are sent via the WSH RPC envelope:
+```json
+{
+  "wscommand": "rpc",
+  "message": {
+    "command": "agent.open",
+    "reqid": "unique-id",
+    "data": { "agent_id": "agentx" }
+  }
+}
+```
+
+Auth via query param: `ws://127.0.0.1:{WS_PORT}/ws?authkey={AUTH_KEY}`
+
+### Getting Auth Credentials
+
+```bash
+# 1. Read IPC token from host log (injected into page URL)
+TOKEN=$(grep "ipc_token=" ~/.agentmux/logs/agentmux-host-v*.log.* | tail -1 | sed 's/.*ipc_token=\([^&"]*\).*/\1/')
+IPC_PORT=$(grep "IPC HTTP server started" ~/.agentmux/logs/agentmux-host-v*.log.* | tail -1 | sed 's/.*127.0.0.1:\([0-9]*\).*/\1/')
+
+# 2. Get backend auth key via CEF IPC
+AUTH=$(curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"cmd":"get_auth_key","args":{}}' "http://127.0.0.1:$IPC_PORT/ipc" | jq -r .data)
+
+# 3. Get WebSocket port
+WS_PORT=$(curl -s -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{"cmd":"get_backend_endpoints","args":{}}' "http://127.0.0.1:$IPC_PORT/ipc" | jq -r '.data.ws | split(":") | last')
+```
+
+### Persistent Process Pipeline
+
+The full flow works:
+1. `agent.open` → block created, persistent controller registered
+2. `agent.send` → CLI spawned with `--input-format stream-json`, stdin message written
+3. Claude Code responds, session ID captured, stdout published to WPS blockfile
+4. Process stays alive for multi-turn (no `CLAUDE_CODE_EXIT_AFTER_STOP_DELAY`)
+
+---
+
+## What's Not Working Yet
+
+### 1. Pane Not Visible After `agent.open`
+
+**Status:** Backend layout tree updated, but frontend doesn't re-render.
+
+**Root cause:** The frontend layout model is a client-side state machine driven by
+`layoutModel.treeReducer(InsertNode)`. Backend-side `LayoutState` writes + event
+broadcasts are insufficient — the frontend's reactive layout model doesn't
+re-derive from raw database state on `waveobj:update` events for layouts.
+
+**Fix needed:** Either:
+- **Option A:** Add a frontend event handler for `layoutaction` events that
+  calls `layoutModel.treeReducer()` when the backend requests a layout change
+- **Option B:** Have `agent.open` return the block ID and let the frontend's
+  existing `createBlock()` handle the layout insertion via a new IPC command
+- **Option C:** Make the frontend layout model reactive to `LayoutState` changes
+  (would also fix cross-window layout sync)
+
+**Recommendation:** Option A — minimal frontend change, backend-driven layout.
+
+### 2. Agent Response Not Rendering in Agent View
+
+**Status:** stdout lines published to WPS blockfile, `useAgentStream` subscribes
+to the correct subject (`"output"`), but no text appears in the agent view.
+
+**Root cause:** Not yet diagnosed. The WPS data flow is:
+`persistent.rs stdout reader` → `handle_append_block_file(broker, blockId, "output", data)`
+→ `broker.publish(EVENT_BLOCK_FILE, ...)` → `frontend global.ts fileSubject.next()`
+→ `useAgentStream subscription`
+
+The `console.log` in `useAgentStream` (added in v0.33.86) was never tested in a
+clean build with a visible pane. Needs debugging with both frontend and backend
+logging enabled simultaneously.
+
+### 3. CLI Auto-Install in `agent.open`
+
+**Status:** `agent.open` returns `CLI_NOT_AVAILABLE` if the npm package isn't
+installed. The caller must pre-install via `npm install --prefix`.
+
+**Fix needed:** Add optional auto-install to `agent.open` — call the same npm
+install logic from `cli_handlers.rs` if the binary isn't found. Add an
+`auto_install: bool` field to the request (default: true).
+
+---
+
+## Files Added
+
+| File | Lines | Purpose |
+|------|-------|---------|
+| `agentmux-srv/src/backend/providers.rs` | ~270 | Static provider registry (claude, codex, gemini) with 7 unit tests |
+| `agentmux-srv/src/backend/agent_config.rs` | ~330 | Config file builder (CLAUDE.md, .mcp.json, skills) with 9 unit tests |
+| `agentmux-srv/src/server/app_api.rs` | ~530 | All 6 command handlers |
+| `docs/specs/app-api-extension.md` | ~280 | Full API spec (Tiers 1-5) |
+| `docs/specs/app-api-status.md` | this file | Implementation status |
+| `docs/analysis/persistent-process-retro-2026-04-10.md` | ~150 | Debug retro (11 issues found and fixed) |
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `agentmux-srv/src/backend/rpc_types.rs` | 7 command constants + 13 request/response structs |
+| `agentmux-srv/src/backend/mod.rs` | `pub mod providers; pub mod agent_config;` |
+| `agentmux-srv/src/server/mod.rs` | `mod app_api;` |
+| `agentmux-srv/src/server/websocket.rs` | `register_app_api_handlers()` call |
+| `agentmux-srv/src/backend/blockcontroller/persistent.rs` | `controller_type_str()` method |
+| `agentmux-srv/src/backend/providers.rs` | `controller_type_str()` impl |
+
+---
+
+## Next Steps
+
+1. **Fix pane visibility** — frontend `layoutaction` event handler (Option A)
+2. **Fix agent response rendering** — debug `useAgentStream` with visible pane
+3. **CLI auto-install** — integrate npm install into `agent.open`
+4. **Tier 2 commands** — `pane.open`, `pane.close`, `pane.list`, `pane.focus`
+5. **HTTP REST gateway** — `/api/v1/agent/*` endpoints for external tools
+6. **MCP integration** — expose App API as MCP tools in the agentmux MCP server

--- a/docs/specs/cef-white-flash-testbed.md
+++ b/docs/specs/cef-white-flash-testbed.md
@@ -1,0 +1,356 @@
+# CEF White Flash Testbed — Spec
+
+## Goal
+
+Build a minimal standalone CEF app (no sidecar, no frontend, no IPC) that reproduces the white flash on startup. Use it to isolate the exact cause and test fixes without risk to the main AgentMux build.
+
+## Why
+
+Every attempt to fix the white flash in AgentMux has broken CEF initialization (GPU process dies, singleton fallback to Chrome, etc.). We need a safe sandbox to iterate fast without 10 version bumps per attempt.
+
+## Architecture
+
+```
+cef-testbed/
+├── Cargo.toml          # depends on cef crate only
+├── src/
+│   └── main.rs         # ~150 lines, minimal CEF app
+├── runtime/            # CEF DLLs + resources (symlinked from dist/cef)
+└── test-page.html      # dark background, simple content
+```
+
+Single binary. Loads a local HTML file with `background: #222`. No sidecar, no IPC server, no frontend build. Just CEF + a window + a page.
+
+## Test Matrix
+
+Each test variant is a small code change in main.rs. Run each, observe with eyes + screen recording (Win+G):
+
+| # | Variant | What it tests |
+|---|---------|--------------|
+| 1 | Baseline: CEF Views, default settings | Reproduce the flash |
+| 2 | CEF Views + `background_color: 0xFF222222` | Does the setting help at all? |
+| 3 | Native window + WS_VISIBLE | Compare native vs Views |
+| 4 | Native window, NO WS_VISIBLE, ShowWindow in on_load_end | Does hidden→show flash? |
+| 5 | Native window, NO WS_VISIBLE, ShowWindow after rAF IPC | Does waiting for paint help? |
+| 6 | Native window + WS_VISIBLE + dark class brush on WM_ERASEBKGND | Does GDI brush help? |
+| 7 | `--disable-gpu` flag | Is it GPU compositor delay? |
+| 8 | `--disable-gpu-compositing` flag | Narrower GPU test |
+
+## Implementation
+
+### Cargo.toml
+
+```toml
+[package]
+name = "cef-testbed"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "cef-testbed"
+path = "src/main.rs"
+
+[dependencies]
+cef = { version = "146", default-features = false, features = ["build-util"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_Graphics_Dwm",
+    "Win32_Graphics_Gdi",
+    "Win32_System_LibraryLoader",
+    "Win32_UI_Controls",
+] }
+```
+
+### test-page.html
+
+```html
+<!doctype html>
+<html>
+<head>
+  <style>
+    html, body { margin: 0; background: #222; color: #f7f7f7; }
+    body { display: flex; align-items: center; justify-content: center; height: 100vh; }
+    h1 { font-family: sans-serif; font-size: 48px; opacity: 0.8; }
+  </style>
+</head>
+<body>
+  <h1>CEF Testbed</h1>
+  <script>
+    // Log paint timing
+    new PerformanceObserver(list => {
+      for (const entry of list.getEntries()) {
+        console.log(`[paint] ${entry.name}: ${entry.startTime.toFixed(1)}ms`);
+      }
+    }).observe({ entryTypes: ['paint'] });
+  </script>
+</body>
+</html>
+```
+
+### main.rs (Baseline — Variant 1)
+
+Minimal CEF Views app. Each variant is a small diff from this baseline.
+
+```rust
+// cef-testbed: minimal CEF app to reproduce and fix white flash.
+// Toggle variants via --variant=N command line flag.
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+use cef::*;
+use std::cell::RefCell;
+
+fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter("info")
+        .with_writer(std::io::stderr)
+        .init();
+
+    tracing::info!("CEF testbed starting");
+
+    let args = cef::args::Args::new();
+    let cmd_line = args.as_cmd_line().expect("Failed to parse args");
+
+    // Subprocess check
+    let type_switch = CefString::from("type");
+    let is_browser = cmd_line.has_switch(Some(&type_switch)) != 1;
+    let ret = execute_process(Some(args.as_main_args()), None, std::ptr::null_mut());
+    if !is_browser {
+        std::process::exit(ret);
+    }
+    assert_eq!(ret, -1);
+
+    // Parse variant number
+    let variant_switch = CefString::from("variant");
+    let variant: u32 = if cmd_line.has_switch(Some(&variant_switch)) != 0 {
+        CefString::from(&cmd_line.switch_value(Some(&variant_switch)))
+            .to_string().parse().unwrap_or(1)
+    } else { 1 };
+    tracing::info!("Running variant {}", variant);
+
+    // Resolve test page URL
+    let exe_dir = std::env::current_exe().ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        .unwrap_or_default();
+    let page_path = exe_dir.join("test-page.html");
+    let url_str = format!("file:///{}", page_path.to_str().unwrap().replace('\\', "/"));
+
+    // CEF App
+    let mut app = TestApp::new(variant, url_str);
+
+    let settings = Settings {
+        no_sandbox: 1,
+        background_color: if variant >= 2 { 0xFF222222 } else { 0 },
+        root_cache_path: CefString::from(
+            exe_dir.join("cef-cache").to_str().unwrap_or("")
+        ),
+        resources_dir_path: CefString::from(exe_dir.to_str().unwrap_or("")),
+        locales_dir_path: CefString::from(
+            exe_dir.join("locales").to_str().unwrap_or("")
+        ),
+        browser_subprocess_path: CefString::from(
+            std::env::current_exe().unwrap().to_str().unwrap_or("")
+        ),
+        ..Default::default()
+    };
+
+    let init = initialize(
+        Some(args.as_main_args()),
+        Some(&settings),
+        Some(&mut app),
+        std::ptr::null_mut(),
+    );
+    if init != 1 {
+        tracing::error!("CEF initialize failed (returned {})", init);
+        std::process::exit(1);
+    }
+
+    tracing::info!("Entering message loop");
+    run_message_loop();
+    shutdown();
+}
+
+// ---- App + BrowserProcessHandler ----
+
+wrap_app! {
+    pub struct TestApp {
+        variant: u32,
+        url: String,
+    }
+    impl App {
+        fn on_before_command_line_processing(
+            &self, _process_type: Option<&CefString>,
+            command_line: Option<&mut CommandLine>,
+        ) {
+            if let Some(cmd) = command_line {
+                let key = CefString::from("disable-features");
+                let val = CefString::from("CalculateNativeWinOcclusion");
+                cmd.append_switch_with_value(Some(&key), Some(&val));
+
+                if self.variant >= 2 {
+                    let bg_key = CefString::from("background-color");
+                    let bg_val = CefString::from("ff222222");
+                    cmd.append_switch_with_value(Some(&bg_key), Some(&bg_val));
+                }
+                if self.variant == 7 {
+                    cmd.append_switch(Some(&CefString::from("disable-gpu")));
+                }
+                if self.variant == 8 {
+                    cmd.append_switch(Some(&CefString::from("disable-gpu-compositing")));
+                }
+            }
+        }
+        fn browser_process_handler(&self) -> Option<BrowserProcessHandler> {
+            Some(TestBPH::new(self.variant, self.url.clone()))
+        }
+    }
+}
+
+wrap_browser_process_handler! {
+    pub struct TestBPH {
+        variant: u32,
+        url: String,
+    }
+    impl BrowserProcessHandler {
+        fn on_context_initialized(&self) {
+            let url = CefString::from(self.url.as_str());
+            let settings = BrowserSettings {
+                background_color: if self.variant >= 2 { 0xFF222222 } else { 0 },
+                ..Default::default()
+            };
+
+            // TODO: Branch on self.variant for Views vs Native mode
+            // For now, always use CEF Views (variant 1-2 baseline)
+
+            let mut client = TestClient::new(self.variant);
+            let mut bv_delegate = TestBVDelegate::new();
+            let browser_view = browser_view_create(
+                client.as_mut(), Some(&url), Some(&settings),
+                None, None, Some(&mut bv_delegate),
+            );
+            let mut wd = TestWindowDelegate::new(
+                RefCell::new(browser_view), self.variant,
+            );
+            window_create_top_level(Some(&mut wd));
+        }
+    }
+}
+
+// ---- Window Delegate ----
+
+wrap_window_delegate! {
+    pub struct TestWindowDelegate {
+        browser_view: RefCell<Option<BrowserView>>,
+        variant: u32,
+    }
+    impl ViewDelegate {
+        fn preferred_size(&self, _view: Option<&mut View>) -> Size {
+            Size { width: 800, height: 600 }
+        }
+    }
+    impl PanelDelegate {}
+    impl WindowDelegate {
+        fn on_window_created(&self, window: Option<&mut Window>) {
+            let bv = self.browser_view.borrow();
+            let (Some(window), Some(bv)) = (window, bv.as_ref()) else { return };
+            let mut view = View::from(bv);
+            window.add_child_view(Some(&mut view));
+            tracing::info!("[variant {}] on_window_created", self.variant);
+            window.show();
+        }
+        fn on_window_destroyed(&self, _window: Option<&mut Window>) {
+            *self.browser_view.borrow_mut() = None;
+        }
+        fn can_close(&self, _window: Option<&mut Window>) -> i32 { 1 }
+        fn initial_show_state(&self, _w: Option<&mut Window>) -> ShowState {
+            ShowState::NORMAL
+        }
+        fn is_frameless(&self, _w: Option<&mut Window>) -> i32 { 0 }
+        fn can_resize(&self, _w: Option<&mut Window>) -> i32 { 1 }
+        fn window_runtime_style(&self) -> RuntimeStyle { RuntimeStyle::ALLOY }
+    }
+}
+
+wrap_browser_view_delegate! {
+    pub struct TestBVDelegate {}
+    impl ViewDelegate {}
+    impl BrowserViewDelegate {
+        fn browser_runtime_style(&self) -> RuntimeStyle { RuntimeStyle::ALLOY }
+    }
+}
+
+// ---- Client + Handlers ----
+
+wrap_client! {
+    pub struct TestClient { variant: u32 }
+    impl Client {
+        fn life_span_handler(&self) -> Option<LifeSpanHandler> {
+            Some(TestLifeSpan::new(self.variant))
+        }
+        fn load_handler(&self) -> Option<LoadHandler> {
+            Some(TestLoadHandler::new(self.variant))
+        }
+    }
+}
+
+wrap_life_span_handler! {
+    struct TestLifeSpan { variant: u32 }
+    impl LifeSpanHandler {
+        fn on_after_created(&self, _browser: Option<&mut Browser>) {
+            tracing::info!("[variant {}] on_after_created", self.variant);
+        }
+        fn on_before_close(&self, _browser: Option<&mut Browser>) {
+            quit_message_loop();
+        }
+    }
+}
+
+wrap_load_handler! {
+    struct TestLoadHandler { variant: u32 }
+    impl LoadHandler {
+        fn on_load_end(
+            &self, _browser: Option<&mut Browser>,
+            frame: Option<&mut Frame>, _status: i32,
+        ) {
+            let Some(frame) = frame else { return };
+            if frame.is_main() != 1 { return; }
+            tracing::info!("[variant {}] on_load_end (main frame)", self.variant);
+        }
+    }
+}
+```
+
+## How to Use
+
+```bash
+# Build
+cargo build -p cef-testbed --release
+
+# Copy CEF DLLs (one-time)
+cp dist/cef/*.dll target/release/
+cp dist/cef/*.pak target/release/
+cp dist/cef/*.bin target/release/
+cp -r dist/cef/locales target/release/
+cp cef-testbed/test-page.html target/release/
+
+# Run variants
+target/release/cef-testbed.exe                  # Variant 1: baseline
+target/release/cef-testbed.exe --variant=2      # + background_color
+target/release/cef-testbed.exe --variant=7      # + disable-gpu
+```
+
+## Recording
+
+Use Win+G (Xbox Game Bar) or OBS to record each variant at 60fps. Frame-step through the recording to see exactly:
+- Which frame shows white
+- How many frames of white before dark content
+- Whether `background_color` changes the flash color
+
+## Success Criteria
+
+Find a variant where the window appears with dark content from the very first visible frame, without breaking CEF initialization.

--- a/docs/specs/clipboard-cef-impl.md
+++ b/docs/specs/clipboard-cef-impl.md
@@ -1,0 +1,111 @@
+# Clipboard for CEF — Implementation Spec
+
+**Date:** 2026-04-02
+**Status:** Spec
+**Problem:** Copy/paste doesn't work in CEF host — Ctrl+C/V, context menu copy/paste all fail silently
+
+## Root Cause
+
+The frontend's `util/clipboard.ts` imports from `@tauri-apps/plugin-clipboard-manager`, which only works in the Tauri host. In CEF, this import fails silently — clipboard operations do nothing.
+
+CEF's Chromium blocks `navigator.clipboard.readText()` without a Permissions-Policy header, so the browser API doesn't work either.
+
+## Solution
+
+Route clipboard through CEF host IPC. The backend code already exists (`clipboard.rs`) but is untracked and not wired up.
+
+## Changes Required
+
+### 1. Host side: Wire up clipboard module
+
+**File: `agentmux-cef/src/commands/mod.rs`**
+```rust
+pub mod clipboard;  // Add this line
+```
+
+**File: `agentmux-cef/src/ipc.rs`** — Add routes:
+```rust
+"read_clipboard" => commands::clipboard::read_clipboard(),
+"write_clipboard" => commands::clipboard::write_clipboard(args),
+```
+
+**File: `agentmux-cef/src/commands/clipboard.rs`** — Already exists (untracked), needs `git add`.
+
+### 2. Frontend side: Route through CEF IPC when in CEF mode
+
+**File: `frontend/util/clipboard.ts`**
+
+Replace Tauri-only implementation with platform-aware routing:
+
+```typescript
+import { getApi } from "@/util/getapi";
+
+// Detect CEF mode
+function isCef(): boolean {
+    return typeof (window as any).__AGENTMUX_IPC_PORT__ !== "undefined";
+}
+
+export async function readText(): Promise<string> {
+    if (isCef()) {
+        return getApi().invokeCommand("read_clipboard", {});
+    }
+    // Tauri fallback
+    const { readText: tauriReadText } = await import("@tauri-apps/plugin-clipboard-manager");
+    return (await tauriReadText()) ?? "";
+}
+
+export async function writeText(text: string): Promise<void> {
+    if (isCef()) {
+        await getApi().invokeCommand("write_clipboard", { text });
+        return;
+    }
+    // Tauri fallback
+    const { writeText: tauriWriteText } = await import("@tauri-apps/plugin-clipboard-manager");
+    await tauriWriteText(text);
+}
+```
+
+Key: Use dynamic `import()` for Tauri so it doesn't fail at load time in CEF.
+
+### 3. CEF API shim: Add clipboard commands
+
+**File: `frontend/util/cef-api.ts`** — Already has `invokeCommand` which handles IPC routing. No changes needed — `readText`/`writeText` in clipboard.ts call it directly.
+
+## Existing Callers (no changes needed)
+
+All these import from `@/util/clipboard` which we're updating:
+- `app.tsx` — read + write
+- `blockframe.tsx` — write
+- `pane-actions.ts` — read + write
+- `markdown.tsx` — write (code blocks copy button)
+- `streamdown.tsx` — write
+- `base-menus.ts` — write (context menu)
+- `usenotification.tsx` — write
+- `agent-view.tsx` — write
+- `termViewModel.ts` — read + write (terminal paste)
+- `termwrap.ts` — write (terminal selection copy)
+
+One exception: `AgentDocumentView.tsx:115` uses `navigator.clipboard.writeText()` directly — should be updated to use `clipboardWriteText`.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `agentmux-cef/src/commands/mod.rs` | Add `pub mod clipboard;` |
+| `agentmux-cef/src/ipc.rs` | Add 2 IPC routes |
+| `agentmux-cef/src/commands/clipboard.rs` | `git add` (already exists) |
+| `frontend/util/clipboard.ts` | CEF IPC routing + dynamic Tauri import |
+| `frontend/app/view/agent/components/AgentDocumentView.tsx` | Replace `navigator.clipboard` with util |
+
+## Test Plan
+
+- [ ] Terminal: Ctrl+C copies selection, Ctrl+V pastes
+- [ ] Context menu: right-click → Copy/Paste works
+- [ ] Code blocks: copy button works
+- [ ] Agent view: copy URL works
+- [ ] Multi-window: clipboard shared (OS clipboard)
+- [ ] Tauri host: still works (dynamic import fallback)
+
+## Complexity
+
+Low — 3 lines on host side (mod + 2 routes), ~20 lines on frontend side.

--- a/docs/specs/command-palette.md
+++ b/docs/specs/command-palette.md
@@ -1,0 +1,395 @@
+# Command Palette — Spec
+
+**Status:** Draft  
+**Target:** v0.35.x  
+**Authors:** AgentA
+
+---
+
+## 1. What It Is
+
+A global fuzzy-search command palette, triggered by `Ctrl+P`, that lets the user (and agents) discover and execute app-level actions without navigating menus.
+
+The palette is a single unified registry. The UI is one entry point into it. Agents and MCP tools are another entry point — same registry, same IDs, same execution paths. There is no "agent API" separate from the "human API"; both call `run_command`.
+
+Design reference: VS Code `Ctrl+Shift+P`, Linear `Ctrl+K`. The AgentMux palette uses `Ctrl+P` only (no `>` prefix distinction — we have one mode to start).
+
+---
+
+## 2. Scope for v1
+
+### In scope
+- Global fuzzy-search over a static command set (defined at app init)
+- Keyboard-only activation and navigation (mouse also works)
+- Agent/MCP programmatic access via a new `run_command` IPC command
+- Five command categories: pane/widget opening, window management, pane splitting, navigation, developer tools
+
+### Out of scope for v1
+- Parameterized commands (e.g., "open terminal in /some/path") — see Section 8
+- Plugin-registered commands — see Section 8
+- Recent commands history
+- Command aliases / user remapping
+- Search across open pane content
+
+---
+
+## 3. Command Categories and Initial Command Set
+
+Five categories. Each command has a stable string ID used in both the UI and the programmatic API.
+
+### Category: open
+
+Open a widget as a new pane in the current tab. Uses `createBlock()` with the appropriate `BlockDef` from `widgets.json`.
+
+| ID | Label | What It Does |
+|----|-------|-------------|
+| `open:terminal` | Open Terminal | Creates a new terminal pane (`view: "term"`, `controller: "shell"`) |
+| `open:agent` | Open Agent | Creates an agent pane (`view: "agent"`, `controller: "cmd"`) |
+| `open:forge` | Open Forge | Creates a forge pane (`view: "forge"`) |
+| `open:sysinfo` | Open System Info | Creates a sysinfo pane (`view: "sysinfo"`) |
+| `open:identity` | Open Identity | Creates an identity pane (`view: "identity"`) |
+| `open:help` | Open Help | Creates a help pane (`view: "help"`) |
+| `open:swarm` | Open Swarm | Creates a swarm pane (`view: "swarm"`) |
+
+### Category: split
+
+Split the currently focused pane. Uses `createBlockSplitHorizontally` / `createBlockSplitVertically` with the default new block def (inherits connection and cwd from focused pane, matching existing behavior in `keymodel.ts`).
+
+| ID | Label | What It Does |
+|----|-------|-------------|
+| `split:right` | Split Right | Splits focused pane horizontally, new pane after |
+| `split:left` | Split Left | Splits focused pane horizontally, new pane before |
+| `split:down` | Split Down | Splits focused pane vertically, new pane after |
+| `split:up` | Split Up | Splits focused pane vertically, new pane before |
+
+### Category: window
+
+Window-level operations. Maps to existing IPC commands.
+
+| ID | Label | What It Does |
+|----|-------|-------------|
+| `window:new` | New Window | Opens a new AgentMux window (`open_new_window`) |
+| `window:close` | Close Window | Closes the current window (`close_window`) |
+| `window:minimize` | Minimize Window | Minimizes the current window (`minimize_window`) |
+| `window:maximize` | Toggle Maximize | Maximizes or restores the current window (`maximize_window`) |
+| `tab:new` | New Tab | Creates a new tab in the current workspace (`createTab()`) |
+| `tab:close` | Close Tab | Closes the active tab (`simpleCloseStaticTab` equivalent) |
+| `tab:next` | Next Tab | Switches to next tab |
+| `tab:prev` | Previous Tab | Switches to previous tab |
+
+### Category: pane
+
+Pane-level operations on the currently focused pane.
+
+| ID | Label | What It Does |
+|----|-------|-------------|
+| `pane:close` | Close Pane | Closes focused pane (`layoutModel.closeFocusedNode`) |
+| `pane:magnify` | Toggle Magnify | Magnifies or restores focused pane (`magnifyNodeToggle`) |
+| `pane:focus:right` | Focus Pane Right | Moves focus right (`switchBlockInDirection`) |
+| `pane:focus:left` | Focus Pane Left | Moves focus left |
+| `pane:focus:up` | Focus Pane Up | Moves focus up |
+| `pane:focus:down` | Focus Pane Down | Moves focus down |
+
+### Category: dev
+
+Developer-facing operations.
+
+| ID | Label | What It Does |
+|----|-------|-------------|
+| `dev:devtools` | Toggle DevTools | Toggles browser inspector (`toggle_devtools` IPC) |
+| `dev:restart_backend` | Restart Backend | Restarts the agentmux-srv sidecar (`restart_backend` IPC) |
+| `dev:open_settings` | Open Settings File | Opens settings JSONC in external editor (`open_in_editor` IPC) |
+
+---
+
+## 4. UI Component
+
+### Activation
+
+`Ctrl+P` opens the palette. `Escape` closes it. `Enter` executes the selected command and closes.
+
+Add to `globalKeyMap` in `frontend/app/store/keymodel.ts`:
+
+```typescript
+globalKeyMap.set("Ctrl:p", () => {
+    commandPaletteModel.open();
+    return true;
+});
+```
+
+`Escape` already calls `modalsModel.popModal()` — the palette registers as a modal so this works for free.
+
+### Component Location
+
+```
+frontend/app/modals/command-palette.tsx
+frontend/app/modals/command-palette.scss
+```
+
+### SolidJS Component Sketch
+
+```tsx
+// CommandPalette.tsx
+import { createSignal, createMemo, For, Show } from "solid-js";
+import { Portal } from "solid-js/web";
+import { commandRegistry, CommandEntry } from "@/app/store/command-registry";
+
+const [query, setQuery] = createSignal("");
+
+const filtered = createMemo(() => {
+    const q = query().toLowerCase().trim();
+    if (!q) return commandRegistry.all();
+    return commandRegistry.all().filter((cmd) =>
+        cmd.label.toLowerCase().includes(q) ||
+        cmd.id.toLowerCase().includes(q) ||
+        cmd.category.toLowerCase().includes(q)
+    );
+});
+```
+
+The palette renders as a centered overlay (not anchored to a pane like `TypeAheadModal`). It uses `Portal` with `document.body` as the mount target. A backdrop div behind it catches clicks to dismiss.
+
+Width: 560px, max-height: 480px, centered horizontally, positioned 20% from top.
+
+### Keyboard Navigation
+
+- `ArrowUp` / `ArrowDown`: move selection
+- `Enter`: execute selected command
+- `Escape`: close without executing
+- Typing filters results
+
+The palette must call `disableGlobalKeybindings()` on open and `enableGlobalKeybindings()` on close to prevent hotkeys from firing while the user types. Both are exported from `keymodel.ts`.
+
+### Modal Registration
+
+Register in `frontend/app/modals/modalregistry.tsx` so `modalsModel` can manage open/close state and `Escape` handling works automatically.
+
+---
+
+## 5. Command Registry (TypeScript)
+
+### Location
+
+```
+frontend/app/store/command-registry.ts
+```
+
+### Shape
+
+```typescript
+export interface CommandEntry {
+    id: string;           // stable, dot-namespaced: "open:terminal"
+    label: string;        // human label shown in palette: "Open Terminal"
+    category: string;     // grouping label: "Open", "Split", "Window", ...
+    icon?: string;        // FA icon name (optional)
+    iconColor?: string;   // hex color (optional, used for widget icons)
+    execute: () => void | Promise<void>;
+}
+
+class CommandRegistry {
+    private commands = new Map<string, CommandEntry>();
+
+    register(entry: CommandEntry): void {
+        this.commands.set(entry.id, entry);
+    }
+
+    get(id: string): CommandEntry | undefined {
+        return this.commands.get(id);
+    }
+
+    all(): CommandEntry[] {
+        return Array.from(this.commands.values());
+    }
+
+    run(id: string): boolean {
+        const cmd = this.commands.get(id);
+        if (!cmd) return false;
+        void Promise.resolve(cmd.execute());
+        return true;
+    }
+}
+
+export const commandRegistry = new CommandRegistry();
+```
+
+### Registration
+
+Commands are registered at app init, after global signals are available. A `registerDefaultCommands()` function in `command-registry.ts` imports from `global.ts`, `keymodel.ts`, and `getApi()`.
+
+```typescript
+// Called once from frontend/wave.ts or cef-init.ts after init
+export function registerDefaultCommands(): void {
+    commandRegistry.register({
+        id: "open:terminal",
+        label: "Open Terminal",
+        category: "Open",
+        icon: "square-terminal",
+        execute: () => createBlock({ meta: { view: "term", controller: "shell" } }),
+    });
+    // ... remaining commands
+}
+```
+
+Widget metadata (icons, colors) is pulled from the known widget definitions — these are static so they can be hardcoded. Do not fetch `widgets.json` at runtime to build the registry.
+
+---
+
+## 6. IPC Handler (Rust)
+
+### New Command: `run_command`
+
+Agents and MCP tools call this endpoint to execute a palette command programmatically. It does not open the UI.
+
+```json
+POST /ipc
+{
+  "cmd": "run_command",
+  "args": { "id": "open:terminal" }
+}
+```
+
+Response on success:
+```json
+{ "success": true, "data": null }
+```
+
+Response on unknown ID:
+```json
+{ "success": false, "error": "Unknown command: open:foobar" }
+```
+
+### Rust-side Implementation
+
+Add to `route_command` in `agentmux-cef/src/ipc.rs`:
+
+```rust
+"run_command" => commands::palette::run_command(state, args).await,
+```
+
+New file: `agentmux-cef/src/commands/palette.rs`
+
+```rust
+pub async fn run_command(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let id = args["id"]
+        .as_str()
+        .ok_or_else(|| "run_command: missing 'id' field".to_string())?;
+
+    // Dispatch to the frontend via a CEF custom event.
+    // The frontend listens for "agentmux-run-command" and calls commandRegistry.run(id).
+    let js = format!(
+        "window.dispatchEvent(new CustomEvent('agentmux-run-command', {{ detail: {{ id: {:?} }} }}));",
+        id
+    );
+    state.execute_js(&js)?;
+
+    Ok(serde_json::Value::Null)
+}
+```
+
+The Rust side does not know which command IDs exist — it forwards to the frontend, which owns the registry. The frontend fires an `agentmux-run-command` CustomEvent with `detail.id`. If the ID is unknown, the frontend logs a warning; the IPC call still returns success (fire-and-forget semantics). If callers need to know whether the command ID was valid, a future version can add a `list_commands` IPC endpoint that returns all registered IDs.
+
+### Frontend Event Listener
+
+In `command-registry.ts`, at module load:
+
+```typescript
+window.addEventListener("agentmux-run-command", (e: CustomEvent) => {
+    const id = e.detail?.id as string;
+    if (!commandRegistry.run(id)) {
+        console.warn(`[command-palette] Unknown command dispatched: ${id}`);
+    }
+});
+```
+
+### Authentication
+
+All IPC calls require `Authorization: Bearer {ipc_token}` — this is already enforced by the existing `handle_ipc` middleware in `ipc.rs`. Agents get the token through the normal `AGENTMUX_AUTH_KEY` / `get_auth_key` bootstrap flow.
+
+---
+
+## 7. Agent / MCP Usage
+
+Agents invoke commands via the same IPC bridge they already use:
+
+```typescript
+// From an agent or MCP tool
+await invokeCommand("run_command", { id: "open:terminal" });
+await invokeCommand("run_command", { id: "split:right" });
+await invokeCommand("run_command", { id: "window:new" });
+```
+
+MCP via `mcp__windows-mcp` can also trigger commands if needed, but the IPC route is preferred because it does not require simulating keystrokes.
+
+Agent-authored commands (e.g., an agent registering a "run my build" command) are out of scope for v1 but the registry API supports it — see Section 8.
+
+---
+
+## 8. Future Extensibility
+
+### Parameterized Commands
+
+Some commands need input: "Open Terminal in..." needs a path, "Focus Pane #N" needs a number. The registry shape can be extended:
+
+```typescript
+interface ParameterizedCommandEntry extends CommandEntry {
+    params: CommandParam[];
+    execute: (params: Record<string, string>) => void | Promise<void>;
+}
+```
+
+The palette UI would show a second input step after the command is selected. The `run_command` IPC would accept an optional `params` map alongside `id`.
+
+### Plugin / Agent-Registered Commands
+
+Any ViewModel or agent could call `commandRegistry.register(...)` to add commands at runtime. The palette displays whatever is in the registry at the time it opens.
+
+For agent-registered commands, a naming convention keeps IDs from colliding: `agent:<agentId>:<action>` (e.g., `agent:agenta:run_tests`). A `list_commands` IPC endpoint (future) would let agents discover what is registered.
+
+### Scoped Commands
+
+Commands that only apply when a specific view is focused (e.g., terminal-specific search commands). The `CommandEntry` interface can gain an optional `isAvailable?: () => boolean` predicate. Commands where `isAvailable()` returns false are hidden from results.
+
+### Keyboard Shortcut Display
+
+Each `CommandEntry` can gain an optional `keybinding?: string` field (e.g., `"Ctrl+D"`). The palette renders it right-aligned in the result row. This is cosmetic — keybindings are still registered separately in `keymodel.ts`.
+
+---
+
+## 9. Implementation Sketch
+
+Minimal walking skeleton, in order:
+
+1. **`frontend/app/store/command-registry.ts`** — `CommandEntry`, `CommandRegistry`, `commandRegistry` singleton, `registerDefaultCommands()`, `agentmux-run-command` event listener.
+
+2. **`agentmux-cef/src/commands/palette.rs`** — `run_command()` handler, dispatches JS event via `state.execute_js()`.
+
+3. **Wire Rust** — add `"run_command"` match arm in `agentmux-cef/src/ipc.rs`, add `pub mod palette;` in `agentmux-cef/src/commands/mod.rs`.
+
+4. **`frontend/app/modals/command-palette.tsx`** + **`command-palette.scss`** — overlay component with input, filtered list, keyboard nav.
+
+5. **Wire keybinding** — add `Ctrl:p` to `globalKeyMap` in `frontend/app/store/keymodel.ts`, calling `commandPaletteModel.open()`.
+
+6. **Wire modal** — add `CommandPalette` to `frontend/app/modals/modalregistry.tsx` so Escape dismissal works.
+
+7. **Call `registerDefaultCommands()`** — from `frontend/cef-init.ts` after `initGlobalAtoms()`.
+
+### No New Dependencies
+
+The component uses SolidJS primitives already in the project. Fuzzy match for v1 is a simple `String.includes()` — no fuzzy library needed. Add one later if substring matching proves insufficient.
+
+### Approximate File Additions / Edits
+
+| File | Change |
+|------|--------|
+| `frontend/app/store/command-registry.ts` | New |
+| `frontend/app/modals/command-palette.tsx` | New |
+| `frontend/app/modals/command-palette.scss` | New |
+| `frontend/app/store/keymodel.ts` | Add `Ctrl:p` binding |
+| `frontend/app/modals/modalregistry.tsx` | Register palette |
+| `frontend/cef-init.ts` | Call `registerDefaultCommands()` |
+| `agentmux-cef/src/commands/palette.rs` | New |
+| `agentmux-cef/src/commands/mod.rs` | Add `pub mod palette;` |
+| `agentmux-cef/src/ipc.rs` | Add `"run_command"` arm |

--- a/docs/specs/gpu-crash-recovery.md
+++ b/docs/specs/gpu-crash-recovery.md
@@ -1,0 +1,211 @@
+# GPU Crash Recovery Spec
+
+**Date:** 2026-04-04
+**Status:** Draft
+**Context:** agentmux-cef v0.33.42 experienced a GPU crash loop (80+ restarts in 6s) on April 4, 2026. No recovery mechanism exists. Full GPU acceleration is enabled with no fallback flags.
+
+---
+
+## Problem
+
+When the CEF GPU process crashes repeatedly, Chromium's internal fallback stack (HARDWARE_GL → SWIFTSHADER → DISPLAY_COMPOSITOR) can exhaust. If all modes fail, Chromium calls `IntentionallyCrashBrowserForUnusableGpuProcess()` — killing the entire application with no user-facing recovery.
+
+**Observed crash sequence (April 4, 2026):**
+```
+11:01:59 — GPU process starts crash-looping
+           ~80 restart attempts in 6 seconds
+           Each: kFatalFailure: Failed to create shared context for virtualization
+11:02:05 — WER dump: agentmux-cef.exe.24548.dmp
+11:11:45 — GPU process stabilizes but degraded:
+           Shared memory region create failed on 3241056 bytes
+           No displays detected. Waiting for next update.
+           Failed to retrieve D3D11 device
+11:12:00 — WER dump: agentmux-cef.exe.36392.dmp
+```
+
+**Root cause:** GPU driver instability or resource exhaustion. Exit code `0x80000003` (`STATUS_BREAKPOINT`) indicates an internal Chromium assertion or driver-triggered breakpoint.
+
+---
+
+## Chromium's Built-in Behavior (What We Get for Free)
+
+1. **Crash counter with forgiveness:** 1 crash forgiven per 5 minutes. 3 crashes within the forgiveness window triggers fallback to next GPU mode.
+2. **Fallback stack on Windows:** `HARDWARE_GL` → `SWIFTSHADER` → `DISPLAY_COMPOSITOR`
+3. **Fatal termination:** If the stack is empty, browser process crashes intentionally.
+4. **No CEF API for GPU crashes:** There is no `OnGpuProcessCrashed` callback. `OnRenderProcessTerminated` only fires for renderer crashes.
+
+---
+
+## Design
+
+### Layer 1: Persistent GPU Health Tracking
+
+Track GPU crash history across sessions in a config file (`~/.agentmux/<version>/gpu-health.json`):
+
+```json
+{
+  "gpu_mode": "hardware",
+  "crash_count": 0,
+  "last_crash_ts": null,
+  "fallback_active": false,
+  "driver_version": "32.0.15.6590",
+  "gpu_vendor": "NVIDIA",
+  "gpu_device": "GeForce GTX 1070"
+}
+```
+
+**On startup:** Read this file before `CefInitialize()`. If `crash_count >= 3` within the last 24 hours, add `--disable-gpu-compositing` to command-line args. If `crash_count >= 6`, add `--disable-gpu`.
+
+**On clean shutdown:** Reset `crash_count` to 0.
+
+**On abnormal exit:** The file retains its last state. Next launch reads the stale `crash_count` and applies the appropriate fallback.
+
+### Layer 2: Watchdog Launcher
+
+A lightweight launcher process (`agentmux-launcher.exe`) that:
+
+1. Spawns `agentmux-cef.exe` as a child process
+2. Monitors its exit code
+3. On abnormal exit (non-zero, especially `0x80000003` or `0xC0000409`):
+   - Increments `crash_count` in `gpu-health.json`
+   - Relaunches with escalated GPU flags based on crash count:
+     - 1st crash: relaunch normally (Chromium likely already fell back internally)
+     - 2nd crash: relaunch with `--disable-gpu-compositing`
+     - 3rd crash: relaunch with `--disable-gpu`
+     - 4th crash: show error dialog, do not relaunch
+4. On clean exit (code 0): exit normally
+
+```
+┌─────────────────────┐
+│ agentmux-launcher   │
+│                     │
+│  spawn ──► agentmux-cef.exe
+│  wait for exit      │
+│                     │
+│  exit code != 0?    │
+│    ├─ bump crash_count
+│    ├─ pick GPU flags │
+│    └─ relaunch       │
+│                     │
+│  exit code == 0?    │
+│    └─ exit           │
+└─────────────────────┘
+```
+
+### Layer 3: In-Process GPU Health Monitor
+
+Inside `agentmux-cef`, monitor for signs of GPU degradation at runtime:
+
+1. **Render heartbeat:** The frontend sends a periodic heartbeat (every 5s) via IPC to the backend. If the backend stops receiving heartbeats for 30s, the renderer is likely frozen due to GPU issues.
+
+2. **Parse CEF log output:** Hook into CEF's log callback (`CefLogSeverity`) and watch for:
+   - `"GPU process exited unexpectedly"` — increment an in-memory counter
+   - `"Shared memory region create failed"` — flag memory pressure
+   - `"No displays detected"` — flag display loss
+   - `"kFatalFailure"` — flag context creation failure
+
+3. **User notification:** When GPU degradation is detected, show a non-blocking banner in the UI:
+   > "Hardware acceleration encountered an issue and has been reduced. [Restart with full acceleration] [Keep current mode]"
+
+### Layer 4: User-Facing Settings
+
+Add a setting in the app preferences:
+
+```
+Hardware Acceleration: [On] [Off] [Auto]
+```
+
+- **On:** No GPU-disabling flags (default for fresh install)
+- **Off:** Always pass `--disable-gpu --disable-gpu-compositing`
+- **Auto:** Use Layer 1 crash tracking to decide at launch
+
+Persisted in `~/.agentmux/<version>/settings.json` as `"gpu_acceleration": "auto" | "on" | "off"`.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Persistent Health File (Low effort, high impact)
+
+**Files:** `agentmux-cef/src/main.rs`
+
+- On startup (before `CefInitialize`): read `gpu-health.json`, apply flags if needed
+- On clean shutdown (`CefShutdown` completes): write `crash_count: 0`
+- Log the GPU mode decision at startup
+
+### Phase 2: Watchdog Launcher (Medium effort)
+
+**New crate:** `agentmux-launcher/`
+
+- Minimal Rust binary (~100 lines)
+- Spawns `agentmux-cef.exe` with appropriate args
+- Monitors exit code, updates `gpu-health.json`
+- Handles relaunch logic with escalating GPU flags
+- Update portable build script to use launcher as entry point
+
+### Phase 3: In-Process Monitor (Medium effort)
+
+**Files:** `agentmux-cef/src/app.rs`, `agentmux-cef/src/client.rs`, frontend IPC
+
+- CEF log hook for GPU-related messages
+- Frontend heartbeat timer → backend IPC endpoint
+- UI banner component for GPU degradation notification
+
+### Phase 4: User Settings (Low effort, depends on Phase 1)
+
+**Files:** `agentmux-cef/src/main.rs`, frontend settings UI
+
+- Add GPU acceleration toggle to settings
+- Read setting on startup, override health-file logic if set to `on` or `off`
+
+---
+
+## CEF Command-Line Flags Reference
+
+| Escalation Level | Flags | Effect |
+|---|---|---|
+| Normal | (none) | Full GPU acceleration |
+| Level 1 | `--disable-gpu-compositing` | Software compositing, GPU still used for WebGL |
+| Level 2 | `--disable-gpu` | No GPU process at all, full software rendering |
+| Level 3 | `--disable-gpu --disable-software-rasterizer` | No GPU, no SwiftShader (minimal, last resort) |
+
+**Note:** `--use-angle=swiftshader` (SwANGLE) is being deprecated upstream. Do not rely on it as a fallback.
+
+---
+
+## Windows-Specific Considerations
+
+### TDR (Timeout Detection and Recovery)
+
+- Windows resets the GPU driver if it hangs for >2 seconds
+- 5+ TDRs within 60 seconds = BSOD (`VIDEO_TDR_TIMEOUT_DETECTED`)
+- TDR events are transparent to the app but contribute to Chromium's internal crash counter
+- Cannot be detected reliably from user-mode; would need to poll Event Viewer (`System` log, source `Display`)
+
+### Shared Memory Failures
+
+The `Shared memory region create failed on 3241056 bytes` error indicates page file exhaustion or commit limit reached. Mitigation:
+- Ensure system page file is set to "System managed" (not a fixed small size)
+- Monitor commit charge on long-running instances
+- Not actionable from the app side — this is an OS resource limit
+
+### Exit Codes to Watch
+
+| Code | Hex | Meaning |
+|---|---|---|
+| -2147483645 | 0x80000003 | STATUS_BREAKPOINT (assertion/debugbreak) |
+| -1073740791 | 0xC0000409 | STATUS_STACK_BUFFER_OVERRUN (fast-fail) |
+| -1073741819 | 0xC0000005 | STATUS_ACCESS_VIOLATION (segfault) |
+| -1073741510 | 0xC000013A | STATUS_CONTROL_C_EXIT (Ctrl+C) |
+
+---
+
+## Open Questions
+
+1. **Should the launcher be a separate binary or integrated into agentmux-cef.exe with a `--watchdog` flag?** Separate binary is simpler but adds a file to the portable distribution.
+
+2. **How long should crash history persist?** Current proposal: 24 hours. Too short and repeat offenders aren't caught. Too long and a one-time driver glitch permanently degrades the experience.
+
+3. **Should we collect GPU info (vendor, device, driver version) at startup for diagnostics?** CEF exposes this via the GPU process but only after initialization.
+
+4. **Do we want to detect TDR events proactively?** Polling Event Viewer is expensive and unreliable. Probably not worth it.

--- a/docs/specs/gpu-recovery-and-cef-init-fix.md
+++ b/docs/specs/gpu-recovery-and-cef-init-fix.md
@@ -1,0 +1,287 @@
+# Implementation Spec: GPU Context Recovery + CEF API Init Fix
+
+**Date:** 2026-04-08
+**Author:** AgentA
+**Related:** [white-screen-overnight-2026-04-08.md](../analysis/white-screen-overnight-2026-04-08.md)
+**Branch:** `agenta/gpu-recovery-cef-init`
+**Affects:** `agentmux-cef`, `frontend`
+
+---
+
+## Problem Statement
+
+Three portable instances (v0.33.62, v0.33.64, v0.33.73) went to solid white screen overnight while the machine and monitor stayed on. Processes remained alive (heartbeats ticking), but the rendering surface was gone. Root cause: `webglcontextlost` event fired (confirmed in v0.33.64 logs) while `--in-process-gpu` was active, leaving no recovery path. Separately, all 3 instances log `Cannot read properties of undefined (reading 'getPlatform')` on every startup — a race condition in CEF API initialization.
+
+---
+
+## Change 1: Remove `--in-process-gpu`
+
+### Rationale
+
+With `--in-process-gpu`, GPU context loss leaves the app in a zombie state — process alive but rendering dead. Without it, Chromium runs GPU compositing in a separate process that can crash and restart transparently. The ~100GB virtual address overhead is irrelevant on 64-bit (0.07% of 128TB VA space) and costs ~20-50MB physical RAM.
+
+### File: `agentmux-cef/src/app.rs`
+
+**Remove lines 249–255:**
+
+```rust
+// DELETE:
+                // Merge GPU process into the browser process. Eliminates one
+                // ~100GB virtual address space reservation from PartitionAlloc
+                // pools (32GB GigaCage + 4×16GB pools + 4GB V8 pointer cage).
+                // Tradeoff: GPU driver crash kills the app instead of just
+                // restarting the GPU process — acceptable for a local desktop app.
+                let gpu_key = CefString::from("in-process-gpu");
+                cmd.append_switch(Some(&gpu_key));
+```
+
+**Keep** the `--renderer-process-limit=1` (lines 257–262) — that's still valuable.
+
+### Expected result
+
+- One additional process in Task Manager: `agentmux-cef-0.33.XX.exe` (GPU process)
+- GPU context loss → GPU process crashes → Chromium restarts it → page re-composits
+- No more zombie white screen state
+
+---
+
+## Change 2: Add `webglcontextlost` recovery handler
+
+### Rationale
+
+Even with a separate GPU process, `webglcontextlost` can occur in rare edge cases (driver TDR, DXGI device removal, GPU resource eviction with multiple instances). The `webglcontextrestored` event is unreliable in Chromium ([electron#11934](https://github.com/electron/electron/issues/11934)). A page reload is the only guaranteed recovery.
+
+### File: `frontend/tauri-bootstrap.ts`
+
+**Add a document-level `webglcontextlost` listener early in `bootstrap()`, before any rendering starts.**
+
+Insert after the `initLogPipe()` call (after line 17, before the static CSS imports):
+
+```typescript
+// Recover from GPU context loss (e.g., driver reset, display power state change).
+// webglcontextrestored is unreliable in Chromium, so reload the page instead.
+// The 'capture: true' flag ensures we see the event even if it fires on a canvas
+// deep in the DOM (xterm WebGL addon, etc).
+let contextLostReloading = false;
+document.addEventListener("webglcontextlost", (event) => {
+    event.preventDefault(); // Tell browser we'll handle recovery
+    if (contextLostReloading) return; // Prevent reload loop from multiple canvases
+    contextLostReloading = true;
+    console.error("[recovery] WebGL context lost — reloading page in 1s");
+    setTimeout(() => window.location.reload(), 1000);
+}, true);
+```
+
+### Why at this level (not in termwrap.ts)
+
+`termwrap.ts:456` already handles per-terminal context loss by falling back to the DOM renderer. But that only covers xterm's canvas. If the **compositor context** (CEF's own rendering) is lost, the entire page goes white — no individual canvas handler can fix that. The document-level handler is the safety net for compositor-level context loss.
+
+### Guard against reload loops
+
+The `contextLostReloading` flag prevents multiple simultaneous reloads. If the driver is permanently dead, the page will reload once, hit context loss again, and reload again — but the 1s delay + flag means it won't spin. In practice, if the GPU process restarts (Change 1), the second load will succeed.
+
+If we want extra safety, we can add a sessionStorage counter:
+
+```typescript
+const reloadCount = parseInt(sessionStorage.getItem("__ctx_lost_reloads") || "0");
+if (reloadCount >= 3) {
+    console.error("[recovery] WebGL context lost 3 times — giving up, switching to DOM renderer");
+    sessionStorage.removeItem("__ctx_lost_reloads");
+    // Force DOM renderer mode globally (set a flag that termwrap reads)
+    sessionStorage.setItem("__force_dom_renderer", "1");
+    return;
+}
+sessionStorage.setItem("__ctx_lost_reloads", String(reloadCount + 1));
+// Clear the counter after 30s of stable running
+setTimeout(() => sessionStorage.removeItem("__ctx_lost_reloads"), 30000);
+```
+
+**Recommendation:** Start with the simple version (no counter). Add the counter only if reload loops are observed in practice.
+
+---
+
+## Change 3: Fix `getPlatform` UNHANDLED-REJECTION
+
+### Root cause
+
+`tauri-bootstrap.ts` statically imports `wave.ts` (line 12):
+```typescript
+import { initBare } from "./wave";
+```
+
+`wave.ts` declares at module scope (line 47):
+```typescript
+let platform: NodeJS.Platform;
+```
+
+This is fine — `platform` is assigned later in `initBare()` at line 408:
+```typescript
+platform = getApi().getPlatform();
+```
+
+The error comes from **something else** calling `getApi().getPlatform()` before `setupCefApi()` completes. Since `getApi()` returns `window.api` (which is `undefined` before `setupCefApi()`), it throws `Cannot read properties of undefined (reading 'getPlatform')`.
+
+### The actual culprit
+
+The error fires during the `initCefApi()` → `Promise.all([...invokeCommand()])` batch (cef-api.ts:72-94). While those IPC calls are in-flight, some **other code** (likely a side effect of static imports, or an eager SolidJS reactive subscription) calls `getApi()` before `window.api` is set.
+
+The `unhandledrejection` handler in `tauri-bootstrap.ts:236` catches it but can't prevent it.
+
+### Fix: Guard `getApi()` to return a safe stub before initialization
+
+**File: `frontend/app/store/global.ts`** (line 521)
+
+Replace:
+```typescript
+export function getApi(): AppApi {
+    return window.api;
+}
+```
+
+With:
+```typescript
+export function getApi(): AppApi {
+    if (!window.api) {
+        throw new Error("[getApi] window.api is not initialized yet — called too early in bootstrap");
+    }
+    return window.api;
+}
+```
+
+This converts a cryptic `Cannot read properties of undefined (reading 'getPlatform')` into a clear `[getApi] window.api is not initialized yet` error that points to the actual problem.
+
+**However**, this won't prevent the error — it just improves the message. The real fix depends on finding what calls `getApi()` before bootstrap completes.
+
+### Better fix: Defensive guard in `initBare()`
+
+**File: `frontend/wave.ts`** (line 404-408)
+
+Replace:
+```typescript
+export async function initBare() {
+    // window.api is guaranteed to exist here — tauri-bootstrap.ts calls
+    // setupTauriApi() or setupCefApi() before calling initBare().
+    // Assign deferred module-level values now.
+    platform = getApi().getPlatform();
+```
+
+With:
+```typescript
+export async function initBare() {
+    // window.api is guaranteed to exist here — tauri-bootstrap.ts calls
+    // setupTauriApi() or setupCefApi() before calling initBare().
+    // Assign deferred module-level values now.
+    if (!window.api) {
+        console.error("[initBare] window.api not available — waiting for host API init");
+        // This should never happen if bootstrap order is correct, but guard against it
+        await new Promise<void>((resolve) => {
+            const check = setInterval(() => {
+                if (window.api) { clearInterval(check); resolve(); }
+            }, 50);
+            setTimeout(() => { clearInterval(check); resolve(); }, 5000); // 5s timeout
+        });
+    }
+    platform = getApi().getPlatform();
+```
+
+### Root cause hunt: find the early caller
+
+To find the actual code that calls `getApi()` too early, add a temporary diagnostic:
+
+**File: `frontend/app/store/global.ts`** (in `getApi()`)
+
+```typescript
+export function getApi(): AppApi {
+    if (!window.api) {
+        console.error("[getApi] called before window.api exists. Stack:", new Error().stack);
+    }
+    return window.api;
+}
+```
+
+Build, launch, check the host log for the stack trace. The stack will show exactly which module/line calls `getApi()` during static import resolution. Fix that caller, then remove the diagnostic.
+
+---
+
+## Files Changed Summary
+
+| File | Change |
+|------|--------|
+| `agentmux-cef/src/app.rs` | Remove `--in-process-gpu` flag (lines 249-255) |
+| `frontend/tauri-bootstrap.ts` | Add `webglcontextlost` document listener (after line 17) |
+| `frontend/app/store/global.ts` | Add diagnostic + guard to `getApi()` (line 521) |
+| `frontend/wave.ts` | Add defensive `window.api` wait in `initBare()` (line 404) |
+
+---
+
+## Verification Plan
+
+### Pre-build checklist
+
+- [ ] `bump patch -m "fix: remove in-process-gpu, add WebGL recovery, fix CEF init race"`
+- [ ] `cargo check -p agentmux-cef` — Rust compiles
+- [ ] `npx tsc --noEmit` — TypeScript compiles
+- [ ] `npm install --package-lock-only` + commit lock sync
+
+### Build and deploy
+
+- [ ] `task cef:package:portable` — produces ZIP on Desktop
+- [ ] Extract to new folder, launch `agentmux.exe`
+
+### Test 1: Startup — no `getPlatform` error
+
+1. Launch portable build
+2. Check host log: `~/.agentmux/logs/agentmux-host-v*.log.*`
+3. **PASS:** No `UNHANDLED-REJECTION` with `getPlatform` in the log
+4. **PASS:** `[fe] ✅ Main application loaded successfully` appears
+5. **PASS:** If diagnostic `getApi()` guard fires, log shows stack trace pointing to the early caller
+
+### Test 2: GPU process visible in Task Manager
+
+1. Open Task Manager → Details tab
+2. **PASS:** Two `agentmux-cef-0.33.XX.exe` entries visible (browser + GPU process)
+3. **PASS:** Previously only one entry existed (in-process GPU was merged)
+
+### Test 3: Memory heartbeat still running
+
+1. Wait 30 seconds after launch
+2. Check host log for `mem_heartbeat` entries
+3. **PASS:** System memory + process memory entries appear every 20s
+
+### Test 4: WebGL context loss recovery (manual trigger)
+
+1. Open DevTools (if available) or use the Chrome DevTools Protocol
+2. In DevTools console, find an xterm canvas and force context loss:
+   ```javascript
+   const canvas = document.querySelector('canvas');
+   const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+   const ext = gl.getExtension('WEBGL_lose_context');
+   ext.loseContext();
+   ```
+3. **PASS:** Log shows `[recovery] WebGL context lost — reloading page in 1s`
+4. **PASS:** Page reloads within ~1s and app is fully functional after reload
+5. **PASS:** Terminal state is restored after reload (backend preserves it)
+
+### Test 5: Overnight soak (the real test)
+
+1. Launch 2 portable instances side by side
+2. Open at least one terminal pane in each
+3. Leave running overnight (8+ hours, machine and monitor stay on)
+4. **PASS:** Both instances still rendering correctly in the morning
+5. **PASS:** No `webglcontextlost` in logs (GPU process handles recovery transparently)
+6. **PASS:** If `webglcontextlost` does fire, page auto-reloaded and app recovered
+
+### Test 6: Multiple rapid context losses (reload loop guard)
+
+1. In DevTools console, trigger `ext.loseContext()` three times in quick succession
+2. **PASS:** Only one reload occurs (flag prevents multiple)
+3. **PASS:** App recovers and is functional after the single reload
+
+### Regression checks
+
+- [ ] Terminal rendering works (text, colors, scrolling)
+- [ ] Per-pane zoom (Ctrl+/-, Ctrl+Scroll) still works
+- [ ] Context menu (right-click) works
+- [ ] Command palette (Ctrl+P) opens
+- [ ] Window close kills all child processes (check Task Manager)
+- [ ] Pane splitting works (terminal shows "running", not "Disconnected")

--- a/docs/specs/portable-build-spec.md
+++ b/docs/specs/portable-build-spec.md
@@ -1,0 +1,127 @@
+# AgentMux Windows Portable Build — Spec
+
+## Goal
+
+A single command that produces a working portable ZIP on Desktop. No manual steps, no version mismatches, no stale artifacts. Any agent should be able to run it.
+
+## Current Problem
+
+The build requires 5 separate commands in the right order, and agents frequently:
+1. Forget to bump version → version check fails in packaging script
+2. Build CEF but not backend → missing `wsh` or `agentmuxsrv-rs`
+3. Build backend but not CEF → stale CEF binary with wrong version
+4. Build frontend with wrong config → missing assets
+5. Skip `cef:bundle` → missing `libcef.dll` and resource paks
+
+## The Single Command
+
+```bash
+task cef:package:portable
+```
+
+This MUST work end-to-end. Currently it only runs the packaging script, assuming everything is pre-built. It needs to be a full pipeline.
+
+## Proposed Taskfile Change
+
+Replace the current `cef:package:portable` task:
+
+```yaml
+cef:package:portable:
+    desc: Build and package AgentMux CEF as a portable ZIP (Windows).
+    platforms: [windows]
+    deps:
+        - build:frontend:prod    # Vite production build → dist/frontend/
+        - build:backend          # agentmuxsrv-rs + wsh → dist/bin/
+        - cef:build              # agentmux-cef.exe → dist/cef/ (also builds launcher)
+        - cef:bundle             # libcef.dll + paks + locales → dist/cef/
+    cmds:
+        - cargo build --release -p agentmux-launcher
+        - bash scripts/package-cef-portable.sh
+```
+
+### Dependency Chain
+
+```
+cef:package:portable
+├── build:frontend:prod     → dist/frontend/ (index.html, assets/, fonts/)
+├── build:backend
+│   ├── build:backend:rust  → dist/bin/agentmuxsrv-rs.x64.exe
+│   └── build:wsh           → dist/bin/wsh-{version}-windows.x64.exe
+├── cef:build               → cargo build --release -p agentmux-cef
+├── cef:bundle              → dist/cef/ (libcef.dll, *.pak, locales/)
+└── scripts/package-cef-portable.sh
+    └── Assembles ~/Desktop/agentmux-cef-{version}-x64-portable/
+```
+
+### What the packaging script does
+
+1. Reads version from `package.json`
+2. Verifies all required files exist:
+   - `target/release/agentmux-cef.exe`
+   - `target/release/agentmux-launcher.exe`
+   - `dist/cef/libcef.dll`
+   - `dist/bin/agentmuxsrv-rs.x64.exe`
+   - `dist/bin/wsh-{version}-windows.x64.exe`
+   - `dist/frontend/index.html`
+3. Creates portable directory structure
+4. Verifies version strings in binaries match `package.json`
+5. Creates ZIP
+
+### Version String Check
+
+The script `grep`s for the version string in the CEF and sidecar binaries. If they don't match `package.json`, it fails. This catches stale builds.
+
+**Common failure:** Agent bumps version but doesn't rebuild. Fix: the task deps force a rebuild.
+
+## Pre-Requisites (one-time setup)
+
+These must exist on the build machine:
+
+| Tool | Path | Check |
+|------|------|-------|
+| Rust/Cargo | `~/.cargo/bin/cargo` | `cargo --version` |
+| Node.js | system PATH | `node --version` |
+| npm | system PATH | `npm --version` |
+| CMake | system PATH or VS | `cmake --version` |
+| Ninja | `/c/Systems/bin/ninja.exe` | `ninja --version` |
+| Visual Studio 2022 | standard install | `cl.exe` via vcvars |
+| Task | system PATH | `task --version` |
+
+## Build Times (approximate)
+
+| Step | First Build | Incremental |
+|------|------------|-------------|
+| Frontend (Vite) | 15s | 5s |
+| Backend (Rust) | 2-3min | 15-30s |
+| CEF host (Rust) | 35s | 35s (CEF SDK rebuild) |
+| CEF bundle (copy DLLs) | 5s | 5s |
+| Launcher (Rust) | 5s | 2s |
+| Packaging script | 10s | 10s |
+| **Total** | **~4min** | **~1.5min** |
+
+## Agent Instructions
+
+For any agent building a portable release:
+
+```bash
+# 1. Bump version (REQUIRED before every build)
+bump patch -m "description" --commit
+
+# 2. Build and package (single command)
+task cef:package:portable
+
+# 3. Test
+# Launch ~/Desktop/agentmux-cef-{version}-x64-portable/agentmux.exe
+```
+
+If `task cef:package:portable` fails:
+- **"not found" error**: Run the missing build step manually (`task build:backend`, `task cef:build`, etc.)
+- **Version mismatch**: You bumped but didn't rebuild. Run `task cef:package:portable` again (deps rebuild)
+- **CMake/Ninja error**: Verify `cmake --version` and `ninja --version` work
+
+## What NOT To Do
+
+- **Don't copy binaries manually** (`cp target/release/agentmux-cef.exe ...`) — use the packaging script
+- **Don't skip the version bump** — the version check will fail
+- **Don't run individual build commands** unless diagnosing a failure — use the single task
+- **Don't kill running AgentMux instances before building** — they're isolated (separate dirs)

--- a/docs/specs/secondary-windows-cef-views.md
+++ b/docs/specs/secondary-windows-cef-views.md
@@ -1,0 +1,189 @@
+# Secondary Windows: Switch from Native to CEF Views
+
+**Date:** 2026-04-02
+**Status:** Spec
+**Depends on:** PR #272 (CEF Views deferred show)
+**Problem:** Secondary windows (new window, tear-off) have no resize handlers
+
+## Background
+
+PR #268-#272 fixed the white flash by switching the main window from native mode to CEF Views with deferred `Show()`. The main window now has:
+- No white flash
+- Resize via CEF Views delegate (`can_resize`)
+- Frameless via CEF Views delegate (`is_frameless`)
+- Snap, minimize, maximize all working
+
+Secondary windows (opened via "new window" button or pane tear-off) still use **native mode** (`browser_host_create_browser` with `WindowInfo`). They lack:
+- Resize handlers (WM_NCHITTEST on parent is blocked by CEF child window)
+- Proper frameless handling (WM_NCCALCSIZE hack doesn't work with CEF child)
+- Consistent behavior with main window
+
+## Root Cause
+
+In native mode, CEF creates a child window (`Chrome_WidgetWin_0`) that fills the entire parent. Mouse events go to the child, not the parent. Our WndProc hooks on the parent (`WM_NCHITTEST`, `WM_NCCALCSIZE`) never receive mouse events, so resize doesn't work.
+
+CEF Views handles this internally — it knows about the browser child and routes hit-testing correctly through its own framework.
+
+## Proposed Fix
+
+Switch secondary windows from native mode to CEF Views, matching the main window.
+
+### Current Flow (native mode)
+
+```
+open_new_window() / open_window_at_position()
+  → build WindowInfo { style: WS_POPUP | ... }
+  → browser_host_create_browser(window_info, client, url, settings)
+  → on_after_created: install_frameless_resize_hook (doesn't work)
+  → on_load_end: ShowWindow via Win32 + WS_THICKFRAME (no resize)
+```
+
+### Proposed Flow (CEF Views)
+
+```
+open_new_window() / open_window_at_position()
+  → browser_view_create(client, url, settings, delegate)
+  → window_create_top_level(window_delegate)
+  → on_window_created: add_child_view, set_bounds, do NOT show
+  → on_load_end: window.show() via CEF Views API
+```
+
+### Files to Change
+
+**1. `agentmux-cef/src/commands/window.rs` — `open_new_window()`**
+
+Replace:
+```rust
+let window_info = cef::WindowInfo {
+    runtime_style: cef::RuntimeStyle::ALLOY,
+    window_name: cef::CefString::from("AgentMux"),
+    style: WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS
+        | WS_MINIMIZEBOX | WS_MAXIMIZEBOX,
+    bounds: cef::Rect { x, y, width, height },
+    ..Default::default()
+};
+browser_host_create_browser(&window_info, client, &url, &settings, None, None);
+```
+
+With:
+```rust
+let browser_view = cef::browser_view_create(
+    client, &url, &settings, None, None, &delegate,
+);
+let window_delegate = SecondaryWindowDelegate::new(
+    browser_view, pos_x, pos_y, win_w, win_h,
+);
+cef::window_create_top_level(&window_delegate);
+```
+
+**2. `agentmux-cef/src/commands/drag.rs` — `open_window_at_position()`**
+
+Same change — replace `browser_host_create_browser` with `browser_view_create` + `window_create_top_level`.
+
+**3. `agentmux-cef/src/app.rs` — Add secondary window delegate**
+
+The main window's `AgentMuxWindowDelegate` already exists. Secondary windows need the same behavior but:
+- Positioned at (pos_x, pos_y) instead of centered 70%
+- May have different size
+
+Options:
+- **Reuse `AgentMuxWindowDelegate`** with position/size parameters
+- **Create `SecondaryWindowDelegate`** (cleaner separation)
+
+Recommendation: Add position/size fields to `AgentMuxWindowDelegate`:
+```rust
+wrap_window_delegate! {
+    pub struct AgentMuxWindowDelegate {
+        browser_view: RefCell<Option<BrowserView>>,
+        initial_bounds: Option<(i32, i32, i32, i32)>,  // NEW: (x, y, w, h)
+    }
+}
+```
+
+In `on_window_created`:
+```rust
+if let Some((x, y, w, h)) = self.initial_bounds {
+    window.set_bounds(Some(&Rect { x, y, width: w, height: h }));
+} else {
+    // Default: 70% of monitor
+    if let Some((x, y, w, h)) = get_monitor_centered_70pct(window) {
+        window.set_bounds(Some(&Rect { x, y, width: w, height: h }));
+    }
+}
+// Do NOT show — deferred to on_load_end
+```
+
+**4. `agentmux-cef/src/client.rs` — Simplify `on_load_end`**
+
+Remove the Win32 `ShowWindow` fallback for native secondary windows. All windows use CEF Views now, so the `browser_view_get_for_browser` path always works:
+
+```rust
+// Show via CEF Views API — works for all windows
+let mut browser_cloned = browser.cloned();
+if let Some(bv) = browser_view_get_for_browser(browser_cloned.as_mut()) {
+    if let Some(window) = bv.window() {
+        if window.is_visible() == 0 {
+            window.show();
+            // focus...
+        }
+    }
+}
+```
+
+**5. `agentmux-cef/src/client.rs` — Remove `install_frameless_resize_hook` for secondary windows**
+
+No longer needed — CEF Views handles frameless via delegate.
+
+**6. `agentmux-cef/src/app.rs` — `AgentMuxBrowserViewDelegate::on_popup_browser_view_created`**
+
+Already creates secondary windows via CEF Views for popups (devtools). May need to pass position/size for tear-off windows.
+
+### What About `RequestContext` Isolation?
+
+Currently, secondary windows use per-window `RequestContext` for renderer process isolation:
+```rust
+let request_context = cef::request_context_create_context(
+    &request_context_settings, None,
+);
+browser_host_create_browser(..., Some(&request_context), ...);
+```
+
+`browser_view_create` also accepts a `RequestContext` parameter. Need to pass it through:
+```rust
+let browser_view = cef::browser_view_create(
+    client, &url, &settings,
+    None,                    // extra_info
+    Some(&request_context),  // request_context — keep isolation
+    &delegate,
+);
+```
+
+### What We Remove
+
+- `install_frameless_resize_hook` call for secondary windows
+- `setup_native_frameless` (DwmExtendFrameIntoClientArea) — already removed
+- Win32 `ShowWindow` + `WS_THICKFRAME` + `SWP_FRAMECHANGED` fallback in `on_load_end`
+- WS_POPUP window style for secondary windows
+- `get_secondary_window_size()` helper (replaced by delegate bounds)
+
+### What We Keep
+
+- `install_frameless_resize_hook` + `setup_native_frameless` functions (may be needed for `--use-native` flag or future use)
+- `ORIGINAL_WNDPROCS` static (same)
+- `get_offset_position()` helper (still needed for positioning)
+
+## Test Plan
+
+- [ ] Main window: no flash, resize, snap, frameless — unchanged
+- [ ] New window button: opens, no flash, resize works, frameless
+- [ ] Pane tear-off: opens at cursor position, no flash, resize works
+- [ ] Secondary window close: doesn't affect main window
+- [ ] Multiple secondary windows: each independent
+- [ ] Page reload in secondary: doesn't re-show (is_visible guard)
+- [ ] macOS/Linux: unaffected (CEF Views is cross-platform)
+
+## Complexity
+
+Medium — the main change is in `commands/window.rs` and `commands/drag.rs` replacing `browser_host_create_browser` with `browser_view_create` + `window_create_top_level`. The delegate already exists and just needs position/size parameterization.
+
+Estimated: ~100 lines changed across 4 files.

--- a/docs/specs/secondary-windows-impl-plan.md
+++ b/docs/specs/secondary-windows-impl-plan.md
@@ -1,0 +1,202 @@
+# Secondary Windows CEF Views — Implementation Plan
+
+**Date:** 2026-04-02
+**Branch:** `agenta/secondary-windows-cef-views`
+**Base:** `origin/main` (after PR #272)
+
+## Pre-flight
+
+1. `git checkout -b agenta/secondary-windows-cef-views origin/main`
+2. Verify main window works: `task cef:package:portable` → test
+
+## Step 1: Parameterize AgentMuxWindowDelegate
+
+**File:** `agentmux-cef/src/app.rs`
+
+Add optional initial bounds to the delegate so it can be reused for secondary windows with custom position/size:
+
+```rust
+wrap_window_delegate! {
+    pub struct AgentMuxWindowDelegate {
+        browser_view: RefCell<Option<BrowserView>>,
+        initial_bounds: Option<(i32, i32, i32, i32)>,  // (x, y, w, h) or None for 70% centered
+    }
+}
+```
+
+Update `on_window_created`:
+```rust
+fn on_window_created(&self, window: Option<&mut Window>) {
+    // ... add_child_view ...
+    
+    if let Some((x, y, w, h)) = self.initial_bounds {
+        window.set_bounds(Some(&Rect { x, y, width: w, height: h }));
+    } else {
+        if let Some((x, y, w, h)) = get_monitor_centered_70pct(window) {
+            window.set_bounds(Some(&Rect { x, y, width: w, height: h }));
+        }
+    }
+    // Do NOT show — deferred to on_load_end
+}
+```
+
+Update existing call sites:
+- `on_context_initialized`: `AgentMuxWindowDelegate::new(RefCell::new(browser_view), None)`
+- `on_popup_browser_view_created`: `AgentMuxWindowDelegate::new(RefCell::new(popup_bv), None)`
+
+**Test:** Main window still works, no regression.
+**Commit:** `refactor: parameterize AgentMuxWindowDelegate with optional bounds`
+
+## Step 2: Switch open_new_window to CEF Views
+
+**File:** `agentmux-cef/src/commands/window.rs`
+
+The function currently builds a `WindowInfo` and calls `browser_host_create_browser`. Replace with CEF Views.
+
+**Before:**
+```rust
+let window_info = cef::WindowInfo { style: WS_POPUP | ..., ... };
+browser_host_create_browser(&window_info, client, &url, &settings, Some(&ctx), None);
+```
+
+**After:**
+```rust
+let mut bv_delegate = AgentMuxBrowserViewDelegate::new(RuntimeStyle::ALLOY);
+let browser_view = cef::browser_view_create(
+    client, &url, &settings, None, Some(&ctx), &mut bv_delegate,
+);
+let mut wd = AgentMuxWindowDelegate::new(
+    RefCell::new(browser_view),
+    Some((pos_x, pos_y, win_w, win_h)),
+);
+cef::window_create_top_level(&mut wd);
+```
+
+**Key details:**
+- `RequestContext` (`ctx`) passed to `browser_view_create` 4th arg (extra_info=None, request_context=Some)
+- Position from `get_offset_position()`
+- Size from `get_secondary_window_size()`
+- Need to import `AgentMuxWindowDelegate`, `AgentMuxBrowserViewDelegate` from `crate::app`
+- Remove the `#[cfg(target_os = "windows")]` / `#[cfg(not)]` branches — CEF Views is cross-platform
+
+**Test:** Click "new window" button → window opens, resize works, no flash.
+**Commit:** `fix: switch open_new_window to CEF Views for resize support`
+
+## Step 3: Switch open_window_at_position to CEF Views
+
+**File:** `agentmux-cef/src/commands/drag.rs`
+
+Same pattern as Step 2. This function opens windows for pane tear-off.
+
+**Before:**
+```rust
+let window_info = cef::WindowInfo { style: WS_POPUP | ..., bounds: cef::Rect { x, y, w, h }, ... };
+browser_host_create_browser(&window_info, client, &url, &settings, Some(&ctx), None);
+```
+
+**After:**
+```rust
+let mut bv_delegate = AgentMuxBrowserViewDelegate::new(RuntimeStyle::ALLOY);
+let browser_view = cef::browser_view_create(
+    client, &url, &settings, None, Some(&ctx), &mut bv_delegate,
+);
+let mut wd = AgentMuxWindowDelegate::new(
+    RefCell::new(browser_view),
+    Some((x, y, w, h)),
+);
+cef::window_create_top_level(&mut wd);
+```
+
+**Test:** Tear off a pane → window opens at cursor, resize works, no flash.
+**Commit:** `fix: switch open_window_at_position to CEF Views`
+
+## Step 4: Simplify on_load_end
+
+**File:** `agentmux-cef/src/client.rs`
+
+Remove the Win32 `ShowWindow` fallback — all windows now use CEF Views:
+
+```rust
+// Show via CEF Views API — works for all windows now
+let mut browser_cloned = browser.cloned();
+if let Some(bv) = browser_view_get_for_browser(browser_cloned.as_mut()) {
+    if let Some(window) = bv.window() {
+        if window.is_visible() == 0 {
+            window.show();
+            if let Some(ref mut b) = browser_cloned {
+                if let Some(host) = b.host() {
+                    host.set_focus(1);
+                }
+            }
+        }
+    }
+}
+```
+
+**Test:** All window types show correctly after content loads.
+**Commit:** `refactor: remove Win32 ShowWindow fallback from on_load_end`
+
+## Step 5: Remove secondary window native mode code from on_after_created
+
+**File:** `agentmux-cef/src/client.rs`
+
+Remove the `install_frameless_resize_hook` call for secondary windows and the `is_secondary` check. CEF Views handles frameless via its delegate.
+
+**Test:** Secondary windows are frameless with resize.
+**Commit:** `refactor: remove install_frameless_resize_hook for secondary windows`
+
+## Step 6: Clean up dead code
+
+**Files:** `agentmux-cef/src/client.rs`, `agentmux-cef/src/commands/window.rs`
+
+Remove:
+- `get_secondary_window_size()` if no longer referenced
+- Win32 `WS_POPUP` style imports if unused
+- Any `#[cfg(target_os = "windows")]` blocks that only served native secondary windows
+
+Keep (still used by `--use-native` flag or potential future use):
+- `install_frameless_resize_hook` function definition
+- `setup_native_frameless` function definition
+- `ORIGINAL_WNDPROCS` static
+
+**Commit:** `refactor: remove dead native-mode code for secondary windows`
+
+## Step 7: Bump version + build + test
+
+```bash
+bump patch -m "fix: secondary windows use CEF Views for resize" --commit
+task cef:package:portable
+```
+
+Test:
+- [ ] Main window: no flash, resize, snap, frameless
+- [ ] New window: no flash, resize, snap, frameless
+- [ ] Tear-off: no flash, resize, positioned correctly
+- [ ] Close secondary: main unaffected
+- [ ] Close main: all windows close
+- [ ] Reopen after close: works (lockfile cleaned)
+
+**Commit:** `chore: bump version to X.Y.Z`
+
+## Step 8: Push + PR
+
+```bash
+git push -u origin agenta/secondary-windows-cef-views
+gh pr create --title "fix: secondary windows use CEF Views for resize"
+```
+
+Wait for reagent review, address feedback, merge.
+
+## Risk Assessment
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| `browser_view_create` API mismatch | Low | Matches main window pattern exactly |
+| `RequestContext` not accepted by `browser_view_create` | Medium | Check cef-rs API signature; may need different parameter position |
+| Secondary window doesn't register in browser map | Low | `on_after_created` handles all browsers regardless of creation method |
+| Tear-off position incorrect | Low | `initial_bounds` passes exact position |
+| Import visibility (delegate types) | Low | Make delegates `pub` if not already |
+
+## Rollback
+
+If anything breaks: revert the branch. Main window is unaffected by these changes (only secondary window creation changes).

--- a/docs/specs/single-instance-new-window.md
+++ b/docs/specs/single-instance-new-window.md
@@ -1,0 +1,170 @@
+# Single Instance + New Window on Re-launch
+
+**Date:** 2026-04-02
+**Status:** Spec
+**Problem:** Double-clicking agentmux.exe when already running opens Chrome (CEF singleton) instead of a new window
+
+## Current Behavior
+
+1. User launches `agentmux.exe` → app opens normally
+2. User double-clicks `agentmux.exe` again → CEF detects the lockfile → delegates to "existing browser session" → Chrome opens at google.com
+
+## Desired Behavior
+
+1. User launches `agentmux.exe` → app opens normally
+2. User double-clicks `agentmux.exe` again → existing instance opens a new window (same as clicking the version button)
+
+## How Other Apps Do This
+
+### Electron
+- Uses `app.requestSingleInstanceLock()`
+- Second instance sends argv to first via IPC (named pipe on Windows)
+- First instance receives `second-instance` event → opens new window
+- Second instance exits
+
+### VS Code
+- Uses a named mutex + socket file
+- Second launch detects mutex → sends "open" command via socket → exits
+
+### Spotify (CEF-based)
+- Uses a named mutex to detect existing instance
+- Second launch sends command via localhost HTTP
+
+## Proposed Approach
+
+### Detection: Named Mutex (Windows)
+
+```rust
+// In main.rs, before CEF init:
+let mutex_name = format!("AgentMux-CEF-v{}", version_slug);
+let mutex = CreateMutexW(null(), FALSE, wide_string(&mutex_name));
+if GetLastError() == ERROR_ALREADY_EXISTS {
+    // Another instance is running — send "new window" command and exit
+    send_new_window_request(ipc_port);
+    std::process::exit(0);
+}
+```
+
+### Communication: Localhost HTTP
+
+The IPC server is already running on a random port. The second instance needs to know which port. Options:
+
+**Option A: Port file**
+- First instance writes port to `~/.agentmux/cef-ipc-port` (or version-specific path)
+- Second instance reads it, sends `POST /ipc` with `{cmd: "open_new_window"}`
+
+**Option B: Named pipe**
+- First instance creates `\\.\pipe\AgentMux-v{version}`
+- Second instance connects, sends "new-window" → first instance handles
+
+**Option C: Registry key**
+- First instance writes port to `HKCU\Software\AgentMux\ipc_port`
+- Second instance reads and sends HTTP request
+
+**Recommendation: Option A (port file)** — simplest, cross-platform, no Windows-specific APIs beyond the mutex.
+
+## Implementation Plan
+
+### Step 1: Write IPC port to file on startup
+
+**File:** `agentmux-cef/src/main.rs`
+
+After IPC server starts:
+```rust
+let port_file = data_dir.join("ipc-port");
+std::fs::write(&port_file, ipc_port.to_string()).ok();
+// Clean up on exit:
+// (handled by Drop or shutdown hook)
+```
+
+### Step 2: Check for existing instance before CEF init
+
+**File:** `agentmux-cef/src/main.rs`
+
+Before `cef::initialize()`:
+```rust
+#[cfg(target_os = "windows")]
+{
+    let mutex_name: Vec<u16> = format!("AgentMux-CEF-{}\0", version_slug)
+        .encode_utf16().collect();
+    unsafe {
+        let mutex = windows_sys::Win32::System::Threading::CreateMutexW(
+            std::ptr::null(), 0, mutex_name.as_ptr(),
+        );
+        if windows_sys::Win32::Foundation::GetLastError() == 183 { // ERROR_ALREADY_EXISTS
+            // Read port file, send new-window request, exit
+            if let Ok(port_str) = std::fs::read_to_string(&port_file) {
+                if let Ok(port) = port_str.trim().parse::<u16>() {
+                    let _ = reqwest::blocking::Client::new()
+                        .post(format!("http://127.0.0.1:{}/ipc", port))
+                        .json(&serde_json::json!({"cmd": "open_new_window"}))
+                        .send();
+                }
+            }
+            std::process::exit(0);
+        }
+    }
+}
+```
+
+Note: Using `reqwest` adds a dependency. Alternative: raw TCP/HTTP with `std::net::TcpStream`.
+
+### Step 3: Clean up port file on shutdown
+
+**File:** `agentmux-cef/src/main.rs`
+
+After `run_message_loop()` returns:
+```rust
+let _ = std::fs::remove_file(&port_file);
+```
+
+### Step 4: Auth token for IPC
+
+The IPC server requires `Authorization: Bearer {token}`. The second instance needs the token. Options:
+- Write token to port file too: `port:token` format
+- Or use a separate token file
+- Or skip auth for `open_new_window` specifically (risky)
+
+**Recommendation:** Write `port:token` to the port file:
+```
+58234:a47a4f18-1234-5678-abcd-ef0123456789
+```
+
+### Step 5: Handle lockfile cleanup
+
+Currently we remove the lockfile on startup. With mutex detection, the second instance exits before touching CEF — no lockfile conflict. The first instance's lockfile is valid.
+
+Remove the lockfile cleanup code? No — keep it as a safety net for crashes where the mutex is released but lockfile remains.
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Port file stale (old instance crashed) | HTTP request fails → fall through to normal launch |
+| Mutex released but port file exists | Normal launch (mutex check passes) |
+| Multiple versions running | Each version has its own mutex name + port file |
+| IPC token mismatch | Request rejected → fall through to normal launch |
+| Firewall blocks localhost | Unlikely but possible → fall through to normal launch |
+
+## Files Changed
+
+1. `agentmux-cef/src/main.rs` — mutex check, port file write/read/cleanup
+2. `agentmux-cef/src/ipc.rs` — possibly skip auth for `open_new_window` from second instance
+3. No frontend changes needed
+
+## Dependencies
+
+- No new crate dependencies if using raw `std::net::TcpStream` for HTTP
+- Or add `ureq` (lightweight HTTP client) for cleaner code
+
+## Complexity
+
+Low-medium. ~50 lines in main.rs. The IPC server and `open_new_window` command already exist.
+
+## Test Plan
+
+- [ ] First launch: works normally, port file created
+- [ ] Second launch (same version): opens new window in first instance, second exits
+- [ ] Kill first instance → second launch: starts fresh (mutex released)
+- [ ] Crash first instance → second launch: port file stale, HTTP fails, starts fresh
+- [ ] Different versions: each runs independently

--- a/docs/specs/tearoff-pane-size.md
+++ b/docs/specs/tearoff-pane-size.md
@@ -1,0 +1,246 @@
+# Spec: Pane Tear-Off Window Sizing
+
+**Status:** Draft  
+**Author:** AgentA  
+**Date:** 2026-04-07  
+
+---
+
+## Problem
+
+When a pane is torn off into a new window, the new window is always 1200×800px (hardcoded in `agentmux-cef/src/commands/drag.rs::open_window_at_position`). The torn-off pane's actual on-screen dimensions are ignored. A small pane in a split layout tears off into a window far larger than expected; a large pane tears off into one that may be smaller.
+
+---
+
+## Goal
+
+The new window should be the same size as the pane that was torn off, positioned so the cursor lands at the same relative point within the window as it occupied within the pane when the drag began.
+
+---
+
+## Data Flow Today
+
+```
+Drag start (TileLayout.win32.tsx)
+  → setCurrentDragPayload({ kind: "tile", node })
+  → NO size captured
+
+Drag end (CrossWindowDragMonitor.win32.tsx)
+  → get_cursor_point() → { x, y }  (current cursor, screen coords)
+  → WorkspaceService.TearOffBlock(blockId, ...)
+  → api.openWindowAtPosition(screenX, screenY, newWsId)
+         ↓
+  IPC: open_window_at_position { screenX, screenY, workspaceId }
+         ↓
+  Rust: hardcoded win_w=1200, win_h=800
+        pos_x = screenX - 600
+        pos_y = screenY - 16
+```
+
+---
+
+## Proposed Data Flow
+
+```
+Drag start (TileLayout.win32.tsx)
+  → capture pane rect: element.getBoundingClientRect()
+  → convert to screen coords (add window.screenX + window.screenLeft offset)
+  → store in drag payload: { kind: "tile", node, paneRect, grabOffset }
+    where:
+      paneRect   = { x, y, w, h }  — pane's screen rect at drag start
+      grabOffset = { dx, dy }       — cursor offset from pane top-left
+
+Drag end (CrossWindowDragMonitor.win32.tsx)
+  → get_cursor_point() → { x, y }  (current cursor, screen coords)
+  → WorkspaceService.TearOffBlock(blockId, ...)
+  → api.openWindowAtPosition(screenX, screenY, newWsId, paneW, paneH, grabOffsetX, grabOffsetY)
+         ↓
+  IPC: open_window_at_position {
+    screenX, screenY, workspaceId,
+    width?,  height?,
+    grabOffsetX?, grabOffsetY?
+  }
+         ↓
+  Rust: win_w = width  ?? 1200
+        win_h = height ?? 800
+        dx    = grabOffsetX ?? win_w / 2
+        dy    = grabOffsetY ?? 20        // title bar default
+        pos_x = screenX - dx
+        pos_y = screenY - dy
+```
+
+The grab offset ensures the new window snaps to where the user's cursor was within the pane — the most natural drag-and-release feel.
+
+---
+
+## Changes Required
+
+### 1. Frontend — capture pane rect at drag start
+
+**File:** `frontend/layout/lib/TileLayout.win32.tsx`
+
+At the point where `setCurrentDragPayload` is called (tile drag begins), read the pane element's bounding rect and compute screen coordinates. The pane's DOM element is the draggable tile; it is available as a ref at the drag handler site.
+
+```typescript
+// At drag start:
+const rect = tileRef.getBoundingClientRect();
+// Convert from viewport to screen coordinates
+const screenLeft = window.screenX ?? window.screenLeft ?? 0;
+const screenTop  = window.screenY ?? window.screenTop  ?? 0;
+// Account for the browser chrome offset (CEF viewport starts below the title bar)
+// window.outerHeight - window.innerHeight gives the chrome height on most platforms.
+const chromeH = window.outerHeight - window.innerHeight;
+const paneRect = {
+    x: rect.left + screenLeft,
+    y: rect.top  + screenTop + chromeH,
+    w: rect.width,
+    h: rect.height,
+};
+const grabOffset = {
+    dx: event.clientX - rect.left,
+    dy: event.clientY - rect.top,
+};
+
+setCurrentDragPayload({ kind: "tile", node, paneRect, grabOffset });
+```
+
+**Extend `DragItemPayload` type** (wherever it is defined — likely `frontend/types/` or inline in TileLayout):
+
+```typescript
+interface DragItemPayload {
+    kind: "tile" | "tab";
+    node?: LayoutNode;
+    paneRect?: { x: number; y: number; w: number; h: number };
+    grabOffset?: { dx: number; dy: number };
+}
+```
+
+### 2. Frontend — pass size through to `openWindowAtPosition`
+
+**File:** `frontend/app/drag/CrossWindowDragMonitor.win32.tsx`
+
+In `performTearOff`, read `paneRect` and `grabOffset` from the current drag payload and forward them:
+
+```typescript
+async function performTearOff(...) {
+    const payload = getCurrentDragPayload();  // or however payload is accessed
+    const paneRect   = payload?.paneRect;
+    const grabOffset = payload?.grabOffset;
+
+    if (dragType === "pane" && payload.blockId) {
+        const newWsId = await WorkspaceService.TearOffBlock(...);
+        if (newWsId) {
+            await api.openWindowAtPosition(
+                screenX, screenY, newWsId,
+                paneRect?.w,
+                paneRect?.h,
+                grabOffset?.dx,
+                grabOffset?.dy,
+            );
+        }
+    }
+}
+```
+
+### 3. Frontend — update `AppApi` interface and CEF API shim
+
+**File:** `frontend/types/custom.d.ts`
+
+```typescript
+openWindowAtPosition(
+    screenX: number,
+    screenY: number,
+    workspaceId?: string,
+    width?: number,
+    height?: number,
+    grabOffsetX?: number,
+    grabOffsetY?: number,
+): Promise<string>;
+```
+
+**File:** `frontend/util/cef-api.ts`
+
+```typescript
+openWindowAtPosition: async (
+    screenX, screenY, workspaceId,
+    width?, height?, grabOffsetX?, grabOffsetY?
+) => {
+    return await invokeCommand<string>("open_window_at_position", {
+        screenX, screenY,
+        workspaceId: workspaceId ?? "",
+        ...(width  != null && { width }),
+        ...(height != null && { height }),
+        ...(grabOffsetX != null && { grabOffsetX }),
+        ...(grabOffsetY != null && { grabOffsetY }),
+    });
+},
+```
+
+### 4. Rust — use passed dimensions
+
+**File:** `agentmux-cef/src/commands/drag.rs::open_window_at_position`
+
+```rust
+pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let screen_x      = args["screenX"].as_f64().unwrap_or(0.0);
+    let screen_y      = args["screenY"].as_f64().unwrap_or(0.0);
+    let workspace_id  = args["workspaceId"].as_str().unwrap_or("").to_string();
+
+    // Use pane size if provided; fall back to default
+    let win_w = args["width"].as_f64().map(|v| v as i32).unwrap_or(1200);
+    let win_h = args["height"].as_f64().map(|v| v as i32).unwrap_or(800);
+
+    // Cursor grab offset within the pane — where the user's mouse was
+    // relative to the pane top-left when the drag started.
+    // Fall back to top-centre / title-bar offset if not provided.
+    let grab_dx = args["grabOffsetX"].as_f64().map(|v| v as i32)
+        .unwrap_or(win_w / 2);
+    let grab_dy = args["grabOffsetY"].as_f64().map(|v| v as i32)
+        .unwrap_or(20);
+
+    // Position so cursor lands at the same spot within the new window
+    let pos_x = ((screen_x as i32) - grab_dx).max(0);
+    let pos_y = ((screen_y as i32) - grab_dy).max(0);
+
+    // ... rest of function unchanged (label, url, pending_window_labels, post_create_window)
+    crate::ui_tasks::post_create_window(
+        state, &url, &label, pos_x, pos_y, win_w, win_h, true,
+    );
+
+    Ok(serde_json::json!(label))
+}
+```
+
+---
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| Pane rect not captured (drag starts before payload set) | Falls back to 1200×800 / centered |
+| Pane smaller than minimum useful window (< 400×300) | Clamp: `win_w = win_w.max(400)`, `win_h = win_h.max(300)` |
+| New window position would be off-screen (pos_x < 0 or > screen width) | Existing `.max(0)` handles left/top; right/bottom clamping can be done by CEF's Views framework naturally |
+| Tab tear-off (whole tab, not single pane) | Tab drag payload also has a pane rect: use the tab's visible content area. Same code path — `paneRect` applies to the tab's content rect. |
+| DPI scaling | `getBoundingClientRect()` returns CSS pixels (logical); `window.screenX/Y` are also logical on most platforms. CEF Views `set_bounds()` expects DIPs, which match. Verify on 125%/150% display scaling. |
+
+---
+
+## Out of Scope
+
+- Remembering window size across sessions (future: persist in workspace meta)
+- Animating the window "flying out" from the pane position
+- Snapping the new window to the same monitor as the source
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `frontend/layout/lib/TileLayout.win32.tsx` | Capture `paneRect` and `grabOffset` at drag start |
+| `frontend/app/drag/CrossWindowDragMonitor.win32.tsx` | Forward `paneRect`/`grabOffset` to `openWindowAtPosition` |
+| `frontend/types/custom.d.ts` | Extend `AppApi.openWindowAtPosition` signature |
+| `frontend/util/cef-api.ts` | Pass width/height/grabOffset to IPC |
+| `agentmux-cef/src/commands/drag.rs` | Use passed size + grab offset; clamp minimum |
+
+No new dependencies. No new IPC commands — extends the existing `open_window_at_position` with optional fields.

--- a/docs/specs/websocket-modularization.md
+++ b/docs/specs/websocket-modularization.md
@@ -1,0 +1,84 @@
+# Spec: websocket.rs Modularization
+
+## Problem
+
+`agentmuxsrv-rs/src/server/websocket.rs` is 2090 lines — a single file containing connection management, message routing, and all RPC command handlers. The monolithic `register_handlers()` function alone is 1590 lines.
+
+## Current Structure
+
+| Section | Lines | LOC | Concern |
+|---------|-------|-----|---------|
+| `handle_ws` + `handle_ws_connection` | 76-246 | 170 | WS upgrade, connection loop, heartbeat |
+| `handle_incoming_text` | 251-446 | 195 | Message parsing, bus ops, RPC dispatch |
+| Config/events handlers | 448-602, 1471-1526 | 200 | get/set config, event sub/unsub, metadata |
+| Block/controller handlers | 644-891 | 250 | Resync, input, subprocess spawn, agent I/O |
+| CLI resolution + auth | 898-1465 | 570 | Binary detection, npm install, auth checks, login |
+| Forge handlers | 1530-2039 | 510 | Agents, content, skills, history, import CRUD |
+| Utilities | 2044-2090 | 50 | cmd wrapper, version detection, input parsing |
+
+## Target Structure
+
+```
+src/server/
+├── websocket.rs              → mod.rs (80 LOC: handle_ws, register_handlers orchestration)
+└── websocket/
+    ├── mod.rs                 re-exports + register_all_handlers()
+    ├── connection.rs          handle_ws_connection, heartbeat (170 LOC)
+    ├── dispatch.rs            handle_incoming_text, bus ops (195 LOC)
+    ├── cli_utils.rs           make_cli_cmd, get_cli_version, parse_block_input (50 LOC)
+    └── handlers/
+        ├── mod.rs             register_*() fns from each module
+        ├── block.rs           controller resync/input, subprocess, agent I/O (250 LOC)
+        ├── cli.rs             resolvecli, checkcliauth, runclilogin (570 LOC)
+        ├── config.rs          config get/set, event sub/unsub, metadata, AI (200 LOC)
+        └── forge.rs           agents/content/skills/history/import CRUD (510 LOC)
+```
+
+Each handler module exports a `register_<group>(router: &mut WshRpcRouter, state: Arc<AppState>)` function.
+
+## Coupling Analysis
+
+| Module | Dependencies | Split Feasibility |
+|--------|-------------|-------------------|
+| **cli.rs** | broker (logging only) | Easy — self-contained |
+| **forge.rs** | wstore, broker | Easy — repetitive CRUD pattern |
+| **config.rs** | config_watcher, wstore, broker | Easy — read-mostly |
+| **block.rs** | blockcontroller, wstore, broker, reactive_handler | Medium — multiple subsystems |
+| **dispatch.rs** | WSIncoming struct, all message types | Medium — routes to many concerns |
+| **connection.rs** | AppState, event bus, RPC engine | Medium — core event demux |
+
+## Implementation Order
+
+1. **Extract cli.rs** (570 LOC, zero coupling to other handlers) — proves the pattern
+2. **Extract forge.rs** (510 LOC, isolated CRUD) — bulk reduction
+3. **Extract config.rs** (200 LOC) — straightforward
+4. **Extract block.rs** (250 LOC) — needs blockcontroller plumbing
+5. **Extract dispatch.rs + connection.rs** — last, hardest (core loop)
+
+Each step: extract → verify `cargo check` → commit. Never move more than one group per commit.
+
+## Shared Types
+
+`WSIncoming` struct stays in `websocket/mod.rs` — all modules need it.
+
+Handler registration pattern (each module):
+```rust
+pub fn register_cli_handlers(router: &mut WshRpcRouter, state: Arc<AppState>) {
+    router.register("resolvecli", {
+        let state = state.clone();
+        move |_ctx, args| { /* ... */ }
+    });
+    // ...
+}
+```
+
+## Public API
+
+Only `handle_ws` is exported (`server/mod.rs` routes to it). Internal structure changes are invisible to the rest of the crate.
+
+## Verification
+
+After each extraction:
+1. `cargo check -p agentmuxsrv-rs` — zero errors
+2. `cargo test -p agentmuxsrv-rs` — tests pass
+3. `task dev` — WebSocket commands still work (terminal, agent pane, forge)

--- a/docs/specs/ws-robustness-impl.md
+++ b/docs/specs/ws-robustness-impl.md
@@ -1,0 +1,149 @@
+# WebSocket Robustness — Implementation Plan
+
+**Date:** 2026-04-02
+**Priority:** P0 — UI freezes are unacceptable
+**Branch:** `agenta/ws-robustness`
+
+## Changes
+
+### 1. Never give up reconnecting (`ws.ts`)
+
+Replace hard cutoff with infinite retry at slower intervals:
+
+```typescript
+// OLD: gives up
+if (this.reconnectTimes > 20) {
+    dlog("cannot connect, giving up");
+    return;
+}
+
+// NEW: never give up, slow down
+const timeoutArr = [0, 0, 2, 5, 10, 10, 30, 60];
+let timeout = 60; // max interval
+if (this.reconnectTimes < timeoutArr.length) {
+    timeout = timeoutArr[this.reconnectTimes];
+}
+// Log every 10th attempt after initial burst
+if (this.reconnectTimes > 10 && this.reconnectTimes % 10 === 0) {
+    console.warn(`[ws] still reconnecting (attempt ${this.reconnectTimes})`);
+}
+```
+
+### 2. Re-query endpoints on reconnect failure (`ws.ts`)
+
+After 3 failed attempts, re-query the IPC server for current backend endpoints:
+
+```typescript
+onclose(event: CloseEvent) {
+    // ... existing code ...
+    if (this.reconnectTimes > 0 && this.reconnectTimes % 3 === 0) {
+        this.refreshEndpoint();
+    }
+    this.reconnect();
+}
+
+private async refreshEndpoint() {
+    try {
+        const endpoints = await invokeCommand<{ws: string, web: string}>("get_backend_endpoints");
+        if (endpoints?.ws) {
+            const newBase = `ws://${endpoints.ws}`;
+            if (newBase !== this.baseHostPort) {
+                console.log(`[ws] endpoint changed: ${this.baseHostPort} → ${newBase}`);
+                this.baseHostPort = newBase;
+            }
+        }
+    } catch (e) {
+        // IPC might also be down — just keep retrying
+    }
+}
+```
+
+### 3. Visibility-based reconnect (`ws.ts`)
+
+Check WS health on window focus:
+
+```typescript
+// In constructor:
+document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible" && !this.open && !this.opening) {
+        console.log("[ws] window visible, attempting reconnect");
+        this.reconnectTimes = 0; // reset backoff
+        this.connectNow("visibility");
+    }
+});
+```
+
+### 4. Solid logging (`ws.ts`)
+
+Replace `dlog` (debug module, hidden by default) with `console.log`/`console.warn` for critical events:
+
+```typescript
+// Always log these (not behind debug flag):
+onopen:    console.log("[ws] connected");
+onclose:   console.warn("[ws] disconnected", event.code, event.reason);
+reconnect: console.log("[ws] reconnecting (attempt ${n})");
+giveup:    // REMOVED — never give up
+```
+
+### 5. CEF host: monitor sidecar process (`sidecar.rs`)
+
+Spawn a background thread that waits for the sidecar `Child` to exit, then emits `backend-terminated` to all browsers:
+
+```rust
+// After spawning sidecar:
+let child_pid = child.id();
+let state_for_monitor = app_state.clone();
+std::thread::spawn(move || {
+    let status = child.wait(); // blocks until sidecar exits
+    tracing::error!("Sidecar exited: {:?}", status);
+    // Emit backend-terminated to all browsers via JS injection
+    let browsers = state_for_monitor.browsers.lock().unwrap();
+    for (_, browser) in browsers.iter() {
+        if let Some(frame) = browser.main_frame() {
+            let js = format!(
+                "window.dispatchEvent(new CustomEvent('backend-terminated', {{detail: {{pid: {}, code: {:?}}}}}));",
+                child_pid, status.as_ref().map(|s| s.code())
+            );
+            let code = CefString::from(js.as_str());
+            let url = CefString::from("");
+            frame.execute_java_script(Some(&code), Some(&url), 0);
+        }
+    }
+});
+```
+
+### 6. Frontend reconnect indicator (`app.tsx` or overlay)
+
+Show a non-blocking banner when WS is disconnected:
+
+```typescript
+// In WSControl:
+onclose() → emit custom event "ws-disconnected"
+onopen()  → emit custom event "ws-connected"
+
+// In App or a dedicated component:
+const [wsConnected, setWsConnected] = createSignal(true);
+window.addEventListener("ws-disconnected", () => setWsConnected(false));
+window.addEventListener("ws-connected", () => setWsConnected(true));
+
+// Render:
+<Show when={!wsConnected()}>
+    <div class="ws-reconnecting-banner">Reconnecting...</div>
+</Show>
+```
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `frontend/app/store/ws.ts` | Never give up, refresh endpoint, visibility reconnect, logging |
+| `agentmux-cef/src/sidecar.rs` | Monitor thread, emit backend-terminated |
+| `frontend/app/app.tsx` or new component | Reconnecting banner |
+
+## Test Plan
+
+- [ ] Kill sidecar → frontend shows "Reconnecting" → sidecar restarts → frontend recovers
+- [ ] Background window 5min → foreground → WS reconnects immediately
+- [ ] Backend restart → WS reconnects to new port
+- [ ] Rapid disconnect/reconnect → no duplicate connections
+- [ ] Check logs: every disconnect/reconnect logged to console

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -89,7 +89,10 @@ export class AgentViewModel implements ViewModel {
         if (provider.authExtraEnv) {
             Object.assign(envVars, provider.authExtraEnv);
         }
-        envVars["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = "30000";
+        // Only set exit delay for subprocess mode — persistent processes must stay alive
+        if (provider.controllerType !== "persistent") {
+            envVars["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = "30000";
+        }
 
         try {
             // Store CLI config in block metadata for the backend to read on AgentInput
@@ -214,8 +217,10 @@ export class AgentViewModel implements ViewModel {
         if (provider.authExtraEnv) {
             Object.assign(envVars, provider.authExtraEnv);
         }
-        // Prevent process hang after result event
-        envVars["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = "30000";
+        // Only set exit delay for subprocess mode — persistent processes must stay alive
+        if (provider.controllerType !== "persistent") {
+            envVars["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = "30000";
+        }
 
         // Build config files to write via backend RPC
         const configFiles = buildConfigFiles(contentMap, skills, agent);

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -569,7 +569,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         const prov = provider();
         if (prov) {
             const runtimeConfig = getRuntimeConfig(block()?.meta);
-            const updatedArgs = buildRuntimeArgs(prov.launchArgs, runtimeConfig);
+            const baseArgs = prov.controllerType === "persistent" && prov.persistentLaunchArgs
+                ? prov.persistentLaunchArgs
+                : prov.launchArgs;
+            const updatedArgs = buildRuntimeArgs(baseArgs, runtimeConfig);
             const oref = WOS.makeORef("block", model.blockId);
             try {
                 await RpcApi.SetMetaCommand(TabRpcClient, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.82",
+  "version": "0.33.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.82",
+      "version": "0.33.83",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.82",
+  "version": "0.33.83",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
High-level programmatic API for agent management. Callers express intent ("open an agent pane with AgentX"), not mechanics ("create block, set 14 metadata keys, resync controller").

**New RPC commands (verified end-to-end via WebSocket):**
- `agent.open` — Create agent pane with Forge agent (idempotent), insert layout node, register controller
- `agent.send` — Send message to persistent/subprocess controller
- `agent.stop` — Stop agent process
- `agent.status` — Get controller state, session ID, exit code
- `agent.list` — List all agent panes across all tabs
- `agent.output` — Read accumulated output from broker history

**New files (+1500 lines):**
- `providers.rs` — Static Rust provider registry (claude, codex, gemini) with 7 unit tests
- `agent_config.rs` — Config file builder (CLAUDE.md, .mcp.json, skills) with 9 unit tests
- `app_api.rs` — All 6 command handlers with layout insertion
- `app-api-extension.md` — Full API spec (Tiers 1-5, future roadmap)
- `app-api-status.md` — Implementation status with known issues
- `persistent-process-retro-2026-04-10.md` — Debug retro (11 issues found)

**Known limitation:** Layout node is written to database + broadcast, but the frontend layout model doesn't re-render from backend-initiated changes. The pane appears on next app restart. Frontend `layoutaction` event handler needed (tracked in status doc).

## Test plan
- [x] `agent.open` with valid Forge agent → block created, controller registered
- [x] `agent.open` twice with same ID → returns existing block (idempotent)
- [x] `agent.send` → persistent process spawns, message delivered, Claude responds
- [x] `agent.status` → returns running state with session ID
- [x] `agent.list` → lists agent pane
- [x] Invalid agent ID → AGENT_NOT_FOUND error
- [x] CLI not installed → CLI_NOT_AVAILABLE error

🤖 Generated with [Claude Code](https://claude.com/claude-code)