### PR TITLE
fix: eliminate agent pane typing lag

### DIFF
--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -49,8 +49,7 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
     };
 
     // Auto-scroll to bottom when new content arrives.
-    // Use MutationObserver to scroll AFTER the DOM has updated.
-    let observer: MutationObserver | null = null;
+    let scrollRafId: number | null = null;
 
     const scrollToBottom = () => {
         if (autoScroll && scrollRef) {
@@ -58,25 +57,20 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
         }
     };
 
-    // Also trigger on signal changes (for initial content)
+    // Scroll when document or log signals change — throttled to one RAF per batch
     createEffect(() => {
         const _docLen = document().length;
         const _logLen = logLines().length;
-        // Defer to next frame so DOM is updated
-        requestAnimationFrame(scrollToBottom);
+        if (scrollRafId == null) {
+            scrollRafId = requestAnimationFrame(() => {
+                scrollRafId = null;
+                scrollToBottom();
+            });
+        }
     });
 
-    // Watch for any DOM mutations inside the scroll container
-    // This catches content appended to existing nodes (text streaming)
-    createEffect(() => {
-        if (!scrollRef) return;
-        observer = new MutationObserver(() => {
-            if (autoScroll) {
-                scrollRef.scrollTop = scrollRef.scrollHeight;
-            }
-        });
-        observer.observe(scrollRef, { childList: true, subtree: true, characterData: true });
-        onCleanup(() => observer?.disconnect());
+    onCleanup(() => {
+        if (scrollRafId != null) cancelAnimationFrame(scrollRafId);
     });
 
     // Detect if user scrolled up (disable auto-scroll)

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -44,6 +44,68 @@ export function useAgentStream({
     let parser = new ClaudeCodeStreamParser();
     let nodeIdSet = new Set<string>();
 
+    // Batching: accumulate parsed nodes between RAF flushes
+    let pendingNew: DocumentNode[] = [];
+    let pendingUpdates: DocumentNode[] = [];
+    let flushRafId: number | null = null;
+
+    // Index for O(1) node lookups during updates
+    let nodeIndexMap = new Map<string, number>();
+
+    function flushPendingNodes() {
+        flushRafId = null;
+        if (pendingNew.length === 0 && pendingUpdates.length === 0) return;
+
+        const batchNew = pendingNew;
+        const batchUpdates = pendingUpdates;
+        pendingNew = [];
+        pendingUpdates = [];
+
+        setDocument((prev) => {
+            // Only copy the array once per flush, not per WebSocket message
+            const result = prev.slice();
+            let mutated = false;
+
+            // Apply updates using index map for O(1) lookup
+            for (const updated of batchUpdates) {
+                const idx = nodeIndexMap.get(updated.id);
+                if (idx != null && idx < result.length) {
+                    const existing = result[idx];
+                    if (existing.type === "markdown" && updated.type === "markdown") {
+                        result[idx] = { ...existing, content: updated.content };
+                    } else {
+                        result[idx] = updated;
+                    }
+                    mutated = true;
+                }
+            }
+
+            // Append new nodes
+            if (batchNew.length > 0) {
+                const baseIdx = result.length;
+                for (let i = 0; i < batchNew.length; i++) {
+                    nodeIndexMap.set(batchNew[i].id, baseIdx + i);
+                    result.push(batchNew[i]);
+                }
+                mutated = true;
+            }
+
+            return mutated ? result : prev;
+        });
+
+        setStreaming((prev) => ({
+            ...prev,
+            lastEventTime: Date.now(),
+            bufferSize: prev.bufferSize + batchNew.length,
+        }));
+    }
+
+    function scheduleFlush() {
+        if (flushRafId == null) {
+            flushRafId = requestAnimationFrame(flushPendingNodes);
+        }
+    }
+
     onMount(() => {
         if (!enabled || !blockId) return;
 
@@ -52,6 +114,9 @@ export function useAgentStream({
         translator = createTranslator(outputFormat);
         parser = new ClaudeCodeStreamParser();
         nodeIdSet = new Set();
+        nodeIndexMap = new Map();
+        pendingNew = [];
+        pendingUpdates = [];
 
         setStreaming((prev) => ({ ...prev, active: true, lastEventTime: Date.now() }));
 
@@ -59,9 +124,12 @@ export function useAgentStream({
 
         console.debug(`[useAgentStream] subscribed blockId=${blockId} format=${outputFormat}`);
         const subscription = fileSubject.subscribe((msg: { fileop: string; data64: string }) => {
-            console.debug(`[useAgentStream] msg blockId=${blockId} fileop=${msg.fileop} len=${msg.data64?.length ?? 0}`);
             if (msg.fileop === "truncate") {
                 // Terminal was cleared — reset document
+                if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
+                pendingNew = [];
+                pendingUpdates = [];
+                nodeIndexMap = new Map();
                 setDocument([]);
                 lineBuffer = "";
                 translator.reset();
@@ -81,11 +149,6 @@ export function useAgentStream({
             const lines = lineBuffer.split("\n");
             lineBuffer = lines.pop() || ""; // Keep incomplete line
 
-            // Process complete lines
-
-            const newNodes: DocumentNode[] = [];
-            const updatedNodes: DocumentNode[] = [];
-
             for (const line of lines) {
                 const trimmed = line.trim();
                 if (!trimmed) continue;
@@ -95,25 +158,22 @@ export function useAgentStream({
                 try {
                     rawEvent = JSON.parse(trimmed);
                 } catch {
-                    // Not valid JSON — skip (could be raw CLI output during init)
                     continue;
                 }
 
                 // Handle stderr events from subprocess
                 if (rawEvent.type === "stderr" && rawEvent.text) {
-                    // Skip benign CLI warnings
                     const text = rawEvent.text.trim();
                     if (text.includes("Fast mode is not available") ||
                         text.includes("[WARN]") && text.length < 200) {
-                        console.log("[useAgentStream] suppressed stderr:", text);
                         continue;
                     }
-                    const stderrNode: DocumentNode = {
+                    pendingNew.push({
                         id: `stderr-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
                         type: "markdown",
                         content: `**stderr:** ${text}`,
-                    };
-                    newNodes.push(stderrNode);
+                    });
+                    scheduleFlush();
                     continue;
                 }
 
@@ -126,57 +186,22 @@ export function useAgentStream({
                     if (!node) continue;
 
                     if (nodeIdSet.has(node.id)) {
-                        // Existing node — append content for text/thinking, replace for others
-                        updatedNodes.push(node);
+                        pendingUpdates.push(node);
                     } else {
                         nodeIdSet.add(node.id);
-                        newNodes.push(node);
+                        pendingNew.push(node);
                     }
                 }
             }
 
-            // Batch update the document signal
-            if (newNodes.length > 0 || updatedNodes.length > 0) {
-                setDocument((prev) => {
-                    let result = [...prev];
-
-                    // Apply updates to existing nodes
-                    for (const updated of updatedNodes) {
-                        const idx = result.findIndex((n) => n.id === updated.id);
-                        if (idx !== -1) {
-                            const existing = result[idx];
-                            if (existing.type === "markdown" && updated.type === "markdown") {
-                                // Replace with accumulated content — the stream parser
-                                // already accumulates deltas into the full text, so we
-                                // must NOT append here or content gets duplicated.
-                                result[idx] = {
-                                    ...existing,
-                                    content: updated.content,
-                                };
-                            } else {
-                                // Replace for other node types (tool_result completing tool_call)
-                                result[idx] = updated;
-                            }
-                        }
-                    }
-
-                    // Append new nodes
-                    if (newNodes.length > 0) {
-                        result = [...result, ...newNodes];
-                    }
-
-                    return result;
-                });
-
-                setStreaming((prev) => ({
-                    ...prev,
-                    lastEventTime: Date.now(),
-                    bufferSize: prev.bufferSize + newNodes.length,
-                }));
+            // Schedule a single flush per animation frame
+            if (pendingNew.length > 0 || pendingUpdates.length > 0) {
+                scheduleFlush();
             }
         });
 
         onCleanup(() => {
+            if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
             subscription.unsubscribe();
             setStreaming((prev) => ({ ...prev, active: false }));
         });


### PR DESCRIPTION
## Summary
- **RAF-batched document updates** in `useAgentStream` — incoming stream events accumulate and flush once per animation frame instead of per WebSocket message
- **O(1) node index map** replaces O(n) `findIndex` scans for document node updates during streaming
- **Removed MutationObserver** in `AgentDocumentView` that triggered forced layout reflows on every DOM mutation during text streaming
- **Throttled auto-scroll** to one RAF per batch

## Root Cause
During agent streaming, `text_delta` events arrive at high frequency (every few tokens). Each WebSocket message triggered:
1. Full document array copy (`[...prev]`)
2. Linear scan per updated node (`findIndex`)
3. MutationObserver firing `scrollTop = scrollHeight` (forced reflow) on every DOM change

This blocked the main thread repeatedly, causing keystrokes to queue behind rendering work.

## Test plan
- [ ] Start an agent session (Claude) and begin a long response
- [ ] Type in the input textarea while the agent is streaming output
- [ ] Verify typing is responsive with no visible lag
- [ ] Verify auto-scroll still works (scrolls to bottom during streaming)
- [ ] Verify manual scroll-up disables auto-scroll, scroll back down re-enables it
- [ ] Verify tool blocks, markdown, and agent messages still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)