### PR TITLE
feat: ultra-long sessions phase 2 — history pagination + reconnect recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.95"
+version = "0.33.96"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.95"
+version = "0.33.96"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.95"
+version = "0.33.96"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.95"
+version = "0.33.96"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -588,50 +588,33 @@ fn register_agent_output(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
-    let wstore = state.wstore.clone();
 
     engine.register_handler(
         COMMAND_BLOCKFILE_LINE_COUNT,
         Box::new(move |data, _ctx| {
             let broker = broker.clone();
-            let wstore = wstore.clone();
             Box::pin(async move {
                 let cmd: CommandBlockfileLineCountData = serde_json::from_value(data)
                     .map_err(|e| format!("blockfile:line_count: {e}"))?;
 
                 tracing::info!(block_id = %cmd.block_id, filename = %cmd.filename, "blockfile:line_count");
 
-                // Fast path: read the pre-computed `session:line_count` meta
-                // field maintained by SessionStatsAccumulator. This is O(1) —
-                // no event history scan. The accumulator updates it debounced
-                // at 1s so the value may trail real-time by up to a second,
-                // which is fine for UI purposes.
+                // Returns the number of lines *currently available* in the
+                // event ring buffer (MAX_PERSIST = 4096 events). For long
+                // sessions this may be LESS than the all-time session line
+                // count — older events have been evicted. This matches the
+                // semantics of `blockfile:read_range` so the two commands
+                // agree on what "offset N" means.
                 //
-                // Currently SessionStatsAccumulator tracks total session lines,
-                // not per-filename. If the caller requests a filename other
-                // than "output" we fall through to an event history scan.
-                let block = wstore
-                    .get::<Block>(&cmd.block_id)
-                    .map_err(|e| format!("blockfile:line_count: {e}"))?
-                    .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", cmd.block_id))?;
-
-                if cmd.filename == "output" {
-                    let count = block.meta.get("session:line_count")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0);
-                    return Ok(Some(serde_json::to_value(
-                        &BlockfileLineCountResult { count },
-                    ).unwrap()));
-                }
-
-                // Fallback: scan event history for non-output filenames
-                // (rare — current persistent/subprocess controllers only
-                // publish to "output")
+                // Callers who need the all-time count should read the
+                // `session:line_count` meta field directly. Until Phase 1.3
+                // (disk-based segmentation) lands, lines outside the ring
+                // buffer window are not retrievable.
                 let scope = format!("block:{}", cmd.block_id);
                 let events = broker.read_event_history(
                     crate::backend::wps::EVENT_BLOCK_FILE,
                     &scope,
-                    10_000,
+                    usize::MAX, // broker clamps to MAX_PERSIST internally
                 );
 
                 let mut count: u64 = 0;
@@ -667,13 +650,11 @@ fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
-    let wstore = state.wstore.clone();
 
     engine.register_handler(
         COMMAND_BLOCKFILE_READ_RANGE,
         Box::new(move |data, _ctx| {
             let broker = broker.clone();
-            let wstore = wstore.clone();
             Box::pin(async move {
                 let cmd: CommandBlockfileReadRangeData = serde_json::from_value(data)
                     .map_err(|e| format!("blockfile:read_range: {e}"))?;
@@ -684,31 +665,31 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let offset = cmd.offset as usize;
                 let end = offset.saturating_add(limit);
 
-                // Get the authoritative total from session meta (fast path for
-                // "output"; O(1)). If unavailable, we'll compute it during the
-                // scan below as a fallback.
-                let mut total: u64 = 0;
-                if cmd.filename == "output" {
-                    if let Ok(Some(block)) = wstore.get::<Block>(&cmd.block_id) {
-                        total = block.meta.get("session:line_count")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                    }
-                }
-
-                // Read events and stream-decode line-by-line. Stop as soon as
-                // we've collected the requested window — avoids the O(n) memory
-                // cost of materializing the entire history.
+                // Read the full event window (capped at the broker's
+                // MAX_PERSIST = 4096 events). The in-memory ring buffer may
+                // not have every event from the start of the session — older
+                // events have been evicted. The `total` we report is the
+                // number of lines *available* right now, not the all-time
+                // count. This is what the frontend should use for pagination
+                // so it never asks for offsets the ring buffer can't serve.
+                //
+                // For all-time totals, use `blockfile:line_count` which reads
+                // `session:line_count` meta (unbounded) — but be aware that
+                // lines outside the ring buffer window are effectively gone
+                // until Phase 1.3 (disk-based segmentation) lands.
                 let scope = format!("block:{}", cmd.block_id);
                 let events = broker.read_event_history(
                     crate::backend::wps::EVENT_BLOCK_FILE,
                     &scope,
-                    10_000,
+                    usize::MAX, // broker clamps to MAX_PERSIST internally
                 );
 
-                let mut lines: Vec<String> = Vec::with_capacity(limit);
-                let mut seen: usize = 0;
-                'outer: for event in events {
+                // First pass: collect all available lines from the ring buffer.
+                // We need the total count before we can apply offset/limit,
+                // because `offset` is expressed relative to the available
+                // window (0 = oldest still-retained line).
+                let mut all_lines: Vec<String> = Vec::new();
+                for event in events {
                     let Some(ref event_data) = event.data else { continue };
                     let ev_filename = event_data.get("filename")
                         .and_then(|v| v.as_str()).unwrap_or("");
@@ -719,25 +700,20 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data64) else { continue };
                     let text = String::from_utf8_lossy(&bytes);
                     for line in text.lines() {
-                        if line.trim().is_empty() {
-                            continue;
-                        }
-                        if seen >= offset && seen < end {
-                            lines.push(line.to_string());
-                        }
-                        seen += 1;
-                        if seen >= end && total > 0 {
-                            // We have the requested window AND an authoritative
-                            // total from meta — safe to stop early.
-                            break 'outer;
+                        if !line.trim().is_empty() {
+                            all_lines.push(line.to_string());
                         }
                     }
                 }
 
-                // If meta didn't give us a total, use what we counted
-                if total == 0 {
-                    total = seen as u64;
-                }
+                let total = all_lines.len() as u64;
+                let clamped_offset = offset.min(all_lines.len());
+                let clamped_end = end.min(all_lines.len());
+                let lines: Vec<String> = if clamped_offset >= clamped_end {
+                    Vec::new()
+                } else {
+                    all_lines[clamped_offset..clamped_end].to_vec()
+                };
 
                 Ok(Some(serde_json::to_value(&BlockfileReadRangeResult {
                     lines,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -670,13 +670,15 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // not have every event from the start of the session — older
                 // events have been evicted. The `total` we report is the
                 // number of lines *available* right now, not the all-time
-                // count. This is what the frontend should use for pagination
-                // so it never asks for offsets the ring buffer can't serve.
+                // count. This matches `blockfile:line_count` semantics
+                // (both commands agree on what "offset N" means) so the
+                // frontend never asks for offsets the ring buffer can't
+                // serve.
                 //
-                // For all-time totals, use `blockfile:line_count` which reads
-                // `session:line_count` meta (unbounded) — but be aware that
-                // lines outside the ring buffer window are effectively gone
-                // until Phase 1.3 (disk-based segmentation) lands.
+                // Callers needing the all-time count can read the
+                // `session:line_count` meta field directly — but be aware
+                // that lines outside the ring buffer window are effectively
+                // gone until Phase 1.3 (disk-based segmentation) lands.
                 let scope = format!("block:{}", cmd.block_id);
                 let events = broker.read_event_history(
                     crate::backend::wps::EVENT_BLOCK_FILE,

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.95"
+version = "0.33.96"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -603,6 +603,16 @@ class RpcApiType {
         return client.wshRpcCall("runclilogin", data, opts);
     }
 
+    // command "blockfile:line_count" [call]
+    BlockfileLineCountCommand(client: WshClient, data: CommandBlockfileLineCountData, opts?: RpcOpts): Promise<BlockfileLineCountResult> {
+        return client.wshRpcCall("blockfile:line_count", data, opts);
+    }
+
+    // command "blockfile:read_range" [call]
+    BlockfileReadRangeCommand(client: WshClient, data: CommandBlockfileReadRangeData, opts?: RpcOpts): Promise<BlockfileReadRangeResult> {
+        return client.wshRpcCall("blockfile:read_range", data, opts);
+    }
+
 }
 
 export const RpcApi = new RpcApiType();

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -50,6 +50,17 @@
     }
 
     // === Status Log (terminal-style) ===
+    .agent-history-loading {
+        padding: 4px 8px;
+        font-family: var(--fixed-font);
+        font-size: 11px;
+        color: var(--secondary-text-color);
+        opacity: 0.6;
+        text-align: center;
+        border-bottom: 1px solid var(--border-color);
+        margin-bottom: 2px;
+    }
+
     .agent-status-log {
         padding: 2px 4px;
         font-family: var(--fixed-font);

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -551,12 +551,23 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
                     const nodes = parseHistoryLines(rangeResp.lines ?? [], outputFormat());
                     if (nodes.length > 0) {
-                        const [, setDoc] = agentAtoms().documentAtom;
-                        setDoc(nodes);
-                        // Notify useAgentStream to seed its indices from the
-                        // just-loaded history. Safe even if this fires before
-                        // or after useAgentStream mounts — the effect rebuilds
-                        // indices idempotently from current document state.
+                        const [doc, setDoc] = agentAtoms().documentAtom;
+                        // Prepend history to whatever is already in the
+                        // document. If useAgentStream has already captured
+                        // live events during the async history load, we
+                        // must not discard them. Dedupe by id — history
+                        // nodes and live nodes can overlap briefly during
+                        // a reconnect where an in-flight turn is also
+                        // visible in the persisted ring buffer.
+                        setDoc((prev) => {
+                            if (prev.length === 0) return nodes;
+                            const seen = new Set(prev.map((n) => n.id));
+                            const historyFresh = nodes.filter((n) => !seen.has(n.id));
+                            return [...historyFresh, ...prev];
+                        });
+                        // Notify useAgentStream to rebuild its nodeIdSet
+                        // and nodeIndexMap from the merged document so
+                        // subsequent live updates target correct indices.
                         bumpDocumentVersion();
                     }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -10,6 +10,7 @@ import { createAgentAtoms } from "./state";
 import type { DocumentNode, SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
+import { parseHistoryLines } from "./parseHistoryLines";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
@@ -383,6 +384,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     const agentAtoms = createMemo(() => createAgentAtoms(model.blockId));
 
+    // ── History pagination state ────────────────────────────────────────────────
+    // These track the window of lines we've loaded from the persisted blockfile.
+    // historyOffset = the line index where the currently-loaded slice starts.
+    // historyTotal  = total lines in the file (from session:line_count meta).
+    const [historyOffset, setHistoryOffset] = createSignal(0);
+    const [historyTotal, setHistoryTotal] = createSignal(0);
+    const [loadingOlder, setLoadingOlder] = createSignal(false);
+
     // Accumulated terminal-style log lines
     type LogLine = { tag: string; text: string; level?: "info" | "error" | "warn" };
     const [logLines, setLogLines] = createSignal<LogLine[]>([]);
@@ -417,6 +426,40 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             return env;
         } catch {
             return undefined; // non-fatal — fall back to default auth dir
+        }
+    };
+
+    // Load the previous page of history (prepend to document).
+    // Called by AgentDocumentView when the user scrolls near the top.
+    const loadOlder = async (): Promise<void> => {
+        const currentOffset = historyOffset();
+        if (currentOffset === 0) return; // already at the beginning
+        if (loadingOlder()) return;
+
+        setLoadingOlder(true);
+        try {
+            const newOffset = Math.max(0, currentOffset - 200);
+            const loadLimit = currentOffset - newOffset;
+
+            const resp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                block_id: model.blockId,
+                filename: "output",
+                offset: newOffset,
+                limit: loadLimit,
+            }, { timeout: 15000 });
+
+            const newNodes = parseHistoryLines(resp.lines ?? [], outputFormat());
+            if (newNodes.length > 0) {
+                const [, setDoc] = agentAtoms().documentAtom;
+                setDoc((prev) => [...newNodes, ...prev]);
+            }
+
+            setHistoryOffset(newOffset);
+            log("history", `loaded ${newNodes.length} older messages (offset ${newOffset})`);
+        } catch (err: any) {
+            log("history", `failed to load older messages: ${err?.message ?? String(err)}`, "warn");
+        } finally {
+            setLoadingOlder(false);
         }
     };
 
@@ -472,6 +515,47 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
         log("agent", `${name} selected (provider: ${provName})`);
         if (cwd) log("env", `working directory: ${cwd}`);
+
+        // Load persisted session history before starting the live stream.
+        // We do this asynchronously so the UI isn't blocked, but we fire it
+        // immediately so history appears as early as possible.
+        (async () => {
+            try {
+                const countResp = await RpcApi.BlockfileLineCountCommand(TabRpcClient, {
+                    block_id: model.blockId,
+                    filename: "output",
+                }, { timeout: 5000 });
+
+                const total = countResp?.count ?? 0;
+                if (total > 0) {
+                    const pageSize = 200;
+                    const offset = Math.max(0, total - pageSize);
+                    const limit = total - offset;
+
+                    const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                        block_id: model.blockId,
+                        filename: "output",
+                        offset,
+                        limit,
+                    }, { timeout: 15000 });
+
+                    const nodes = parseHistoryLines(rangeResp.lines ?? [], outputFormat());
+                    if (nodes.length > 0) {
+                        const [, setDoc] = agentAtoms().documentAtom;
+                        setDoc(nodes);
+                    }
+
+                    // Store pagination state for subsequent loadOlder() calls
+                    setHistoryOffset(offset);
+                    setHistoryTotal(total);
+
+                    log("history", `loaded ${nodes.length} of ${total} previous messages`);
+                }
+            } catch (err: any) {
+                // Non-fatal — fresh session or backend not ready yet
+                log("history", `could not load history: ${err?.message ?? String(err)}`, "warn");
+            }
+        })();
 
         // Full launch flow: CLI resolution → auth check → controller registration
         startLaunchFlow();
@@ -721,6 +805,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 logLines={logLines}
                 authUrl={authUrl}
                 onSubagentClick={handleSubagentClick}
+                onLoadOlder={loadOlder}
+                loadingOlder={loadingOlder}
             />
 
             <Show when={loginWaiting()}>

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -392,6 +392,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const [historyTotal, setHistoryTotal] = createSignal(0);
     const [loadingOlder, setLoadingOlder] = createSignal(false);
 
+    // Bumped on every external document mutation (history load, prepend).
+    // useAgentStream watches this and rebuilds its internal nodeIdSet +
+    // nodeIndexMap so live-stream updates continue targeting the right
+    // node indices after the document has been reshaped from outside.
+    const [documentVersion, setDocumentVersion] = createSignal(0);
+    const bumpDocumentVersion = () => setDocumentVersion((v) => v + 1);
+
     // Accumulated terminal-style log lines
     type LogLine = { tag: string; text: string; level?: "info" | "error" | "warn" };
     const [logLines, setLogLines] = createSignal<LogLine[]>([]);
@@ -452,6 +459,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             if (newNodes.length > 0) {
                 const [, setDoc] = agentAtoms().documentAtom;
                 setDoc((prev) => [...newNodes, ...prev]);
+                // Notify useAgentStream to rebuild its index map so live
+                // updates target the correct nodes after the prepend.
+                bumpDocumentVersion();
             }
 
             setHistoryOffset(newOffset);
@@ -543,13 +553,23 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     if (nodes.length > 0) {
                         const [, setDoc] = agentAtoms().documentAtom;
                         setDoc(nodes);
+                        // Notify useAgentStream to seed its indices from the
+                        // just-loaded history. Safe even if this fires before
+                        // or after useAgentStream mounts — the effect rebuilds
+                        // indices idempotently from current document state.
+                        bumpDocumentVersion();
                     }
 
-                    // Store pagination state for subsequent loadOlder() calls
+                    // Store pagination state for subsequent loadOlder() calls.
+                    // `resp.total` from the backend is the actual available
+                    // line count (clamped to the event ring buffer window),
+                    // not the all-time session:line_count. Use it so the
+                    // frontend never asks for offsets the backend can't serve.
+                    const available = rangeResp.total ?? total;
                     setHistoryOffset(offset);
-                    setHistoryTotal(total);
+                    setHistoryTotal(available);
 
-                    log("history", `loaded ${nodes.length} of ${total} previous messages`);
+                    log("history", `loaded ${nodes.length} of ${available} previous messages`);
                 }
             } catch (err: any) {
                 // Non-fatal — fresh session or backend not ready yet
@@ -626,13 +646,17 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         onCleanup(() => unsubCompleted());
     });
 
-    // Subscribe to subprocess output and parse into DocumentNodes
+    // Subscribe to subprocess output and parse into DocumentNodes.
+    // `documentVersion` is bumped whenever we mutate the document externally
+    // (history load / prepend), causing useAgentStream to rebuild its
+    // nodeIdSet and nodeIndexMap.
     useAgentStream({
         blockId: model.blockId,
         outputFormat: outputFormat(),
         documentAtom: agentAtoms().documentAtom,
         streamingStateAtom: agentAtoms().streamingStateAtom,
         enabled: true,
+        documentVersion,
     });
 
     // Send user message

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -27,13 +27,19 @@ interface AgentDocumentViewProps {
     logLines: Accessor<LogLine[]>;
     authUrl?: Accessor<string | null>;
     onSubagentClick?: (node: SubagentLinkNode) => void;
+    /** Called when the user scrolls near the top — load the previous page of history. */
+    onLoadOlder?: () => Promise<void>;
+    /** Whether an older-history load is currently in progress. */
+    loadingOlder?: Accessor<boolean>;
 }
 
-export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick }: AgentDocumentViewProps): JSX.Element => {
+export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick, onLoadOlder, loadingOlder }: AgentDocumentViewProps): JSX.Element => {
     const [document] = documentAtom;
     const [documentState, setDocumentState] = documentStateAtom;
     let scrollRef!: HTMLDivElement;
     let autoScroll = true;
+    // Guard against concurrent older-history fetches triggered by scroll
+    let loadingOlderInFlight = false;
 
     // Toggle collapsed state for a node
     const toggleCollapse = (nodeId: string) => {
@@ -73,11 +79,37 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
         if (scrollRafId != null) cancelAnimationFrame(scrollRafId);
     });
 
-    // Detect if user scrolled up (disable auto-scroll)
+    // Detect if user scrolled up (disable auto-scroll) and trigger older-history load
     const handleScroll = () => {
         if (!scrollRef) return;
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
         autoScroll = scrollHeight - scrollTop - clientHeight < 50;
+
+        // Trigger older-history load when near the top
+        if (
+            onLoadOlder &&
+            scrollTop < 50 &&
+            !loadingOlderInFlight &&
+            !(loadingOlder?.())
+        ) {
+            // Snapshot scroll anchor before content is prepended
+            const snapshotScrollHeight = scrollHeight;
+            const snapshotScrollTop = scrollTop;
+            loadingOlderInFlight = true;
+            onLoadOlder().then(() => {
+                // Restore scroll position so the user's viewport doesn't jump.
+                // Use a RAF so the DOM has updated with the new nodes first.
+                requestAnimationFrame(() => {
+                    if (scrollRef) {
+                        scrollRef.scrollTop =
+                            scrollRef.scrollHeight - snapshotScrollHeight + snapshotScrollTop;
+                    }
+                    loadingOlderInFlight = false;
+                });
+            }).catch(() => {
+                loadingOlderInFlight = false;
+            });
+        }
     };
 
     return (
@@ -86,6 +118,11 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
             ref={scrollRef}
             onScroll={handleScroll}
         >
+            {/* Older-history loading indicator — pinned at the very top */}
+            <Show when={loadingOlder?.()}>
+                <div class="agent-history-loading">Loading older messages...</div>
+            </Show>
+
             {/* Log lines always shown at the top */}
             <Show when={logLines().length > 0}>
                 <div class="agent-status-log">

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -1,0 +1,61 @@
+// Copyright 2025, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * parseHistoryLines — batch-parse a slice of persisted NDJSON lines into
+ * DocumentNodes using the same pipeline as useAgentStream.
+ *
+ * This is a pure function (no signals, no side-effects) so it can be called
+ * from onMount without touching SolidJS reactivity.
+ */
+
+import { createTranslator } from "./providers/translator-factory";
+import { ClaudeCodeStreamParser } from "./stream-parser";
+import type { DocumentNode } from "./types";
+
+/**
+ * Parse an array of raw NDJSON lines (as stored in the "output" blockfile)
+ * and return the resulting DocumentNodes.
+ *
+ * @param lines        Raw text lines from blockfile:read_range
+ * @param outputFormat Provider output format string (e.g. "claude-stream-json")
+ * @returns            Ordered array of DocumentNodes, deduped by node id
+ */
+export function parseHistoryLines(
+    lines: string[],
+    outputFormat: string,
+): DocumentNode[] {
+    const translator = createTranslator(outputFormat);
+    const parser = new ClaudeCodeStreamParser();
+    const nodes: DocumentNode[] = [];
+    const seen = new Set<string>();
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("{")) continue;
+
+        let rawEvent: any;
+        try {
+            rawEvent = JSON.parse(trimmed);
+        } catch {
+            // Corrupt line — skip silently (same as useAgentStream behaviour)
+            continue;
+        }
+
+        // Handle stderr events (unlikely in persisted history, but be safe)
+        if (rawEvent.type === "stderr") continue;
+
+        // Translate provider-specific envelope → StreamEvent[]
+        const streamEvents = translator.translate(rawEvent);
+
+        for (const event of streamEvents) {
+            const node = parser.parseLine(JSON.stringify(event));
+            if (!node) continue;
+            if (seen.has(node.id)) continue;
+            seen.add(node.id);
+            nodes.push(node);
+        }
+    }
+
+    return nodes;
+}

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -135,15 +135,11 @@ export class ClaudeTranslator implements OutputTranslator {
                 events.push({
                     type: "text",
                     content: block.text,
-                    messageId: message.id || `msg-${Date.now()}`,
-                    timestamp: Date.now(),
                 });
             } else if (block.type === "thinking" && block.thinking) {
                 events.push({
                     type: "thinking",
                     content: block.thinking,
-                    messageId: message.id || `msg-${Date.now()}`,
-                    timestamp: Date.now(),
                 });
             } else if (block.type === "tool_use") {
                 this.currentToolCallId = block.id;
@@ -153,10 +149,11 @@ export class ClaudeTranslator implements OutputTranslator {
                 }
                 events.push({
                     type: "tool_call",
-                    toolCallId: block.id,
-                    toolName: block.name,
-                    args: typeof block.input === "string" ? block.input : JSON.stringify(block.input || {}),
-                    timestamp: Date.now(),
+                    tool: block.name,
+                    id: block.id,
+                    params: typeof block.input === "object" && block.input !== null
+                        ? block.input
+                        : {},
                 });
             }
         }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -9,7 +9,7 @@
 
 import { getFileSubject } from "@/app/store/wps";
 import { base64ToArray } from "@/util/util";
-import { onCleanup, onMount } from "solid-js";
+import { createEffect, onCleanup, onMount } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import { ClaudeCodeStreamParser } from "./stream-parser";
 import type { SignalPair } from "./state";
@@ -23,6 +23,13 @@ interface UseAgentStreamOpts {
     documentAtom: SignalPair<DocumentNode[]>;
     streamingStateAtom: SignalPair<StreamingState>;
     enabled: boolean;
+    /**
+     * Version signal bumped by external document mutations (e.g. history
+     * load or prepend). When this changes, the hook rebuilds its internal
+     * `nodeIdSet` and `nodeIndexMap` from the current documentAtom so live
+     * updates continue to target the correct nodes.
+     */
+    documentVersion?: () => number;
 }
 
 /**
@@ -34,6 +41,7 @@ export function useAgentStream({
     documentAtom,
     streamingStateAtom,
     enabled,
+    documentVersion,
 }: UseAgentStreamOpts): void {
     const [, setDocument] = documentAtom;
     const [, setStreaming] = streamingStateAtom;
@@ -123,15 +131,34 @@ export function useAgentStream({
         pendingNew = [];
         pendingUpdates = [];
 
-        // Seed the dedup set from any history nodes already in the document
-        // (loaded by the history-load step in agent-view.tsx before this hook
-        // mounts). This prevents live-stream events from re-inserting nodes
-        // that were restored from persisted history.
         const [doc] = documentAtom;
-        const existingNodes = doc();
-        for (let i = 0; i < existingNodes.length; i++) {
-            nodeIdSet.add(existingNodes[i].id);
-            nodeIndexMap.set(existingNodes[i].id, i);
+
+        // Rebuild dedup set + index map from whatever is currently in the
+        // document. Called on mount and whenever `documentVersion()` changes
+        // (history load, history prepend). This keeps live-stream updates
+        // targeting the correct node indices after external mutations.
+        const rebuildIndicesFromDocument = () => {
+            const existingNodes = doc();
+            nodeIdSet = new Set();
+            nodeIndexMap = new Map();
+            for (let i = 0; i < existingNodes.length; i++) {
+                nodeIdSet.add(existingNodes[i].id);
+                nodeIndexMap.set(existingNodes[i].id, i);
+            }
+        };
+
+        // Initial seed — covers history nodes that were loaded before this
+        // hook mounted.
+        rebuildIndicesFromDocument();
+
+        // Reactive rebuild whenever the caller bumps documentVersion after
+        // an external prepend/load. The first invocation runs immediately
+        // (SolidJS semantics) which is fine — it's idempotent.
+        if (documentVersion != null) {
+            createEffect(() => {
+                documentVersion();
+                rebuildIndicesFromDocument();
+            });
         }
 
         setStreaming((prev) => ({ ...prev, active: true, lastEventTime: Date.now() }));

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -9,7 +9,7 @@
 
 import { getFileSubject } from "@/app/store/wps";
 import { base64ToArray } from "@/util/util";
-import { createEffect, onCleanup, onMount } from "solid-js";
+import { createEffect, onCleanup, onMount, untrack } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import { ClaudeCodeStreamParser } from "./stream-parser";
 import type { SignalPair } from "./state";
@@ -134,11 +134,13 @@ export function useAgentStream({
         const [doc] = documentAtom;
 
         // Rebuild dedup set + index map from whatever is currently in the
-        // document. Called on mount and whenever `documentVersion()` changes
-        // (history load, history prepend). This keeps live-stream updates
-        // targeting the correct node indices after external mutations.
+        // document. `doc()` is wrapped in `untrack` so the createEffect
+        // below only subscribes to documentVersion — NOT to the document
+        // signal itself. Without this, the rebuild would fire on every
+        // streaming flush (since flushPendingNodes calls setDoc), which
+        // would be O(n) per live event.
         const rebuildIndicesFromDocument = () => {
-            const existingNodes = doc();
+            const existingNodes = untrack(() => doc());
             nodeIdSet = new Set();
             nodeIndexMap = new Map();
             for (let i = 0; i < existingNodes.length; i++) {
@@ -151,7 +153,7 @@ export function useAgentStream({
         // hook mounted.
         rebuildIndicesFromDocument();
 
-        // Reactive rebuild whenever the caller bumps documentVersion after
+        // Reactive rebuild only when the caller bumps documentVersion after
         // an external prepend/load. The first invocation runs immediately
         // (SolidJS semantics) which is fine — it's idempotent.
         if (documentVersion != null) {

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -123,6 +123,17 @@ export function useAgentStream({
         pendingNew = [];
         pendingUpdates = [];
 
+        // Seed the dedup set from any history nodes already in the document
+        // (loaded by the history-load step in agent-view.tsx before this hook
+        // mounts). This prevents live-stream events from re-inserting nodes
+        // that were restored from persisted history.
+        const [doc] = documentAtom;
+        const existingNodes = doc();
+        for (let i = 0; i < existingNodes.length; i++) {
+            nodeIdSet.add(existingNodes[i].id);
+            nodeIndexMap.set(existingNodes[i].id, i);
+        }
+
         setStreaming((prev) => ({ ...prev, active: true, lastEventTime: Date.now() }));
 
         const fileSubject = getFileSubject(blockId, OutputFileName);

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1641,6 +1641,31 @@ declare global {
         raw_output: string;
     };
 
+    // wshrpc.CommandBlockfileLineCountData
+    type CommandBlockfileLineCountData = {
+        block_id: string;
+        filename: string;
+    };
+
+    // wshrpc.BlockfileLineCountResult
+    type BlockfileLineCountResult = {
+        count: number;
+    };
+
+    // wshrpc.CommandBlockfileReadRangeData
+    type CommandBlockfileReadRangeData = {
+        block_id: string;
+        filename: string;
+        offset: number;
+        limit: number;
+    };
+
+    // wshrpc.BlockfileReadRangeResult
+    type BlockfileReadRangeResult = {
+        lines: string[];
+        total: number;
+    };
+
 }
 
 export {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.95",
+  "version": "0.33.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.95",
+      "version": "0.33.96",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.95",
+  "version": "0.33.96",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Phase 2 of `docs/plans/ultra-long-sessions.md`. Builds on PR #336's backend pagination API to give agent panes memory of their previous history.

**Supersedes PR #337** — that branch had a bad rebase state. This is a clean cherry-pick from main with all review feedback addressed.

## User-visible behavior
- Reopen an agent pane → see your previous conversation immediately
- Scroll to the top → older messages load in place, viewport stays stable
- Works with streaming — live updates target correct node indices even after history prepend

## Implementation

### New file: `parseHistoryLines.ts`
Pure function that runs the same `translator → parser` pipeline as `useAgentStream` but over a batch of NDJSON strings. Dedupes by node id.

### `useAgentStream.ts` — `documentVersion` prop
New optional `documentVersion: () => number` prop. The hook uses `createEffect` to rebuild `nodeIdSet` and `nodeIndexMap` from the current document whenever the version bumps. This handles the race between history load (async) and hook mount (sync), plus subsequent prepends from `loadOlder`.

### `agent-view.tsx` — history loading flow
- `createSignal` for `historyOffset`, `historyTotal`, `loadingOlder`, `documentVersion`
- `onMount` async IIFE: calls `blockfile:line_count`, then `blockfile:read_range` for the tail window, populates document, bumps `documentVersion`
- `loadOlder()` prepends previous page, bumps `documentVersion`
- Passes `documentVersion` into `useAgentStream`

### `AgentDocumentView.tsx` — scroll-top detection
- `onLoadOlder` / `loadingOlder` props
- `handleScroll` detects `scrollTop < 50 && !loadingOlder()`
- Snapshots scroll state, calls `onLoadOlder`, RAF-restores position after resolve
- "Loading older messages…" banner at top

### Backend `read_range` / `line_count` — ring buffer semantics
Both commands now agree: the returned `total` is the number of lines **currently available** in the event ring buffer (capped at `MAX_PERSIST = 4096` events). Offsets are relative to the oldest retained line.

This fixes the inconsistency where `line_count` returned the all-time session:line_count but `read_range` could only serve lines from the ring buffer window — the frontend could compute offsets the backend couldn't satisfy.

Callers needing the all-time count can read `session:line_count` meta directly. True multi-session persistence awaits Phase 1.3 (disk segmentation).

## Also fixed
`claude-translator.ts` — the `handleAssistantMessage` fix from an earlier session used wrong field names. Now matches the actual type shape (`content`, `tool`, `id`, `params`).

## Not in this PR
- Output segmentation (1.3)
- Timeline minimap (2.4)
- Search / bookmarks / archival / digest (3.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)