### PR TITLE
feat: ultra-long sessions — output segmentation + timeline + bookmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.95"
+version = "0.33.96"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.96"
+version = "0.33.97"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.95"
+version = "0.33.96"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.95"
+version = "0.33.96"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.96"
+version = "0.33.97"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.95"
+version = "0.33.96"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.96"
+version = "0.33.97"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.96"
+version = "0.33.97"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.95"
+version = "0.33.96"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -27,6 +27,7 @@ use std::sync::{Arc, RwLock};
 use serde::{Deserialize, Serialize};
 
 use super::eventbus::EventBus;
+use super::storage::filestore::FileStore;
 use super::storage::wstore::WaveStore;
 use super::obj::{Block, MetaMapType, TermSize};
 use super::wps::Broker;
@@ -282,6 +283,7 @@ pub fn resync_controller(
     broker: Option<Arc<Broker>>,
     event_bus: Option<Arc<EventBus>>,
     wstore: Option<Arc<WaveStore>>,
+    filestore: Option<Arc<FileStore>>,
 ) -> Result<(), String> {
     let block_id = &block.oid;
     let block_meta = &block.meta;
@@ -356,6 +358,7 @@ pub fn resync_controller(
                 broker,
                 event_bus,
                 wstore,
+                filestore,
             );
             let ctrl = Arc::new(ctrl);
             register_controller(block_id, ctrl.clone());
@@ -368,6 +371,7 @@ pub fn resync_controller(
                 broker,
                 event_bus,
                 wstore,
+                filestore,
             );
             let ctrl = Arc::new(ctrl);
             register_controller(block_id, ctrl.clone());
@@ -511,7 +515,7 @@ mod tests {
             ..Default::default()
         };
         // No "controller" key in meta = no-op
-        let result = resync_controller(&block, "tab-1", None, false, None, None, None);
+        let result = resync_controller(&block, "tab-1", None, false, None, None, None, None);
         assert!(result.is_ok());
     }
 
@@ -528,7 +532,7 @@ mod tests {
             meta,
             ..Default::default()
         };
-        let result = resync_controller(&block, "tab-1", None, false, None, None, None);
+        let result = resync_controller(&block, "tab-1", None, false, None, None, None, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("unknown controller type"));
     }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -32,6 +32,7 @@ use super::{
 };
 use super::health::{classify_output_line, HealthMonitor};
 use crate::backend::eventbus::EventBus;
+use crate::backend::storage::filestore::FileStore;
 use crate::backend::storage::wstore::WaveStore;
 use crate::backend::wps;
 
@@ -74,6 +75,8 @@ pub struct PersistentSubprocessController {
     broker: Option<Arc<wps::Broker>>,
     event_bus: Option<Arc<EventBus>>,
     wstore: Option<Arc<WaveStore>>,
+    /// FileStore for write-through persistence of output lines (Phase 1.3).
+    filestore: Option<Arc<FileStore>>,
     health_monitor: Arc<HealthMonitor>,
 }
 
@@ -84,6 +87,7 @@ impl PersistentSubprocessController {
         broker: Option<Arc<wps::Broker>>,
         event_bus: Option<Arc<EventBus>>,
         wstore: Option<Arc<WaveStore>>,
+        filestore: Option<Arc<FileStore>>,
     ) -> Self {
         let health_monitor = Arc::new(HealthMonitor::new(
             block_id.clone(),
@@ -104,6 +108,7 @@ impl PersistentSubprocessController {
             broker,
             event_bus,
             wstore,
+            filestore,
             health_monitor,
         }
     }
@@ -279,6 +284,7 @@ impl PersistentSubprocessController {
         let inner_read = Arc::clone(&self.inner);
         let wstore_read = self.wstore.clone();
         let event_bus_read = self.event_bus.clone();
+        let filestore_read = self.filestore.clone();
         let health_read = Arc::clone(&self.health_monitor);
         let session_id_field = config.session_id_field.clone();
 
@@ -354,7 +360,8 @@ impl PersistentSubprocessController {
                     }
                 }
 
-                // Publish line as WPS blockfile event
+                // Publish line as WPS blockfile event and write-through to FileStore
+                // for persistent history (Phase 1.3).
                 tracing::info!(
                     block_id = %block_id_read,
                     line_len = line.len(),
@@ -367,6 +374,7 @@ impl PersistentSubprocessController {
                         &block_id_read,
                         PERSISTENT_OUTPUT_SUBJECT,
                         line_with_newline.as_bytes(),
+                        filestore_read.as_ref(),
                     );
                 } else {
                     tracing::warn!(block_id = %block_id_read, "persistent stdout: no broker available");

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -36,6 +36,7 @@ use super::{
 };
 use crate::backend::eventbus::EventBus;
 use crate::backend::shellexec::{ConnInterface, ShellProc};
+use crate::backend::storage::filestore::FileStore;
 use crate::backend::storage::wstore::WaveStore;
 use crate::backend::obj::{self, MetaMapType};
 use crate::backend::wps;
@@ -731,6 +732,7 @@ impl Controller for ShellController {
                                 &block_id_read,
                                 "term",
                                 &buf[..n],
+                                None, // PTY output is raw terminal data; no FileStore write-through
                             );
                         }
                     }
@@ -912,16 +914,20 @@ impl Controller for ShellController {
 
 // ---- File operation helpers ----
 
-/// Append data to a block's terminal output file and publish a WPS event.
+/// Append data to a block's terminal output file, publish a WPS event,
+/// and write-through to FileStore (if provided).
+///
 /// Port of Go's `HandleAppendBlockFile`.
+///
+/// The FileStore write is fire-and-forget: if it fails we emit a warning but
+/// never propagate the error back to the hot stdout-reader path.
 pub fn handle_append_block_file(
     broker: &wps::Broker,
     block_id: &str,
     filename: &str,
     data: &[u8],
+    filestore: Option<&Arc<FileStore>>,
 ) {
-    // In a full implementation, this would also write to FileStore.
-    // For now, just publish the WPS event.
     let data64 = base64::engine::general_purpose::STANDARD.encode(data);
 
     let event_data = wps::WSFileEventData {
@@ -940,6 +946,56 @@ pub fn handle_append_block_file(
     };
 
     broker.publish(event);
+
+    // Write-through to FileStore for persistent history (Phase 1.3).
+    // Create the file lazily on first append; if the file already exists
+    // we skip make_file and go straight to append_data.
+    if let Some(fs) = filestore {
+        let needs_create = match fs.stat(block_id, filename) {
+            Ok(None) => true,
+            Ok(Some(_)) => false,
+            Err(e) => {
+                tracing::warn!(
+                    block_id = %block_id,
+                    filename = %filename,
+                    error = %e,
+                    "filestore stat failed; skipping write-through"
+                );
+                return;
+            }
+        };
+
+        if needs_create {
+            if let Err(e) = fs.make_file(
+                block_id,
+                filename,
+                std::collections::HashMap::new(),
+                crate::backend::storage::filestore::FileOpts::default(),
+            ) {
+                // AlreadyExists is benign (race between two appends); anything
+                // else is worth warning about.
+                use crate::backend::storage::error::StoreError;
+                if !matches!(e, StoreError::AlreadyExists) {
+                    tracing::warn!(
+                        block_id = %block_id,
+                        filename = %filename,
+                        error = %e,
+                        "filestore make_file failed; skipping write-through"
+                    );
+                    return;
+                }
+            }
+        }
+
+        if let Err(e) = fs.append_data(block_id, filename, data) {
+            tracing::warn!(
+                block_id = %block_id,
+                filename = %filename,
+                error = %e,
+                "filestore append_data failed"
+            );
+        }
+    }
 }
 
 /// Truncate a block's terminal output file and publish a WPS event.
@@ -1268,7 +1324,7 @@ mod tests {
             },
         );
 
-        handle_append_block_file(&broker, "block-1", "term", b"hello world");
+        handle_append_block_file(&broker, "block-1", "term", b"hello world", None);
 
         // Check event was published
         let _history = broker.read_event_history(wps::EVENT_BLOCK_FILE, "block:block-1", 10);
@@ -1327,7 +1383,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = super::super::resync_controller(&block, "tab-1", None, false, None, None, None);
+        let result = super::super::resync_controller(&block, "tab-1", None, false, None, None, None, None);
         assert!(result.is_ok());
 
         let ctrl = super::super::get_controller("resync-test-block");
@@ -1336,5 +1392,54 @@ mod tests {
 
         // Cleanup
         super::super::delete_controller("resync-test-block");
+    }
+
+    /// Phase 1.3 integration test: write output via handle_append_block_file with a
+    /// FileStore, then verify the data is readable back from the store.
+    #[test]
+    fn test_handle_append_block_file_writes_to_filestore() {
+        use crate::backend::storage::filestore::FileStore;
+        use std::sync::Arc;
+
+        let broker = wps::Broker::new();
+        let fs = Arc::new(FileStore::open_in_memory().expect("open in-memory filestore"));
+
+        let block_id = "test-block-fs";
+        let filename = "output";
+
+        // First append — file does not exist yet; handle_append_block_file must create it lazily.
+        let line1 = b"line one\n";
+        handle_append_block_file(&broker, block_id, filename, line1, Some(&fs));
+
+        // Second append
+        let line2 = b"line two\n";
+        handle_append_block_file(&broker, block_id, filename, line2, Some(&fs));
+
+        // Read back from FileStore
+        let data = fs.read_file(block_id, filename)
+            .expect("read_file ok")
+            .expect("data present");
+
+        let text = String::from_utf8(data).expect("valid utf8");
+        assert!(text.contains("line one"), "expected 'line one' in {:?}", text);
+        assert!(text.contains("line two"), "expected 'line two' in {:?}", text);
+
+        // Also verify total size matches
+        let stat = fs.stat(block_id, filename).unwrap().unwrap();
+        assert_eq!(stat.size, (line1.len() + line2.len()) as i64);
+
+        // Verify WPS events were also published (broker path still works)
+        broker.subscribe(
+            "test-route-fs",
+            wps::SubscriptionRequest {
+                event: wps::EVENT_BLOCK_FILE.to_string(),
+                scopes: vec![format!("block:{}", block_id)],
+                allscopes: false,
+            },
+        );
+        // Re-publish one more line to confirm broker still receives events alongside filestore
+        handle_append_block_file(&broker, block_id, filename, b"line three\n", Some(&fs));
+        let stat_after = fs.stat(block_id, filename).unwrap().unwrap();
+        assert_eq!(stat_after.size, (line1.len() + line2.len() + b"line three\n".len()) as i64);
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -31,6 +31,7 @@ use super::{
 };
 use super::health::{classify_output_line, HealthMonitor};
 use crate::backend::eventbus::EventBus;
+use crate::backend::storage::filestore::FileStore;
 use crate::backend::storage::wstore::WaveStore;
 use crate::backend::wps;
 
@@ -98,6 +99,8 @@ pub struct SubprocessController {
     event_bus: Option<Arc<EventBus>>,
     /// Wave object store for block metadata persistence.
     wstore: Option<Arc<WaveStore>>,
+    /// FileStore for write-through persistence of output lines (Phase 1.3).
+    filestore: Option<Arc<FileStore>>,
     /// Agent health monitor (output activity + error tracking).
     health_monitor: Arc<HealthMonitor>,
 }
@@ -110,6 +113,7 @@ impl SubprocessController {
         broker: Option<Arc<wps::Broker>>,
         event_bus: Option<Arc<EventBus>>,
         wstore: Option<Arc<WaveStore>>,
+        filestore: Option<Arc<FileStore>>,
     ) -> Self {
         let health_monitor = Arc::new(HealthMonitor::new(
             block_id.clone(),
@@ -130,6 +134,7 @@ impl SubprocessController {
             broker,
             event_bus,
             wstore,
+            filestore,
             health_monitor,
         }
     }
@@ -306,6 +311,7 @@ impl SubprocessController {
         let inner_read = Arc::clone(&self.inner);
         let wstore_read = self.wstore.clone();
         let event_bus_read = self.event_bus.clone();
+        let filestore_read = self.filestore.clone();
         let health_read = Arc::clone(&self.health_monitor);
         let session_id_field = config.session_id_field.clone();
         tokio::spawn(async move {
@@ -398,6 +404,7 @@ impl SubprocessController {
                 }
 
                 // Publish the NDJSON line as a WPS blockfile event on the "output" subject
+                // and write-through to FileStore for persistent history (Phase 1.3).
                 if let Some(ref broker) = broker_read {
                     tracing::info!(block_id = %block_id_read, line = %trimmed, "subprocess stdout → blockfile");
                     // Include the newline so the frontend line splitter works correctly
@@ -407,6 +414,7 @@ impl SubprocessController {
                         &block_id_read,
                         SUBPROCESS_OUTPUT_SUBJECT,
                         line_with_newline.as_bytes(),
+                        filestore_read.as_ref(),
                     );
                 }
             }
@@ -628,6 +636,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert_eq!(ctrl.controller_type(), BLOCK_CONTROLLER_SUBPROCESS);
         assert_eq!(ctrl.block_id(), "block-1");
@@ -645,6 +654,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let result = ctrl.send_input(BlockInputUnion::data(b"hello".to_vec()));
         assert!(result.is_err());
@@ -656,6 +666,7 @@ mod tests {
         let ctrl = SubprocessController::new(
             "tab-1".to_string(),
             "block-1".to_string(),
+            None,
             None,
             None,
             None,
@@ -676,6 +687,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let result = ctrl.stop(true, STATUS_DONE);
         assert!(result.is_ok());
@@ -692,6 +704,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(ctrl.session_id().is_none());
     }
@@ -701,6 +714,7 @@ mod tests {
         let ctrl = SubprocessController::new(
             "tab-1".to_string(),
             "block-1".to_string(),
+            None,
             None,
             None,
             None,
@@ -715,6 +729,8 @@ mod tests {
             working_dir: String::new(),
             env_vars: HashMap::new(),
             message: "test".to_string(),
+            resume_flag: String::new(),
+            session_id_field: "session_id".to_string(),
         };
 
         let result = ctrl.spawn_turn(config);

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -38,6 +38,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();
     let event_bus = state.event_bus.clone();
+    let filestore = state.filestore.clone();
 
     engine.register_handler(
         COMMAND_AGENT_OPEN,
@@ -45,6 +46,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
             let wstore = wstore.clone();
             let broker = broker.clone();
             let event_bus = event_bus.clone();
+            let filestore = filestore.clone();
             Box::pin(async move {
                 let cmd: CommandAgentOpenData = serde_json::from_value(data)
                     .map_err(|e| format!("agent.open: {e}"))?;
@@ -86,6 +88,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         let _ = blockcontroller::resync_controller(
                             &block_for_resync, &tab_id, None, true,
                             Some(broker.clone()), Some(event_bus.clone()), Some(wstore.clone()),
+                            Some(filestore.clone()),
                         );
                     }
                     let status = blockcontroller::get_block_controller_status(&existing.oid)
@@ -236,6 +239,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     Some(broker.clone()),
                     Some(event_bus.clone()),
                     Some(wstore.clone()),
+                    Some(filestore.clone()),
                 )?;
 
                 // 10. Broadcast block + tab + layout updates to frontend
@@ -588,28 +592,64 @@ fn register_agent_output(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
+    let filestore = state.filestore.clone();
 
     engine.register_handler(
         COMMAND_BLOCKFILE_LINE_COUNT,
         Box::new(move |data, _ctx| {
             let broker = broker.clone();
+            let filestore = filestore.clone();
             Box::pin(async move {
                 let cmd: CommandBlockfileLineCountData = serde_json::from_value(data)
                     .map_err(|e| format!("blockfile:line_count: {e}"))?;
 
                 tracing::info!(block_id = %cmd.block_id, filename = %cmd.filename, "blockfile:line_count");
 
-                // Returns the number of lines *currently available* in the
-                // event ring buffer (MAX_PERSIST = 4096 events). For long
-                // sessions this may be LESS than the all-time session line
-                // count — older events have been evicted. This matches the
-                // semantics of `blockfile:read_range` so the two commands
-                // agree on what "offset N" means.
+                // Phase 1.3: Prefer FileStore (persistent, no size cap) over the
+                // WPS broker ring buffer (MAX_PERSIST = 4096 events).
                 //
-                // Callers who need the all-time count should read the
-                // `session:line_count` meta field directly. Until Phase 1.3
-                // (disk-based segmentation) lands, lines outside the ring
-                // buffer window are not retrievable.
+                // If FileStore has the file and it is non-empty, count lines in
+                // the persisted bytes. Otherwise fall back to the ring buffer so
+                // sessions that pre-date Phase 1.3 (no FileStore writes yet) still
+                // work correctly.
+                let filestore_count = match filestore.stat(&cmd.block_id, &cmd.filename) {
+                    Ok(Some(ref wf)) if wf.size > 0 => {
+                        match filestore.read_file(&cmd.block_id, &cmd.filename) {
+                            Ok(Some(bytes)) => {
+                                let text = String::from_utf8_lossy(&bytes);
+                                let count = text.lines()
+                                    .filter(|l| !l.trim().is_empty())
+                                    .count() as u64;
+                                Some(count)
+                            }
+                            Ok(None) => None,
+                            Err(e) => {
+                                tracing::warn!(
+                                    block_id = %cmd.block_id,
+                                    filename = %cmd.filename,
+                                    error = %e,
+                                    "blockfile:line_count: filestore read failed, falling back to ring buffer"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    Ok(_) => None, // file absent or empty → fall back
+                    Err(e) => {
+                        tracing::warn!(
+                            block_id = %cmd.block_id,
+                            error = %e,
+                            "blockfile:line_count: filestore stat failed, falling back to ring buffer"
+                        );
+                        None
+                    }
+                };
+
+                if let Some(count) = filestore_count {
+                    return Ok(Some(serde_json::to_value(&BlockfileLineCountResult { count }).unwrap()));
+                }
+
+                // Fallback: count from WPS event ring buffer (capped at MAX_PERSIST = 4096).
                 let scope = format!("block:{}", cmd.block_id);
                 let events = broker.read_event_history(
                     crate::backend::wps::EVENT_BLOCK_FILE,
@@ -650,11 +690,13 @@ fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
+    let filestore = state.filestore.clone();
 
     engine.register_handler(
         COMMAND_BLOCKFILE_READ_RANGE,
         Box::new(move |data, _ctx| {
             let broker = broker.clone();
+            let filestore = filestore.clone();
             Box::pin(async move {
                 let cmd: CommandBlockfileReadRangeData = serde_json::from_value(data)
                     .map_err(|e| format!("blockfile:read_range: {e}"))?;
@@ -665,48 +707,77 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let offset = cmd.offset as usize;
                 let end = offset.saturating_add(limit);
 
-                // Read the full event window (capped at the broker's
-                // MAX_PERSIST = 4096 events). The in-memory ring buffer may
-                // not have every event from the start of the session — older
-                // events have been evicted. The `total` we report is the
-                // number of lines *available* right now, not the all-time
-                // count. This matches `blockfile:line_count` semantics
-                // (both commands agree on what "offset N" means) so the
-                // frontend never asks for offsets the ring buffer can't
-                // serve.
+                // Phase 1.3: Prefer FileStore (persistent, no size cap) over the
+                // WPS broker ring buffer (MAX_PERSIST = 4096 events).
                 //
-                // Callers needing the all-time count can read the
-                // `session:line_count` meta field directly — but be aware
-                // that lines outside the ring buffer window are effectively
-                // gone until Phase 1.3 (disk-based segmentation) lands.
-                let scope = format!("block:{}", cmd.block_id);
-                let events = broker.read_event_history(
-                    crate::backend::wps::EVENT_BLOCK_FILE,
-                    &scope,
-                    usize::MAX, // broker clamps to MAX_PERSIST internally
-                );
-
-                // First pass: collect all available lines from the ring buffer.
-                // We need the total count before we can apply offset/limit,
-                // because `offset` is expressed relative to the available
-                // window (0 = oldest still-retained line).
-                let mut all_lines: Vec<String> = Vec::new();
-                for event in events {
-                    let Some(ref event_data) = event.data else { continue };
-                    let ev_filename = event_data.get("filename")
-                        .and_then(|v| v.as_str()).unwrap_or("");
-                    if ev_filename != cmd.filename {
-                        continue;
-                    }
-                    let Some(data64) = event_data.get("data64").and_then(|v| v.as_str()) else { continue };
-                    let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data64) else { continue };
-                    let text = String::from_utf8_lossy(&bytes);
-                    for line in text.lines() {
-                        if !line.trim().is_empty() {
-                            all_lines.push(line.to_string());
+                // If FileStore has the file and it is non-empty, read from disk.
+                // Otherwise fall back to ring buffer for backward compatibility.
+                let filestore_lines = match filestore.stat(&cmd.block_id, &cmd.filename) {
+                    Ok(Some(ref wf)) if wf.size > 0 => {
+                        match filestore.read_file(&cmd.block_id, &cmd.filename) {
+                            Ok(Some(bytes)) => {
+                                let text = String::from_utf8_lossy(&bytes);
+                                let lines: Vec<String> = text.lines()
+                                    .filter(|l| !l.trim().is_empty())
+                                    .map(|l| l.to_string())
+                                    .collect();
+                                Some(lines)
+                            }
+                            Ok(None) => None,
+                            Err(e) => {
+                                tracing::warn!(
+                                    block_id = %cmd.block_id,
+                                    filename = %cmd.filename,
+                                    error = %e,
+                                    "blockfile:read_range: filestore read failed, falling back to ring buffer"
+                                );
+                                None
+                            }
                         }
                     }
-                }
+                    Ok(_) => None, // file absent or empty → fall back
+                    Err(e) => {
+                        tracing::warn!(
+                            block_id = %cmd.block_id,
+                            error = %e,
+                            "blockfile:read_range: filestore stat failed, falling back to ring buffer"
+                        );
+                        None
+                    }
+                };
+
+                let all_lines = if let Some(lines) = filestore_lines {
+                    lines
+                } else {
+                    // Fallback: reconstruct from WPS event ring buffer.
+                    // The ring buffer holds at most MAX_PERSIST = 4096 events;
+                    // older events are evicted. Offset 0 = oldest retained line.
+                    let scope = format!("block:{}", cmd.block_id);
+                    let events = broker.read_event_history(
+                        crate::backend::wps::EVENT_BLOCK_FILE,
+                        &scope,
+                        usize::MAX, // broker clamps to MAX_PERSIST internally
+                    );
+
+                    let mut lines: Vec<String> = Vec::new();
+                    for event in events {
+                        let Some(ref event_data) = event.data else { continue };
+                        let ev_filename = event_data.get("filename")
+                            .and_then(|v| v.as_str()).unwrap_or("");
+                        if ev_filename != cmd.filename {
+                            continue;
+                        }
+                        let Some(data64) = event_data.get("data64").and_then(|v| v.as_str()) else { continue };
+                        let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data64) else { continue };
+                        let text = String::from_utf8_lossy(&bytes);
+                        for line in text.lines() {
+                            if !line.trim().is_empty() {
+                                lines.push(line.to_string());
+                            }
+                        }
+                    }
+                    lines
+                };
 
                 let total = all_lines.len() as u64;
                 let clamped_offset = offset.min(all_lines.len());

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -588,50 +588,33 @@ fn register_agent_output(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
-    let wstore = state.wstore.clone();
 
     engine.register_handler(
         COMMAND_BLOCKFILE_LINE_COUNT,
         Box::new(move |data, _ctx| {
             let broker = broker.clone();
-            let wstore = wstore.clone();
             Box::pin(async move {
                 let cmd: CommandBlockfileLineCountData = serde_json::from_value(data)
                     .map_err(|e| format!("blockfile:line_count: {e}"))?;
 
                 tracing::info!(block_id = %cmd.block_id, filename = %cmd.filename, "blockfile:line_count");
 
-                // Fast path: read the pre-computed `session:line_count` meta
-                // field maintained by SessionStatsAccumulator. This is O(1) —
-                // no event history scan. The accumulator updates it debounced
-                // at 1s so the value may trail real-time by up to a second,
-                // which is fine for UI purposes.
+                // Returns the number of lines *currently available* in the
+                // event ring buffer (MAX_PERSIST = 4096 events). For long
+                // sessions this may be LESS than the all-time session line
+                // count — older events have been evicted. This matches the
+                // semantics of `blockfile:read_range` so the two commands
+                // agree on what "offset N" means.
                 //
-                // Currently SessionStatsAccumulator tracks total session lines,
-                // not per-filename. If the caller requests a filename other
-                // than "output" we fall through to an event history scan.
-                let block = wstore
-                    .get::<Block>(&cmd.block_id)
-                    .map_err(|e| format!("blockfile:line_count: {e}"))?
-                    .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", cmd.block_id))?;
-
-                if cmd.filename == "output" {
-                    let count = block.meta.get("session:line_count")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0);
-                    return Ok(Some(serde_json::to_value(
-                        &BlockfileLineCountResult { count },
-                    ).unwrap()));
-                }
-
-                // Fallback: scan event history for non-output filenames
-                // (rare — current persistent/subprocess controllers only
-                // publish to "output")
+                // Callers who need the all-time count should read the
+                // `session:line_count` meta field directly. Until Phase 1.3
+                // (disk-based segmentation) lands, lines outside the ring
+                // buffer window are not retrievable.
                 let scope = format!("block:{}", cmd.block_id);
                 let events = broker.read_event_history(
                     crate::backend::wps::EVENT_BLOCK_FILE,
                     &scope,
-                    10_000,
+                    usize::MAX, // broker clamps to MAX_PERSIST internally
                 );
 
                 let mut count: u64 = 0;
@@ -667,13 +650,11 @@ fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
-    let wstore = state.wstore.clone();
 
     engine.register_handler(
         COMMAND_BLOCKFILE_READ_RANGE,
         Box::new(move |data, _ctx| {
             let broker = broker.clone();
-            let wstore = wstore.clone();
             Box::pin(async move {
                 let cmd: CommandBlockfileReadRangeData = serde_json::from_value(data)
                     .map_err(|e| format!("blockfile:read_range: {e}"))?;
@@ -684,31 +665,31 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let offset = cmd.offset as usize;
                 let end = offset.saturating_add(limit);
 
-                // Get the authoritative total from session meta (fast path for
-                // "output"; O(1)). If unavailable, we'll compute it during the
-                // scan below as a fallback.
-                let mut total: u64 = 0;
-                if cmd.filename == "output" {
-                    if let Ok(Some(block)) = wstore.get::<Block>(&cmd.block_id) {
-                        total = block.meta.get("session:line_count")
-                            .and_then(|v| v.as_u64())
-                            .unwrap_or(0);
-                    }
-                }
-
-                // Read events and stream-decode line-by-line. Stop as soon as
-                // we've collected the requested window — avoids the O(n) memory
-                // cost of materializing the entire history.
+                // Read the full event window (capped at the broker's
+                // MAX_PERSIST = 4096 events). The in-memory ring buffer may
+                // not have every event from the start of the session — older
+                // events have been evicted. The `total` we report is the
+                // number of lines *available* right now, not the all-time
+                // count. This is what the frontend should use for pagination
+                // so it never asks for offsets the ring buffer can't serve.
+                //
+                // For all-time totals, use `blockfile:line_count` which reads
+                // `session:line_count` meta (unbounded) — but be aware that
+                // lines outside the ring buffer window are effectively gone
+                // until Phase 1.3 (disk-based segmentation) lands.
                 let scope = format!("block:{}", cmd.block_id);
                 let events = broker.read_event_history(
                     crate::backend::wps::EVENT_BLOCK_FILE,
                     &scope,
-                    10_000,
+                    usize::MAX, // broker clamps to MAX_PERSIST internally
                 );
 
-                let mut lines: Vec<String> = Vec::with_capacity(limit);
-                let mut seen: usize = 0;
-                'outer: for event in events {
+                // First pass: collect all available lines from the ring buffer.
+                // We need the total count before we can apply offset/limit,
+                // because `offset` is expressed relative to the available
+                // window (0 = oldest still-retained line).
+                let mut all_lines: Vec<String> = Vec::new();
+                for event in events {
                     let Some(ref event_data) = event.data else { continue };
                     let ev_filename = event_data.get("filename")
                         .and_then(|v| v.as_str()).unwrap_or("");
@@ -719,25 +700,20 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data64) else { continue };
                     let text = String::from_utf8_lossy(&bytes);
                     for line in text.lines() {
-                        if line.trim().is_empty() {
-                            continue;
-                        }
-                        if seen >= offset && seen < end {
-                            lines.push(line.to_string());
-                        }
-                        seen += 1;
-                        if seen >= end && total > 0 {
-                            // We have the requested window AND an authoritative
-                            // total from meta — safe to stop early.
-                            break 'outer;
+                        if !line.trim().is_empty() {
+                            all_lines.push(line.to_string());
                         }
                     }
                 }
 
-                // If meta didn't give us a total, use what we counted
-                if total == 0 {
-                    total = seen as u64;
-                }
+                let total = all_lines.len() as u64;
+                let clamped_offset = offset.min(all_lines.len());
+                let clamped_end = end.min(all_lines.len());
+                let lines: Vec<String> = if clamped_offset >= clamped_end {
+                    Vec::new()
+                } else {
+                    all_lines[clamped_offset..clamped_end].to_vec()
+                };
 
                 Ok(Some(serde_json::to_value(&BlockfileReadRangeResult {
                     lines,

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -670,13 +670,15 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // not have every event from the start of the session — older
                 // events have been evicted. The `total` we report is the
                 // number of lines *available* right now, not the all-time
-                // count. This is what the frontend should use for pagination
-                // so it never asks for offsets the ring buffer can't serve.
+                // count. This matches `blockfile:line_count` semantics
+                // (both commands agree on what "offset N" means) so the
+                // frontend never asks for offsets the ring buffer can't
+                // serve.
                 //
-                // For all-time totals, use `blockfile:line_count` which reads
-                // `session:line_count` meta (unbounded) — but be aware that
-                // lines outside the ring buffer window are effectively gone
-                // until Phase 1.3 (disk-based segmentation) lands.
+                // Callers needing the all-time count can read the
+                // `session:line_count` meta field directly — but be aware
+                // that lines outside the ring buffer window are effectively
+                // gone until Phase 1.3 (disk-based segmentation) lands.
                 let scope = format!("block:{}", cmd.block_id);
                 let events = broker.read_event_history(
                     crate::backend::wps::EVENT_BLOCK_FILE,

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -43,6 +43,7 @@ fn test_state() -> AppState {
         local_web_url: String::new(),
         subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus)),
         history_service: Arc::new(crate::backend::history::HistoryService::new()),
+        lan_discovery: None,
     }
 }
 

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -603,12 +603,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
     let wstore_resync = state.wstore.clone();
     let broker_resync = state.broker.clone();
     let event_bus_resync = state.event_bus.clone();
+    let filestore_resync = state.filestore.clone();
     engine.register_handler(
         COMMAND_CONTROLLER_RESYNC,
         Box::new(move |data, _ctx| {
             let wstore = wstore_resync.clone();
             let broker = broker_resync.clone();
             let event_bus = event_bus_resync.clone();
+            let filestore = filestore_resync.clone();
             Box::pin(async move {
                 let cmd: CommandControllerResyncData = serde_json::from_value(data)
                     .map_err(|e| format!("controllerresync: {e}"))?;
@@ -630,6 +632,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     Some(broker),
                     Some(event_bus),
                     Some(wstore),
+                    Some(filestore),
                 )?;
                 Ok(None)
             })
@@ -654,12 +657,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
     let wstore_spawn = state.wstore.clone();
     let broker_spawn = state.broker.clone();
     let event_bus_spawn = state.event_bus.clone();
+    let filestore_spawn = state.filestore.clone();
     engine.register_handler(
         COMMAND_SUBPROCESS_SPAWN,
         Box::new(move |data, _ctx| {
             let wstore = wstore_spawn.clone();
             let broker = broker_spawn.clone();
             let event_bus = event_bus_spawn.clone();
+            let filestore = filestore_spawn.clone();
             Box::pin(async move {
                 let cmd: CommandSubprocessSpawnData = serde_json::from_value(data)
                     .map_err(|e| format!("subprocessspawn: {e}"))?;
@@ -680,6 +685,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                             Some(broker),
                             Some(event_bus),
                             Some(wstore),
+                            Some(filestore),
                         );
                         let ctrl = std::sync::Arc::new(ctrl);
                         blockcontroller::register_controller(&cmd.blockid, ctrl.clone());

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.96"
+version = "0.33.97"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.95"
+version = "0.33.96"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -603,6 +603,16 @@ class RpcApiType {
         return client.wshRpcCall("runclilogin", data, opts);
     }
 
+    // command "blockfile:line_count" [call]
+    BlockfileLineCountCommand(client: WshClient, data: CommandBlockfileLineCountData, opts?: RpcOpts): Promise<BlockfileLineCountResult> {
+        return client.wshRpcCall("blockfile:line_count", data, opts);
+    }
+
+    // command "blockfile:read_range" [call]
+    BlockfileReadRangeCommand(client: WshClient, data: CommandBlockfileReadRangeData, opts?: RpcOpts): Promise<BlockfileReadRangeResult> {
+        return client.wshRpcCall("blockfile:read_range", data, opts);
+    }
+
 }
 
 export const RpcApi = new RpcApiType();

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -50,6 +50,17 @@
     }
 
     // === Status Log (terminal-style) ===
+    .agent-history-loading {
+        padding: 4px 8px;
+        font-family: var(--fixed-font);
+        font-size: 11px;
+        color: var(--secondary-text-color);
+        opacity: 0.6;
+        text-align: center;
+        border-bottom: 1px solid var(--border-color);
+        margin-bottom: 2px;
+    }
+
     .agent-status-log {
         padding: 2px 4px;
         font-family: var(--fixed-font);

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1944,4 +1944,326 @@
             }
         }
     }
+
+    // === Timeline Minimap ===
+    // .agent-document-wrapper wraps the scroll container + the timeline gutter
+    // side by side using flex so the timeline sits flush to the right edge of
+    // the document area without stealing space from the scroll container.
+    .agent-document-wrapper {
+        flex: 1;
+        display: flex;
+        flex-direction: row;
+        overflow: hidden;
+        min-height: 0;
+    }
+
+    // The timeline gutter: 22px wide, full height, sits to the right.
+    .agent-timeline {
+        width: 22px;
+        flex-shrink: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 2px 0;
+        gap: 2px;
+        background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+        border-left: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+        user-select: none;
+        cursor: pointer;
+        overflow: hidden;
+    }
+
+    // Tiny time labels at top/bottom of the gutter
+    .agent-timeline-label {
+        font-size: 8px;
+        line-height: 1;
+        color: var(--secondary-text-color);
+        opacity: 0.5;
+        white-space: nowrap;
+        writing-mode: vertical-lr;
+        transform: rotate(180deg);
+        flex-shrink: 0;
+        max-height: 40px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        &--top {
+            // intentionally empty — just use the shared .agent-timeline-label rules
+        }
+
+        &--bottom {
+            // intentionally empty
+        }
+    }
+
+    // The clickable track area between the two labels — fills remaining height.
+    .agent-timeline-track {
+        flex: 1;
+        width: 100%;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        overflow: hidden;
+    }
+
+    // Container that holds all the density bars end-to-end, top = session start.
+    .agent-timeline-bars {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: flex-end;
+        gap: 1px;
+        padding: 0 2px;
+    }
+
+    // Individual density bar — width is fixed, height proportional to bucket count.
+    .agent-timeline-bar {
+        width: 10px;
+        min-height: 1px;
+        border-radius: 1px;
+        background: var(--accent-color, #4a9eff);
+        opacity: 0.55;
+        transition: opacity 0.1s, height 0.2s;
+        flex-shrink: 0;
+
+        &:hover {
+            opacity: 0.9;
+        }
+
+        // Empty buckets get a very faint tick so the track stays legible
+        &--empty {
+            height: 1px !important;
+            opacity: 0.12;
+        }
+    }
+
+    // Horizontal line that tracks the current scroll position.
+    .agent-timeline-scroll-indicator {
+        position: absolute;
+        left: 1px;
+        right: 1px;
+        height: 2px;
+        background: var(--main-text-color, #fff);
+        opacity: 0.75;
+        border-radius: 1px;
+        pointer-events: none;
+        // Smooth scroll indicator movement on RAF updates
+        transition: top 0.1s linear;
+    }
+
+    // === Bookmarks ===
+
+    // Subtle left-border highlight on bookmarked nodes.
+    .agent-node-bookmarked {
+        border-left: 2px solid var(--warning-color, #eab308) !important;
+        padding-left: 2px;
+        position: relative;
+    }
+
+    // Small bookmark button shown on hover in the top-right corner of each node wrapper.
+    .agent-bookmark-btn {
+        position: absolute;
+        top: 2px;
+        right: 2px;
+        width: 18px;
+        height: 18px;
+        padding: 0;
+        background: none;
+        border: none;
+        border-radius: 3px;
+        font-size: 11px;
+        line-height: 18px;
+        text-align: center;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+        opacity: 0;
+        transition: opacity 0.12s, color 0.12s, background 0.12s;
+        z-index: 2;
+        user-select: none;
+
+        &--active {
+            color: var(--warning-color, #eab308);
+            opacity: 0.9;
+        }
+
+        &:hover {
+            background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
+            color: var(--warning-color, #eab308);
+        }
+    }
+
+    // Show the bookmark button when the parent wrapper is hovered.
+    .agent-document-node-wrapper:hover .agent-bookmark-btn {
+        opacity: 0.7;
+    }
+
+    // Node wrapper must be position:relative so the absolute bookmark btn works.
+    .agent-document-node-wrapper {
+        position: relative;
+    }
+
+    // === Bookmarks Panel ===
+    .agent-bookmarks-panel {
+        flex-shrink: 0;
+        border-bottom: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--warning-color, #eab308) 4%, var(--main-bg-color));
+        font-size: 12px;
+        max-height: 220px;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .agent-bookmarks-header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 8px;
+        cursor: pointer;
+        user-select: none;
+        border-bottom: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--warning-color, #eab308) 6%, var(--main-bg-color));
+        flex-shrink: 0;
+
+        &:hover {
+            background: color-mix(in srgb, var(--warning-color, #eab308) 10%, var(--main-bg-color));
+        }
+    }
+
+    .agent-bookmarks-icon {
+        font-size: 13px;
+        flex-shrink: 0;
+    }
+
+    .agent-bookmarks-title {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--main-text-color);
+        flex: 1;
+        text-transform: uppercase;
+        letter-spacing: 0.4px;
+    }
+
+    .agent-bookmarks-count {
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
+        border-radius: 8px;
+        padding: 1px 6px;
+        min-width: 16px;
+        text-align: center;
+    }
+
+    .agent-bookmarks-chevron {
+        font-size: 9px;
+        color: var(--secondary-text-color);
+        flex-shrink: 0;
+    }
+
+    .agent-bookmarks-list {
+        overflow-y: auto;
+        flex: 1;
+        padding: 2px 0;
+    }
+
+    .agent-bookmarks-empty {
+        padding: 8px 10px;
+        font-size: 11px;
+        color: var(--secondary-text-color);
+        font-style: italic;
+        text-align: center;
+    }
+
+    .agent-bookmark-entry {
+        padding: 4px 8px;
+        cursor: pointer;
+        transition: background 0.1s;
+        border-bottom: 1px solid color-mix(in srgb, var(--border-color) 50%, transparent);
+
+        &:last-child {
+            border-bottom: none;
+        }
+
+        &:hover {
+            background: color-mix(in srgb, var(--accent-color) 8%, transparent);
+        }
+    }
+
+    .agent-bookmark-entry-main {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+    }
+
+    .agent-bookmark-label {
+        flex: 1;
+        font-size: 11px;
+        font-weight: 500;
+        color: var(--main-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        cursor: text;
+    }
+
+    .agent-bookmark-rename-input {
+        flex: 1;
+        font-size: 11px;
+        font-family: inherit;
+        background: var(--main-bg-color);
+        color: var(--main-text-color);
+        border: 1px solid var(--accent-color);
+        border-radius: 2px;
+        padding: 1px 4px;
+        outline: none;
+        min-width: 0;
+    }
+
+    .agent-bookmark-time {
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        flex-shrink: 0;
+        opacity: 0.7;
+        white-space: nowrap;
+    }
+
+    .agent-bookmark-delete {
+        flex-shrink: 0;
+        width: 16px;
+        height: 16px;
+        padding: 0;
+        background: none;
+        border: none;
+        border-radius: 2px;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+        font-size: 13px;
+        line-height: 16px;
+        text-align: center;
+        opacity: 0;
+        transition: opacity 0.1s, color 0.1s;
+
+        .agent-bookmark-entry:hover & {
+            opacity: 0.6;
+        }
+
+        &:hover {
+            opacity: 1 !important;
+            color: var(--error-color);
+        }
+    }
+
+    .agent-bookmark-preview {
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        opacity: 0.65;
+        margin-top: 1px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-family: var(--fixed-font, monospace);
+    }
 }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -551,12 +551,23 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
                     const nodes = parseHistoryLines(rangeResp.lines ?? [], outputFormat());
                     if (nodes.length > 0) {
-                        const [, setDoc] = agentAtoms().documentAtom;
-                        setDoc(nodes);
-                        // Notify useAgentStream to seed its indices from the
-                        // just-loaded history. Safe even if this fires before
-                        // or after useAgentStream mounts — the effect rebuilds
-                        // indices idempotently from current document state.
+                        const [doc, setDoc] = agentAtoms().documentAtom;
+                        // Prepend history to whatever is already in the
+                        // document. If useAgentStream has already captured
+                        // live events during the async history load, we
+                        // must not discard them. Dedupe by id — history
+                        // nodes and live nodes can overlap briefly during
+                        // a reconnect where an in-flight turn is also
+                        // visible in the persisted ring buffer.
+                        setDoc((prev) => {
+                            if (prev.length === 0) return nodes;
+                            const seen = new Set(prev.map((n) => n.id));
+                            const historyFresh = nodes.filter((n) => !seen.has(n.id));
+                            return [...historyFresh, ...prev];
+                        });
+                        // Notify useAgentStream to rebuild its nodeIdSet
+                        // and nodeIndexMap from the merged document so
+                        // subsequent live updates target correct indices.
                         bumpDocumentVersion();
                     }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -7,13 +7,14 @@ import type { AgentViewModel } from "./agent-model";
 import { buildRuntimeArgs, getRuntimeConfig } from "./buildRuntimeArgs";
 import { getProvider, type ProviderDefinition } from "./providers";
 import { createAgentAtoms } from "./state";
-import type { DocumentNode, SubagentLinkNode } from "./types";
+import type { Bookmark, DocumentNode, SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
 import { parseHistoryLines } from "./parseHistoryLines";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
+import { BookmarksPanel } from "./components/BookmarksPanel";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
 import { waveEventSubscribe } from "@/app/store/wps";
@@ -655,6 +656,16 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             },
         });
         onCleanup(() => unsubCompleted());
+
+        // Ctrl+B — toggle bookmarks panel
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.ctrlKey && e.key === "b") {
+                e.preventDefault();
+                setShowBookmarks((v) => !v);
+            }
+        };
+        window.addEventListener("keydown", handleKeyDown);
+        onCleanup(() => window.removeEventListener("keydown", handleKeyDown));
     });
 
     // Subscribe to subprocess output and parse into DocumentNodes.
@@ -776,6 +787,102 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         }
     };
 
+    // Session timeline metadata — read from block meta so the minimap knows
+    // the real time range of the session (set by the backend as activity flows).
+    const sessionStartTsMs = createMemo<number | null>(() => {
+        const v = block()?.meta?.["session:start_ts_ms"];
+        return typeof v === "number" ? v : null;
+    });
+    const sessionLastActivityMs = createMemo<number | null>(() => {
+        const v = block()?.meta?.["session:last_activity_ms"];
+        return typeof v === "number" ? v : null;
+    });
+
+    // ── Bookmarks ───────────────────────────────────────────────────────────────
+
+    // Read bookmarks reactively from block meta ("agent:bookmarks").
+    const bookmarks = createMemo<Bookmark[]>(() => {
+        const raw = block()?.meta?.["agent:bookmarks"];
+        if (!Array.isArray(raw)) return [];
+        return raw as Bookmark[];
+    });
+
+    // Derived set of bookmarked nodeIds for O(1) look-up in the renderer.
+    const bookmarkedNodeIds = createMemo<Set<string>>(
+        () => new Set(bookmarks().map((b) => b.nodeId)),
+    );
+
+    // Whether the bookmarks panel is visible.
+    const [showBookmarks, setShowBookmarks] = createSignal(false);
+
+    // Mutable ref to the scrollToNode function exposed by AgentDocumentView.
+    let scrollToNodeFn: ((nodeId: string) => void) | null = null;
+
+    const saveBookmarks = async (next: Bookmark[]): Promise<void> => {
+        await RpcApi.SetMetaCommand(TabRpcClient, {
+            oref: WOS.makeORef("block", model.blockId),
+            meta: { "agent:bookmarks": next },
+        });
+    };
+
+    /** Extract plain text preview from a DocumentNode (≤80 chars). */
+    const nodePreview = (node: DocumentNode): string => {
+        let raw = "";
+        switch (node.type) {
+            case "markdown":    raw = node.content; break;
+            case "user_message": raw = node.message; break;
+            case "tool":        raw = node.summary || node.tool; break;
+            case "agent_message": raw = node.summary || node.message; break;
+            case "section":     raw = node.title; break;
+            case "subagent_link": raw = node.slug || node.subagentId; break;
+        }
+        return raw.replace(/\s+/g, " ").trim().slice(0, 80);
+    };
+
+    const handleBookmark = (node: DocumentNode): void => {
+        const current = bookmarks();
+        const existingIdx = current.findIndex((b) => b.nodeId === node.id);
+        let next: Bookmark[];
+        if (existingIdx >= 0) {
+            // Remove existing bookmark
+            next = current.filter((_, i) => i !== existingIdx);
+        } else {
+            const preview = nodePreview(node);
+            const label = preview.slice(0, 60) || node.id;
+            const newBookmark: Bookmark = {
+                id: crypto.randomUUID(),
+                nodeId: node.id,
+                createdAt: Date.now(),
+                label,
+                preview,
+            };
+            next = [...current, newBookmark];
+            // Open the panel on first bookmark
+            setShowBookmarks(true);
+        }
+        saveBookmarks(next).catch((err) => {
+            log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    const handleBookmarkDelete = (id: string): void => {
+        const next = bookmarks().filter((b) => b.id !== id);
+        saveBookmarks(next).catch((err) => {
+            log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    const handleBookmarkRename = (id: string, label: string): void => {
+        const next = bookmarks().map((b) => (b.id === id ? { ...b, label } : b));
+        saveBookmarks(next).catch((err) => {
+            log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    const handleBookmarkJump = (nodeId: string): void => {
+        if (scrollToNodeFn) scrollToNodeFn(nodeId);
+    };
+
     // Per-pane zoom: read term:zoom from block meta (same key as terminal panes)
     const zoomFactor = createMemo(() => {
         const meta = block()?.meta;
@@ -834,6 +941,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 providerId={provider()?.id ?? ""}
             />
 
+            <Show when={showBookmarks()}>
+                <BookmarksPanel
+                    bookmarks={bookmarks}
+                    onJump={handleBookmarkJump}
+                    onDelete={handleBookmarkDelete}
+                    onRename={handleBookmarkRename}
+                />
+            </Show>
+
             <AgentDocumentView
                 documentAtom={agentAtoms().documentAtom}
                 documentStateAtom={agentAtoms().documentStateAtom}
@@ -842,6 +958,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 onSubagentClick={handleSubagentClick}
                 onLoadOlder={loadOlder}
                 loadingOlder={loadingOlder}
+                startTsMs={sessionStartTsMs}
+                endTsMs={sessionLastActivityMs}
+                bookmarkedNodeIds={bookmarkedNodeIds}
+                onBookmark={handleBookmark}
+                scrollToNodeRef={(fn) => { scrollToNodeFn = fn; }}
             />
 
             <Show when={loginWaiting()}>

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -10,6 +10,7 @@ import { createAgentAtoms } from "./state";
 import type { DocumentNode, SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
+import { parseHistoryLines } from "./parseHistoryLines";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
@@ -383,6 +384,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     const agentAtoms = createMemo(() => createAgentAtoms(model.blockId));
 
+    // ── History pagination state ────────────────────────────────────────────────
+    // These track the window of lines we've loaded from the persisted blockfile.
+    // historyOffset = the line index where the currently-loaded slice starts.
+    // historyTotal  = total lines in the file (from session:line_count meta).
+    const [historyOffset, setHistoryOffset] = createSignal(0);
+    const [historyTotal, setHistoryTotal] = createSignal(0);
+    const [loadingOlder, setLoadingOlder] = createSignal(false);
+
     // Accumulated terminal-style log lines
     type LogLine = { tag: string; text: string; level?: "info" | "error" | "warn" };
     const [logLines, setLogLines] = createSignal<LogLine[]>([]);
@@ -417,6 +426,40 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             return env;
         } catch {
             return undefined; // non-fatal — fall back to default auth dir
+        }
+    };
+
+    // Load the previous page of history (prepend to document).
+    // Called by AgentDocumentView when the user scrolls near the top.
+    const loadOlder = async (): Promise<void> => {
+        const currentOffset = historyOffset();
+        if (currentOffset === 0) return; // already at the beginning
+        if (loadingOlder()) return;
+
+        setLoadingOlder(true);
+        try {
+            const newOffset = Math.max(0, currentOffset - 200);
+            const loadLimit = currentOffset - newOffset;
+
+            const resp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                block_id: model.blockId,
+                filename: "output",
+                offset: newOffset,
+                limit: loadLimit,
+            }, { timeout: 15000 });
+
+            const newNodes = parseHistoryLines(resp.lines ?? [], outputFormat());
+            if (newNodes.length > 0) {
+                const [, setDoc] = agentAtoms().documentAtom;
+                setDoc((prev) => [...newNodes, ...prev]);
+            }
+
+            setHistoryOffset(newOffset);
+            log("history", `loaded ${newNodes.length} older messages (offset ${newOffset})`);
+        } catch (err: any) {
+            log("history", `failed to load older messages: ${err?.message ?? String(err)}`, "warn");
+        } finally {
+            setLoadingOlder(false);
         }
     };
 
@@ -472,6 +515,47 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
         log("agent", `${name} selected (provider: ${provName})`);
         if (cwd) log("env", `working directory: ${cwd}`);
+
+        // Load persisted session history before starting the live stream.
+        // We do this asynchronously so the UI isn't blocked, but we fire it
+        // immediately so history appears as early as possible.
+        (async () => {
+            try {
+                const countResp = await RpcApi.BlockfileLineCountCommand(TabRpcClient, {
+                    block_id: model.blockId,
+                    filename: "output",
+                }, { timeout: 5000 });
+
+                const total = countResp?.count ?? 0;
+                if (total > 0) {
+                    const pageSize = 200;
+                    const offset = Math.max(0, total - pageSize);
+                    const limit = total - offset;
+
+                    const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                        block_id: model.blockId,
+                        filename: "output",
+                        offset,
+                        limit,
+                    }, { timeout: 15000 });
+
+                    const nodes = parseHistoryLines(rangeResp.lines ?? [], outputFormat());
+                    if (nodes.length > 0) {
+                        const [, setDoc] = agentAtoms().documentAtom;
+                        setDoc(nodes);
+                    }
+
+                    // Store pagination state for subsequent loadOlder() calls
+                    setHistoryOffset(offset);
+                    setHistoryTotal(total);
+
+                    log("history", `loaded ${nodes.length} of ${total} previous messages`);
+                }
+            } catch (err: any) {
+                // Non-fatal — fresh session or backend not ready yet
+                log("history", `could not load history: ${err?.message ?? String(err)}`, "warn");
+            }
+        })();
 
         // Full launch flow: CLI resolution → auth check → controller registration
         startLaunchFlow();
@@ -721,6 +805,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 logLines={logLines}
                 authUrl={authUrl}
                 onSubagentClick={handleSubagentClick}
+                onLoadOlder={loadOlder}
+                loadingOlder={loadingOlder}
             />
 
             <Show when={loginWaiting()}>

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -392,6 +392,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const [historyTotal, setHistoryTotal] = createSignal(0);
     const [loadingOlder, setLoadingOlder] = createSignal(false);
 
+    // Bumped on every external document mutation (history load, prepend).
+    // useAgentStream watches this and rebuilds its internal nodeIdSet +
+    // nodeIndexMap so live-stream updates continue targeting the right
+    // node indices after the document has been reshaped from outside.
+    const [documentVersion, setDocumentVersion] = createSignal(0);
+    const bumpDocumentVersion = () => setDocumentVersion((v) => v + 1);
+
     // Accumulated terminal-style log lines
     type LogLine = { tag: string; text: string; level?: "info" | "error" | "warn" };
     const [logLines, setLogLines] = createSignal<LogLine[]>([]);
@@ -452,6 +459,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             if (newNodes.length > 0) {
                 const [, setDoc] = agentAtoms().documentAtom;
                 setDoc((prev) => [...newNodes, ...prev]);
+                // Notify useAgentStream to rebuild its index map so live
+                // updates target the correct nodes after the prepend.
+                bumpDocumentVersion();
             }
 
             setHistoryOffset(newOffset);
@@ -543,13 +553,23 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     if (nodes.length > 0) {
                         const [, setDoc] = agentAtoms().documentAtom;
                         setDoc(nodes);
+                        // Notify useAgentStream to seed its indices from the
+                        // just-loaded history. Safe even if this fires before
+                        // or after useAgentStream mounts — the effect rebuilds
+                        // indices idempotently from current document state.
+                        bumpDocumentVersion();
                     }
 
-                    // Store pagination state for subsequent loadOlder() calls
+                    // Store pagination state for subsequent loadOlder() calls.
+                    // `resp.total` from the backend is the actual available
+                    // line count (clamped to the event ring buffer window),
+                    // not the all-time session:line_count. Use it so the
+                    // frontend never asks for offsets the backend can't serve.
+                    const available = rangeResp.total ?? total;
                     setHistoryOffset(offset);
-                    setHistoryTotal(total);
+                    setHistoryTotal(available);
 
-                    log("history", `loaded ${nodes.length} of ${total} previous messages`);
+                    log("history", `loaded ${nodes.length} of ${available} previous messages`);
                 }
             } catch (err: any) {
                 // Non-fatal — fresh session or backend not ready yet
@@ -626,13 +646,17 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         onCleanup(() => unsubCompleted());
     });
 
-    // Subscribe to subprocess output and parse into DocumentNodes
+    // Subscribe to subprocess output and parse into DocumentNodes.
+    // `documentVersion` is bumped whenever we mutate the document externally
+    // (history load / prepend), causing useAgentStream to rebuild its
+    // nodeIdSet and nodeIndexMap.
     useAgentStream({
         blockId: model.blockId,
         outputFormat: outputFormat(),
         documentAtom: agentAtoms().documentAtom,
         streamingStateAtom: agentAtoms().streamingStateAtom,
         enabled: true,
+        documentVersion,
     });
 
     // Send user message

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -27,13 +27,19 @@ interface AgentDocumentViewProps {
     logLines: Accessor<LogLine[]>;
     authUrl?: Accessor<string | null>;
     onSubagentClick?: (node: SubagentLinkNode) => void;
+    /** Called when the user scrolls near the top — load the previous page of history. */
+    onLoadOlder?: () => Promise<void>;
+    /** Whether an older-history load is currently in progress. */
+    loadingOlder?: Accessor<boolean>;
 }
 
-export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick }: AgentDocumentViewProps): JSX.Element => {
+export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick, onLoadOlder, loadingOlder }: AgentDocumentViewProps): JSX.Element => {
     const [document] = documentAtom;
     const [documentState, setDocumentState] = documentStateAtom;
     let scrollRef!: HTMLDivElement;
     let autoScroll = true;
+    // Guard against concurrent older-history fetches triggered by scroll
+    let loadingOlderInFlight = false;
 
     // Toggle collapsed state for a node
     const toggleCollapse = (nodeId: string) => {
@@ -73,11 +79,37 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
         if (scrollRafId != null) cancelAnimationFrame(scrollRafId);
     });
 
-    // Detect if user scrolled up (disable auto-scroll)
+    // Detect if user scrolled up (disable auto-scroll) and trigger older-history load
     const handleScroll = () => {
         if (!scrollRef) return;
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
         autoScroll = scrollHeight - scrollTop - clientHeight < 50;
+
+        // Trigger older-history load when near the top
+        if (
+            onLoadOlder &&
+            scrollTop < 50 &&
+            !loadingOlderInFlight &&
+            !(loadingOlder?.())
+        ) {
+            // Snapshot scroll anchor before content is prepended
+            const snapshotScrollHeight = scrollHeight;
+            const snapshotScrollTop = scrollTop;
+            loadingOlderInFlight = true;
+            onLoadOlder().then(() => {
+                // Restore scroll position so the user's viewport doesn't jump.
+                // Use a RAF so the DOM has updated with the new nodes first.
+                requestAnimationFrame(() => {
+                    if (scrollRef) {
+                        scrollRef.scrollTop =
+                            scrollRef.scrollHeight - snapshotScrollHeight + snapshotScrollTop;
+                    }
+                    loadingOlderInFlight = false;
+                });
+            }).catch(() => {
+                loadingOlderInFlight = false;
+            });
+        }
     };
 
     return (
@@ -86,6 +118,11 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
             ref={scrollRef}
             onScroll={handleScroll}
         >
+            {/* Older-history loading indicator — pinned at the very top */}
+            <Show when={loadingOlder?.()}>
+                <div class="agent-history-loading">Loading older messages...</div>
+            </Show>
+
             {/* Log lines always shown at the top */}
             <Show when={logLines().length > 0}>
                 <div class="agent-status-log">

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -7,13 +7,15 @@
  * When no document nodes exist yet, shows accumulated log lines (terminal-style).
  */
 
-import { createEffect, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
+import { createEffect, createSignal, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import { AgentMessageBlock } from "./AgentMessageBlock";
+import { AgentTimeline } from "./AgentTimeline";
 import { MarkdownBlock } from "./MarkdownBlock";
 import { SubagentLinkBlock } from "./SubagentLinkBlock";
 import { ToolBlock } from "./ToolBlock";
+import { ContextMenuModel } from "@/app/store/contextmenu";
 
 export interface LogLine {
     tag: string;        // "agent", "cli", "auth", "env", "error", etc.
@@ -31,15 +33,41 @@ interface AgentDocumentViewProps {
     onLoadOlder?: () => Promise<void>;
     /** Whether an older-history load is currently in progress. */
     loadingOlder?: Accessor<boolean>;
+    /** session:start_ts_ms from block meta — enables the timeline minimap. */
+    startTsMs?: Accessor<number | null>;
+    /** session:last_activity_ms from block meta — enables the timeline minimap. */
+    endTsMs?: Accessor<number | null>;
+    /** Set of bookmarked node IDs — drives the bookmarked visual indicator. */
+    bookmarkedNodeIds?: Accessor<Set<string>>;
+    /** Called when the user bookmarks or un-bookmarks a node via context menu. */
+    onBookmark?: (node: DocumentNode) => void;
+    /** Expose a scrollToNode function to the parent for jump-to-bookmark support. */
+    scrollToNodeRef?: (fn: (nodeId: string) => void) => void;
 }
 
-export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick, onLoadOlder, loadingOlder }: AgentDocumentViewProps): JSX.Element => {
+export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick, onLoadOlder, loadingOlder, startTsMs, endTsMs, bookmarkedNodeIds, onBookmark, scrollToNodeRef }: AgentDocumentViewProps): JSX.Element => {
     const [document] = documentAtom;
     const [documentState, setDocumentState] = documentStateAtom;
     let scrollRef!: HTMLDivElement;
     let autoScroll = true;
     // Guard against concurrent older-history fetches triggered by scroll
     let loadingOlderInFlight = false;
+    // 0..1 fraction of the current scroll position within the document
+    const [scrollFraction, setScrollFraction] = createSignal(0);
+
+    // Scroll to a node by its data-node-id attribute.
+    // Exposed to the parent via scrollToNodeRef so BookmarksPanel can call it.
+    const scrollToNode = (nodeId: string) => {
+        const el = scrollRef?.querySelector(`[data-node-id="${nodeId}"]`);
+        if (el) {
+            el.scrollIntoView({ behavior: "smooth", block: "center" });
+            // Disable auto-scroll after a manual jump
+            autoScroll = false;
+        }
+    };
+
+    // Expose scrollToNode to the parent on mount
+    if (scrollToNodeRef) scrollToNodeRef(scrollToNode);
 
     // Toggle collapsed state for a node
     const toggleCollapse = (nodeId: string) => {
@@ -85,6 +113,10 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
         autoScroll = scrollHeight - scrollTop - clientHeight < 50;
 
+        // Update timeline scroll indicator
+        const maxScroll = scrollHeight - clientHeight;
+        setScrollFraction(maxScroll > 0 ? Math.min(1, scrollTop / maxScroll) : 0);
+
         // Trigger older-history load when near the top
         if (
             onLoadOlder &&
@@ -112,7 +144,18 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
         }
     };
 
+    // Called when the user clicks the timeline — scroll the document to that position.
+    const handleTimelineJump = (fraction: number) => {
+        if (!scrollRef) return;
+        const { scrollHeight, clientHeight } = scrollRef;
+        const maxScroll = scrollHeight - clientHeight;
+        scrollRef.scrollTop = fraction * maxScroll;
+        // Disable auto-scroll when the user manually jumps to a position
+        autoScroll = fraction >= 0.98;
+    };
+
     return (
+        <div class="agent-document-wrapper">
         <div
             class="agent-document"
             ref={scrollRef}
@@ -164,17 +207,65 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                 skip layout/paint for off-screen nodes — critical for
                 long sessions where thousands of DOM elements accumulate. */}
             <For each={document()}>
-                {(node) => (
-                    <div class="agent-document-node-wrapper">
-                        <DocumentNodeRenderer
-                            node={node}
-                            collapsed={documentState().collapsedNodes.has(node.id)}
-                            onToggle={() => toggleCollapse(node.id)}
-                            onSubagentClick={onSubagentClick}
-                        />
-                    </div>
-                )}
+                {(node) => {
+                    const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
+
+                    const handleContextMenu = (e: MouseEvent) => {
+                        if (!onBookmark) return;
+                        // Don't show bookmark menu on top of text selections — let the parent handle those.
+                        const sel = window.getSelection()?.toString();
+                        if (sel) return;
+                        e.preventDefault();
+                        e.stopPropagation();
+                        ContextMenuModel.showContextMenu(
+                            [
+                                {
+                                    label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
+                                    click: () => onBookmark(node),
+                                },
+                            ],
+                            e,
+                        );
+                    };
+
+                    return (
+                        <div
+                            class="agent-document-node-wrapper"
+                            classList={{ "agent-node-bookmarked": isBookmarked() }}
+                            data-node-id={node.id}
+                            onContextMenu={handleContextMenu}
+                        >
+                            {/* Bookmark indicator button — shown on hover */}
+                            <Show when={onBookmark != null}>
+                                <button
+                                    class="agent-bookmark-btn"
+                                    classList={{ "agent-bookmark-btn--active": isBookmarked() }}
+                                    onClick={(e) => { e.stopPropagation(); onBookmark!(node); }}
+                                    title={isBookmarked() ? "Remove bookmark" : "Bookmark this message"}
+                                >
+                                    {isBookmarked() ? "\uD83D\uDD16" : "\uD83D\uDD16"}
+                                </button>
+                            </Show>
+                            <DocumentNodeRenderer
+                                node={node}
+                                collapsed={documentState().collapsedNodes.has(node.id)}
+                                onToggle={() => toggleCollapse(node.id)}
+                                onSubagentClick={onSubagentClick}
+                            />
+                        </div>
+                    );
+                }}
             </For>
+        </div>
+        <Show when={startTsMs != null && endTsMs != null}>
+            <AgentTimeline
+                document={document}
+                startTsMs={startTsMs ?? (() => null)}
+                endTsMs={endTsMs ?? (() => null)}
+                scrollPosition={scrollFraction}
+                onJump={handleTimelineJump}
+            />
+        </Show>
         </div>
     );
 };

--- a/frontend/app/view/agent/components/AgentTimeline.tsx
+++ b/frontend/app/view/agent/components/AgentTimeline.tsx
@@ -1,0 +1,120 @@
+// Copyright 2025, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentTimeline — compact vertical minimap shown in the right gutter of the
+ * agent document view.
+ *
+ * - Divides the session time range into ~30 activity buckets.
+ * - Renders a proportional bar for each bucket (height = message density).
+ * - Overlays a thin horizontal line at the current scroll position.
+ * - Clicking anywhere on the track calls onJump(fraction) so the parent can
+ *   scroll the document to the equivalent position.
+ */
+
+import { createMemo, For, Show, type Accessor, type JSX } from "solid-js";
+import type { DocumentNode } from "../types";
+
+interface AgentTimelineProps {
+    document: Accessor<DocumentNode[]>;
+    /** session:start_ts_ms from block meta (ms since epoch) */
+    startTsMs: Accessor<number | null>;
+    /** session:last_activity_ms from block meta (ms since epoch) */
+    endTsMs: Accessor<number | null>;
+    /** Current scroll fraction in the document container, 0..1 */
+    scrollPosition: Accessor<number>;
+    /** Called with 0..1 fraction when the user clicks the track */
+    onJump: (fraction: number) => void;
+}
+
+const BUCKET_COUNT = 30;
+
+/** Format a ms-epoch timestamp as HH:MM (locale-aware). */
+function formatTime(ms: number): string {
+    const d = new Date(ms);
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export const AgentTimeline = (props: AgentTimelineProps): JSX.Element => {
+    // Divide the session time range into BUCKET_COUNT slices and count nodes
+    // per slice. Nodes that carry an explicit `timestamp` field are placed into
+    // their true bucket; those without one are distributed uniformly by index.
+    const buckets = createMemo(() => {
+        const start = props.startTsMs();
+        const end = props.endTsMs();
+        const nodes = props.document();
+        if (!start || !end || end <= start || nodes.length === 0) return [];
+
+        const range = end - start;
+        const bucketSize = range / BUCKET_COUNT;
+        const counts = new Array<number>(BUCKET_COUNT).fill(0);
+
+        for (let i = 0; i < nodes.length; i++) {
+            const n = nodes[i];
+            let ts: number;
+            if (typeof (n as any).timestamp === "number") {
+                ts = (n as any).timestamp as number;
+            } else {
+                // Fall back to linear interpolation by node index
+                ts = start + (range * i) / nodes.length;
+            }
+            const bucket = Math.min(
+                BUCKET_COUNT - 1,
+                Math.max(0, Math.floor((ts - start) / bucketSize)),
+            );
+            counts[bucket]++;
+        }
+
+        const maxCount = Math.max(...counts, 1);
+        return counts.map((c, i) => ({
+            index: i,
+            count: c,
+            // Height as percentage of the tallest bucket (never 0 — give empty
+            // buckets a 1px minimum so the track still looks anchored)
+            heightPct: c > 0 ? Math.max(8, (c / maxCount) * 100) : 0,
+            tsMs: start + i * bucketSize,
+        }));
+    });
+
+    const handleClick = (e: MouseEvent) => {
+        const target = e.currentTarget as HTMLDivElement;
+        const rect = target.getBoundingClientRect();
+        const fraction = (e.clientY - rect.top) / rect.height;
+        props.onJump(Math.max(0, Math.min(1, fraction)));
+    };
+
+    return (
+        <Show when={props.startTsMs() != null && props.endTsMs() != null}>
+            <div class="agent-timeline" title="Session timeline — click to jump">
+                <div class="agent-timeline-label agent-timeline-label--top">
+                    {formatTime(props.startTsMs()!)}
+                </div>
+                <div class="agent-timeline-track" onClick={handleClick}>
+                    {/* Activity density bars */}
+                    <div class="agent-timeline-bars">
+                        <For each={buckets()}>
+                            {(b) => (
+                                <div
+                                    class="agent-timeline-bar"
+                                    classList={{ "agent-timeline-bar--empty": b.count === 0 }}
+                                    style={{ height: `${b.heightPct}%` }}
+                                    title={`${b.count} message${b.count === 1 ? "" : "s"} around ${formatTime(b.tsMs)}`}
+                                />
+                            )}
+                        </For>
+                    </div>
+                    {/* Current scroll position indicator */}
+                    <div
+                        class="agent-timeline-scroll-indicator"
+                        style={{ top: `${props.scrollPosition() * 100}%` }}
+                    />
+                </div>
+                <div class="agent-timeline-label agent-timeline-label--bottom">
+                    {formatTime(props.endTsMs()!)}
+                </div>
+            </div>
+        </Show>
+    );
+};
+
+AgentTimeline.displayName = "AgentTimeline";

--- a/frontend/app/view/agent/components/BookmarksPanel.tsx
+++ b/frontend/app/view/agent/components/BookmarksPanel.tsx
@@ -1,0 +1,142 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BookmarksPanel — collapsible panel listing all bookmarks for the current agent pane.
+ *
+ * Bookmarks are stored in block meta under "agent:bookmarks" as a JSON array.
+ * Clicking a bookmark calls onJump which scrolls the matching node into view.
+ */
+
+import { createSignal, For, Show, type Accessor, type JSX } from "solid-js";
+import type { Bookmark } from "../types";
+
+export interface BookmarksPanelProps {
+    bookmarks: Accessor<Bookmark[]>;
+    onJump: (nodeId: string) => void;
+    onDelete: (id: string) => void;
+    onRename: (id: string, label: string) => void;
+}
+
+/**
+ * Format a Unix-ms timestamp as a short relative or absolute string.
+ */
+function formatTimestamp(ms: number): string {
+    const now = Date.now();
+    const diff = now - ms;
+    if (diff < 60_000) return "just now";
+    if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+    return new Date(ms).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export const BookmarksPanel = ({
+    bookmarks,
+    onJump,
+    onDelete,
+    onRename,
+}: BookmarksPanelProps): JSX.Element => {
+    const [collapsed, setCollapsed] = createSignal(false);
+    // Track which bookmark is being renamed
+    const [renamingId, setRenamingId] = createSignal<string | null>(null);
+    const [renameValue, setRenameValue] = createSignal("");
+
+    const sorted = () => [...bookmarks()].sort((a, b) => b.createdAt - a.createdAt);
+
+    const startRename = (bm: Bookmark, e: MouseEvent) => {
+        e.stopPropagation();
+        setRenamingId(bm.id);
+        setRenameValue(bm.label);
+    };
+
+    const commitRename = (id: string) => {
+        const val = renameValue().trim();
+        if (val) onRename(id, val);
+        setRenamingId(null);
+    };
+
+    const handleRenameKeyDown = (id: string, e: KeyboardEvent) => {
+        if (e.key === "Enter") commitRename(id);
+        if (e.key === "Escape") setRenamingId(null);
+    };
+
+    return (
+        <div class="agent-bookmarks-panel">
+            {/* Panel header */}
+            <div
+                class="agent-bookmarks-header"
+                onClick={() => setCollapsed((v) => !v)}
+                title={collapsed() ? "Show bookmarks" : "Hide bookmarks"}
+            >
+                <span class="agent-bookmarks-icon">&#x1F516;</span>
+                <span class="agent-bookmarks-title">Bookmarks</span>
+                <span class="agent-bookmarks-count">{bookmarks().length}</span>
+                <span class="agent-bookmarks-chevron">{collapsed() ? "\u25BA" : "\u25BC"}</span>
+            </div>
+
+            {/* Bookmark list */}
+            <Show when={!collapsed()}>
+                <Show
+                    when={sorted().length > 0}
+                    fallback={
+                        <div class="agent-bookmarks-empty">No bookmarks yet. Right-click a message to bookmark it.</div>
+                    }
+                >
+                    <div class="agent-bookmarks-list">
+                        <For each={sorted()}>
+                            {(bm) => (
+                                <div
+                                    class="agent-bookmark-entry"
+                                    onClick={() => onJump(bm.nodeId)}
+                                    title="Click to scroll to this message"
+                                >
+                                    <div class="agent-bookmark-entry-main">
+                                        {/* Label — editable on double-click */}
+                                        <Show
+                                            when={renamingId() === bm.id}
+                                            fallback={
+                                                <span
+                                                    class="agent-bookmark-label"
+                                                    onDblClick={(e) => startRename(bm, e)}
+                                                    title="Double-click to rename"
+                                                >
+                                                    {bm.label}
+                                                </span>
+                                            }
+                                        >
+                                            <input
+                                                class="agent-bookmark-rename-input"
+                                                value={renameValue()}
+                                                onInput={(e) => setRenameValue(e.currentTarget.value)}
+                                                onKeyDown={(e) => handleRenameKeyDown(bm.id, e)}
+                                                onBlur={() => commitRename(bm.id)}
+                                                onClick={(e) => e.stopPropagation()}
+                                                autofocus
+                                            />
+                                        </Show>
+
+                                        <span class="agent-bookmark-time">{formatTimestamp(bm.createdAt)}</span>
+
+                                        {/* Delete button */}
+                                        <button
+                                            class="agent-bookmark-delete"
+                                            onClick={(e) => { e.stopPropagation(); onDelete(bm.id); }}
+                                            title="Remove bookmark"
+                                        >
+                                            &times;
+                                        </button>
+                                    </div>
+
+                                    {/* Preview text */}
+                                    <div class="agent-bookmark-preview">{bm.preview}</div>
+                                </div>
+                            )}
+                        </For>
+                    </div>
+                </Show>
+            </Show>
+        </div>
+    );
+};
+
+BookmarksPanel.displayName = "BookmarksPanel";

--- a/frontend/app/view/agent/parseHistoryLines.ts
+++ b/frontend/app/view/agent/parseHistoryLines.ts
@@ -1,0 +1,61 @@
+// Copyright 2025, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * parseHistoryLines — batch-parse a slice of persisted NDJSON lines into
+ * DocumentNodes using the same pipeline as useAgentStream.
+ *
+ * This is a pure function (no signals, no side-effects) so it can be called
+ * from onMount without touching SolidJS reactivity.
+ */
+
+import { createTranslator } from "./providers/translator-factory";
+import { ClaudeCodeStreamParser } from "./stream-parser";
+import type { DocumentNode } from "./types";
+
+/**
+ * Parse an array of raw NDJSON lines (as stored in the "output" blockfile)
+ * and return the resulting DocumentNodes.
+ *
+ * @param lines        Raw text lines from blockfile:read_range
+ * @param outputFormat Provider output format string (e.g. "claude-stream-json")
+ * @returns            Ordered array of DocumentNodes, deduped by node id
+ */
+export function parseHistoryLines(
+    lines: string[],
+    outputFormat: string,
+): DocumentNode[] {
+    const translator = createTranslator(outputFormat);
+    const parser = new ClaudeCodeStreamParser();
+    const nodes: DocumentNode[] = [];
+    const seen = new Set<string>();
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || !trimmed.startsWith("{")) continue;
+
+        let rawEvent: any;
+        try {
+            rawEvent = JSON.parse(trimmed);
+        } catch {
+            // Corrupt line — skip silently (same as useAgentStream behaviour)
+            continue;
+        }
+
+        // Handle stderr events (unlikely in persisted history, but be safe)
+        if (rawEvent.type === "stderr") continue;
+
+        // Translate provider-specific envelope → StreamEvent[]
+        const streamEvents = translator.translate(rawEvent);
+
+        for (const event of streamEvents) {
+            const node = parser.parseLine(JSON.stringify(event));
+            if (!node) continue;
+            if (seen.has(node.id)) continue;
+            seen.add(node.id);
+            nodes.push(node);
+        }
+    }
+
+    return nodes;
+}

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -135,15 +135,11 @@ export class ClaudeTranslator implements OutputTranslator {
                 events.push({
                     type: "text",
                     content: block.text,
-                    messageId: message.id || `msg-${Date.now()}`,
-                    timestamp: Date.now(),
                 });
             } else if (block.type === "thinking" && block.thinking) {
                 events.push({
                     type: "thinking",
                     content: block.thinking,
-                    messageId: message.id || `msg-${Date.now()}`,
-                    timestamp: Date.now(),
                 });
             } else if (block.type === "tool_use") {
                 this.currentToolCallId = block.id;
@@ -153,10 +149,11 @@ export class ClaudeTranslator implements OutputTranslator {
                 }
                 events.push({
                     type: "tool_call",
-                    toolCallId: block.id,
-                    toolName: block.name,
-                    args: typeof block.input === "string" ? block.input : JSON.stringify(block.input || {}),
-                    timestamp: Date.now(),
+                    tool: block.name,
+                    id: block.id,
+                    params: typeof block.input === "object" && block.input !== null
+                        ? block.input
+                        : {},
                 });
             }
         }

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -242,6 +242,22 @@ export interface UserMessageEvent {
 }
 
 /**
+ * Bookmark — pins a document node for quick navigation.
+ * Stored as a JSON array under block meta key "agent:bookmarks".
+ *
+ * Known limitation: if the session is replayed from history, node IDs are
+ * regenerated (UUIDs) and will not match the stored nodeId. The `preview`
+ * text can be used as a fallback to search for the original content.
+ */
+export interface Bookmark {
+    id: string;       // uuid — unique bookmark identifier
+    nodeId: string;   // DocumentNode.id this bookmark points to
+    createdAt: number; // Unix ms
+    label: string;    // user-editable; defaults to first 60 chars of node content
+    preview: string;  // immutable snapshot of node content at bookmark time (80 chars)
+}
+
+/**
  * Document state (managed by Jotai atoms)
  */
 export interface DocumentState {

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -9,7 +9,7 @@
 
 import { getFileSubject } from "@/app/store/wps";
 import { base64ToArray } from "@/util/util";
-import { onCleanup, onMount } from "solid-js";
+import { createEffect, onCleanup, onMount } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import { ClaudeCodeStreamParser } from "./stream-parser";
 import type { SignalPair } from "./state";
@@ -23,6 +23,13 @@ interface UseAgentStreamOpts {
     documentAtom: SignalPair<DocumentNode[]>;
     streamingStateAtom: SignalPair<StreamingState>;
     enabled: boolean;
+    /**
+     * Version signal bumped by external document mutations (e.g. history
+     * load or prepend). When this changes, the hook rebuilds its internal
+     * `nodeIdSet` and `nodeIndexMap` from the current documentAtom so live
+     * updates continue to target the correct nodes.
+     */
+    documentVersion?: () => number;
 }
 
 /**
@@ -34,6 +41,7 @@ export function useAgentStream({
     documentAtom,
     streamingStateAtom,
     enabled,
+    documentVersion,
 }: UseAgentStreamOpts): void {
     const [, setDocument] = documentAtom;
     const [, setStreaming] = streamingStateAtom;
@@ -123,15 +131,34 @@ export function useAgentStream({
         pendingNew = [];
         pendingUpdates = [];
 
-        // Seed the dedup set from any history nodes already in the document
-        // (loaded by the history-load step in agent-view.tsx before this hook
-        // mounts). This prevents live-stream events from re-inserting nodes
-        // that were restored from persisted history.
         const [doc] = documentAtom;
-        const existingNodes = doc();
-        for (let i = 0; i < existingNodes.length; i++) {
-            nodeIdSet.add(existingNodes[i].id);
-            nodeIndexMap.set(existingNodes[i].id, i);
+
+        // Rebuild dedup set + index map from whatever is currently in the
+        // document. Called on mount and whenever `documentVersion()` changes
+        // (history load, history prepend). This keeps live-stream updates
+        // targeting the correct node indices after external mutations.
+        const rebuildIndicesFromDocument = () => {
+            const existingNodes = doc();
+            nodeIdSet = new Set();
+            nodeIndexMap = new Map();
+            for (let i = 0; i < existingNodes.length; i++) {
+                nodeIdSet.add(existingNodes[i].id);
+                nodeIndexMap.set(existingNodes[i].id, i);
+            }
+        };
+
+        // Initial seed — covers history nodes that were loaded before this
+        // hook mounted.
+        rebuildIndicesFromDocument();
+
+        // Reactive rebuild whenever the caller bumps documentVersion after
+        // an external prepend/load. The first invocation runs immediately
+        // (SolidJS semantics) which is fine — it's idempotent.
+        if (documentVersion != null) {
+            createEffect(() => {
+                documentVersion();
+                rebuildIndicesFromDocument();
+            });
         }
 
         setStreaming((prev) => ({ ...prev, active: true, lastEventTime: Date.now() }));

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -9,7 +9,7 @@
 
 import { getFileSubject } from "@/app/store/wps";
 import { base64ToArray } from "@/util/util";
-import { createEffect, onCleanup, onMount } from "solid-js";
+import { createEffect, onCleanup, onMount, untrack } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import { ClaudeCodeStreamParser } from "./stream-parser";
 import type { SignalPair } from "./state";
@@ -134,11 +134,13 @@ export function useAgentStream({
         const [doc] = documentAtom;
 
         // Rebuild dedup set + index map from whatever is currently in the
-        // document. Called on mount and whenever `documentVersion()` changes
-        // (history load, history prepend). This keeps live-stream updates
-        // targeting the correct node indices after external mutations.
+        // document. `doc()` is wrapped in `untrack` so the createEffect
+        // below only subscribes to documentVersion — NOT to the document
+        // signal itself. Without this, the rebuild would fire on every
+        // streaming flush (since flushPendingNodes calls setDoc), which
+        // would be O(n) per live event.
         const rebuildIndicesFromDocument = () => {
-            const existingNodes = doc();
+            const existingNodes = untrack(() => doc());
             nodeIdSet = new Set();
             nodeIndexMap = new Map();
             for (let i = 0; i < existingNodes.length; i++) {
@@ -151,7 +153,7 @@ export function useAgentStream({
         // hook mounted.
         rebuildIndicesFromDocument();
 
-        // Reactive rebuild whenever the caller bumps documentVersion after
+        // Reactive rebuild only when the caller bumps documentVersion after
         // an external prepend/load. The first invocation runs immediately
         // (SolidJS semantics) which is fine — it's idempotent.
         if (documentVersion != null) {

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -123,6 +123,17 @@ export function useAgentStream({
         pendingNew = [];
         pendingUpdates = [];
 
+        // Seed the dedup set from any history nodes already in the document
+        // (loaded by the history-load step in agent-view.tsx before this hook
+        // mounts). This prevents live-stream events from re-inserting nodes
+        // that were restored from persisted history.
+        const [doc] = documentAtom;
+        const existingNodes = doc();
+        for (let i = 0; i < existingNodes.length; i++) {
+            nodeIdSet.add(existingNodes[i].id);
+            nodeIndexMap.set(existingNodes[i].id, i);
+        }
+
         setStreaming((prev) => ({ ...prev, active: true, lastEventTime: Date.now() }));
 
         const fileSubject = getFileSubject(blockId, OutputFileName);

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -858,6 +858,10 @@ declare global {
             model?: string | null;
             effort?: string | null;
         };
+        "agent:bookmarks"?: unknown[];
+        "session:start_ts_ms"?: number;
+        "session:last_activity_ms"?: number;
+        "session:line_count"?: number;
         "subagent:*"?: boolean;
         "subagent:id"?: string;
         "subagent:slug"?: string;

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1641,6 +1641,31 @@ declare global {
         raw_output: string;
     };
 
+    // wshrpc.CommandBlockfileLineCountData
+    type CommandBlockfileLineCountData = {
+        block_id: string;
+        filename: string;
+    };
+
+    // wshrpc.BlockfileLineCountResult
+    type BlockfileLineCountResult = {
+        count: number;
+    };
+
+    // wshrpc.CommandBlockfileReadRangeData
+    type CommandBlockfileReadRangeData = {
+        block_id: string;
+        filename: string;
+        offset: number;
+        limit: number;
+    };
+
+    // wshrpc.BlockfileReadRangeResult
+    type BlockfileReadRangeResult = {
+        lines: string[];
+        total: number;
+    };
+
 }
 
 export {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.96",
+  "version": "0.33.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.96",
+      "version": "0.33.97",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.95",
+  "version": "0.33.96",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.95",
+      "version": "0.33.96",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.95",
+  "version": "0.33.96",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.96",
+  "version": "0.33.97",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Three phases of `docs/plans/ultra-long-sessions.md` delivered together (they're tightly interrelated).

### Phase 1.3 — Output segmentation (disk-backed persistence)
Every stdout line is now written through to the existing FileStore in addition to the WPS ring buffer. `blockfile:read_range` / `blockfile:line_count` prefer FileStore for historical data; ring buffer is a fallback. Sessions with >4096 events can now retrieve full history — the missing piece PR #338 flagged.

### Phase 2.4 — Timeline minimap
Vertical gutter on the right of the agent pane:
- Session start / end timestamps (from `session:start_ts_ms` / `session:last_activity_ms`)
- 30 activity density bars
- Scroll position indicator
- Click to jump

### Phase 3.2 — Bookmarks
- Right-click message → bookmark
- Ctrl+B toggles bookmarks panel
- Panel sorted by recency, rename (dclick) / delete / click to jump
- Persisted in `agent:bookmarks` block meta, survives pane close/reopen

## Composition rationale
- **Timeline reads session meta** from Phase 1.4 (PR #336) — no new data needed
- **Bookmarks use node IDs** from paginated history (PR #338) — known limitation that IDs differ across pane reopens (documented)
- **Output segmentation is the foundation** that makes timeline + bookmarks useful for multi-day sessions — without it, history paginates into the evicted void

## Not in this PR
- Phase 3.1 In-session search
- Phase 3.3 Session archival + cleanup
- Phase 3.4 AI session digest
- Phase 4 Resilience hardening

## Test plan
- [ ] Long session (1000+ messages): reopen pane → full history retrievable
- [ ] Close and restart AgentMux → session history persists on disk via FileStore
- [ ] Timeline minimap renders when session has >0 line count, click jumps scroll
- [ ] Right-click message → "Bookmark this message" → pin persists, appears in panel
- [ ] Ctrl+B toggles panel, click entry scrolls to node

🤖 Generated with [Claude Code](https://claude.com/claude-code)