### PR TITLE
feat: ultra-long sessions — output segmentation + timeline + bookmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.96"
+version = "0.33.97"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.96"
+version = "0.33.97"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.96"
+version = "0.33.97"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.96"
+version = "0.33.97"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.96"
+version = "0.33.97"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -27,6 +27,7 @@ use std::sync::{Arc, RwLock};
 use serde::{Deserialize, Serialize};
 
 use super::eventbus::EventBus;
+use super::storage::filestore::FileStore;
 use super::storage::wstore::WaveStore;
 use super::obj::{Block, MetaMapType, TermSize};
 use super::wps::Broker;
@@ -282,6 +283,7 @@ pub fn resync_controller(
     broker: Option<Arc<Broker>>,
     event_bus: Option<Arc<EventBus>>,
     wstore: Option<Arc<WaveStore>>,
+    filestore: Option<Arc<FileStore>>,
 ) -> Result<(), String> {
     let block_id = &block.oid;
     let block_meta = &block.meta;
@@ -356,6 +358,7 @@ pub fn resync_controller(
                 broker,
                 event_bus,
                 wstore,
+                filestore,
             );
             let ctrl = Arc::new(ctrl);
             register_controller(block_id, ctrl.clone());
@@ -368,6 +371,7 @@ pub fn resync_controller(
                 broker,
                 event_bus,
                 wstore,
+                filestore,
             );
             let ctrl = Arc::new(ctrl);
             register_controller(block_id, ctrl.clone());
@@ -511,7 +515,7 @@ mod tests {
             ..Default::default()
         };
         // No "controller" key in meta = no-op
-        let result = resync_controller(&block, "tab-1", None, false, None, None, None);
+        let result = resync_controller(&block, "tab-1", None, false, None, None, None, None);
         assert!(result.is_ok());
     }
 
@@ -528,7 +532,7 @@ mod tests {
             meta,
             ..Default::default()
         };
-        let result = resync_controller(&block, "tab-1", None, false, None, None, None);
+        let result = resync_controller(&block, "tab-1", None, false, None, None, None, None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("unknown controller type"));
     }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -32,6 +32,7 @@ use super::{
 };
 use super::health::{classify_output_line, HealthMonitor};
 use crate::backend::eventbus::EventBus;
+use crate::backend::storage::filestore::FileStore;
 use crate::backend::storage::wstore::WaveStore;
 use crate::backend::wps;
 
@@ -74,6 +75,8 @@ pub struct PersistentSubprocessController {
     broker: Option<Arc<wps::Broker>>,
     event_bus: Option<Arc<EventBus>>,
     wstore: Option<Arc<WaveStore>>,
+    /// FileStore for write-through persistence of output lines (Phase 1.3).
+    filestore: Option<Arc<FileStore>>,
     health_monitor: Arc<HealthMonitor>,
 }
 
@@ -84,6 +87,7 @@ impl PersistentSubprocessController {
         broker: Option<Arc<wps::Broker>>,
         event_bus: Option<Arc<EventBus>>,
         wstore: Option<Arc<WaveStore>>,
+        filestore: Option<Arc<FileStore>>,
     ) -> Self {
         let health_monitor = Arc::new(HealthMonitor::new(
             block_id.clone(),
@@ -104,6 +108,7 @@ impl PersistentSubprocessController {
             broker,
             event_bus,
             wstore,
+            filestore,
             health_monitor,
         }
     }
@@ -279,6 +284,7 @@ impl PersistentSubprocessController {
         let inner_read = Arc::clone(&self.inner);
         let wstore_read = self.wstore.clone();
         let event_bus_read = self.event_bus.clone();
+        let filestore_read = self.filestore.clone();
         let health_read = Arc::clone(&self.health_monitor);
         let session_id_field = config.session_id_field.clone();
 
@@ -354,7 +360,8 @@ impl PersistentSubprocessController {
                     }
                 }
 
-                // Publish line as WPS blockfile event
+                // Publish line as WPS blockfile event and write-through to FileStore
+                // for persistent history (Phase 1.3).
                 tracing::info!(
                     block_id = %block_id_read,
                     line_len = line.len(),
@@ -367,6 +374,7 @@ impl PersistentSubprocessController {
                         &block_id_read,
                         PERSISTENT_OUTPUT_SUBJECT,
                         line_with_newline.as_bytes(),
+                        filestore_read.as_ref(),
                     );
                 } else {
                     tracing::warn!(block_id = %block_id_read, "persistent stdout: no broker available");

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -36,6 +36,7 @@ use super::{
 };
 use crate::backend::eventbus::EventBus;
 use crate::backend::shellexec::{ConnInterface, ShellProc};
+use crate::backend::storage::filestore::FileStore;
 use crate::backend::storage::wstore::WaveStore;
 use crate::backend::obj::{self, MetaMapType};
 use crate::backend::wps;
@@ -731,6 +732,7 @@ impl Controller for ShellController {
                                 &block_id_read,
                                 "term",
                                 &buf[..n],
+                                None, // PTY output is raw terminal data; no FileStore write-through
                             );
                         }
                     }
@@ -912,16 +914,20 @@ impl Controller for ShellController {
 
 // ---- File operation helpers ----
 
-/// Append data to a block's terminal output file and publish a WPS event.
+/// Append data to a block's terminal output file, publish a WPS event,
+/// and write-through to FileStore (if provided).
+///
 /// Port of Go's `HandleAppendBlockFile`.
+///
+/// The FileStore write is fire-and-forget: if it fails we emit a warning but
+/// never propagate the error back to the hot stdout-reader path.
 pub fn handle_append_block_file(
     broker: &wps::Broker,
     block_id: &str,
     filename: &str,
     data: &[u8],
+    filestore: Option<&Arc<FileStore>>,
 ) {
-    // In a full implementation, this would also write to FileStore.
-    // For now, just publish the WPS event.
     let data64 = base64::engine::general_purpose::STANDARD.encode(data);
 
     let event_data = wps::WSFileEventData {
@@ -940,6 +946,56 @@ pub fn handle_append_block_file(
     };
 
     broker.publish(event);
+
+    // Write-through to FileStore for persistent history (Phase 1.3).
+    // Create the file lazily on first append; if the file already exists
+    // we skip make_file and go straight to append_data.
+    if let Some(fs) = filestore {
+        let needs_create = match fs.stat(block_id, filename) {
+            Ok(None) => true,
+            Ok(Some(_)) => false,
+            Err(e) => {
+                tracing::warn!(
+                    block_id = %block_id,
+                    filename = %filename,
+                    error = %e,
+                    "filestore stat failed; skipping write-through"
+                );
+                return;
+            }
+        };
+
+        if needs_create {
+            if let Err(e) = fs.make_file(
+                block_id,
+                filename,
+                std::collections::HashMap::new(),
+                crate::backend::storage::filestore::FileOpts::default(),
+            ) {
+                // AlreadyExists is benign (race between two appends); anything
+                // else is worth warning about.
+                use crate::backend::storage::error::StoreError;
+                if !matches!(e, StoreError::AlreadyExists) {
+                    tracing::warn!(
+                        block_id = %block_id,
+                        filename = %filename,
+                        error = %e,
+                        "filestore make_file failed; skipping write-through"
+                    );
+                    return;
+                }
+            }
+        }
+
+        if let Err(e) = fs.append_data(block_id, filename, data) {
+            tracing::warn!(
+                block_id = %block_id,
+                filename = %filename,
+                error = %e,
+                "filestore append_data failed"
+            );
+        }
+    }
 }
 
 /// Truncate a block's terminal output file and publish a WPS event.
@@ -1268,7 +1324,7 @@ mod tests {
             },
         );
 
-        handle_append_block_file(&broker, "block-1", "term", b"hello world");
+        handle_append_block_file(&broker, "block-1", "term", b"hello world", None);
 
         // Check event was published
         let _history = broker.read_event_history(wps::EVENT_BLOCK_FILE, "block:block-1", 10);
@@ -1327,7 +1383,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = super::super::resync_controller(&block, "tab-1", None, false, None, None, None);
+        let result = super::super::resync_controller(&block, "tab-1", None, false, None, None, None, None);
         assert!(result.is_ok());
 
         let ctrl = super::super::get_controller("resync-test-block");
@@ -1336,5 +1392,54 @@ mod tests {
 
         // Cleanup
         super::super::delete_controller("resync-test-block");
+    }
+
+    /// Phase 1.3 integration test: write output via handle_append_block_file with a
+    /// FileStore, then verify the data is readable back from the store.
+    #[test]
+    fn test_handle_append_block_file_writes_to_filestore() {
+        use crate::backend::storage::filestore::FileStore;
+        use std::sync::Arc;
+
+        let broker = wps::Broker::new();
+        let fs = Arc::new(FileStore::open_in_memory().expect("open in-memory filestore"));
+
+        let block_id = "test-block-fs";
+        let filename = "output";
+
+        // First append — file does not exist yet; handle_append_block_file must create it lazily.
+        let line1 = b"line one\n";
+        handle_append_block_file(&broker, block_id, filename, line1, Some(&fs));
+
+        // Second append
+        let line2 = b"line two\n";
+        handle_append_block_file(&broker, block_id, filename, line2, Some(&fs));
+
+        // Read back from FileStore
+        let data = fs.read_file(block_id, filename)
+            .expect("read_file ok")
+            .expect("data present");
+
+        let text = String::from_utf8(data).expect("valid utf8");
+        assert!(text.contains("line one"), "expected 'line one' in {:?}", text);
+        assert!(text.contains("line two"), "expected 'line two' in {:?}", text);
+
+        // Also verify total size matches
+        let stat = fs.stat(block_id, filename).unwrap().unwrap();
+        assert_eq!(stat.size, (line1.len() + line2.len()) as i64);
+
+        // Verify WPS events were also published (broker path still works)
+        broker.subscribe(
+            "test-route-fs",
+            wps::SubscriptionRequest {
+                event: wps::EVENT_BLOCK_FILE.to_string(),
+                scopes: vec![format!("block:{}", block_id)],
+                allscopes: false,
+            },
+        );
+        // Re-publish one more line to confirm broker still receives events alongside filestore
+        handle_append_block_file(&broker, block_id, filename, b"line three\n", Some(&fs));
+        let stat_after = fs.stat(block_id, filename).unwrap().unwrap();
+        assert_eq!(stat_after.size, (line1.len() + line2.len() + b"line three\n".len()) as i64);
     }
 }

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -31,6 +31,7 @@ use super::{
 };
 use super::health::{classify_output_line, HealthMonitor};
 use crate::backend::eventbus::EventBus;
+use crate::backend::storage::filestore::FileStore;
 use crate::backend::storage::wstore::WaveStore;
 use crate::backend::wps;
 
@@ -98,6 +99,8 @@ pub struct SubprocessController {
     event_bus: Option<Arc<EventBus>>,
     /// Wave object store for block metadata persistence.
     wstore: Option<Arc<WaveStore>>,
+    /// FileStore for write-through persistence of output lines (Phase 1.3).
+    filestore: Option<Arc<FileStore>>,
     /// Agent health monitor (output activity + error tracking).
     health_monitor: Arc<HealthMonitor>,
 }
@@ -110,6 +113,7 @@ impl SubprocessController {
         broker: Option<Arc<wps::Broker>>,
         event_bus: Option<Arc<EventBus>>,
         wstore: Option<Arc<WaveStore>>,
+        filestore: Option<Arc<FileStore>>,
     ) -> Self {
         let health_monitor = Arc::new(HealthMonitor::new(
             block_id.clone(),
@@ -130,6 +134,7 @@ impl SubprocessController {
             broker,
             event_bus,
             wstore,
+            filestore,
             health_monitor,
         }
     }
@@ -306,6 +311,7 @@ impl SubprocessController {
         let inner_read = Arc::clone(&self.inner);
         let wstore_read = self.wstore.clone();
         let event_bus_read = self.event_bus.clone();
+        let filestore_read = self.filestore.clone();
         let health_read = Arc::clone(&self.health_monitor);
         let session_id_field = config.session_id_field.clone();
         tokio::spawn(async move {
@@ -398,6 +404,7 @@ impl SubprocessController {
                 }
 
                 // Publish the NDJSON line as a WPS blockfile event on the "output" subject
+                // and write-through to FileStore for persistent history (Phase 1.3).
                 if let Some(ref broker) = broker_read {
                     tracing::info!(block_id = %block_id_read, line = %trimmed, "subprocess stdout → blockfile");
                     // Include the newline so the frontend line splitter works correctly
@@ -407,6 +414,7 @@ impl SubprocessController {
                         &block_id_read,
                         SUBPROCESS_OUTPUT_SUBJECT,
                         line_with_newline.as_bytes(),
+                        filestore_read.as_ref(),
                     );
                 }
             }
@@ -628,6 +636,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert_eq!(ctrl.controller_type(), BLOCK_CONTROLLER_SUBPROCESS);
         assert_eq!(ctrl.block_id(), "block-1");
@@ -645,6 +654,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let result = ctrl.send_input(BlockInputUnion::data(b"hello".to_vec()));
         assert!(result.is_err());
@@ -656,6 +666,7 @@ mod tests {
         let ctrl = SubprocessController::new(
             "tab-1".to_string(),
             "block-1".to_string(),
+            None,
             None,
             None,
             None,
@@ -676,6 +687,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         let result = ctrl.stop(true, STATUS_DONE);
         assert!(result.is_ok());
@@ -692,6 +704,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         );
         assert!(ctrl.session_id().is_none());
     }
@@ -701,6 +714,7 @@ mod tests {
         let ctrl = SubprocessController::new(
             "tab-1".to_string(),
             "block-1".to_string(),
+            None,
             None,
             None,
             None,
@@ -715,6 +729,8 @@ mod tests {
             working_dir: String::new(),
             env_vars: HashMap::new(),
             message: "test".to_string(),
+            resume_flag: String::new(),
+            session_id_field: "session_id".to_string(),
         };
 
         let result = ctrl.spawn_turn(config);

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -38,6 +38,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let wstore = state.wstore.clone();
     let broker = state.broker.clone();
     let event_bus = state.event_bus.clone();
+    let filestore = state.filestore.clone();
 
     engine.register_handler(
         COMMAND_AGENT_OPEN,
@@ -45,6 +46,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
             let wstore = wstore.clone();
             let broker = broker.clone();
             let event_bus = event_bus.clone();
+            let filestore = filestore.clone();
             Box::pin(async move {
                 let cmd: CommandAgentOpenData = serde_json::from_value(data)
                     .map_err(|e| format!("agent.open: {e}"))?;
@@ -86,6 +88,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         let _ = blockcontroller::resync_controller(
                             &block_for_resync, &tab_id, None, true,
                             Some(broker.clone()), Some(event_bus.clone()), Some(wstore.clone()),
+                            Some(filestore.clone()),
                         );
                     }
                     let status = blockcontroller::get_block_controller_status(&existing.oid)
@@ -236,6 +239,7 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     Some(broker.clone()),
                     Some(event_bus.clone()),
                     Some(wstore.clone()),
+                    Some(filestore.clone()),
                 )?;
 
                 // 10. Broadcast block + tab + layout updates to frontend
@@ -588,28 +592,64 @@ fn register_agent_output(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
+    let filestore = state.filestore.clone();
 
     engine.register_handler(
         COMMAND_BLOCKFILE_LINE_COUNT,
         Box::new(move |data, _ctx| {
             let broker = broker.clone();
+            let filestore = filestore.clone();
             Box::pin(async move {
                 let cmd: CommandBlockfileLineCountData = serde_json::from_value(data)
                     .map_err(|e| format!("blockfile:line_count: {e}"))?;
 
                 tracing::info!(block_id = %cmd.block_id, filename = %cmd.filename, "blockfile:line_count");
 
-                // Returns the number of lines *currently available* in the
-                // event ring buffer (MAX_PERSIST = 4096 events). For long
-                // sessions this may be LESS than the all-time session line
-                // count — older events have been evicted. This matches the
-                // semantics of `blockfile:read_range` so the two commands
-                // agree on what "offset N" means.
+                // Phase 1.3: Prefer FileStore (persistent, no size cap) over the
+                // WPS broker ring buffer (MAX_PERSIST = 4096 events).
                 //
-                // Callers who need the all-time count should read the
-                // `session:line_count` meta field directly. Until Phase 1.3
-                // (disk-based segmentation) lands, lines outside the ring
-                // buffer window are not retrievable.
+                // If FileStore has the file and it is non-empty, count lines in
+                // the persisted bytes. Otherwise fall back to the ring buffer so
+                // sessions that pre-date Phase 1.3 (no FileStore writes yet) still
+                // work correctly.
+                let filestore_count = match filestore.stat(&cmd.block_id, &cmd.filename) {
+                    Ok(Some(ref wf)) if wf.size > 0 => {
+                        match filestore.read_file(&cmd.block_id, &cmd.filename) {
+                            Ok(Some(bytes)) => {
+                                let text = String::from_utf8_lossy(&bytes);
+                                let count = text.lines()
+                                    .filter(|l| !l.trim().is_empty())
+                                    .count() as u64;
+                                Some(count)
+                            }
+                            Ok(None) => None,
+                            Err(e) => {
+                                tracing::warn!(
+                                    block_id = %cmd.block_id,
+                                    filename = %cmd.filename,
+                                    error = %e,
+                                    "blockfile:line_count: filestore read failed, falling back to ring buffer"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    Ok(_) => None, // file absent or empty → fall back
+                    Err(e) => {
+                        tracing::warn!(
+                            block_id = %cmd.block_id,
+                            error = %e,
+                            "blockfile:line_count: filestore stat failed, falling back to ring buffer"
+                        );
+                        None
+                    }
+                };
+
+                if let Some(count) = filestore_count {
+                    return Ok(Some(serde_json::to_value(&BlockfileLineCountResult { count }).unwrap()));
+                }
+
+                // Fallback: count from WPS event ring buffer (capped at MAX_PERSIST = 4096).
                 let scope = format!("block:{}", cmd.block_id);
                 let events = broker.read_event_history(
                     crate::backend::wps::EVENT_BLOCK_FILE,
@@ -650,11 +690,13 @@ fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
+    let filestore = state.filestore.clone();
 
     engine.register_handler(
         COMMAND_BLOCKFILE_READ_RANGE,
         Box::new(move |data, _ctx| {
             let broker = broker.clone();
+            let filestore = filestore.clone();
             Box::pin(async move {
                 let cmd: CommandBlockfileReadRangeData = serde_json::from_value(data)
                     .map_err(|e| format!("blockfile:read_range: {e}"))?;
@@ -665,48 +707,77 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let offset = cmd.offset as usize;
                 let end = offset.saturating_add(limit);
 
-                // Read the full event window (capped at the broker's
-                // MAX_PERSIST = 4096 events). The in-memory ring buffer may
-                // not have every event from the start of the session — older
-                // events have been evicted. The `total` we report is the
-                // number of lines *available* right now, not the all-time
-                // count. This matches `blockfile:line_count` semantics
-                // (both commands agree on what "offset N" means) so the
-                // frontend never asks for offsets the ring buffer can't
-                // serve.
+                // Phase 1.3: Prefer FileStore (persistent, no size cap) over the
+                // WPS broker ring buffer (MAX_PERSIST = 4096 events).
                 //
-                // Callers needing the all-time count can read the
-                // `session:line_count` meta field directly — but be aware
-                // that lines outside the ring buffer window are effectively
-                // gone until Phase 1.3 (disk-based segmentation) lands.
-                let scope = format!("block:{}", cmd.block_id);
-                let events = broker.read_event_history(
-                    crate::backend::wps::EVENT_BLOCK_FILE,
-                    &scope,
-                    usize::MAX, // broker clamps to MAX_PERSIST internally
-                );
-
-                // First pass: collect all available lines from the ring buffer.
-                // We need the total count before we can apply offset/limit,
-                // because `offset` is expressed relative to the available
-                // window (0 = oldest still-retained line).
-                let mut all_lines: Vec<String> = Vec::new();
-                for event in events {
-                    let Some(ref event_data) = event.data else { continue };
-                    let ev_filename = event_data.get("filename")
-                        .and_then(|v| v.as_str()).unwrap_or("");
-                    if ev_filename != cmd.filename {
-                        continue;
-                    }
-                    let Some(data64) = event_data.get("data64").and_then(|v| v.as_str()) else { continue };
-                    let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data64) else { continue };
-                    let text = String::from_utf8_lossy(&bytes);
-                    for line in text.lines() {
-                        if !line.trim().is_empty() {
-                            all_lines.push(line.to_string());
+                // If FileStore has the file and it is non-empty, read from disk.
+                // Otherwise fall back to ring buffer for backward compatibility.
+                let filestore_lines = match filestore.stat(&cmd.block_id, &cmd.filename) {
+                    Ok(Some(ref wf)) if wf.size > 0 => {
+                        match filestore.read_file(&cmd.block_id, &cmd.filename) {
+                            Ok(Some(bytes)) => {
+                                let text = String::from_utf8_lossy(&bytes);
+                                let lines: Vec<String> = text.lines()
+                                    .filter(|l| !l.trim().is_empty())
+                                    .map(|l| l.to_string())
+                                    .collect();
+                                Some(lines)
+                            }
+                            Ok(None) => None,
+                            Err(e) => {
+                                tracing::warn!(
+                                    block_id = %cmd.block_id,
+                                    filename = %cmd.filename,
+                                    error = %e,
+                                    "blockfile:read_range: filestore read failed, falling back to ring buffer"
+                                );
+                                None
+                            }
                         }
                     }
-                }
+                    Ok(_) => None, // file absent or empty → fall back
+                    Err(e) => {
+                        tracing::warn!(
+                            block_id = %cmd.block_id,
+                            error = %e,
+                            "blockfile:read_range: filestore stat failed, falling back to ring buffer"
+                        );
+                        None
+                    }
+                };
+
+                let all_lines = if let Some(lines) = filestore_lines {
+                    lines
+                } else {
+                    // Fallback: reconstruct from WPS event ring buffer.
+                    // The ring buffer holds at most MAX_PERSIST = 4096 events;
+                    // older events are evicted. Offset 0 = oldest retained line.
+                    let scope = format!("block:{}", cmd.block_id);
+                    let events = broker.read_event_history(
+                        crate::backend::wps::EVENT_BLOCK_FILE,
+                        &scope,
+                        usize::MAX, // broker clamps to MAX_PERSIST internally
+                    );
+
+                    let mut lines: Vec<String> = Vec::new();
+                    for event in events {
+                        let Some(ref event_data) = event.data else { continue };
+                        let ev_filename = event_data.get("filename")
+                            .and_then(|v| v.as_str()).unwrap_or("");
+                        if ev_filename != cmd.filename {
+                            continue;
+                        }
+                        let Some(data64) = event_data.get("data64").and_then(|v| v.as_str()) else { continue };
+                        let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data64) else { continue };
+                        let text = String::from_utf8_lossy(&bytes);
+                        for line in text.lines() {
+                            if !line.trim().is_empty() {
+                                lines.push(line.to_string());
+                            }
+                        }
+                    }
+                    lines
+                };
 
                 let total = all_lines.len() as u64;
                 let clamped_offset = offset.min(all_lines.len());

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -592,61 +592,35 @@ fn register_agent_output(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
 fn register_blockfile_line_count(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let broker = state.broker.clone();
-    let filestore = state.filestore.clone();
+    let wstore = state.wstore.clone();
 
     engine.register_handler(
         COMMAND_BLOCKFILE_LINE_COUNT,
         Box::new(move |data, _ctx| {
             let broker = broker.clone();
-            let filestore = filestore.clone();
+            let wstore = wstore.clone();
             Box::pin(async move {
                 let cmd: CommandBlockfileLineCountData = serde_json::from_value(data)
                     .map_err(|e| format!("blockfile:line_count: {e}"))?;
 
                 tracing::info!(block_id = %cmd.block_id, filename = %cmd.filename, "blockfile:line_count");
 
-                // Phase 1.3: Prefer FileStore (persistent, no size cap) over the
-                // WPS broker ring buffer (MAX_PERSIST = 4096 events).
-                //
-                // If FileStore has the file and it is non-empty, count lines in
-                // the persisted bytes. Otherwise fall back to the ring buffer so
-                // sessions that pre-date Phase 1.3 (no FileStore writes yet) still
-                // work correctly.
-                let filestore_count = match filestore.stat(&cmd.block_id, &cmd.filename) {
-                    Ok(Some(ref wf)) if wf.size > 0 => {
-                        match filestore.read_file(&cmd.block_id, &cmd.filename) {
-                            Ok(Some(bytes)) => {
-                                let text = String::from_utf8_lossy(&bytes);
-                                let count = text.lines()
-                                    .filter(|l| !l.trim().is_empty())
-                                    .count() as u64;
-                                Some(count)
-                            }
-                            Ok(None) => None,
-                            Err(e) => {
-                                tracing::warn!(
-                                    block_id = %cmd.block_id,
-                                    filename = %cmd.filename,
-                                    error = %e,
-                                    "blockfile:line_count: filestore read failed, falling back to ring buffer"
-                                );
-                                None
-                            }
+                // Fast path: read session:line_count meta (O(1), maintained
+                // by SessionStatsAccumulator). For "output" filename this is
+                // the authoritative total — matches the unbounded counter
+                // that SessionStats increments on every line. FileStore's
+                // persisted line count will trail meta by up to the debounce
+                // interval (1s), and reading the full file just to count
+                // lines is O(file size) which defeats the point of a fast
+                // line_count endpoint.
+                if cmd.filename == "output" {
+                    if let Ok(Some(block)) = wstore.get::<Block>(&cmd.block_id) {
+                        if let Some(count) = block.meta.get("session:line_count").and_then(|v| v.as_u64()) {
+                            return Ok(Some(serde_json::to_value(
+                                &BlockfileLineCountResult { count },
+                            ).unwrap()));
                         }
                     }
-                    Ok(_) => None, // file absent or empty → fall back
-                    Err(e) => {
-                        tracing::warn!(
-                            block_id = %cmd.block_id,
-                            error = %e,
-                            "blockfile:line_count: filestore stat failed, falling back to ring buffer"
-                        );
-                        None
-                    }
-                };
-
-                if let Some(count) = filestore_count {
-                    return Ok(Some(serde_json::to_value(&BlockfileLineCountResult { count }).unwrap()));
                 }
 
                 // Fallback: count from WPS event ring buffer (capped at MAX_PERSIST = 4096).

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -43,6 +43,7 @@ fn test_state() -> AppState {
         local_web_url: String::new(),
         subagent_watcher: Arc::new(crate::backend::subagent_watcher::SubagentWatcher::new(event_bus)),
         history_service: Arc::new(crate::backend::history::HistoryService::new()),
+        lan_discovery: None,
     }
 }
 

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -603,12 +603,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
     let wstore_resync = state.wstore.clone();
     let broker_resync = state.broker.clone();
     let event_bus_resync = state.event_bus.clone();
+    let filestore_resync = state.filestore.clone();
     engine.register_handler(
         COMMAND_CONTROLLER_RESYNC,
         Box::new(move |data, _ctx| {
             let wstore = wstore_resync.clone();
             let broker = broker_resync.clone();
             let event_bus = event_bus_resync.clone();
+            let filestore = filestore_resync.clone();
             Box::pin(async move {
                 let cmd: CommandControllerResyncData = serde_json::from_value(data)
                     .map_err(|e| format!("controllerresync: {e}"))?;
@@ -630,6 +632,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     Some(broker),
                     Some(event_bus),
                     Some(wstore),
+                    Some(filestore),
                 )?;
                 Ok(None)
             })
@@ -654,12 +657,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
     let wstore_spawn = state.wstore.clone();
     let broker_spawn = state.broker.clone();
     let event_bus_spawn = state.event_bus.clone();
+    let filestore_spawn = state.filestore.clone();
     engine.register_handler(
         COMMAND_SUBPROCESS_SPAWN,
         Box::new(move |data, _ctx| {
             let wstore = wstore_spawn.clone();
             let broker = broker_spawn.clone();
             let event_bus = event_bus_spawn.clone();
+            let filestore = filestore_spawn.clone();
             Box::pin(async move {
                 let cmd: CommandSubprocessSpawnData = serde_json::from_value(data)
                     .map_err(|e| format!("subprocessspawn: {e}"))?;
@@ -680,6 +685,7 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                             Some(broker),
                             Some(event_bus),
                             Some(wstore),
+                            Some(filestore),
                         );
                         let ctrl = std::sync::Arc::new(ctrl);
                         blockcontroller::register_controller(&cmd.blockid, ctrl.clone());

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.96"
+version = "0.33.97"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1944,4 +1944,326 @@
             }
         }
     }
+
+    // === Timeline Minimap ===
+    // .agent-document-wrapper wraps the scroll container + the timeline gutter
+    // side by side using flex so the timeline sits flush to the right edge of
+    // the document area without stealing space from the scroll container.
+    .agent-document-wrapper {
+        flex: 1;
+        display: flex;
+        flex-direction: row;
+        overflow: hidden;
+        min-height: 0;
+    }
+
+    // The timeline gutter: 22px wide, full height, sits to the right.
+    .agent-timeline {
+        width: 22px;
+        flex-shrink: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: 2px 0;
+        gap: 2px;
+        background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+        border-left: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+        user-select: none;
+        cursor: pointer;
+        overflow: hidden;
+    }
+
+    // Tiny time labels at top/bottom of the gutter
+    .agent-timeline-label {
+        font-size: 8px;
+        line-height: 1;
+        color: var(--secondary-text-color);
+        opacity: 0.5;
+        white-space: nowrap;
+        writing-mode: vertical-lr;
+        transform: rotate(180deg);
+        flex-shrink: 0;
+        max-height: 40px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        &--top {
+            // intentionally empty — just use the shared .agent-timeline-label rules
+        }
+
+        &--bottom {
+            // intentionally empty
+        }
+    }
+
+    // The clickable track area between the two labels — fills remaining height.
+    .agent-timeline-track {
+        flex: 1;
+        width: 100%;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+        overflow: hidden;
+    }
+
+    // Container that holds all the density bars end-to-end, top = session start.
+    .agent-timeline-bars {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: flex-end;
+        gap: 1px;
+        padding: 0 2px;
+    }
+
+    // Individual density bar — width is fixed, height proportional to bucket count.
+    .agent-timeline-bar {
+        width: 10px;
+        min-height: 1px;
+        border-radius: 1px;
+        background: var(--accent-color, #4a9eff);
+        opacity: 0.55;
+        transition: opacity 0.1s, height 0.2s;
+        flex-shrink: 0;
+
+        &:hover {
+            opacity: 0.9;
+        }
+
+        // Empty buckets get a very faint tick so the track stays legible
+        &--empty {
+            height: 1px !important;
+            opacity: 0.12;
+        }
+    }
+
+    // Horizontal line that tracks the current scroll position.
+    .agent-timeline-scroll-indicator {
+        position: absolute;
+        left: 1px;
+        right: 1px;
+        height: 2px;
+        background: var(--main-text-color, #fff);
+        opacity: 0.75;
+        border-radius: 1px;
+        pointer-events: none;
+        // Smooth scroll indicator movement on RAF updates
+        transition: top 0.1s linear;
+    }
+
+    // === Bookmarks ===
+
+    // Subtle left-border highlight on bookmarked nodes.
+    .agent-node-bookmarked {
+        border-left: 2px solid var(--warning-color, #eab308) !important;
+        padding-left: 2px;
+        position: relative;
+    }
+
+    // Small bookmark button shown on hover in the top-right corner of each node wrapper.
+    .agent-bookmark-btn {
+        position: absolute;
+        top: 2px;
+        right: 2px;
+        width: 18px;
+        height: 18px;
+        padding: 0;
+        background: none;
+        border: none;
+        border-radius: 3px;
+        font-size: 11px;
+        line-height: 18px;
+        text-align: center;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+        opacity: 0;
+        transition: opacity 0.12s, color 0.12s, background 0.12s;
+        z-index: 2;
+        user-select: none;
+
+        &--active {
+            color: var(--warning-color, #eab308);
+            opacity: 0.9;
+        }
+
+        &:hover {
+            background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
+            color: var(--warning-color, #eab308);
+        }
+    }
+
+    // Show the bookmark button when the parent wrapper is hovered.
+    .agent-document-node-wrapper:hover .agent-bookmark-btn {
+        opacity: 0.7;
+    }
+
+    // Node wrapper must be position:relative so the absolute bookmark btn works.
+    .agent-document-node-wrapper {
+        position: relative;
+    }
+
+    // === Bookmarks Panel ===
+    .agent-bookmarks-panel {
+        flex-shrink: 0;
+        border-bottom: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--warning-color, #eab308) 4%, var(--main-bg-color));
+        font-size: 12px;
+        max-height: 220px;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .agent-bookmarks-header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 4px 8px;
+        cursor: pointer;
+        user-select: none;
+        border-bottom: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--warning-color, #eab308) 6%, var(--main-bg-color));
+        flex-shrink: 0;
+
+        &:hover {
+            background: color-mix(in srgb, var(--warning-color, #eab308) 10%, var(--main-bg-color));
+        }
+    }
+
+    .agent-bookmarks-icon {
+        font-size: 13px;
+        flex-shrink: 0;
+    }
+
+    .agent-bookmarks-title {
+        font-size: 11px;
+        font-weight: 600;
+        color: var(--main-text-color);
+        flex: 1;
+        text-transform: uppercase;
+        letter-spacing: 0.4px;
+    }
+
+    .agent-bookmarks-count {
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
+        border-radius: 8px;
+        padding: 1px 6px;
+        min-width: 16px;
+        text-align: center;
+    }
+
+    .agent-bookmarks-chevron {
+        font-size: 9px;
+        color: var(--secondary-text-color);
+        flex-shrink: 0;
+    }
+
+    .agent-bookmarks-list {
+        overflow-y: auto;
+        flex: 1;
+        padding: 2px 0;
+    }
+
+    .agent-bookmarks-empty {
+        padding: 8px 10px;
+        font-size: 11px;
+        color: var(--secondary-text-color);
+        font-style: italic;
+        text-align: center;
+    }
+
+    .agent-bookmark-entry {
+        padding: 4px 8px;
+        cursor: pointer;
+        transition: background 0.1s;
+        border-bottom: 1px solid color-mix(in srgb, var(--border-color) 50%, transparent);
+
+        &:last-child {
+            border-bottom: none;
+        }
+
+        &:hover {
+            background: color-mix(in srgb, var(--accent-color) 8%, transparent);
+        }
+    }
+
+    .agent-bookmark-entry-main {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-width: 0;
+    }
+
+    .agent-bookmark-label {
+        flex: 1;
+        font-size: 11px;
+        font-weight: 500;
+        color: var(--main-text-color);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        cursor: text;
+    }
+
+    .agent-bookmark-rename-input {
+        flex: 1;
+        font-size: 11px;
+        font-family: inherit;
+        background: var(--main-bg-color);
+        color: var(--main-text-color);
+        border: 1px solid var(--accent-color);
+        border-radius: 2px;
+        padding: 1px 4px;
+        outline: none;
+        min-width: 0;
+    }
+
+    .agent-bookmark-time {
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        flex-shrink: 0;
+        opacity: 0.7;
+        white-space: nowrap;
+    }
+
+    .agent-bookmark-delete {
+        flex-shrink: 0;
+        width: 16px;
+        height: 16px;
+        padding: 0;
+        background: none;
+        border: none;
+        border-radius: 2px;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+        font-size: 13px;
+        line-height: 16px;
+        text-align: center;
+        opacity: 0;
+        transition: opacity 0.1s, color 0.1s;
+
+        .agent-bookmark-entry:hover & {
+            opacity: 0.6;
+        }
+
+        &:hover {
+            opacity: 1 !important;
+            color: var(--error-color);
+        }
+    }
+
+    .agent-bookmark-preview {
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        opacity: 0.65;
+        margin-top: 1px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-family: var(--fixed-font, monospace);
+    }
 }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -7,13 +7,14 @@ import type { AgentViewModel } from "./agent-model";
 import { buildRuntimeArgs, getRuntimeConfig } from "./buildRuntimeArgs";
 import { getProvider, type ProviderDefinition } from "./providers";
 import { createAgentAtoms } from "./state";
-import type { DocumentNode, SubagentLinkNode } from "./types";
+import type { Bookmark, DocumentNode, SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
 import { parseHistoryLines } from "./parseHistoryLines";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
+import { BookmarksPanel } from "./components/BookmarksPanel";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
 import { waveEventSubscribe } from "@/app/store/wps";
@@ -655,6 +656,16 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             },
         });
         onCleanup(() => unsubCompleted());
+
+        // Ctrl+B — toggle bookmarks panel
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.ctrlKey && e.key === "b") {
+                e.preventDefault();
+                setShowBookmarks((v) => !v);
+            }
+        };
+        window.addEventListener("keydown", handleKeyDown);
+        onCleanup(() => window.removeEventListener("keydown", handleKeyDown));
     });
 
     // Subscribe to subprocess output and parse into DocumentNodes.
@@ -776,6 +787,102 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         }
     };
 
+    // Session timeline metadata — read from block meta so the minimap knows
+    // the real time range of the session (set by the backend as activity flows).
+    const sessionStartTsMs = createMemo<number | null>(() => {
+        const v = block()?.meta?.["session:start_ts_ms"];
+        return typeof v === "number" ? v : null;
+    });
+    const sessionLastActivityMs = createMemo<number | null>(() => {
+        const v = block()?.meta?.["session:last_activity_ms"];
+        return typeof v === "number" ? v : null;
+    });
+
+    // ── Bookmarks ───────────────────────────────────────────────────────────────
+
+    // Read bookmarks reactively from block meta ("agent:bookmarks").
+    const bookmarks = createMemo<Bookmark[]>(() => {
+        const raw = block()?.meta?.["agent:bookmarks"];
+        if (!Array.isArray(raw)) return [];
+        return raw as Bookmark[];
+    });
+
+    // Derived set of bookmarked nodeIds for O(1) look-up in the renderer.
+    const bookmarkedNodeIds = createMemo<Set<string>>(
+        () => new Set(bookmarks().map((b) => b.nodeId)),
+    );
+
+    // Whether the bookmarks panel is visible.
+    const [showBookmarks, setShowBookmarks] = createSignal(false);
+
+    // Mutable ref to the scrollToNode function exposed by AgentDocumentView.
+    let scrollToNodeFn: ((nodeId: string) => void) | null = null;
+
+    const saveBookmarks = async (next: Bookmark[]): Promise<void> => {
+        await RpcApi.SetMetaCommand(TabRpcClient, {
+            oref: WOS.makeORef("block", model.blockId),
+            meta: { "agent:bookmarks": next },
+        });
+    };
+
+    /** Extract plain text preview from a DocumentNode (≤80 chars). */
+    const nodePreview = (node: DocumentNode): string => {
+        let raw = "";
+        switch (node.type) {
+            case "markdown":    raw = node.content; break;
+            case "user_message": raw = node.message; break;
+            case "tool":        raw = node.summary || node.tool; break;
+            case "agent_message": raw = node.summary || node.message; break;
+            case "section":     raw = node.title; break;
+            case "subagent_link": raw = node.slug || node.subagentId; break;
+        }
+        return raw.replace(/\s+/g, " ").trim().slice(0, 80);
+    };
+
+    const handleBookmark = (node: DocumentNode): void => {
+        const current = bookmarks();
+        const existingIdx = current.findIndex((b) => b.nodeId === node.id);
+        let next: Bookmark[];
+        if (existingIdx >= 0) {
+            // Remove existing bookmark
+            next = current.filter((_, i) => i !== existingIdx);
+        } else {
+            const preview = nodePreview(node);
+            const label = preview.slice(0, 60) || node.id;
+            const newBookmark: Bookmark = {
+                id: crypto.randomUUID(),
+                nodeId: node.id,
+                createdAt: Date.now(),
+                label,
+                preview,
+            };
+            next = [...current, newBookmark];
+            // Open the panel on first bookmark
+            setShowBookmarks(true);
+        }
+        saveBookmarks(next).catch((err) => {
+            log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    const handleBookmarkDelete = (id: string): void => {
+        const next = bookmarks().filter((b) => b.id !== id);
+        saveBookmarks(next).catch((err) => {
+            log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    const handleBookmarkRename = (id: string, label: string): void => {
+        const next = bookmarks().map((b) => (b.id === id ? { ...b, label } : b));
+        saveBookmarks(next).catch((err) => {
+            log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    const handleBookmarkJump = (nodeId: string): void => {
+        if (scrollToNodeFn) scrollToNodeFn(nodeId);
+    };
+
     // Per-pane zoom: read term:zoom from block meta (same key as terminal panes)
     const zoomFactor = createMemo(() => {
         const meta = block()?.meta;
@@ -834,6 +941,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 providerId={provider()?.id ?? ""}
             />
 
+            <Show when={showBookmarks()}>
+                <BookmarksPanel
+                    bookmarks={bookmarks}
+                    onJump={handleBookmarkJump}
+                    onDelete={handleBookmarkDelete}
+                    onRename={handleBookmarkRename}
+                />
+            </Show>
+
             <AgentDocumentView
                 documentAtom={agentAtoms().documentAtom}
                 documentStateAtom={agentAtoms().documentStateAtom}
@@ -842,6 +958,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 onSubagentClick={handleSubagentClick}
                 onLoadOlder={loadOlder}
                 loadingOlder={loadingOlder}
+                startTsMs={sessionStartTsMs}
+                endTsMs={sessionLastActivityMs}
+                bookmarkedNodeIds={bookmarkedNodeIds}
+                onBookmark={handleBookmark}
+                scrollToNodeRef={(fn) => { scrollToNodeFn = fn; }}
             />
 
             <Show when={loginWaiting()}>

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { writeText as clipboardWriteText } from "@/util/clipboard";
+import { focusedBlockId } from "@/util/focusutil";
 import { createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import type { AgentViewModel } from "./agent-model";
 import { buildRuntimeArgs, getRuntimeConfig } from "./buildRuntimeArgs";
@@ -657,9 +658,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         });
         onCleanup(() => unsubCompleted());
 
-        // Ctrl+B — toggle bookmarks panel
+        // Ctrl+B — toggle bookmarks panel.
+        // Only fires for THIS pane if it's the currently focused block.
+        // Without this check, Ctrl+B would toggle every open agent pane's
+        // bookmarks panel simultaneously (all panes register the listener
+        // at window level).
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.ctrlKey && e.key === "b") {
+                const focused = focusedBlockId();
+                if (focused !== model.blockId) return;
                 e.preventDefault();
                 setShowBookmarks((v) => !v);
             }

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -7,13 +7,15 @@
  * When no document nodes exist yet, shows accumulated log lines (terminal-style).
  */
 
-import { createEffect, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
+import { createEffect, createSignal, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import { AgentMessageBlock } from "./AgentMessageBlock";
+import { AgentTimeline } from "./AgentTimeline";
 import { MarkdownBlock } from "./MarkdownBlock";
 import { SubagentLinkBlock } from "./SubagentLinkBlock";
 import { ToolBlock } from "./ToolBlock";
+import { ContextMenuModel } from "@/app/store/contextmenu";
 
 export interface LogLine {
     tag: string;        // "agent", "cli", "auth", "env", "error", etc.
@@ -31,15 +33,41 @@ interface AgentDocumentViewProps {
     onLoadOlder?: () => Promise<void>;
     /** Whether an older-history load is currently in progress. */
     loadingOlder?: Accessor<boolean>;
+    /** session:start_ts_ms from block meta — enables the timeline minimap. */
+    startTsMs?: Accessor<number | null>;
+    /** session:last_activity_ms from block meta — enables the timeline minimap. */
+    endTsMs?: Accessor<number | null>;
+    /** Set of bookmarked node IDs — drives the bookmarked visual indicator. */
+    bookmarkedNodeIds?: Accessor<Set<string>>;
+    /** Called when the user bookmarks or un-bookmarks a node via context menu. */
+    onBookmark?: (node: DocumentNode) => void;
+    /** Expose a scrollToNode function to the parent for jump-to-bookmark support. */
+    scrollToNodeRef?: (fn: (nodeId: string) => void) => void;
 }
 
-export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick, onLoadOlder, loadingOlder }: AgentDocumentViewProps): JSX.Element => {
+export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick, onLoadOlder, loadingOlder, startTsMs, endTsMs, bookmarkedNodeIds, onBookmark, scrollToNodeRef }: AgentDocumentViewProps): JSX.Element => {
     const [document] = documentAtom;
     const [documentState, setDocumentState] = documentStateAtom;
     let scrollRef!: HTMLDivElement;
     let autoScroll = true;
     // Guard against concurrent older-history fetches triggered by scroll
     let loadingOlderInFlight = false;
+    // 0..1 fraction of the current scroll position within the document
+    const [scrollFraction, setScrollFraction] = createSignal(0);
+
+    // Scroll to a node by its data-node-id attribute.
+    // Exposed to the parent via scrollToNodeRef so BookmarksPanel can call it.
+    const scrollToNode = (nodeId: string) => {
+        const el = scrollRef?.querySelector(`[data-node-id="${nodeId}"]`);
+        if (el) {
+            el.scrollIntoView({ behavior: "smooth", block: "center" });
+            // Disable auto-scroll after a manual jump
+            autoScroll = false;
+        }
+    };
+
+    // Expose scrollToNode to the parent on mount
+    if (scrollToNodeRef) scrollToNodeRef(scrollToNode);
 
     // Toggle collapsed state for a node
     const toggleCollapse = (nodeId: string) => {
@@ -85,6 +113,10 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
         autoScroll = scrollHeight - scrollTop - clientHeight < 50;
 
+        // Update timeline scroll indicator
+        const maxScroll = scrollHeight - clientHeight;
+        setScrollFraction(maxScroll > 0 ? Math.min(1, scrollTop / maxScroll) : 0);
+
         // Trigger older-history load when near the top
         if (
             onLoadOlder &&
@@ -112,7 +144,18 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
         }
     };
 
+    // Called when the user clicks the timeline — scroll the document to that position.
+    const handleTimelineJump = (fraction: number) => {
+        if (!scrollRef) return;
+        const { scrollHeight, clientHeight } = scrollRef;
+        const maxScroll = scrollHeight - clientHeight;
+        scrollRef.scrollTop = fraction * maxScroll;
+        // Disable auto-scroll when the user manually jumps to a position
+        autoScroll = fraction >= 0.98;
+    };
+
     return (
+        <div class="agent-document-wrapper">
         <div
             class="agent-document"
             ref={scrollRef}
@@ -164,17 +207,65 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                 skip layout/paint for off-screen nodes — critical for
                 long sessions where thousands of DOM elements accumulate. */}
             <For each={document()}>
-                {(node) => (
-                    <div class="agent-document-node-wrapper">
-                        <DocumentNodeRenderer
-                            node={node}
-                            collapsed={documentState().collapsedNodes.has(node.id)}
-                            onToggle={() => toggleCollapse(node.id)}
-                            onSubagentClick={onSubagentClick}
-                        />
-                    </div>
-                )}
+                {(node) => {
+                    const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
+
+                    const handleContextMenu = (e: MouseEvent) => {
+                        if (!onBookmark) return;
+                        // Don't show bookmark menu on top of text selections — let the parent handle those.
+                        const sel = window.getSelection()?.toString();
+                        if (sel) return;
+                        e.preventDefault();
+                        e.stopPropagation();
+                        ContextMenuModel.showContextMenu(
+                            [
+                                {
+                                    label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
+                                    click: () => onBookmark(node),
+                                },
+                            ],
+                            e,
+                        );
+                    };
+
+                    return (
+                        <div
+                            class="agent-document-node-wrapper"
+                            classList={{ "agent-node-bookmarked": isBookmarked() }}
+                            data-node-id={node.id}
+                            onContextMenu={handleContextMenu}
+                        >
+                            {/* Bookmark indicator button — shown on hover */}
+                            <Show when={onBookmark != null}>
+                                <button
+                                    class="agent-bookmark-btn"
+                                    classList={{ "agent-bookmark-btn--active": isBookmarked() }}
+                                    onClick={(e) => { e.stopPropagation(); onBookmark!(node); }}
+                                    title={isBookmarked() ? "Remove bookmark" : "Bookmark this message"}
+                                >
+                                    {isBookmarked() ? "\uD83D\uDD16" : "\uD83D\uDD16"}
+                                </button>
+                            </Show>
+                            <DocumentNodeRenderer
+                                node={node}
+                                collapsed={documentState().collapsedNodes.has(node.id)}
+                                onToggle={() => toggleCollapse(node.id)}
+                                onSubagentClick={onSubagentClick}
+                            />
+                        </div>
+                    );
+                }}
             </For>
+        </div>
+        <Show when={startTsMs != null && endTsMs != null}>
+            <AgentTimeline
+                document={document}
+                startTsMs={startTsMs ?? (() => null)}
+                endTsMs={endTsMs ?? (() => null)}
+                scrollPosition={scrollFraction}
+                onJump={handleTimelineJump}
+            />
+        </Show>
         </div>
     );
 };

--- a/frontend/app/view/agent/components/AgentTimeline.tsx
+++ b/frontend/app/view/agent/components/AgentTimeline.tsx
@@ -1,0 +1,120 @@
+// Copyright 2025, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentTimeline — compact vertical minimap shown in the right gutter of the
+ * agent document view.
+ *
+ * - Divides the session time range into ~30 activity buckets.
+ * - Renders a proportional bar for each bucket (height = message density).
+ * - Overlays a thin horizontal line at the current scroll position.
+ * - Clicking anywhere on the track calls onJump(fraction) so the parent can
+ *   scroll the document to the equivalent position.
+ */
+
+import { createMemo, For, Show, type Accessor, type JSX } from "solid-js";
+import type { DocumentNode } from "../types";
+
+interface AgentTimelineProps {
+    document: Accessor<DocumentNode[]>;
+    /** session:start_ts_ms from block meta (ms since epoch) */
+    startTsMs: Accessor<number | null>;
+    /** session:last_activity_ms from block meta (ms since epoch) */
+    endTsMs: Accessor<number | null>;
+    /** Current scroll fraction in the document container, 0..1 */
+    scrollPosition: Accessor<number>;
+    /** Called with 0..1 fraction when the user clicks the track */
+    onJump: (fraction: number) => void;
+}
+
+const BUCKET_COUNT = 30;
+
+/** Format a ms-epoch timestamp as HH:MM (locale-aware). */
+function formatTime(ms: number): string {
+    const d = new Date(ms);
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export const AgentTimeline = (props: AgentTimelineProps): JSX.Element => {
+    // Divide the session time range into BUCKET_COUNT slices and count nodes
+    // per slice. Nodes that carry an explicit `timestamp` field are placed into
+    // their true bucket; those without one are distributed uniformly by index.
+    const buckets = createMemo(() => {
+        const start = props.startTsMs();
+        const end = props.endTsMs();
+        const nodes = props.document();
+        if (!start || !end || end <= start || nodes.length === 0) return [];
+
+        const range = end - start;
+        const bucketSize = range / BUCKET_COUNT;
+        const counts = new Array<number>(BUCKET_COUNT).fill(0);
+
+        for (let i = 0; i < nodes.length; i++) {
+            const n = nodes[i];
+            let ts: number;
+            if (typeof (n as any).timestamp === "number") {
+                ts = (n as any).timestamp as number;
+            } else {
+                // Fall back to linear interpolation by node index
+                ts = start + (range * i) / nodes.length;
+            }
+            const bucket = Math.min(
+                BUCKET_COUNT - 1,
+                Math.max(0, Math.floor((ts - start) / bucketSize)),
+            );
+            counts[bucket]++;
+        }
+
+        const maxCount = Math.max(...counts, 1);
+        return counts.map((c, i) => ({
+            index: i,
+            count: c,
+            // Height as percentage of the tallest bucket (never 0 — give empty
+            // buckets a 1px minimum so the track still looks anchored)
+            heightPct: c > 0 ? Math.max(8, (c / maxCount) * 100) : 0,
+            tsMs: start + i * bucketSize,
+        }));
+    });
+
+    const handleClick = (e: MouseEvent) => {
+        const target = e.currentTarget as HTMLDivElement;
+        const rect = target.getBoundingClientRect();
+        const fraction = (e.clientY - rect.top) / rect.height;
+        props.onJump(Math.max(0, Math.min(1, fraction)));
+    };
+
+    return (
+        <Show when={props.startTsMs() != null && props.endTsMs() != null}>
+            <div class="agent-timeline" title="Session timeline — click to jump">
+                <div class="agent-timeline-label agent-timeline-label--top">
+                    {formatTime(props.startTsMs()!)}
+                </div>
+                <div class="agent-timeline-track" onClick={handleClick}>
+                    {/* Activity density bars */}
+                    <div class="agent-timeline-bars">
+                        <For each={buckets()}>
+                            {(b) => (
+                                <div
+                                    class="agent-timeline-bar"
+                                    classList={{ "agent-timeline-bar--empty": b.count === 0 }}
+                                    style={{ height: `${b.heightPct}%` }}
+                                    title={`${b.count} message${b.count === 1 ? "" : "s"} around ${formatTime(b.tsMs)}`}
+                                />
+                            )}
+                        </For>
+                    </div>
+                    {/* Current scroll position indicator */}
+                    <div
+                        class="agent-timeline-scroll-indicator"
+                        style={{ top: `${props.scrollPosition() * 100}%` }}
+                    />
+                </div>
+                <div class="agent-timeline-label agent-timeline-label--bottom">
+                    {formatTime(props.endTsMs()!)}
+                </div>
+            </div>
+        </Show>
+    );
+};
+
+AgentTimeline.displayName = "AgentTimeline";

--- a/frontend/app/view/agent/components/BookmarksPanel.tsx
+++ b/frontend/app/view/agent/components/BookmarksPanel.tsx
@@ -1,0 +1,142 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BookmarksPanel — collapsible panel listing all bookmarks for the current agent pane.
+ *
+ * Bookmarks are stored in block meta under "agent:bookmarks" as a JSON array.
+ * Clicking a bookmark calls onJump which scrolls the matching node into view.
+ */
+
+import { createSignal, For, Show, type Accessor, type JSX } from "solid-js";
+import type { Bookmark } from "../types";
+
+export interface BookmarksPanelProps {
+    bookmarks: Accessor<Bookmark[]>;
+    onJump: (nodeId: string) => void;
+    onDelete: (id: string) => void;
+    onRename: (id: string, label: string) => void;
+}
+
+/**
+ * Format a Unix-ms timestamp as a short relative or absolute string.
+ */
+function formatTimestamp(ms: number): string {
+    const now = Date.now();
+    const diff = now - ms;
+    if (diff < 60_000) return "just now";
+    if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+    return new Date(ms).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export const BookmarksPanel = ({
+    bookmarks,
+    onJump,
+    onDelete,
+    onRename,
+}: BookmarksPanelProps): JSX.Element => {
+    const [collapsed, setCollapsed] = createSignal(false);
+    // Track which bookmark is being renamed
+    const [renamingId, setRenamingId] = createSignal<string | null>(null);
+    const [renameValue, setRenameValue] = createSignal("");
+
+    const sorted = () => [...bookmarks()].sort((a, b) => b.createdAt - a.createdAt);
+
+    const startRename = (bm: Bookmark, e: MouseEvent) => {
+        e.stopPropagation();
+        setRenamingId(bm.id);
+        setRenameValue(bm.label);
+    };
+
+    const commitRename = (id: string) => {
+        const val = renameValue().trim();
+        if (val) onRename(id, val);
+        setRenamingId(null);
+    };
+
+    const handleRenameKeyDown = (id: string, e: KeyboardEvent) => {
+        if (e.key === "Enter") commitRename(id);
+        if (e.key === "Escape") setRenamingId(null);
+    };
+
+    return (
+        <div class="agent-bookmarks-panel">
+            {/* Panel header */}
+            <div
+                class="agent-bookmarks-header"
+                onClick={() => setCollapsed((v) => !v)}
+                title={collapsed() ? "Show bookmarks" : "Hide bookmarks"}
+            >
+                <span class="agent-bookmarks-icon">&#x1F516;</span>
+                <span class="agent-bookmarks-title">Bookmarks</span>
+                <span class="agent-bookmarks-count">{bookmarks().length}</span>
+                <span class="agent-bookmarks-chevron">{collapsed() ? "\u25BA" : "\u25BC"}</span>
+            </div>
+
+            {/* Bookmark list */}
+            <Show when={!collapsed()}>
+                <Show
+                    when={sorted().length > 0}
+                    fallback={
+                        <div class="agent-bookmarks-empty">No bookmarks yet. Right-click a message to bookmark it.</div>
+                    }
+                >
+                    <div class="agent-bookmarks-list">
+                        <For each={sorted()}>
+                            {(bm) => (
+                                <div
+                                    class="agent-bookmark-entry"
+                                    onClick={() => onJump(bm.nodeId)}
+                                    title="Click to scroll to this message"
+                                >
+                                    <div class="agent-bookmark-entry-main">
+                                        {/* Label — editable on double-click */}
+                                        <Show
+                                            when={renamingId() === bm.id}
+                                            fallback={
+                                                <span
+                                                    class="agent-bookmark-label"
+                                                    onDblClick={(e) => startRename(bm, e)}
+                                                    title="Double-click to rename"
+                                                >
+                                                    {bm.label}
+                                                </span>
+                                            }
+                                        >
+                                            <input
+                                                class="agent-bookmark-rename-input"
+                                                value={renameValue()}
+                                                onInput={(e) => setRenameValue(e.currentTarget.value)}
+                                                onKeyDown={(e) => handleRenameKeyDown(bm.id, e)}
+                                                onBlur={() => commitRename(bm.id)}
+                                                onClick={(e) => e.stopPropagation()}
+                                                autofocus
+                                            />
+                                        </Show>
+
+                                        <span class="agent-bookmark-time">{formatTimestamp(bm.createdAt)}</span>
+
+                                        {/* Delete button */}
+                                        <button
+                                            class="agent-bookmark-delete"
+                                            onClick={(e) => { e.stopPropagation(); onDelete(bm.id); }}
+                                            title="Remove bookmark"
+                                        >
+                                            &times;
+                                        </button>
+                                    </div>
+
+                                    {/* Preview text */}
+                                    <div class="agent-bookmark-preview">{bm.preview}</div>
+                                </div>
+                            )}
+                        </For>
+                    </div>
+                </Show>
+            </Show>
+        </div>
+    );
+};
+
+BookmarksPanel.displayName = "BookmarksPanel";

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -242,6 +242,22 @@ export interface UserMessageEvent {
 }
 
 /**
+ * Bookmark — pins a document node for quick navigation.
+ * Stored as a JSON array under block meta key "agent:bookmarks".
+ *
+ * Known limitation: if the session is replayed from history, node IDs are
+ * regenerated (UUIDs) and will not match the stored nodeId. The `preview`
+ * text can be used as a fallback to search for the original content.
+ */
+export interface Bookmark {
+    id: string;       // uuid — unique bookmark identifier
+    nodeId: string;   // DocumentNode.id this bookmark points to
+    createdAt: number; // Unix ms
+    label: string;    // user-editable; defaults to first 60 chars of node content
+    preview: string;  // immutable snapshot of node content at bookmark time (80 chars)
+}
+
+/**
  * Document state (managed by Jotai atoms)
  */
 export interface DocumentState {

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -858,6 +858,10 @@ declare global {
             model?: string | null;
             effort?: string | null;
         };
+        "agent:bookmarks"?: unknown[];
+        "session:start_ts_ms"?: number;
+        "session:last_activity_ms"?: number;
+        "session:line_count"?: number;
         "subagent:*"?: boolean;
         "subagent:id"?: string;
         "subagent:slug"?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.96",
+  "version": "0.33.97",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.96",
+      "version": "0.33.97",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.96",
+  "version": "0.33.97",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Three phases of `docs/plans/ultra-long-sessions.md` in one bundle.

**Supersedes PR #339** — that branch had a merge conflict with PR #338. This is a clean cherry-pick from main with all review feedback addressed.

### Phase 1.3 — Output segmentation (disk-backed persistence)
Every stdout line is written through to the existing FileStore. `blockfile:read_range` reads from FileStore (persistent, no size cap). Sessions with >4096 events can now retrieve full history.

### Phase 2.4 — Timeline minimap
Vertical gutter: session start/end timestamps, 30 activity density bars, scroll position indicator, click to jump.

### Phase 3.2 — Bookmarks
Right-click message → bookmark. Ctrl+B toggles panel (pane-scoped). Persists in `agent:bookmarks` block meta.

## Review fixes
- **`line_count` uses meta fast path** — reads `session:line_count` meta (O(1)) instead of loading FileStore bytes to count lines. Falls through to ring buffer for non-output filenames.
- **Ctrl+B is pane-scoped** — gated on `focusedBlockId() === model.blockId` so opening bookmarks in one pane doesn't toggle every pane's bookmarks panel.

## Known limitation
`read_range` still loads the full file into memory via `FileStore.read_file()` — O(file size) per call. Only runs on pane-open and loadOlder clicks (not per keystroke), so acceptable for now. True byte-range streaming would require adding `read_at` to FileStore — tracked as follow-up.

## Not in this PR
- Phase 3.1 In-session search
- Phase 3.3 Session archival
- Phase 3.4 AI digest
- Phase 4 Resilience polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)