### PR TITLE
feat: ultra-long sessions phase 3 — search + archive + digest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.97"
+version = "0.33.98"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.97"
+version = "0.33.98"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.97"
+version = "0.33.98"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.97"
+version = "0.33.98"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -60,6 +60,7 @@ dependencies = [
  "clap",
  "crash-handler",
  "dirs",
+ "flate2",
  "json_comments",
  "libc",
  "mdns-sd",
@@ -73,6 +74,7 @@ dependencies = [
  "serde_json",
  "subtle",
  "sysinfo",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
@@ -88,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.97"
+version = "0.33.98"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.98"
+version = "0.33.99"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.98"
+version = "0.33.99"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.98"
+version = "0.33.99"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.98"
+version = "0.33.99"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.98"
+version = "0.33.99"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.98"
+version = "0.33.99"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.97"
+version = "0.33.98"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.97"
+version = "0.33.98"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.98"
+version = "0.33.99"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.98"
+version = "0.33.99"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.97"
+version = "0.33.98"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.97"
+version = "0.33.98"
 edition = "2021"
 description = "AgentMux Rust backend server"
 
@@ -38,6 +38,7 @@ parking_lot = "0.12"
 notify = "7"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 mdns-sd = "0.12"
+flate2 = "1"
 
 [target.'cfg(windows)'.dependencies]
 # Out-of-process crash dump capture via VEH + named-pipe IPC.
@@ -53,3 +54,4 @@ winres = "0.1"
 tower = { version = "0.5", features = ["util"] }
 serde_json = "1"
 libc = "0.2"
+tempfile = "3"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.98"
+version = "0.33.99"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -20,6 +20,7 @@ pub mod rpc;
 pub mod rpc_types;
 pub mod schema;
 pub mod service;
+pub mod session_archive;
 pub mod shellexec;
 pub mod shellintegration;
 pub mod sigutil;

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -301,6 +301,14 @@ pub const COMMAND_AGENT_STREAM: &str = "agent.stream";
 pub const COMMAND_BLOCKFILE_LINE_COUNT: &str = "blockfile:line_count";
 pub const COMMAND_BLOCKFILE_READ_RANGE: &str = "blockfile:read_range";
 
+// App API Tier 1 — session archival commands
+pub const COMMAND_SESSION_ARCHIVE: &str = "session:archive";
+pub const COMMAND_SESSION_RESTORE: &str = "session:restore";
+pub const COMMAND_SESSION_EXPORT: &str = "session:export";
+
+// Session digest
+pub const COMMAND_SESSION_DIGEST: &str = "session:digest";
+
 // ---- Client type constants ----
 
 pub const CLIENT_TYPE_CONN_SERVER: &str = "connserver";
@@ -707,6 +715,79 @@ pub struct CommandBlockfileReadRangeData {
 pub struct BlockfileReadRangeResult {
     pub lines: Vec<String>,
     pub total: u64,
+}
+
+// ---- Session digest types ----
+
+/// Request for session:digest — generate or return a cached AI summary of the session.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandSessionDigestData {
+    pub block_id: String,
+    /// If true, regenerate even if a cached digest exists.
+    pub force: Option<bool>,
+}
+
+/// Response from session:digest.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SessionDigestResult {
+    /// AI-generated summary text (Markdown).
+    pub summary: String,
+    /// Unix milliseconds when this digest was generated.
+    pub generated_at: i64,
+    /// true if we returned a previously-cached result (no new activity since last run).
+    pub cached: bool,
+}
+
+// ---- Session archival types ----
+
+/// Request for session:archive — compress and archive a session's FileStore output.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandSessionArchiveData {
+    pub block_id: String,
+}
+
+/// Response from session:archive.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SessionArchiveResult {
+    pub block_id: String,
+    pub archived_bytes: u64,
+    pub archived_at: i64,
+}
+
+/// Request for session:restore — decompress archive back into FileStore.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandSessionRestoreData {
+    pub block_id: String,
+}
+
+/// Response from session:restore.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SessionRestoreResult {
+    pub block_id: String,
+    pub restored_bytes: u64,
+}
+
+/// Request for session:export — read session output and return as base64 JSONL.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandSessionExportData {
+    pub block_id: String,
+}
+
+/// Response from session:export.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SessionExportResult {
+    /// base64-encoded JSONL content (the raw output file bytes).
+    pub content: String,
+    pub line_count: u64,
+    pub byte_count: u64,
 }
 
 /// Matches Go's `FileDataAt`

--- a/agentmux-srv/src/backend/session_archive.rs
+++ b/agentmux-srv/src/backend/session_archive.rs
@@ -1,0 +1,562 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Session archival and cleanup (Phase 3.3 — ultra-long-sessions).
+//!
+//! Responsibilities:
+//!   1. Periodic sweep: archive sessions inactive for `inactive_days` days by
+//!      compressing their FileStore "output" file to `archive_dir/<block_id>.jsonl.gz`
+//!      and freeing the FileStore entry.
+//!   2. Storage cap: after archiving, prune oldest `.gz` files until total archive
+//!      disk usage is below `max_total_bytes` (default 2 GB).
+//!
+//! The archive/restore/export logic used by the sweep is the same as the
+//! RPC handlers in `server/app_api.rs` — both call `archive_session_output`
+//! and `read_session_output` from this module.
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use flate2::Compression;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+
+use crate::backend::blockcontroller::session_stats::{
+    META_SESSION_LAST_ACTIVITY_MS, META_SESSION_LINE_COUNT,
+};
+use crate::backend::obj::{Block, MetaMapType};
+use crate::backend::storage::filestore::{FileStore, FileMeta, FileOpts};
+use crate::backend::storage::wstore::WaveStore;
+
+// ---- Meta key constants for archival state ----
+
+/// Unix ms when the session was last archived.
+pub const META_SESSION_ARCHIVED_AT: &str = "session:archived_at";
+/// Byte count before compression (original output size).
+pub const META_SESSION_ARCHIVED_BYTES: &str = "session:archived_bytes";
+/// Absolute path to the `.jsonl.gz` archive file.
+pub const META_SESSION_ARCHIVE_PATH: &str = "session:archive_path";
+
+/// FileStore filename for session output.
+const OUTPUT_FILENAME: &str = "output";
+
+// ---------------------------------------------------------------------------
+// Shared helpers — used by both the RPC handlers and the sweep
+// ---------------------------------------------------------------------------
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+/// Compress `data` with gzip and write to `dest_path`.
+fn write_gz(data: &[u8], dest_path: &Path) -> Result<(), String> {
+    let file = std::fs::File::create(dest_path)
+        .map_err(|e| format!("create archive file {}: {e}", dest_path.display()))?;
+    let mut encoder = GzEncoder::new(file, Compression::default());
+    encoder.write_all(data)
+        .map_err(|e| format!("compress: {e}"))?;
+    encoder.finish()
+        .map_err(|e| format!("gz finish: {e}"))?;
+    Ok(())
+}
+
+/// Decompress a `.gz` file and return raw bytes.
+fn read_gz(src_path: &Path) -> Result<Vec<u8>, String> {
+    let file = std::fs::File::open(src_path)
+        .map_err(|e| format!("open archive {}: {e}", src_path.display()))?;
+    let mut decoder = GzDecoder::new(file);
+    let mut out = Vec::new();
+    decoder.read_to_end(&mut out)
+        .map_err(|e| format!("decompress: {e}"))?;
+    Ok(out)
+}
+
+/// Ensure the archive directory exists.
+fn ensure_archive_dir(archive_dir: &Path) -> Result<(), String> {
+    std::fs::create_dir_all(archive_dir)
+        .map_err(|e| format!("create archive dir {}: {e}", archive_dir.display()))
+}
+
+// ---------------------------------------------------------------------------
+// archive_session_output
+// ---------------------------------------------------------------------------
+
+/// Archive the FileStore "output" file for `block_id`:
+///   1. Read bytes from FileStore.
+///   2. Compress to `archive_dir/<block_id>.jsonl.gz`.
+///   3. Delete the FileStore entry to reclaim SQLite space.
+///   4. Write archive meta keys to the block.
+///
+/// Returns `(archived_bytes, archived_at_ms)`.
+/// If the FileStore entry is missing or empty, returns `(0, now_ms)` — no-op.
+pub fn archive_session_output(
+    wstore: &Arc<WaveStore>,
+    filestore: &Arc<FileStore>,
+    block_id: &str,
+    archive_dir: &Path,
+) -> Result<(u64, i64), String> {
+    // Read existing data from FileStore
+    let raw_bytes = match filestore.read_file(block_id, OUTPUT_FILENAME) {
+        Ok(Some(b)) if !b.is_empty() => b,
+        Ok(_) => {
+            // Nothing to archive
+            return Ok((0, now_ms()));
+        }
+        Err(e) => return Err(format!("filestore read: {e}")),
+    };
+
+    let archived_bytes = raw_bytes.len() as u64;
+
+    ensure_archive_dir(archive_dir)?;
+
+    let archive_path = archive_dir.join(format!("{}.jsonl.gz", block_id));
+    write_gz(&raw_bytes, &archive_path)?;
+
+    // Delete from FileStore so SQLite reclaims the space
+    if let Err(e) = filestore.delete_file(block_id, OUTPUT_FILENAME) {
+        tracing::warn!(
+            block_id = %block_id,
+            error = %e,
+            "session_archive: failed to delete filestore entry after archiving"
+        );
+    }
+
+    let archived_at = now_ms();
+
+    // Write archive metadata to the block
+    let mut meta = MetaMapType::new();
+    meta.insert(META_SESSION_ARCHIVED_AT.to_string(), serde_json::json!(archived_at));
+    meta.insert(META_SESSION_ARCHIVED_BYTES.to_string(), serde_json::json!(archived_bytes));
+    meta.insert(
+        META_SESSION_ARCHIVE_PATH.to_string(),
+        serde_json::json!(archive_path.to_string_lossy().as_ref()),
+    );
+
+    let oref_str = format!("block:{}", block_id);
+    crate::server::service::update_object_meta(wstore, &oref_str, &meta)
+        .map_err(|e| format!("update_object_meta: {e}"))?;
+
+    tracing::info!(
+        block_id = %block_id,
+        archived_bytes = archived_bytes,
+        archive_path = %archive_path.display(),
+        "session archived"
+    );
+
+    Ok((archived_bytes, archived_at))
+}
+
+// ---------------------------------------------------------------------------
+// restore_session_output
+// ---------------------------------------------------------------------------
+
+/// Restore an archived session back into FileStore:
+///   1. Read `session:archive_path` from block meta.
+///   2. Decompress and write bytes back via `make_file` + `append_data`.
+///   3. Clear archive meta keys (keep the .gz file as backup).
+pub fn restore_session_output(
+    wstore: &Arc<WaveStore>,
+    filestore: &Arc<FileStore>,
+    block_id: &str,
+) -> Result<u64, String> {
+    // Read archive path from block meta
+    let block: Block = wstore
+        .get(block_id)
+        .map_err(|e| format!("wstore.get: {e}"))?
+        .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", block_id))?;
+
+    let archive_path_str = block
+        .meta
+        .get(META_SESSION_ARCHIVE_PATH)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("session:archive_path not set for block {}", block_id))?
+        .to_string();
+
+    let archive_path = PathBuf::from(&archive_path_str);
+    let raw_bytes = read_gz(&archive_path)?;
+    let restored_bytes = raw_bytes.len() as u64;
+
+    // Recreate the FileStore entry (may already be gone after archival)
+    let _ = filestore.delete_file(block_id, OUTPUT_FILENAME); // ignore "not found"
+    filestore
+        .make_file(block_id, OUTPUT_FILENAME, FileMeta::default(), FileOpts::default())
+        .map_err(|e| format!("make_file: {e}"))?;
+    filestore
+        .append_data(block_id, OUTPUT_FILENAME, &raw_bytes)
+        .map_err(|e| format!("append_data: {e}"))?;
+
+    // Clear archive meta keys (keep the .gz as backup — don't delete it)
+    let mut meta = MetaMapType::new();
+    meta.insert(META_SESSION_ARCHIVED_AT.to_string(), serde_json::Value::Null);
+    meta.insert(META_SESSION_ARCHIVED_BYTES.to_string(), serde_json::Value::Null);
+    meta.insert(META_SESSION_ARCHIVE_PATH.to_string(), serde_json::Value::Null);
+
+    let oref_str = format!("block:{}", block_id);
+    crate::server::service::update_object_meta(wstore, &oref_str, &meta)
+        .map_err(|e| format!("update_object_meta: {e}"))?;
+
+    tracing::info!(
+        block_id = %block_id,
+        restored_bytes = restored_bytes,
+        archive_path = %archive_path_str,
+        "session restored"
+    );
+
+    Ok(restored_bytes)
+}
+
+// ---------------------------------------------------------------------------
+// read_session_output — used by session:export
+// ---------------------------------------------------------------------------
+
+/// Read the raw session output bytes, whether from FileStore (live) or archive.
+/// Returns `(bytes, line_count)`.
+pub fn read_session_output(
+    wstore: &Arc<WaveStore>,
+    filestore: &Arc<FileStore>,
+    block_id: &str,
+) -> Result<(Vec<u8>, u64), String> {
+    // Check if session is archived
+    let block: Block = wstore
+        .get(block_id)
+        .map_err(|e| format!("wstore.get: {e}"))?
+        .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", block_id))?;
+
+    let is_archived = block
+        .meta
+        .get(META_SESSION_ARCHIVED_AT)
+        .and_then(|v| v.as_i64())
+        .map(|v| v > 0)
+        .unwrap_or(false);
+
+    let raw_bytes = if is_archived {
+        let archive_path_str = block
+            .meta
+            .get(META_SESSION_ARCHIVE_PATH)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "session:archive_path not set".to_string())?
+            .to_string();
+        read_gz(Path::new(&archive_path_str))?
+    } else {
+        filestore
+            .read_file(block_id, OUTPUT_FILENAME)
+            .map_err(|e| format!("filestore read: {e}"))?
+            .unwrap_or_default()
+    };
+
+    let line_count = bytecount_lines(&raw_bytes);
+    Ok((raw_bytes, line_count))
+}
+
+/// Count non-empty lines in a byte buffer.
+fn bytecount_lines(data: &[u8]) -> u64 {
+    let text = String::from_utf8_lossy(data);
+    text.lines().filter(|l| !l.trim().is_empty()).count() as u64
+}
+
+// ---------------------------------------------------------------------------
+// Default archive directory
+// ---------------------------------------------------------------------------
+
+/// Returns `~/.agentmux/archives/`, or `None` if the home directory cannot be determined.
+pub fn default_archive_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".agentmux").join("archives"))
+}
+
+// ---------------------------------------------------------------------------
+// SessionArchiver — periodic sweep
+// ---------------------------------------------------------------------------
+
+/// Periodic session archival + storage cap enforcement.
+pub struct SessionArchiver {
+    wstore: Arc<WaveStore>,
+    filestore: Arc<FileStore>,
+    /// Sessions with no activity for this many days get archived.
+    pub inactive_days: u64,
+    /// Maximum total bytes across all `.jsonl.gz` archives.
+    pub max_total_bytes: u64,
+    /// Directory where `.jsonl.gz` files are written.
+    pub archive_dir: PathBuf,
+}
+
+/// Statistics from a single sweep run.
+#[derive(Debug, Clone, Default)]
+pub struct SessionArchiverStats {
+    pub archived_count: u32,
+    pub pruned_count: u32,
+    pub bytes_freed: u64,
+}
+
+impl SessionArchiver {
+    pub fn new(
+        wstore: Arc<WaveStore>,
+        filestore: Arc<FileStore>,
+        inactive_days: u64,
+        max_total_bytes: u64,
+        archive_dir: PathBuf,
+    ) -> Self {
+        Self { wstore, filestore, inactive_days, max_total_bytes, archive_dir }
+    }
+
+    /// Run one sweep:
+    ///   1. Find all agent blocks inactive for `inactive_days`.
+    ///   2. Archive each one (compress → delete FileStore).
+    ///   3. Prune oldest archives if total disk usage exceeds `max_total_bytes`.
+    pub async fn sweep(&self) -> Result<SessionArchiverStats, String> {
+        let mut stats = SessionArchiverStats::default();
+        let now = now_ms();
+        let cutoff_ms = self.inactive_days as i64 * 86_400_000;
+
+        // Collect all blocks
+        let all_blocks: Vec<Block> = self
+            .wstore
+            .get_all::<Block>()
+            .map_err(|e| format!("get_all blocks: {e}"))?;
+
+        for block in &all_blocks {
+            // Only agent panes
+            let view = block.meta.get("view").and_then(|v| v.as_str()).unwrap_or("");
+            if view != "agent" {
+                continue;
+            }
+
+            // Skip if already archived
+            let archived_at = block
+                .meta
+                .get(META_SESSION_ARCHIVED_AT)
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+            if archived_at > 0 {
+                continue;
+            }
+
+            // Skip if session:last_activity_ms is missing (fresh session)
+            let last_activity = match block
+                .meta
+                .get(META_SESSION_LAST_ACTIVITY_MS)
+                .and_then(|v| v.as_i64())
+            {
+                Some(v) if v > 0 => v,
+                _ => continue,
+            };
+
+            // Skip if session has no lines
+            let line_count = block
+                .meta
+                .get(META_SESSION_LINE_COUNT)
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            if line_count == 0 {
+                continue;
+            }
+
+            // Check inactivity threshold
+            if now - last_activity < cutoff_ms {
+                continue;
+            }
+
+            // Archive it
+            match archive_session_output(
+                &self.wstore,
+                &self.filestore,
+                &block.oid,
+                &self.archive_dir,
+            ) {
+                Ok((bytes, _)) => {
+                    stats.archived_count += 1;
+                    stats.bytes_freed += bytes;
+                    tracing::info!(
+                        block_id = %block.oid,
+                        bytes_freed = bytes,
+                        "session archiver: auto-archived inactive session"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        block_id = %block.oid,
+                        error = %e,
+                        "session archiver: failed to archive session"
+                    );
+                }
+            }
+        }
+
+        // Prune oldest archives if over the storage cap
+        stats.pruned_count = self.prune_archives(&mut stats.bytes_freed)?;
+
+        Ok(stats)
+    }
+
+    /// Delete oldest `.jsonl.gz` files until total size is under `max_total_bytes`.
+    /// Returns number of files deleted.
+    fn prune_archives(&self, bytes_freed: &mut u64) -> Result<u32, String> {
+        let Ok(entries) = std::fs::read_dir(&self.archive_dir) else {
+            return Ok(0);
+        };
+
+        // Collect (mtime, path, size) for all .jsonl.gz files
+        let mut files: Vec<(std::time::SystemTime, PathBuf, u64)> = entries
+            .flatten()
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .map(|x| x == "gz")
+                    .unwrap_or(false)
+            })
+            .filter_map(|e| {
+                let meta = e.metadata().ok()?;
+                let mtime = meta.modified().ok()?;
+                let size = meta.len();
+                Some((mtime, e.path(), size))
+            })
+            .collect();
+
+        // Sort oldest-first
+        files.sort_by_key(|(mtime, _, _)| *mtime);
+
+        let total: u64 = files.iter().map(|(_, _, s)| s).sum();
+        if total <= self.max_total_bytes {
+            return Ok(0);
+        }
+
+        let mut remaining = total;
+        let mut pruned = 0u32;
+
+        for (_, path, size) in &files {
+            if remaining <= self.max_total_bytes {
+                break;
+            }
+            if let Err(e) = std::fs::remove_file(path) {
+                tracing::warn!(path = %path.display(), error = %e, "session archiver: failed to prune archive");
+                continue;
+            }
+            remaining = remaining.saturating_sub(*size);
+            *bytes_freed += size;
+            pruned += 1;
+            tracing::info!(
+                path = %path.display(),
+                size_freed = size,
+                "session archiver: pruned archive"
+            );
+        }
+
+        Ok(pruned)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use crate::backend::storage::filestore::FileStore;
+    use crate::backend::storage::wstore::WaveStore;
+
+    /// Verify that a block with old last_activity gets archived by the sweeper.
+    /// Uses in-memory stores — no disk I/O needed for this unit test.
+    #[tokio::test]
+    async fn test_sweep_archives_inactive_session() {
+        // Build a temp dir for archives
+        let tmp_dir = tempfile::tempdir().expect("tempdir");
+        let archive_dir = tmp_dir.path().to_path_buf();
+
+        // In-memory FileStore with output data
+        let filestore = Arc::new(
+            FileStore::open_in_memory().expect("filestore"),
+        );
+        // Write a fake "output" file for block "blk-sweep-test"
+        let block_id = "blk-sweep-test";
+        filestore
+            .make_file(block_id, OUTPUT_FILENAME, FileMeta::default(), FileOpts::default())
+            .expect("make_file");
+        filestore
+            .append_data(block_id, OUTPUT_FILENAME, b"line1\nline2\n")
+            .expect("append_data");
+
+        // In-memory WaveStore
+        let db_dir = tmp_dir.path().join("wdb");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let wstore = Arc::new(
+            WaveStore::open(&db_dir.join("wave.db")).expect("wstore"),
+        );
+
+        // Insert a fake Block object with required meta
+        use crate::backend::obj::{Block, MetaMapType};
+        let mut meta = MetaMapType::new();
+        meta.insert("view".to_string(), serde_json::json!("agent"));
+        // last_activity 10 days ago (well past the 7-day threshold)
+        let ten_days_ago = now_ms() - 10 * 86_400_000;
+        meta.insert(
+            META_SESSION_LAST_ACTIVITY_MS.to_string(),
+            serde_json::json!(ten_days_ago),
+        );
+        meta.insert(META_SESSION_LINE_COUNT.to_string(), serde_json::json!(2u64));
+
+        let mut block = Block {
+            oid: block_id.to_string(),
+            parentoref: String::new(),
+            version: 1,
+            runtimeopts: None,
+            stickers: None,
+            meta,
+            subblockids: None,
+        };
+        wstore.insert(&mut block).expect("wstore insert");
+
+        // Run the archiver (1-day inactive threshold to keep test fast)
+        let archiver = SessionArchiver::new(
+            wstore.clone(),
+            filestore.clone(),
+            1, // 1 day inactive threshold
+            2 * 1024 * 1024 * 1024,
+            archive_dir.clone(),
+        );
+
+        let stats = archiver.sweep().await.expect("sweep");
+        assert_eq!(stats.archived_count, 1, "should archive 1 session");
+        assert!(stats.bytes_freed > 0, "should free bytes");
+
+        // Verify the FileStore entry was deleted
+        let remaining = filestore.stat(block_id, OUTPUT_FILENAME).unwrap();
+        assert!(remaining.is_none(), "filestore entry should be deleted after archive");
+
+        // Verify the .gz file was created
+        let gz_path = archive_dir.join(format!("{}.jsonl.gz", block_id));
+        assert!(gz_path.exists(), ".gz file should exist");
+
+        // Verify the block meta was updated
+        let updated_block: Option<Block> = wstore.get(block_id).unwrap();
+        let updated_block = updated_block.expect("block still in store");
+        let archived_at = updated_block
+            .meta
+            .get(META_SESSION_ARCHIVED_AT)
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        assert!(archived_at > 0, "session:archived_at should be set");
+    }
+
+    #[test]
+    fn test_bytecount_lines() {
+        assert_eq!(bytecount_lines(b""), 0);
+        assert_eq!(bytecount_lines(b"line1\n"), 1);
+        assert_eq!(bytecount_lines(b"line1\nline2\n"), 2);
+        assert_eq!(bytecount_lines(b"  \n\nline3\n"), 1); // blanks excluded
+    }
+
+    #[test]
+    fn test_gz_roundtrip() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let data = b"hello compressed world\nline2\n";
+        write_gz(data, tmp.path()).unwrap();
+        let out = read_gz(tmp.path()).unwrap();
+        assert_eq!(out, data);
+    }
+}

--- a/agentmux-srv/src/backend/session_archive.rs
+++ b/agentmux-srv/src/backend/session_archive.rs
@@ -117,18 +117,12 @@ pub fn archive_session_output(
     let archive_path = archive_dir.join(format!("{}.jsonl.gz", block_id));
     write_gz(&raw_bytes, &archive_path)?;
 
-    // Delete from FileStore so SQLite reclaims the space
-    if let Err(e) = filestore.delete_file(block_id, OUTPUT_FILENAME) {
-        tracing::warn!(
-            block_id = %block_id,
-            error = %e,
-            "session_archive: failed to delete filestore entry after archiving"
-        );
-    }
-
     let archived_at = now_ms();
 
-    // Write archive metadata to the block
+    // Write archive metadata BEFORE deleting the FileStore entry. If the meta
+    // update fails, the session data is still retrievable from FileStore and
+    // the orphaned .gz can be cleaned up by the next sweep. Deleting first
+    // would orphan the session if the meta write then failed.
     let mut meta = MetaMapType::new();
     meta.insert(META_SESSION_ARCHIVED_AT.to_string(), serde_json::json!(archived_at));
     meta.insert(META_SESSION_ARCHIVED_BYTES.to_string(), serde_json::json!(archived_bytes));
@@ -138,8 +132,20 @@ pub fn archive_session_output(
     );
 
     let oref_str = format!("block:{}", block_id);
-    crate::server::service::update_object_meta(wstore, &oref_str, &meta)
-        .map_err(|e| format!("update_object_meta: {e}"))?;
+    if let Err(e) = crate::server::service::update_object_meta(wstore, &oref_str, &meta) {
+        // Roll back the archive file so we don't leak disk on retry
+        let _ = std::fs::remove_file(&archive_path);
+        return Err(format!("update_object_meta: {e}"));
+    }
+
+    // Meta is now persisted; safe to reclaim the FileStore entry
+    if let Err(e) = filestore.delete_file(block_id, OUTPUT_FILENAME) {
+        tracing::warn!(
+            block_id = %block_id,
+            error = %e,
+            "session_archive: failed to delete filestore entry after archiving (meta already updated)"
+        );
+    }
 
     tracing::info!(
         block_id = %block_id,

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -384,6 +384,29 @@ async fn main() {
     // History service — discovers and indexes past CLI agent conversations
     let history_service = Arc::new(backend::history::HistoryService::new());
 
+    // Session archiver — auto-archive sessions inactive for >7 days, cap at 2 GB
+    {
+        let archiver = Arc::new(backend::session_archive::SessionArchiver::new(
+            wstore.clone(),
+            filestore.clone(),
+            7,                              // inactive days
+            2 * 1024 * 1024 * 1024,         // 2 GB max
+            dirs::home_dir()
+                .unwrap_or_default()
+                .join(".agentmux")
+                .join("archives"),
+        ));
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+                match archiver.sweep().await {
+                    Ok(stats) => tracing::info!(?stats, "session archiver sweep complete"),
+                    Err(e) => tracing::warn!(error = %e, "session archiver sweep failed"),
+                }
+            }
+        });
+    }
+
     // 5. Bind 2 TCP listeners on 127.0.0.1:0 (web + ws — separate ports matching Go)
     let web_listener = TcpListener::bind("127.0.0.1:0")
         .await

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -384,17 +384,16 @@ async fn main() {
     // History service — discovers and indexes past CLI agent conversations
     let history_service = Arc::new(backend::history::HistoryService::new());
 
-    // Session archiver — auto-archive sessions inactive for >7 days, cap at 2 GB
-    {
+    // Session archiver — auto-archive sessions inactive for >7 days, cap at 2 GB.
+    // Skip if home directory can't be determined (would otherwise fall back to a
+    // relative path and create archives under the current working directory).
+    if let Some(archive_dir) = backend::session_archive::default_archive_dir() {
         let archiver = Arc::new(backend::session_archive::SessionArchiver::new(
             wstore.clone(),
             filestore.clone(),
             7,                              // inactive days
             2 * 1024 * 1024 * 1024,         // 2 GB max
-            dirs::home_dir()
-                .unwrap_or_default()
-                .join(".agentmux")
-                .join("archives"),
+            archive_dir,
         ));
         tokio::spawn(async move {
             loop {
@@ -405,6 +404,8 @@ async fn main() {
                 }
             }
         });
+    } else {
+        tracing::warn!("session archiver: home dir unavailable, archiver disabled");
     }
 
     // 5. Bind 2 TCP listeners on 127.0.0.1:0 (web + ws — separate ports matching Go)

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1178,20 +1178,38 @@ async fn invoke_cli_for_digest(
         _ => std::collections::HashMap::new(),
     };
 
+    // Pipe the prompt via stdin rather than passing it as a CLI arg — Linux
+    // caps individual argv entries at MAX_ARG_STRLEN (~128 KB), and a digest
+    // over 200 lines of session content can easily exceed that. Using `-p`
+    // with an empty string arg tells Claude CLI to read the prompt from stdin.
+    let mut child = crate::server::cli_handlers::make_cli_cmd(cli_path)
+        .args(["-p", "--output-format", "stream-json", "--verbose"])
+        .envs(&auth_env)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map_err(|e| format!("failed to spawn digest CLI: {e}"))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        stdin
+            .write_all(prompt.as_bytes())
+            .await
+            .map_err(|e| format!("digest CLI stdin write: {e}"))?;
+        stdin
+            .shutdown()
+            .await
+            .map_err(|e| format!("digest CLI stdin shutdown: {e}"))?;
+    }
+
     let output = tokio::time::timeout(
         std::time::Duration::from_secs(60),
-        crate::server::cli_handlers::make_cli_cmd(cli_path)
-            .args(["-p", "--output-format", "stream-json", "--verbose"])
-            .arg(prompt)
-            .envs(&auth_env)
-            .stdin(std::process::Stdio::null())
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
-            .output(),
+        child.wait_with_output(),
     )
     .await
     .map_err(|_| "digest CLI timed out after 60s".to_string())?
-    .map_err(|e| format!("failed to spawn digest CLI: {e}"))?;
+    .map_err(|e| format!("digest CLI wait: {e}"))?;
 
     if !output.status.success() {
         return Err(format!("digest CLI exited with status {}", output.status));

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -14,6 +14,7 @@ use crate::backend::obj::{self, Block, Tab, Workspace, MetaMapType};
 use crate::backend::providers;
 use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::*;
+use crate::backend::session_archive;
 use crate::backend::storage::wstore::WaveStore;
 
 use super::AppState;
@@ -28,6 +29,10 @@ pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_agent_output(engine, state);
     register_blockfile_line_count(engine, state);
     register_blockfile_read_range(engine, state);
+    register_session_digest(engine, state);
+    register_session_archive_handler(engine, state);
+    register_session_restore_handler(engine, state);
+    register_session_export_handler(engine, state);
 }
 
 // ---------------------------------------------------------------------------
@@ -769,6 +774,457 @@ fn register_blockfile_read_range(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+}
+
+// ---------------------------------------------------------------------------
+// session:archive
+// ---------------------------------------------------------------------------
+
+fn register_session_archive_handler(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let filestore = state.filestore.clone();
+
+    engine.register_handler(
+        COMMAND_SESSION_ARCHIVE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let filestore = filestore.clone();
+            Box::pin(async move {
+                let cmd: CommandSessionArchiveData = serde_json::from_value(data)
+                    .map_err(|e| format!("session:archive: {e}"))?;
+
+                tracing::info!(block_id = %cmd.block_id, "session:archive");
+
+                let archive_dir = session_archive::default_archive_dir()
+                    .ok_or_else(|| "cannot determine home directory".to_string())?;
+
+                let (archived_bytes, archived_at) = session_archive::archive_session_output(
+                    &wstore,
+                    &filestore,
+                    &cmd.block_id,
+                    &archive_dir,
+                )?;
+
+                Ok(Some(serde_json::to_value(&SessionArchiveResult {
+                    block_id: cmd.block_id,
+                    archived_bytes,
+                    archived_at,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// session:restore
+// ---------------------------------------------------------------------------
+
+fn register_session_restore_handler(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let filestore = state.filestore.clone();
+
+    engine.register_handler(
+        COMMAND_SESSION_RESTORE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let filestore = filestore.clone();
+            Box::pin(async move {
+                let cmd: CommandSessionRestoreData = serde_json::from_value(data)
+                    .map_err(|e| format!("session:restore: {e}"))?;
+
+                tracing::info!(block_id = %cmd.block_id, "session:restore");
+
+                let restored_bytes = session_archive::restore_session_output(
+                    &wstore,
+                    &filestore,
+                    &cmd.block_id,
+                )?;
+
+                Ok(Some(serde_json::to_value(&SessionRestoreResult {
+                    block_id: cmd.block_id,
+                    restored_bytes,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// session:export
+// ---------------------------------------------------------------------------
+
+fn register_session_export_handler(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let filestore = state.filestore.clone();
+
+    engine.register_handler(
+        COMMAND_SESSION_EXPORT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let filestore = filestore.clone();
+            Box::pin(async move {
+                let cmd: CommandSessionExportData = serde_json::from_value(data)
+                    .map_err(|e| format!("session:export: {e}"))?;
+
+                tracing::info!(block_id = %cmd.block_id, "session:export");
+
+                let (raw_bytes, line_count) = session_archive::read_session_output(
+                    &wstore,
+                    &filestore,
+                    &cmd.block_id,
+                )?;
+
+                let byte_count = raw_bytes.len() as u64;
+                let content = base64::engine::general_purpose::STANDARD.encode(&raw_bytes);
+
+                Ok(Some(serde_json::to_value(&SessionExportResult {
+                    content,
+                    line_count,
+                    byte_count,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// session:digest
+// ---------------------------------------------------------------------------
+
+fn register_session_digest(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let filestore = state.filestore.clone();
+    let broker = state.broker.clone();
+
+    engine.register_handler(
+        COMMAND_SESSION_DIGEST,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let filestore = filestore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandSessionDigestData = serde_json::from_value(data)
+                    .map_err(|e| format!("session:digest: {e}"))?;
+
+                tracing::info!(block_id = %cmd.block_id, force = ?cmd.force, "session:digest");
+
+                let force = cmd.force.unwrap_or(false);
+
+                // Read block meta
+                let block: Block = wstore
+                    .get(&cmd.block_id)
+                    .map_err(|e| format!("session:digest: {e}"))?
+                    .ok_or_else(|| format!("BLOCK_NOT_FOUND: {}", cmd.block_id))?;
+
+                // Check for a valid cached digest
+                let cached_summary = block.meta.get("session:digest_summary")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let cached_generated_at = block.meta.get("session:digest_generated_at")
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let digest_last_line_count = block.meta.get("session:digest_last_line_count")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+
+                // Current line count from meta (O(1))
+                let current_line_count = block.meta.get("session:line_count")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+
+                // Serve cache if: not forced, cached digest exists, AND fewer than 20 new lines
+                // since the digest was last generated.
+                let lines_since_digest = current_line_count.saturating_sub(digest_last_line_count);
+                if !force && cached_summary.is_some() && lines_since_digest < 20 {
+                    return Ok(Some(serde_json::to_value(&SessionDigestResult {
+                        summary: cached_summary.unwrap(),
+                        generated_at: cached_generated_at,
+                        cached: true,
+                    }).unwrap()));
+                }
+
+                // --- Generate a new digest ---
+
+                // Read up to the last 200 lines from FileStore, falling back to the WPS ring buffer.
+                let all_lines: Vec<String> = {
+                    let filestore_lines = match filestore.stat(&cmd.block_id, "output") {
+                        Ok(Some(ref wf)) if wf.size > 0 => {
+                            match filestore.read_file(&cmd.block_id, "output") {
+                                Ok(Some(bytes)) => {
+                                    let text = String::from_utf8_lossy(&bytes);
+                                    let lines: Vec<String> = text.lines()
+                                        .filter(|l| !l.trim().is_empty())
+                                        .map(|l| l.to_string())
+                                        .collect();
+                                    Some(lines)
+                                }
+                                _ => None,
+                            }
+                        }
+                        _ => None,
+                    };
+
+                    if let Some(lines) = filestore_lines {
+                        lines
+                    } else {
+                        // Fallback: WPS ring buffer
+                        let scope = format!("block:{}", cmd.block_id);
+                        let events = broker.read_event_history(
+                            crate::backend::wps::EVENT_BLOCK_FILE,
+                            &scope,
+                            usize::MAX,
+                        );
+                        let mut lines: Vec<String> = Vec::new();
+                        for event in events {
+                            let Some(ref ed) = event.data else { continue };
+                            let fname = ed.get("filename").and_then(|v| v.as_str()).unwrap_or("");
+                            if fname != "output" { continue; }
+                            if let Some(d64) = ed.get("data64").and_then(|v| v.as_str()) {
+                                if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(d64) {
+                                    let text = String::from_utf8_lossy(&bytes);
+                                    for line in text.lines() {
+                                        if !line.trim().is_empty() {
+                                            lines.push(line.to_string());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        lines
+                    }
+                };
+
+                // Take the last 200 lines
+                let n = all_lines.len();
+                let start = n.saturating_sub(200);
+                let window: Vec<&str> = all_lines[start..].iter().map(|s| s.as_str()).collect();
+
+                if window.is_empty() {
+                    return Ok(Some(serde_json::to_value(&SessionDigestResult {
+                        summary: String::new(),
+                        generated_at: 0,
+                        cached: false,
+                    }).unwrap()));
+                }
+
+                // Extract meaningful text (skip system events and raw stream deltas)
+                let extracted = extract_digest_text(&window);
+
+                if extracted.is_empty() {
+                    return Ok(Some(serde_json::to_value(&SessionDigestResult {
+                        summary: String::new(),
+                        generated_at: 0,
+                        cached: false,
+                    }).unwrap()));
+                }
+
+                // Locate the Claude CLI (stored in block meta as "cmd" by runLaunchFlow)
+                let cli_path = obj::meta_get_string(&block.meta, "cmd", "");
+                if cli_path.is_empty() {
+                    tracing::warn!(block_id = %cmd.block_id, "session:digest: no CLI path in meta");
+                    return Ok(Some(serde_json::to_value(&SessionDigestResult {
+                        summary: String::new(),
+                        generated_at: 0,
+                        cached: false,
+                    }).unwrap()));
+                }
+
+                // Build the summarization prompt
+                let prompt = format!(
+                    "Summarize this AI coding session in 3-4 sentences. Focus on: what was worked on, \
+                     tools used, any errors encountered, and the current state. Be concise and factual.\n\n\
+                     Session content (last 200 events):\n\n{}",
+                    extracted
+                );
+
+                // Invoke the Claude CLI and extract the summary text
+                let summary = match invoke_cli_for_digest(&cli_path, &prompt, &block.meta).await {
+                    Ok(text) => text,
+                    Err(e) => {
+                        tracing::warn!(block_id = %cmd.block_id, error = %e, "session:digest: CLI invocation failed");
+                        String::new()
+                    }
+                };
+
+                if summary.is_empty() {
+                    return Ok(Some(serde_json::to_value(&SessionDigestResult {
+                        summary: String::new(),
+                        generated_at: 0,
+                        cached: false,
+                    }).unwrap()));
+                }
+
+                // Cache in block meta
+                let generated_at = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+
+                let mut meta_update = obj::MetaMapType::new();
+                meta_update.insert("session:digest_summary".to_string(), json!(summary.clone()));
+                meta_update.insert("session:digest_generated_at".to_string(), json!(generated_at));
+                meta_update.insert("session:digest_last_line_count".to_string(), json!(current_line_count));
+
+                if let Err(e) = crate::server::service::update_object_meta(
+                    &wstore,
+                    &format!("block:{}", cmd.block_id),
+                    &meta_update,
+                ) {
+                    tracing::warn!(block_id = %cmd.block_id, error = %e, "session:digest: failed to cache in meta");
+                }
+
+                Ok(Some(serde_json::to_value(&SessionDigestResult {
+                    summary,
+                    generated_at,
+                    cached: false,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+/// Extract meaningful text from raw stream-json lines for digest summarization.
+/// Skips system/result events and raw stream_event deltas; extracts assistant text
+/// and tool call summaries.
+fn extract_digest_text(lines: &[&str]) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    for line in lines {
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(line) else { continue };
+
+        let msg_type = val.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+        match msg_type {
+            "assistant" => {
+                if let Some(content) = val.get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(|c| c.as_array())
+                {
+                    for block in content {
+                        let btype = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                        if btype == "text" {
+                            if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
+                                let trimmed = text.trim();
+                                if !trimmed.is_empty() {
+                                    parts.push(format!("[assistant] {}", trimmed));
+                                }
+                            }
+                        } else if btype == "tool_use" {
+                            let tool_name = block.get("name")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("unknown");
+                            parts.push(format!("[tool] {}", tool_name));
+                        }
+                    }
+                }
+            }
+            "user" => {
+                if let Some(content) = val.get("message")
+                    .and_then(|m| m.get("content"))
+                    .and_then(|c| c.as_array())
+                {
+                    for block in content {
+                        let btype = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
+                        if btype == "tool_result" {
+                            let is_error = block.get("is_error")
+                                .and_then(|v| v.as_bool())
+                                .unwrap_or(false);
+                            if is_error {
+                                let err_text = block.get("content")
+                                    .and_then(|c| c.as_str())
+                                    .unwrap_or("(error)")
+                                    .chars().take(120).collect::<String>();
+                                parts.push(format!("[error] {}", err_text));
+                            }
+                        } else if btype == "text" {
+                            if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
+                                let trimmed = text.trim();
+                                if !trimmed.is_empty() {
+                                    parts.push(format!("[user] {}", trimmed));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            "result" => {
+                if let Some(cost) = val.get("total_cost_usd").and_then(|v| v.as_f64()) {
+                    if let Some(turns) = val.get("num_turns").and_then(|v| v.as_u64()) {
+                        parts.push(format!("[summary] {} turns, ${:.4} total cost", turns, cost));
+                    }
+                }
+            }
+            // Skip: system, stream_event (deltas), rate_limit_event
+            _ => {}
+        }
+    }
+
+    parts.join("\n")
+}
+
+/// Invoke the Claude CLI with a prompt and extract the text response.
+/// Uses `-p --output-format stream-json --verbose` (non-interactive mode).
+async fn invoke_cli_for_digest(
+    cli_path: &str,
+    prompt: &str,
+    meta: &obj::MetaMapType,
+) -> Result<String, String> {
+    // Inherit auth env from block meta (CLAUDE_CONFIG_DIR, etc.)
+    let auth_env: std::collections::HashMap<String, String> = match meta.get("cmd:env") {
+        Some(serde_json::Value::Object(obj_map)) => obj_map
+            .iter()
+            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+            .collect(),
+        _ => std::collections::HashMap::new(),
+    };
+
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        crate::server::cli_handlers::make_cli_cmd(cli_path)
+            .args(["-p", "--output-format", "stream-json", "--verbose"])
+            .arg(prompt)
+            .envs(&auth_env)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .output(),
+    )
+    .await
+    .map_err(|_| "digest CLI timed out after 60s".to_string())?
+    .map_err(|e| format!("failed to spawn digest CLI: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!("digest CLI exited with status {}", output.status));
+    }
+
+    // Parse stream-json output — capture the last assistant text block
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut last_text = String::new();
+
+    for line in stdout.lines() {
+        let Ok(val) = serde_json::from_str::<serde_json::Value>(line) else { continue };
+        let msg_type = val.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if msg_type == "assistant" {
+            if let Some(content) = val.get("message")
+                .and_then(|m| m.get("content"))
+                .and_then(|c| c.as_array())
+            {
+                for block in content {
+                    if block.get("type").and_then(|v| v.as_str()) == Some("text") {
+                        if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
+                            last_text = text.trim().to_string();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if last_text.is_empty() {
+        return Err("no text content in digest CLI response".to_string());
+    }
+
+    Ok(last_text)
 }
 
 // ---------------------------------------------------------------------------

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1180,14 +1180,16 @@ async fn invoke_cli_for_digest(
 
     // Pipe the prompt via stdin rather than passing it as a CLI arg — Linux
     // caps individual argv entries at MAX_ARG_STRLEN (~128 KB), and a digest
-    // over 200 lines of session content can easily exceed that. Using `-p`
-    // with an empty string arg tells Claude CLI to read the prompt from stdin.
+    // over 200 lines of session content can easily exceed that.
+    // `kill_on_drop(true)` ensures the child is terminated if the timeout
+    // future below is dropped — tokio `Child` does NOT kill on drop by default.
     let mut child = crate::server::cli_handlers::make_cli_cmd(cli_path)
         .args(["-p", "--output-format", "stream-json", "--verbose"])
         .envs(&auth_env)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
         .spawn()
         .map_err(|e| format!("failed to spawn digest CLI: {e}"))?;
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.98"
+version = "0.33.99"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.97"
+version = "0.33.98"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -613,6 +613,26 @@ class RpcApiType {
         return client.wshRpcCall("blockfile:read_range", data, opts);
     }
 
+    // command "session:digest" [call]
+    SessionDigestCommand(client: WshClient, data: CommandSessionDigestData, opts?: RpcOpts): Promise<SessionDigestResult> {
+        return client.wshRpcCall("session:digest", data, opts);
+    }
+
+    // command "session:archive" [call]
+    SessionArchiveCommand(client: WshClient, data: CommandSessionArchiveData, opts?: RpcOpts): Promise<SessionArchiveResult> {
+        return client.wshRpcCall("session:archive", data, opts);
+    }
+
+    // command "session:restore" [call]
+    SessionRestoreCommand(client: WshClient, data: CommandSessionRestoreData, opts?: RpcOpts): Promise<SessionRestoreResult> {
+        return client.wshRpcCall("session:restore", data, opts);
+    }
+
+    // command "session:export" [call]
+    SessionExportCommand(client: WshClient, data: CommandSessionExportData, opts?: RpcOpts): Promise<SessionExportResult> {
+        return client.wshRpcCall("session:export", data, opts);
+    }
+
 }
 
 export const RpcApi = new RpcApiType();

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -2266,4 +2266,194 @@
         text-overflow: ellipsis;
         font-family: var(--fixed-font, monospace);
     }
+
+    // === In-session Search Bar ===
+
+    .agent-search-bar {
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 8px;
+        background: color-mix(in srgb, var(--accent-color, #4a9eff) 6%, var(--main-bg-color));
+        border-bottom: 1px solid var(--border-color);
+        // Sticky so it stays visible while the document scrolls beneath it
+        position: sticky;
+        top: 0;
+        z-index: 10;
+    }
+
+    .agent-search-input {
+        flex: 1;
+        min-width: 0;
+        background: var(--main-bg-color);
+        color: var(--main-text-color);
+        border: 1px solid var(--border-color);
+        border-radius: 3px;
+        padding: 3px 6px;
+        font-size: 12px;
+        font-family: inherit;
+        outline: none;
+        transition: border-color 0.15s;
+
+        &:focus {
+            border-color: var(--accent-color, #4a9eff);
+        }
+
+        &::placeholder {
+            color: var(--secondary-text-color);
+            opacity: 0.6;
+        }
+    }
+
+    .agent-search-counter {
+        flex-shrink: 0;
+        font-size: 11px;
+        color: var(--secondary-text-color);
+        white-space: nowrap;
+        min-width: 56px;
+        text-align: right;
+        opacity: 0.75;
+    }
+
+    .agent-search-btn {
+        flex-shrink: 0;
+        width: 22px;
+        height: 22px;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        border: 1px solid transparent;
+        border-radius: 3px;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+        font-size: 11px;
+        line-height: 1;
+        transition: background 0.1s, color 0.1s, border-color 0.1s;
+
+        &:hover {
+            background: color-mix(in srgb, var(--accent-color, #4a9eff) 15%, transparent);
+            border-color: var(--border-color);
+            color: var(--main-text-color);
+        }
+
+        &--close {
+            font-size: 14px;
+            margin-left: 2px;
+
+            &:hover {
+                background: color-mix(in srgb, var(--error-color, #f87171) 15%, transparent);
+                border-color: color-mix(in srgb, var(--error-color, #f87171) 40%, transparent);
+                color: var(--error-color, #f87171);
+            }
+        }
+    }
+
+    // === Search-match highlight ===
+
+    .agent-node-search-match {
+        // Subtle accent-tinted background to flag the matched node
+        background: color-mix(in srgb, var(--accent-color, #4a9eff) 10%, transparent) !important;
+        // Left border acts as a gutter indicator
+        border-left: 3px solid var(--accent-color, #4a9eff) !important;
+        border-radius: 2px;
+        // Small padding-left offset to compensate for the border
+        padding-left: 4px;
+        // Brief animation so the highlight is immediately noticeable when
+        // navigating between matches
+        animation: search-match-flash 0.25s ease-out;
+    }
+
+    @keyframes search-match-flash {
+        from {
+            background: color-mix(in srgb, var(--accent-color, #4a9eff) 28%, transparent);
+        }
+        to {
+            background: color-mix(in srgb, var(--accent-color, #4a9eff) 10%, transparent);
+        }
+    }
+
+    // === Session digest banner ===
+
+    .agent-session-digest {
+        margin: 4px 0 2px;
+        padding: 6px 8px;
+        background: color-mix(in srgb, var(--accent-color, #4a9eff) 8%, transparent);
+        border: 1px solid var(--accent-color, #4a9eff);
+        border-radius: 4px;
+        font-size: 12px;
+        flex-shrink: 0;
+    }
+
+    .agent-session-digest-header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-weight: 600;
+        color: var(--main-text-color);
+    }
+
+    .agent-session-digest-title {
+        flex: 1;
+        color: var(--accent-color, #4a9eff);
+        font-size: 12px;
+    }
+
+    .agent-session-digest-age {
+        font-weight: normal;
+        opacity: 0.7;
+        font-size: 11px;
+    }
+
+    .agent-session-digest-toggle,
+    .agent-session-digest-action {
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 2px 5px;
+        color: var(--secondary-text-color);
+        opacity: 0.75;
+        font-size: 12px;
+        line-height: 1;
+        border-radius: 3px;
+        transition: opacity 0.1s, background 0.1s;
+        flex-shrink: 0;
+
+        &:hover:not(:disabled) {
+            opacity: 1;
+            background: color-mix(in srgb, var(--accent-color, #4a9eff) 15%, transparent);
+        }
+
+        &:disabled {
+            cursor: default;
+            opacity: 0.4;
+        }
+    }
+
+    .agent-session-digest-dismiss:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--error-color, #f87171) 15%, transparent);
+        color: var(--error-color, #f87171);
+    }
+
+    .agent-session-digest-body {
+        padding: 6px 2px 2px;
+        line-height: 1.5;
+        color: var(--main-text-color);
+
+        // Markdown renders <p> tags — tighten spacing inside the banner
+        p {
+            margin: 0 0 4px;
+            &:last-child { margin-bottom: 0; }
+        }
+    }
+
+    .agent-session-digest-loading,
+    .agent-session-digest-empty {
+        padding: 6px 2px 2px;
+        opacity: 0.6;
+        font-style: italic;
+        color: var(--secondary-text-color);
+    }
 }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -15,7 +15,9 @@ import { parseHistoryLines } from "./parseHistoryLines";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
+import { AgentSearchBar } from "./components/AgentSearchBar";
 import { BookmarksPanel } from "./components/BookmarksPanel";
+import { SessionDigestBanner } from "./components/SessionDigestBanner";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
 import { waveEventSubscribe } from "@/app/store/wps";
@@ -394,6 +396,14 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const [historyTotal, setHistoryTotal] = createSignal(0);
     const [loadingOlder, setLoadingOlder] = createSignal(false);
 
+    // ── Session digest ──────────────────────────────────────────────────────────
+    // Shows a collapsible AI-generated summary when the user returns to a stale
+    // session (idle >1 hour with >20 lines of new activity).
+    const [digestSummary, setDigestSummary] = createSignal<string | null>(null);
+    const [digestGeneratedAt, setDigestGeneratedAt] = createSignal<number | null>(null);
+    const [digestLoading, setDigestLoading] = createSignal(false);
+    const [digestDismissed, setDigestDismissed] = createSignal(false);
+
     // Bumped on every external document mutation (history load, prepend).
     // useAgentStream watches this and rebuilds its internal nodeIdSet +
     // nodeIndexMap so live-stream updates continue targeting the right
@@ -474,6 +484,34 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             setLoadingOlder(false);
         }
     };
+
+    // Fetch (or regenerate) the session digest via the session:digest RPC.
+    // `force=true` bypasses the cache and re-invokes the Claude CLI.
+    const fetchDigest = async (force = false): Promise<void> => {
+        if (digestLoading()) return;
+        setDigestLoading(true);
+        try {
+            const result = await RpcApi.SessionDigestCommand(TabRpcClient, {
+                block_id: model.blockId,
+                force,
+            }, { timeout: 90000 }); // 60s CLI + headroom
+
+            if (result.summary) {
+                setDigestSummary(result.summary);
+                setDigestGeneratedAt(result.generated_at > 0 ? result.generated_at : null);
+            } else {
+                // Backend returned an empty summary (CLI unavailable, etc.) — hide the banner
+                setDigestSummary(null);
+            }
+        } catch (err: any) {
+            log("digest", `failed to generate session digest: ${err?.message ?? String(err)}`, "warn");
+            setDigestSummary(null);
+        } finally {
+            setDigestLoading(false);
+        }
+    };
+
+    const dismissDigest = () => setDigestDismissed(true);
 
     // Runs the full launch flow; can be triggered at mount time or via retry.
     const startLaunchFlow = async () => {
@@ -590,6 +628,48 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             }
         })();
 
+        // ── Session digest auto-trigger ─────────────────────────────────────────
+        // Decide whether to show (or generate) a digest on pane open.
+        // Conditions: the session was idle for >1 hour AND has >20 lines.
+        // We use block meta for both facts; no extra RPC needed.
+        (() => {
+            const meta = block()?.meta ?? {};
+            const lastActivityMs: number = typeof meta["session:last_activity_ms"] === "number"
+                ? (meta["session:last_activity_ms"] as number)
+                : 0;
+            const lineCount: number = typeof meta["session:line_count"] === "number"
+                ? (meta["session:line_count"] as number)
+                : 0;
+            const cachedDigest = typeof meta["session:digest_summary"] === "string"
+                ? (meta["session:digest_summary"] as string)
+                : null;
+            const cachedDigestAt: number = typeof meta["session:digest_generated_at"] === "number"
+                ? (meta["session:digest_generated_at"] as number)
+                : 0;
+            const digestLastLineCount: number = typeof meta["session:digest_last_line_count"] === "number"
+                ? (meta["session:digest_last_line_count"] as number)
+                : 0;
+
+            const idleMs = lastActivityMs > 0 ? Date.now() - lastActivityMs : 0;
+            const idleOverOneHour = idleMs > 3600000;
+            const linesSinceDigest = lineCount - digestLastLineCount;
+
+            if (cachedDigest) {
+                // Always show the cached digest if available — let the backend decide
+                // on staleness when the user clicks Regenerate.
+                setDigestSummary(cachedDigest);
+                setDigestGeneratedAt(cachedDigestAt > 0 ? cachedDigestAt : null);
+
+                // Auto-regenerate in the background if idle >1h AND stale (>20 new lines)
+                if (idleOverOneHour && linesSinceDigest >= 20) {
+                    fetchDigest(false); // non-forced — backend will regenerate due to line delta
+                }
+            } else if (idleOverOneHour && lineCount > 20) {
+                // No cached digest — auto-generate one (takes 2-5s; show loading state)
+                fetchDigest(false);
+            }
+        })();
+
         // Full launch flow: CLI resolution → auth check → controller registration
         startLaunchFlow();
 
@@ -659,16 +739,27 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         onCleanup(() => unsubCompleted());
 
         // Ctrl+B — toggle bookmarks panel.
-        // Only fires for THIS pane if it's the currently focused block.
-        // Without this check, Ctrl+B would toggle every open agent pane's
-        // bookmarks panel simultaneously (all panes register the listener
-        // at window level).
+        // Ctrl+F — toggle search bar.
+        // Both are scoped to THIS pane via focusedBlockId() so that only the
+        // focused pane responds when multiple agent panes are open.
         const handleKeyDown = (e: KeyboardEvent) => {
+            const focused = focusedBlockId();
+            if (focused !== model.blockId) return;
+
             if (e.ctrlKey && e.key === "b") {
-                const focused = focusedBlockId();
-                if (focused !== model.blockId) return;
                 e.preventDefault();
                 setShowBookmarks((v) => !v);
+            } else if (e.ctrlKey && e.key === "f") {
+                e.preventDefault();
+                // Capture current state BEFORE toggling so we know if this
+                // Ctrl+F press is opening or closing the bar.
+                const wasVisible = searchVisible();
+                if (wasVisible) {
+                    // Second Ctrl+F press closes and clears state.
+                    searchClose();
+                } else {
+                    setSearchVisible(true);
+                }
             }
         };
         window.addEventListener("keydown", handleKeyDown);
@@ -825,6 +916,81 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // Mutable ref to the scrollToNode function exposed by AgentDocumentView.
     let scrollToNodeFn: ((nodeId: string) => void) | null = null;
 
+    // ── In-session search ───────────────────────────────────────────────────────
+    // Searches over the currently-loaded document slice only. Searching the
+    // full persisted history would require a backend blockfile:search RPC —
+    // out of scope for this PR.
+
+    const [searchVisible, setSearchVisible] = createSignal(false);
+    /** Node IDs whose text content matches the active query. */
+    const [searchMatches, setSearchMatches] = createSignal<string[]>([]);
+    /** 0-based index into searchMatches. -1 when there are no matches. */
+    const [searchCurrentIndex, setSearchCurrentIndex] = createSignal(-1);
+
+    /** Extract searchable plain text from any document node. */
+    const nodeSearchText = (node: DocumentNode): string => {
+        switch (node.type) {
+            case "markdown":      return node.content;
+            case "user_message":  return node.message;
+            case "agent_message": return node.message;
+            case "tool":          return node.tool + " " + JSON.stringify(node.params ?? {});
+            case "section":       return node.title;
+            case "subagent_link": return node.slug + " " + node.subagentId;
+            default:              return "";
+        }
+    };
+
+    const performSearch = (query: string) => {
+        if (!query.trim()) {
+            setSearchMatches([]);
+            setSearchCurrentIndex(-1);
+            return;
+        }
+        const q = query.toLowerCase();
+        const [doc] = agentAtoms().documentAtom;
+        const matches: string[] = [];
+        for (const node of doc()) {
+            if (nodeSearchText(node).toLowerCase().includes(q)) {
+                matches.push(node.id);
+            }
+        }
+        setSearchMatches(matches);
+        const newIndex = matches.length > 0 ? 0 : -1;
+        setSearchCurrentIndex(newIndex);
+        if (newIndex >= 0 && scrollToNodeFn) {
+            scrollToNodeFn(matches[0]);
+        }
+    };
+
+    const searchNext = () => {
+        const matches = searchMatches();
+        if (matches.length === 0) return;
+        const next = (searchCurrentIndex() + 1) % matches.length;
+        setSearchCurrentIndex(next);
+        if (scrollToNodeFn) scrollToNodeFn(matches[next]);
+    };
+
+    const searchPrev = () => {
+        const matches = searchMatches();
+        if (matches.length === 0) return;
+        const prev = (searchCurrentIndex() - 1 + matches.length) % matches.length;
+        setSearchCurrentIndex(prev);
+        if (scrollToNodeFn) scrollToNodeFn(matches[prev]);
+    };
+
+    const searchClose = () => {
+        setSearchVisible(false);
+        setSearchMatches([]);
+        setSearchCurrentIndex(-1);
+    };
+
+    /** Node id of the currently highlighted search result, or null. */
+    const searchHighlightId = createMemo<string | null>(() => {
+        const matches = searchMatches();
+        const idx = searchCurrentIndex();
+        return idx >= 0 && idx < matches.length ? matches[idx] : null;
+    });
+
     const saveBookmarks = async (next: Bookmark[]): Promise<void> => {
         await RpcApi.SetMetaCommand(TabRpcClient, {
             oref: WOS.makeORef("block", model.blockId),
@@ -957,6 +1123,26 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 />
             </Show>
 
+            <AgentSearchBar
+                visible={searchVisible}
+                onSearch={performSearch}
+                onNext={searchNext}
+                onPrev={searchPrev}
+                onClose={searchClose}
+                matchIndex={searchCurrentIndex}
+                matchCount={() => searchMatches().length}
+            />
+
+            <Show when={!digestDismissed()}>
+                <SessionDigestBanner
+                    summary={digestSummary}
+                    generatedAt={digestGeneratedAt}
+                    loading={digestLoading}
+                    onDismiss={dismissDigest}
+                    onRegenerate={() => fetchDigest(true)}
+                />
+            </Show>
+
             <AgentDocumentView
                 documentAtom={agentAtoms().documentAtom}
                 documentStateAtom={agentAtoms().documentStateAtom}
@@ -970,6 +1156,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 bookmarkedNodeIds={bookmarkedNodeIds}
                 onBookmark={handleBookmark}
                 scrollToNodeRef={(fn) => { scrollToNodeFn = fn; }}
+                highlightNodeId={searchHighlightId}
             />
 
             <Show when={loginWaiting()}>

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -4,6 +4,9 @@
 /**
  * AgentControlBar - Collapsible runtime controls for permission mode,
  * model, and effort level. Changes take effect on the next turn.
+ *
+ * Also shows Archive / Export / Restore session management buttons
+ * when the session has data (session:line_count > 0).
  */
 
 import { createSignal, Show, type JSX } from "solid-js";
@@ -53,6 +56,9 @@ const EFFORT_LABELS: Record<string, string> = {
 
 export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControlBarProps): JSX.Element => {
     const [expanded, setExpanded] = createSignal(false);
+    const [archiveBusy, setArchiveBusy] = createSignal(false);
+    const [exportBusy, setExportBusy] = createSignal(false);
+    const [restoreBusy, setRestoreBusy] = createSignal(false);
 
     const runtime = (): AgentRuntimeConfig => getRuntimeConfig(blockAtom()?.meta);
 
@@ -87,11 +93,100 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
         return parts.join(" · ");
     };
 
+    // ── Session management helpers ──────────────────────────────────────────────
+
+    const lineCount = (): number =>
+        (blockAtom()?.meta?.["session:line_count"] as number | undefined) ?? 0;
+
+    const isArchived = (): boolean => {
+        const archivedAt = blockAtom()?.meta?.["session:archived_at"] as number | undefined;
+        return (archivedAt ?? 0) > 0;
+    };
+
+    const archivedAtLabel = (): string => {
+        const ts = blockAtom()?.meta?.["session:archived_at"] as number | undefined;
+        if (!ts) return "";
+        return new Date(ts).toLocaleString();
+    };
+
+    const handleArchive = async () => {
+        if (archiveBusy()) return;
+        setArchiveBusy(true);
+        try {
+            await RpcApi.SessionArchiveCommand(TabRpcClient, { block_id: blockId });
+        } catch (e) {
+            console.error("session:archive failed:", e);
+        } finally {
+            setArchiveBusy(false);
+        }
+    };
+
+    const handleRestore = async () => {
+        if (restoreBusy()) return;
+        setRestoreBusy(true);
+        try {
+            await RpcApi.SessionRestoreCommand(TabRpcClient, { block_id: blockId });
+        } catch (e) {
+            console.error("session:restore failed:", e);
+        } finally {
+            setRestoreBusy(false);
+        }
+    };
+
+    const handleExport = async () => {
+        if (exportBusy()) return;
+        setExportBusy(true);
+        try {
+            const result = await RpcApi.SessionExportCommand(TabRpcClient, { block_id: blockId });
+            // Decode base64 and trigger a browser download
+            const raw = atob(result.content);
+            const bytes = new Uint8Array(raw.length);
+            for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+            const blob = new Blob([bytes], { type: "application/x-ndjson" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            const ts = Date.now();
+            a.href = url;
+            a.download = `session-${blockId.slice(0, 8)}-${ts}.jsonl`;
+            a.click();
+            URL.revokeObjectURL(url);
+        } catch (e) {
+            console.error("session:export failed:", e);
+        } finally {
+            setExportBusy(false);
+        }
+    };
+
     // Only show for Claude provider (Phase 1)
     if (providerId !== "claude") return null;
 
     return (
         <div class="agent-control-bar">
+            {/* ── Archived badge (shown when session is archived) ── */}
+            <Show when={isArchived()}>
+                <div class="agent-archived-banner">
+                    <span class="agent-archived-label" title={`Archived at ${archivedAtLabel()}`}>
+                        Archived
+                    </span>
+                    <button
+                        class="agent-session-btn agent-session-btn-restore"
+                        disabled={restoreBusy()}
+                        onClick={handleRestore}
+                        title="Restore session data from archive"
+                    >
+                        {restoreBusy() ? "Restoring…" : "Restore"}
+                    </button>
+                    <button
+                        class="agent-session-btn agent-session-btn-export"
+                        disabled={exportBusy()}
+                        onClick={handleExport}
+                        title="Export session as .jsonl"
+                    >
+                        {exportBusy() ? "Exporting…" : "Export"}
+                    </button>
+                </div>
+            </Show>
+
             <div
                 class="agent-control-bar-header"
                 onClick={() => setExpanded(!expanded())}
@@ -153,6 +248,31 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
                             <option value="max">Max (Opus only)</option>
                         </select>
                     </div>
+
+                    {/* ── Session management buttons (shown when there is history) ── */}
+                    <Show when={lineCount() > 0 && !isArchived()}>
+                        <div class="agent-control-row agent-control-row-session">
+                            <label class="agent-control-label">Session</label>
+                            <div class="agent-session-actions">
+                                <button
+                                    class="agent-session-btn agent-session-btn-archive"
+                                    disabled={archiveBusy()}
+                                    onClick={handleArchive}
+                                    title="Compress and archive session history to free disk space"
+                                >
+                                    {archiveBusy() ? "Archiving…" : "Archive"}
+                                </button>
+                                <button
+                                    class="agent-session-btn agent-session-btn-export"
+                                    disabled={exportBusy()}
+                                    onClick={handleExport}
+                                    title="Download session history as .jsonl"
+                                >
+                                    {exportBusy() ? "Exporting…" : "Export"}
+                                </button>
+                            </div>
+                        </div>
+                    </Show>
                 </div>
             </Show>
         </div>

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -43,9 +43,11 @@ interface AgentDocumentViewProps {
     onBookmark?: (node: DocumentNode) => void;
     /** Expose a scrollToNode function to the parent for jump-to-bookmark support. */
     scrollToNodeRef?: (fn: (nodeId: string) => void) => void;
+    /** The node id of the currently highlighted search match (if any). */
+    highlightNodeId?: Accessor<string | null>;
 }
 
-export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick, onLoadOlder, loadingOlder, startTsMs, endTsMs, bookmarkedNodeIds, onBookmark, scrollToNodeRef }: AgentDocumentViewProps): JSX.Element => {
+export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick, onLoadOlder, loadingOlder, startTsMs, endTsMs, bookmarkedNodeIds, onBookmark, scrollToNodeRef, highlightNodeId }: AgentDocumentViewProps): JSX.Element => {
     const [document] = documentAtom;
     const [documentState, setDocumentState] = documentStateAtom;
     let scrollRef!: HTMLDivElement;
@@ -231,7 +233,10 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                     return (
                         <div
                             class="agent-document-node-wrapper"
-                            classList={{ "agent-node-bookmarked": isBookmarked() }}
+                            classList={{
+                                "agent-node-bookmarked": isBookmarked(),
+                                "agent-node-search-match": highlightNodeId?.() === node.id,
+                            }}
                             data-node-id={node.id}
                             onContextMenu={handleContextMenu}
                         >

--- a/frontend/app/view/agent/components/AgentSearchBar.tsx
+++ b/frontend/app/view/agent/components/AgentSearchBar.tsx
@@ -1,0 +1,95 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentSearchBar — in-session search overlay for agent panes.
+ *
+ * Appears as a sticky banner at the top of the pane when Ctrl+F is pressed.
+ * Performs case-insensitive substring search over the currently-loaded document
+ * nodes (the in-memory slice, not the full persisted history — searching the
+ * full history would require a backend blockfile:search RPC, which is out of
+ * scope for this PR).
+ *
+ * Keyboard handling:
+ *   Enter        → next match
+ *   Shift+Enter  → previous match
+ *   Escape       → close
+ */
+
+import { Show, type Accessor, type JSX } from "solid-js";
+
+export interface AgentSearchBarProps {
+    visible: Accessor<boolean>;
+    onSearch: (query: string) => void;
+    onNext: () => void;
+    onPrev: () => void;
+    onClose: () => void;
+    /** 0-based index of the current match. -1 if no matches. */
+    matchIndex: Accessor<number>;
+    matchCount: Accessor<number>;
+}
+
+export const AgentSearchBar = (props: AgentSearchBarProps): JSX.Element => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+            e.preventDefault();
+            props.onClose();
+        } else if (e.key === "Enter") {
+            e.preventDefault();
+            if (e.shiftKey) props.onPrev();
+            else props.onNext();
+        }
+    };
+
+    const counterText = () => {
+        const count = props.matchCount();
+        if (count === 0) return "0 matches";
+        return `${props.matchIndex() + 1} of ${count}`;
+    };
+
+    return (
+        <Show when={props.visible()}>
+            <div class="agent-search-bar">
+                <input
+                    ref={(el) => {
+                        // Auto-focus when the bar appears. The setTimeout defers
+                        // the focus call past the current render frame so the
+                        // element is guaranteed to be mounted and visible.
+                        setTimeout(() => el?.focus(), 0);
+                    }}
+                    class="agent-search-input"
+                    type="text"
+                    placeholder="Search messages..."
+                    onInput={(e) => {
+                        props.onSearch(e.currentTarget.value);
+                    }}
+                    onKeyDown={handleKeyDown}
+                />
+                <span class="agent-search-counter">{counterText()}</span>
+                <button
+                    class="agent-search-btn"
+                    onClick={props.onPrev}
+                    title="Previous match (Shift+Enter)"
+                >
+                    &#x25B2;
+                </button>
+                <button
+                    class="agent-search-btn"
+                    onClick={props.onNext}
+                    title="Next match (Enter)"
+                >
+                    &#x25BC;
+                </button>
+                <button
+                    class="agent-search-btn agent-search-btn--close"
+                    onClick={props.onClose}
+                    title="Close search (Esc)"
+                >
+                    &times;
+                </button>
+            </div>
+        </Show>
+    );
+};
+
+AgentSearchBar.displayName = "AgentSearchBar";

--- a/frontend/app/view/agent/components/SessionDigestBanner.tsx
+++ b/frontend/app/view/agent/components/SessionDigestBanner.tsx
@@ -1,0 +1,88 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SessionDigestBanner — collapsible AI-generated summary of recent session activity.
+ *
+ * Shown when the user returns to an agent pane that was idle for >1 hour and has
+ * accumulated >20 lines of new activity since the last visit.
+ */
+
+import { createSignal, Show, type Accessor, type JSX } from "solid-js";
+import { Markdown } from "@/app/element/markdown";
+
+interface SessionDigestBannerProps {
+    summary: Accessor<string | null>;
+    generatedAt: Accessor<number | null>;
+    loading: Accessor<boolean>;
+    onDismiss: () => void;
+    onRegenerate: () => void;
+}
+
+function formatAge(ms: number): string {
+    const diff = Date.now() - ms;
+    const hours = Math.floor(diff / 3600000);
+    if (hours < 1) return "just now";
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+}
+
+export const SessionDigestBanner = (props: SessionDigestBannerProps): JSX.Element => {
+    const [expanded, setExpanded] = createSignal(true);
+
+    return (
+        <Show when={props.summary() != null || props.loading()}>
+            <div class="agent-session-digest">
+                <div class="agent-session-digest-header">
+                    <button
+                        class="agent-session-digest-toggle"
+                        onClick={() => setExpanded((v) => !v)}
+                        title={expanded() ? "Collapse" : "Expand"}
+                    >
+                        {expanded() ? "\u25BC" : "\u25B6"}
+                    </button>
+                    <span class="agent-session-digest-title">
+                        Session digest
+                        <Show when={props.generatedAt()}>
+                            {(ts) => (
+                                <span class="agent-session-digest-age">
+                                    {" \u00B7 "}{formatAge(ts())}
+                                </span>
+                            )}
+                        </Show>
+                    </span>
+                    <button
+                        class="agent-session-digest-action"
+                        onClick={props.onRegenerate}
+                        title="Regenerate digest"
+                        disabled={props.loading()}
+                    >
+                        {"\u21BB"}
+                    </button>
+                    <button
+                        class="agent-session-digest-action agent-session-digest-dismiss"
+                        onClick={props.onDismiss}
+                        title="Dismiss"
+                    >
+                        {"\u00D7"}
+                    </button>
+                </div>
+                <Show when={expanded() && props.loading()}>
+                    <div class="agent-session-digest-loading">Generating digest\u2026</div>
+                </Show>
+                <Show when={expanded() && !props.loading()}>
+                    <div class="agent-session-digest-body">
+                        <Show
+                            when={props.summary()}
+                            fallback={<span class="agent-session-digest-empty">No summary available.</span>}
+                        >
+                            {(s) => <Markdown text={s()} />}
+                        </Show>
+                    </div>
+                </Show>
+            </div>
+        </Show>
+    );
+};
+
+SessionDigestBanner.displayName = "SessionDigestBanner";

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1670,6 +1670,55 @@ declare global {
         total: number;
     };
 
+    // wshrpc.CommandSessionDigestData
+    type CommandSessionDigestData = {
+        block_id: string;
+        force?: boolean;
+    };
+
+    // wshrpc.SessionDigestResult
+    type SessionDigestResult = {
+        summary: string;
+        generated_at: number;
+        cached: boolean;
+    };
+
+    // wshrpc.CommandSessionArchiveData
+    type CommandSessionArchiveData = {
+        block_id: string;
+    };
+
+    // wshrpc.SessionArchiveResult
+    type SessionArchiveResult = {
+        block_id: string;
+        archived_bytes: number;
+        archived_at: number;
+    };
+
+    // wshrpc.CommandSessionRestoreData
+    type CommandSessionRestoreData = {
+        block_id: string;
+    };
+
+    // wshrpc.SessionRestoreResult
+    type SessionRestoreResult = {
+        block_id: string;
+        restored_bytes: number;
+    };
+
+    // wshrpc.CommandSessionExportData
+    type CommandSessionExportData = {
+        block_id: string;
+    };
+
+    // wshrpc.SessionExportResult
+    type SessionExportResult = {
+        /** base64-encoded JSONL content (raw output file bytes) */
+        content: string;
+        line_count: number;
+        byte_count: number;
+    };
+
 }
 
 export {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.98",
+  "version": "0.33.99",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.98",
+      "version": "0.33.99",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.97",
+  "version": "0.33.98",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.97",
+      "version": "0.33.98",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.98",
+  "version": "0.33.99",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.97",
+  "version": "0.33.98",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 3 of the ultra-long sessions plan — bundles the three remaining Phase 3 features into one PR:

- **3.1 In-session search (Ctrl+F)** — pane-scoped search bar over the document node list, highlight + scroll-to-match, Enter/Shift+Enter for next/prev, Esc to close.
- **3.3 Session archival** — backend `SessionArchiver` sweeps sessions inactive for >7 days to gzip'd JSONL under `~/.agentmux/archives/`, with 2 GB total cap + LRU eviction. Frontend exposes Archive / Restore / Export buttons in the expanded agent control bar, with browser download for export.
- **3.4 AI session digest** — new `session:digest` RPC reads the tail of the session, extracts text, and invokes the block's own Claude CLI (via `make_cli_cmd`) to generate a concise summary. Rendered in a collapsible `SessionDigestBanner` above the document with Dismiss + Regenerate.

Plus:
- `blockfile:line_count` now uses `session:line_count` meta (O(1)) as fast path.
- Search: Ctrl+F listener gated on `focusedBlockId() === model.blockId` (pane-scoped, no global capture).

## Files

New:
- `agentmux-srv/src/backend/session_archive.rs` (+ 3 unit tests)
- `frontend/app/view/agent/components/AgentSearchBar.tsx`
- `frontend/app/view/agent/components/SessionDigestBanner.tsx`

Modified:
- `agentmux-srv/src/main.rs` — spawn hourly archiver sweep
- `agentmux-srv/src/server/app_api.rs` — archive/restore/export/digest handlers
- `agentmux-srv/src/backend/rpc_types.rs` — command constants + result structs
- `agentmux-srv/Cargo.toml` — flate2, tempfile
- `frontend/app/view/agent/agent-view.tsx` — search + digest wiring
- `frontend/app/view/agent/components/AgentDocumentView.tsx` — highlight prop
- `frontend/app/view/agent/components/AgentControlBar.tsx` — archive/export/restore buttons
- `frontend/app/view/agent/agent-view.scss` — styles
- `frontend/types/gotypes.d.ts`, `frontend/app/store/wshclientapi.ts` — type/command plumbing

14 files changed, 1887 insertions(+), 10 deletions(-).

## Test plan

- [ ] `cargo check -p agentmux-srv` clean (verified)
- [ ] `npx tsc --noEmit` clean (verified)
- [ ] Unit tests for `session_archive` pass (sweep, bytecount, gz roundtrip)
- [ ] Ctrl+F opens search bar only in the focused agent pane
- [ ] Archive button archives current session; Restore reloads it from disk
- [ ] Export downloads `session-<blockId>-<ts>.jsonl`
- [ ] Digest banner populates after first generation; Regenerate re-invokes CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)