### PR TITLE
feat: ultra-long sessions phase 4 — resilience hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.99"
+version = "0.33.100"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.99"
+version = "0.33.100"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.99"
+version = "0.33.100"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.99"
+version = "0.33.100"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.99"
+version = "0.33.100"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.99"
+version = "0.33.100"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.99"
+version = "0.33.100"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.99"
+version = "0.33.100"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.99"
+version = "0.33.100"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -15,6 +15,7 @@ pub mod health;
 pub mod persistent;
 pub mod pidregistry;
 pub mod process_tree;
+pub mod session_recovery;
 pub mod session_stats;
 pub mod shell;
 pub mod subprocess;

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -257,6 +257,13 @@ impl PersistentSubprocessController {
         }
         self.publish_status();
 
+        // Record active pid for crash recovery (Phase 4.2). If the server
+        // dies while this subprocess is running, scan_orphans() will find
+        // the stale pid on next boot and flag the session as interrupted.
+        if let Some(ref wstore) = self.wstore {
+            super::session_recovery::mark_active_pid(wstore, &self.block_id, pid);
+        }
+
         // Spawn stdin writer task
         tokio::spawn(async move {
             let mut stdin = stdin;
@@ -388,6 +395,7 @@ impl PersistentSubprocessController {
         let block_id_wait = self.block_id.clone();
         let inner_wait = Arc::clone(&self.inner);
         let broker_wait = self.broker.clone();
+        let wstore_wait = self.wstore.clone();
 
         tokio::spawn(async move {
             tokio::select! {
@@ -406,6 +414,11 @@ impl PersistentSubprocessController {
                     inner.kill_tx = None;
                     Self::set_status(&mut inner, STATUS_DONE);
                     drop(inner);
+
+                    // Clear active pid — clean exit, no recovery needed.
+                    if let Some(ref wstore) = wstore_wait {
+                        super::session_recovery::clear_active_pid(wstore, &block_id_wait);
+                    }
 
                     // Publish status
                     if let Some(ref broker) = broker_wait {
@@ -449,6 +462,12 @@ impl PersistentSubprocessController {
                     inner.stdin_tx = None;
                     inner.kill_tx = None;
                     Self::set_status(&mut inner, STATUS_DONE);
+                    drop(inner);
+
+                    // Clear active pid — user-initiated stop, no recovery needed.
+                    if let Some(ref wstore) = wstore_wait {
+                        super::session_recovery::clear_active_pid(wstore, &block_id_wait);
+                    }
                 }
             }
         });

--- a/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
+++ b/agentmux-srv/src/backend/blockcontroller/session_recovery.rs
@@ -1,0 +1,218 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Session recovery after unclean shutdown (Phase 4.2 — ultra-long-sessions).
+//!
+//! When a persistent agent subprocess is running and the server is killed
+//! (crash, OS reboot, task-kill), the subprocess dies with it but the block's
+//! session history is preserved in FileStore. On next startup, we want to:
+//!
+//!   1. Detect that a session was running when the server died, so we can
+//!      surface it to the user as "this session was interrupted".
+//!   2. Let the user resume: the persistent controller already supports
+//!      `--resume <session_id>` on the next input, so the recovery UX is
+//!      simply "click resume, type your next message, get picked up mid-flight".
+//!
+//! The mechanism is a single boolean meta flag: `session:active_pid`. It's
+//! set on subprocess spawn, cleared on clean exit (graceful or killed). If
+//! this flag is still set when the server boots, the process is definitely
+//! gone (old PID from a dead process), so we transfer it to
+//! `session:was_interrupted = true`.
+//!
+//! `session:was_interrupted` is a frontend-only signal — the backend doesn't
+//! consume it. The frontend `AgentControlBar` renders a banner when it's set,
+//! and `service:update_object_meta` clears it when the user dismisses.
+
+use std::sync::Arc;
+
+use crate::backend::obj::{Block, MetaMapType};
+use crate::backend::storage::wstore::WaveStore;
+
+/// PID of the current running subprocess; 0 or missing = no process.
+pub const META_SESSION_ACTIVE_PID: &str = "session:active_pid";
+/// Set to `true` by startup scan when a pre-existing `active_pid` is found.
+pub const META_SESSION_WAS_INTERRUPTED: &str = "session:was_interrupted";
+
+/// Record that a subprocess with `pid` has been spawned for `block_id`.
+/// Best-effort — logs on failure but never panics.
+pub fn mark_active_pid(wstore: &Arc<WaveStore>, block_id: &str, pid: u32) {
+    let mut meta = MetaMapType::new();
+    meta.insert(META_SESSION_ACTIVE_PID.to_string(), serde_json::json!(pid));
+    // Clear any stale interrupt flag — we're running again.
+    meta.insert(META_SESSION_WAS_INTERRUPTED.to_string(), serde_json::Value::Null);
+    let oref_str = format!("block:{}", block_id);
+    if let Err(e) = crate::server::service::update_object_meta(wstore, &oref_str, &meta) {
+        tracing::warn!(block_id = %block_id, error = %e, "session_recovery: failed to mark active pid");
+    }
+}
+
+/// Clear `session:active_pid` — called when the subprocess exits for any reason.
+pub fn clear_active_pid(wstore: &Arc<WaveStore>, block_id: &str) {
+    let mut meta = MetaMapType::new();
+    meta.insert(META_SESSION_ACTIVE_PID.to_string(), serde_json::Value::Null);
+    let oref_str = format!("block:{}", block_id);
+    if let Err(e) = crate::server::service::update_object_meta(wstore, &oref_str, &meta) {
+        tracing::warn!(block_id = %block_id, error = %e, "session_recovery: failed to clear active pid");
+    }
+}
+
+/// Scan all blocks at server startup. For any agent block that still has
+/// `session:active_pid` set, transfer the flag to `session:was_interrupted`.
+///
+/// Returns the number of orphaned sessions found.
+pub fn scan_orphans(wstore: &Arc<WaveStore>) -> u32 {
+    let all_blocks = match wstore.get_all::<Block>() {
+        Ok(blocks) => blocks,
+        Err(e) => {
+            tracing::warn!(error = %e, "session_recovery: scan_orphans get_all failed");
+            return 0;
+        }
+    };
+
+    let mut count = 0u32;
+    for block in &all_blocks {
+        // Only agent panes
+        let view = block.meta.get("view").and_then(|v| v.as_str()).unwrap_or("");
+        if view != "agent" {
+            continue;
+        }
+
+        // Check for a stale active_pid
+        let pid = block
+            .meta
+            .get(META_SESSION_ACTIVE_PID)
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        if pid == 0 {
+            continue;
+        }
+
+        // Transfer: clear active_pid, set was_interrupted
+        let mut update = MetaMapType::new();
+        update.insert(META_SESSION_ACTIVE_PID.to_string(), serde_json::Value::Null);
+        update.insert(
+            META_SESSION_WAS_INTERRUPTED.to_string(),
+            serde_json::json!(true),
+        );
+        let oref_str = format!("block:{}", block.oid);
+        match crate::server::service::update_object_meta(wstore, &oref_str, &update) {
+            Ok(()) => {
+                count += 1;
+                tracing::info!(
+                    block_id = %block.oid,
+                    stale_pid = pid,
+                    "session_recovery: marked orphaned session as interrupted"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    block_id = %block.oid,
+                    error = %e,
+                    "session_recovery: failed to mark orphan"
+                );
+            }
+        }
+    }
+
+    if count > 0 {
+        tracing::info!(count = count, "session_recovery: scan_orphans complete");
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::obj::Block;
+
+    /// Verify that scan_orphans transfers active_pid → was_interrupted on
+    /// agent blocks, and leaves non-agent blocks + blocks without active_pid
+    /// untouched.
+    #[test]
+    fn test_scan_orphans_transfers_flag() {
+        let tmp = tempfile::tempdir().unwrap();
+        let wstore = Arc::new(WaveStore::open(&tmp.path().join("wave.db")).unwrap());
+
+        // ORef parser requires valid UUIDs, so generate them inline.
+        let orphan_id = "11111111-1111-1111-1111-111111111111";
+        let clean_id = "22222222-2222-2222-2222-222222222222";
+        let term_id = "33333333-3333-3333-3333-333333333333";
+
+        // Agent block with stale active_pid — should be flagged.
+        let mut orphan = Block {
+            oid: orphan_id.to_string(),
+            parentoref: String::new(),
+            version: 1,
+            runtimeopts: None,
+            stickers: None,
+            meta: {
+                let mut m = MetaMapType::new();
+                m.insert("view".to_string(), serde_json::json!("agent"));
+                m.insert(META_SESSION_ACTIVE_PID.to_string(), serde_json::json!(12345u32));
+                m
+            },
+            subblockids: None,
+        };
+        wstore.insert(&mut orphan).unwrap();
+
+        // Agent block without active_pid — should be left alone.
+        let mut clean = Block {
+            oid: clean_id.to_string(),
+            parentoref: String::new(),
+            version: 1,
+            runtimeopts: None,
+            stickers: None,
+            meta: {
+                let mut m = MetaMapType::new();
+                m.insert("view".to_string(), serde_json::json!("agent"));
+                m
+            },
+            subblockids: None,
+        };
+        wstore.insert(&mut clean).unwrap();
+
+        // Non-agent block with active_pid (shouldn't exist in practice, but
+        // sanity check the view filter) — should be left alone.
+        let mut nonagent = Block {
+            oid: term_id.to_string(),
+            parentoref: String::new(),
+            version: 1,
+            runtimeopts: None,
+            stickers: None,
+            meta: {
+                let mut m = MetaMapType::new();
+                m.insert("view".to_string(), serde_json::json!("term"));
+                m.insert(META_SESSION_ACTIVE_PID.to_string(), serde_json::json!(67890u32));
+                m
+            },
+            subblockids: None,
+        };
+        wstore.insert(&mut nonagent).unwrap();
+
+        let count = scan_orphans(&wstore);
+        assert_eq!(count, 1, "exactly one agent orphan should be flagged");
+
+        // Verify orphan block meta
+        let after: Block = wstore.get(orphan_id).unwrap().unwrap();
+        assert!(
+            after.meta.get(META_SESSION_ACTIVE_PID).and_then(|v| v.as_u64()).unwrap_or(0) == 0,
+            "active_pid should be cleared"
+        );
+        assert_eq!(
+            after.meta.get(META_SESSION_WAS_INTERRUPTED).and_then(|v| v.as_bool()),
+            Some(true),
+            "was_interrupted should be true"
+        );
+
+        // Clean block untouched
+        let clean_after: Block = wstore.get(clean_id).unwrap().unwrap();
+        assert!(clean_after.meta.get(META_SESSION_WAS_INTERRUPTED).is_none());
+
+        // Non-agent block untouched (still has active_pid)
+        let term_after: Block = wstore.get(term_id).unwrap().unwrap();
+        assert_eq!(
+            term_after.meta.get(META_SESSION_ACTIVE_PID).and_then(|v| v.as_u64()),
+            Some(67890),
+        );
+    }
+}

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -316,6 +316,19 @@ async fn main() {
     // Runs on every startup to catch any corruption from prior sessions.
     heal_all_layouts(&wstore);
 
+    // Session recovery (Phase 4.2): scan for agent blocks that still have
+    // `session:active_pid` from a previous run — those sessions were killed
+    // by a crash/reboot. Transfer to `session:was_interrupted` so the
+    // frontend can show a reconnect banner.
+    let orphan_count = backend::blockcontroller::session_recovery::scan_orphans(&wstore);
+    if orphan_count > 0 {
+        tracing::info!(
+            orphan_count = orphan_count,
+            "session_recovery: flagged {} interrupted sessions for user reconnect",
+            orphan_count
+        );
+    }
+
     // Auto-seed Forge agents on first launch (or empty DB)
     backend::forge_seed::auto_seed_on_startup(&wstore);
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.99"
+version = "0.33.100"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -450,6 +450,40 @@
         font-size: 11px;
     }
 
+    .agent-interrupted-banner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 4px 8px;
+        background: color-mix(in srgb, var(--accent-color, #3b82f6) 14%, transparent);
+        border-bottom: 1px solid color-mix(in srgb, var(--accent-color, #3b82f6) 30%, transparent);
+        font-size: 11px;
+        color: var(--main-text-color);
+
+        .agent-interrupted-label {
+            flex: 1 1 auto;
+            min-width: 0;
+        }
+    }
+
+    .agent-large-session-banner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 4px 8px;
+        background: color-mix(in srgb, var(--warning-color, #eab308) 14%, transparent);
+        border-bottom: 1px solid color-mix(in srgb, var(--warning-color, #eab308) 30%, transparent);
+        font-size: 11px;
+        color: var(--main-text-color);
+
+        .agent-large-session-label {
+            flex: 1 1 auto;
+            min-width: 0;
+        }
+    }
+
     .agent-control-bar-header {
         display: flex;
         align-items: center;

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -160,8 +160,67 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
     // Only show for Claude provider (Phase 1)
     if (providerId !== "claude") return null;
 
+    // 4.1 Graceful degradation: warn when session grows unwieldy (500K lines).
+    // Browser still handles this via content-visibility, but we surface the state
+    // so the user can archive + start fresh if they want a cleaner session.
+    const LARGE_SESSION_THRESHOLD = 500_000;
+    const isLargeSession = (): boolean =>
+        !isArchived() && lineCount() >= LARGE_SESSION_THRESHOLD;
+
+    // 4.2 Multi-day continuity: server sets `session:was_interrupted` when it
+    // finds a stale `session:active_pid` on startup (i.e. the previous server
+    // process died with a subprocess running). The next user message will
+    // automatically `--resume` the session, so the banner just lets the user
+    // know what happened and offers a "Dismiss" to clear the flag.
+    const wasInterrupted = (): boolean =>
+        (blockAtom()?.meta?.["session:was_interrupted"] as boolean | undefined) === true;
+
+    const dismissInterrupted = async () => {
+        try {
+            await RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: WOS.makeORef("block", blockId),
+                meta: { "session:was_interrupted": null } as MetaType,
+            });
+        } catch (e) {
+            console.error("failed to clear was_interrupted:", e);
+        }
+    };
+
     return (
         <div class="agent-control-bar">
+            {/* ── Interrupted-session recovery banner (4.2 multi-day continuity) ── */}
+            <Show when={wasInterrupted()}>
+                <div class="agent-interrupted-banner">
+                    <span class="agent-interrupted-label">
+                        Session was interrupted by a restart. Your next message will resume it.
+                    </span>
+                    <button
+                        class="agent-session-btn agent-session-btn-dismiss"
+                        onClick={dismissInterrupted}
+                        title="Dismiss this notice"
+                    >
+                        Dismiss
+                    </button>
+                </div>
+            </Show>
+
+            {/* ── Large session warning (4.1 graceful degradation) ── */}
+            <Show when={isLargeSession()}>
+                <div class="agent-large-session-banner">
+                    <span class="agent-large-session-label">
+                        Session has {lineCount().toLocaleString()} lines. Consider archiving to free disk space.
+                    </span>
+                    <button
+                        class="agent-session-btn agent-session-btn-archive"
+                        disabled={archiveBusy()}
+                        onClick={handleArchive}
+                        title="Archive this session and start fresh"
+                    >
+                        {archiveBusy() ? "Archiving…" : "Archive"}
+                    </button>
+                </div>
+            </Show>
+
             {/* ── Archived badge (shown when session is archived) ── */}
             <Show when={isArchived()}>
                 <div class="agent-archived-banner">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.99",
+  "version": "0.33.100",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.99",
+      "version": "0.33.100",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.99",
+  "version": "0.33.100",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Final phase of the ultra-long sessions plan (docs/plans/ultra-long-sessions.md). Completes the resilience + edge-cases block.

**4.1 Graceful degradation under load**
- New warning banner in \`AgentControlBar\` when \`session:line_count >= 500_000\`, with a one-click Archive button. Uses the existing Phase 3 archive RPC.
- Backend write rate-limiting intentionally **omitted**: SQLite WAL (already enabled) + the WPS persist ring buffer already provide correct backpressure for runaway output. Throttling without a demonstrated saturation issue is premature optimization.

**4.2 Multi-day session continuity**
- New module \`backend/blockcontroller/session_recovery.rs\` exposing \`mark_active_pid\`, \`clear_active_pid\`, and \`scan_orphans\`.
- Two meta flags:
  - \`session:active_pid\` — set on persistent subprocess spawn, cleared on clean exit (graceful or killed).
  - \`session:was_interrupted\` — set on startup by \`scan_orphans()\` when a stale \`active_pid\` is still present (i.e. the previous server died mid-session).
- \`scan_orphans()\` runs once at \`main.rs\` startup after the layout heal.
- Frontend surfaces the state as an info banner above the control bar: _\"Session was interrupted by a restart. Your next message will resume it.\"_ + Dismiss button that clears the flag via \`SetMetaCommand\`.
- The existing \`--resume session_id\` path in \`subprocess.rs\` already picks up the session on the next turn, so the UX is pure notification — no new RPC needed.
- Unit test covers the state transition and the agent-vs-non-agent filter.

**Already-implemented items verified in-place**
- SQLite WAL mode on FileStore (\`filestore/core.rs:69\`)
- \`--resume\` session_id on subprocess respawn (\`subprocess.rs:193-209\`)
- WPS broker serialized publish + fanout (\`wps.rs:221-238\`)

**4.3 Concurrent access** — no changes required. WPS broker fanout is already correct (single-mutex publish). Per-operation FileStore locks are sufficient for the existing \`read_range\` + live-append pattern; explicit snapshot isolation would be a large refactor without a demonstrated race.

## Files

New:
- \`agentmux-srv/src/backend/blockcontroller/session_recovery.rs\` (+ unit test)

Modified:
- \`agentmux-srv/src/backend/blockcontroller/mod.rs\` — register module
- \`agentmux-srv/src/backend/blockcontroller/persistent.rs\` — mark/clear active_pid on spawn + both exit paths
- \`agentmux-srv/src/main.rs\` — call \`scan_orphans()\` at startup
- \`frontend/app/view/agent/components/AgentControlBar.tsx\` — large-session + interrupted banners
- \`frontend/app/view/agent/agent-view.scss\` — banner styles

## Test plan

- [x] \`cargo check -p agentmux-srv\` clean
- [x] \`cargo test -p agentmux-srv session_recovery\` — state transition passes
- [ ] Manual: kill agentmux-srv mid-session, restart, verify the interrupted banner appears and the session resumes on next message
- [ ] Manual: confirm 500K-line banner renders (can temporarily lower threshold to trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)