### PR TITLE
feat: retro follow-ups — bump wrapper + size tracking + cleanups

### DIFF
--- a/.bump.json
+++ b/.bump.json
@@ -34,27 +34,16 @@
   ],
   "lockfiles": [
     {
-      "type": "npm",
-      "strategy": "npm-version",
-      "command": "npm install --package-lock-only",
-      "allowFailure": true
-    },
-    {
       "type": "cargo",
       "command": "cargo generate-lockfile"
     }
   ],
-  "history": {
-    "file": "VERSION_HISTORY.md",
-    "format": "table",
-    "template": "| {{version}}-fork | v0.12.0 | {{date}} | {{agent}} | {{message}} |"
-  },
+  "_npm_lockfile_note": "npm lockfile sync is handled by scripts/bump-wrapper.sh because bump-cli's 'npm-version' strategy fails with 'Unknown error' inside its temporary git state and silently skips the lockfile. Use scripts/bump-wrapper.sh instead of bare bump.",
   "git": {
     "add": [
       "package.json",
       "package-lock.json",
       "Cargo.lock",
-      "VERSION_HISTORY.md",
       "agentmux-srv/Cargo.toml",
       "agentmux-wsh/Cargo.toml",
       "agentmux-cef/Cargo.toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.102"
+version = "0.33.103"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.102"
+version = "0.33.103"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.102"
+version = "0.33.103"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.102"
+version = "0.33.103"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.102"
+version = "0.33.103"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.100"
+version = "0.33.101"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.100"
+version = "0.33.101"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.100"
+version = "0.33.101"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.100"
+version = "0.33.101"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.100"
+version = "0.33.101"
 dependencies = [
  "base64",
  "clap",
@@ -2323,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.101"
+version = "0.33.102"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.101"
+version = "0.33.102"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.101"
+version = "0.33.102"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.101"
+version = "0.33.102"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.101"
+version = "0.33.102"
 dependencies = [
  "base64",
  "clap",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -8,6 +8,18 @@ This document tracks the version history of AgentMux (forked from waveterm).
 
 ---
 
+## Sizes (CEF portable, Windows x64)
+
+Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
+
+| Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
+|---------|------|------------------|-----------------------|------|
+| 0.33.102 | 2026-04-12 | 155.5 MiB | 320.0 MiB | post-ultra-long-sessions |
+| 0.33.91 | 2026-04-12 | 151.8 MiB | 320.8 MiB | pre-ultra-long-sessions |
+| (pre-ANGLE) | 2026-03-29 | 147.7 MiB | 309.8 MiB | no libEGL/libGLESv2 |
+
+---
+
 ## Version History (Latest First)
 
 ### v0.32.89 (2026-03-25)

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.100"
+version = "0.33.101"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.102"
+version = "0.33.103"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.101"
+version = "0.33.102"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.102"
+version = "0.33.103"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.101"
+version = "0.33.102"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.100"
+version = "0.33.101"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.100"
+version = "0.33.101"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.102"
+version = "0.33.103"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.101"
+version = "0.33.102"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.101"
+version = "0.33.102"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.100"
+version = "0.33.101"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.102"
+version = "0.33.103"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.102"
+version = "0.33.103"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.101"
+version = "0.33.102"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.100"
+version = "0.33.101"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/docs/retros/2026-04-12-portable-size-audit.md
+++ b/docs/retros/2026-04-12-portable-size-audit.md
@@ -1,0 +1,158 @@
+# Portable Build Size Audit — 2026-04-12
+
+**Prompting question:** Why is the `0.33.101` portable ZIP about 10 MB larger than "a couple versions back"?
+
+**Short answer:** It isn't growing now — the 10 MiB delta comes from a *single* commit on Mar 29 that added the ANGLE GPU DLLs back into the portable bundle. Every CEF portable built after that commit carries the same ~8 MB GPU cost. Since that commit, actual growth across ~2 weeks of shipping has been **~1 MiB**.
+
+---
+
+## 1. The numbers
+
+### Compressed (.zip)
+
+| Build | File | Size | Date |
+|-------|------|------|------|
+| Mar 29 (pre-ANGLE) | `dist/agentmux-cef-portable.zip` | 154,875,851 B = **147.70 MiB** | 2026-03-29 |
+| 0.33.91 | `~/Desktop/agentmux-cef-0.33.91-x64-portable.zip` | 159,169,750 B = **151.80 MiB** | 2026-04-12 06:05 |
+| 0.33.101 | `~/Desktop/agentmux-cef-0.33.101-x64-portable.zip` | 163,004,060 B = **155.46 MiB** | 2026-04-12 16:31 |
+
+### Uncompressed directory
+
+| Build | Size |
+|-------|------|
+| Mar 29 (pre-ANGLE) | **309.83 MiB** |
+| 0.33.91 | **320.81 MiB** |
+| 0.33.101 | **319.95 MiB** |
+
+The 0.33.101 directory is actually **~1 MiB *smaller*** than 0.33.91 (a stale duplicate `wsh` binary in `runtime/bin/` was removed). Only the ZIP appears larger because Vite asset hashes changed, reducing deflate compressibility slightly.
+
+---
+
+## 2. File-level delta — Mar 29 → 0.33.101 (uncompressed)
+
+| Item                                   | Mar 29       | 0.33.101     | Delta        | Notes |
+|----------------------------------------|--------------|--------------|--------------|-------|
+| `libGLESv2.dll` (ANGLE GL ES)          | — (absent)   | 7,824,896    | **+7.46 MiB**| GPU acceleration |
+| `libEGL.dll` (ANGLE EGL)               | — (absent)   | 506,368      | **+0.48 MiB**| GPU acceleration |
+| `chrome_elf.dll`                       | 2,482,688    | 2,491,904    | +0.009 MiB   | CEF minor bump |
+| `libcef.dll`                           | 262,319,104  | 262,272,512  | -0.044 MiB   | CEF minor bump |
+| `d3dcompiler_47.dll`                   | 4,741,480    | 4,741,480    | 0            | unchanged |
+| `agentmux-srv` (Rust sidecar)          | 8,991,744    | 9,433,600    | +0.42 MiB    | 2 weeks of features |
+| `agentmux-cef.exe` + launcher (split)  | 2,553,344    | 3,173,376    | +0.59 MiB    | layout changed, see §4 |
+| `wsh-*.exe`                            | ~1,191,424   | 1,191,424    | ~0           | (dedup: -1.19 MiB vs 0.33.91) |
+| Frontend assets (paks, js bundles)     | ~             | ~             | ~+1.1 MiB    | new mermaid/code-splitting artifacts |
+| **Uncompressed total**                 | **324,877,437** | **335,488,382** | **+10.12 MiB** | |
+
+The ~10.12 MiB delta **is almost entirely GPU DLLs** (+7.94 MiB of 10.12). Everything else combined is ~2.2 MiB and reflects two weeks of normal shipping.
+
+---
+
+## 3. When & why the GPU DLLs landed
+
+**Commit:** `8e15fe7`
+**Date:** 2026-03-29 19:56 PDT
+**Author:** AgentA
+**Title:** `feat(cef): optimized portable packaging + size reduction spec`
+
+### What that commit did (from its own body)
+
+> - Update cef:bundle to strip SwiftShader, WebGPU DLLs, extra locales (~30 MB savings)
+> - **Keep GPU support (ANGLE libEGL/libGLESv2, d3dcompiler_47)**
+> - Keep en-US locale only (49 others stripped)
+> - Add cef:package:portable task for Windows (flat layout, ZIP output)
+
+The same commit **stripped ~30 MB of unused bytes** (SwiftShader, WebGPU, non-en-US locales) **and** **added back the ANGLE GPU stack** (`libEGL.dll` + `libGLESv2.dll`). Net effect on that day was still a *reduction* versus the fully-unstripped CEF build.
+
+### Why GPU stays in
+
+ANGLE is what CEF uses on Windows to translate WebGL / hardware-accelerated CSS into D3D11 calls. Without `libEGL.dll` + `libGLESv2.dll` CEF falls back to CPU/software rendering, which:
+
+- re-introduces the white flash on window open (the bug the v0.33.39 fix put to rest)
+- kills perceived scroll smoothness on large DOMs (the exact thing we just spent Phase 1-2 of ultra-long-sessions fixing via `content-visibility: auto`)
+- makes high-DPI text look fuzzy
+
+So the 8 MiB is load-bearing — it pays for the rendering quality that the rest of the plan depends on.
+
+### Why the Mar 29 ZIP on disk doesn't have the DLLs
+
+`dist/agentmux-cef-portable.zip` is dated 2026-03-29 — same day as the commit but built from `main` **before** `8e15fe7` landed. That's why it's the last surviving snapshot of the pre-ANGLE bundle, and why it confused the comparison: it's the only baseline we have that predates the GPU addition.
+
+Every build produced after `8e15fe7` (including 0.33.91 and 0.33.101) contains the DLLs.
+
+---
+
+## 4. Second-order changes worth mentioning
+
+### 4.1 Launcher layout split (~+0.59 MiB)
+
+Pre-Mar 29 layout (flat):
+
+```
+agentmux.exe                   2,553,344  ← monolithic CEF host
+agentmuxsrv-rs.x64.exe          8,991,744
+libcef.dll
+...
+```
+
+Post-Mar 29 layout (launcher + runtime/):
+
+```
+agentmux.exe                     348,672  ← thin launcher, sets DLL path
+runtime/
+  agentmux-cef-<ver>.exe       2,824,704  ← versioned CEF host
+  agentmux-srv-<ver>-windows.x64.exe
+  libcef.dll
+  ...
+```
+
+Total launcher+host went from **2,553,344 → 3,173,376** bytes = **+0.59 MiB**. In exchange, multiple AgentMux versions can now coexist on the same machine because all versioned bits live under `runtime/` under their own version prefix, and the tiny launcher is interchangeable.
+
+### 4.2 Rust sidecar growth (~+0.42 MiB)
+
+`agentmux-srv` grew from 8,991,744 → 9,433,600 B (+0.42 MiB) over two weeks. Given the volume of work in that window (full ultra-long-sessions plan: pagination API, FileStore LRU, session stats, session archival, session digest, search handlers, session recovery, and all the RPC/type plumbing), **0.42 MiB of binary growth is tiny**. That's 420 KB for roughly 1,900 lines of new Rust shipped across 5 PRs.
+
+No single feature moves the needle — it's noise from extra RPC handlers + the `flate2` dependency (for gzip archives).
+
+### 4.3 `wsh` binary deduplication (-1.19 MiB, 0.33.91 → 0.33.101)
+
+The 0.33.91 build had `wsh-0.33.91-windows.x64.exe` in **both** `runtime/bin/` AND `runtime/`. The portable packaging script ended up copying it twice because the source is both installed to `dist/bin/` and `dist/bin/wsh-*`. The 0.33.101 build has it only in `runtime/`, which is where the CEF host actually launches it from.
+
+This is unintentional cleanup — whatever prevented the double-copy between 0.33.91 and 0.33.101 is beneficial, but worth tracking down to make sure we're not about to lose the binary somewhere the launcher expects it. **Action:** verify `wsh` still works in the 0.33.101 portable when a terminal pane is opened.
+
+### 4.4 Frontend compressibility drift (~+3.8 MiB in the ZIP only)
+
+The uncompressed dir shrank by ~1 MiB between 0.33.91 and 0.33.101, but the ZIP *grew* by ~3.8 MiB. That's entirely from the Vite asset hashes changing:
+
+- In 0.33.91, `architectureDiagram-VXUJARFQ-C68p5l6Y.js`
+- In 0.33.101, `architectureDiagram-VXUJARFQ-8wu5pz0g.js`
+
+Same bytes (149,106 each), different filename. Since each file is independently deflated inside a ZIP, the filename doesn't affect deflate directly — but the overall mermaid asset graph got rebundled during the dev builds that happened between 91 and 101, and a couple of chunks ended up with slightly less-compressible payloads. Individual compressibility deltas of 20-30 KB across 200+ frontend files add up.
+
+**This is not a real problem.** It's ordinary Vite churn, not shipped code size. Only matters if we start shipping the zip over slow networks.
+
+---
+
+## 5. What this *doesn't* explain — and why that's fine
+
+- **Nothing in this audit is a bug.** The size is within expected bounds for a CEF desktop app with GPU acceleration and a Rust sidecar.
+- **Nothing in the ultra-long-sessions plan meaningfully grew the bundle.** Phase 1-4 added ~420 KB to `agentmux-srv` and nothing to DLL shipping. If we'd added a new runtime dependency (say, SQLite from vendored sources), we'd see MiB-level growth on the sidecar.
+- **Nothing can be stripped further without regression risk.** The only remaining low-hanging fruit is `d3dcompiler_47.dll` (4.52 MiB), but CEF's D3D shader pipeline needs it at runtime.
+
+---
+
+## 6. Open questions / follow-ups
+
+1. **Is `dist/agentmux-cef-portable.zip` still useful?** It's the pre-ANGLE snapshot; nothing else. Either delete it to prevent future confusion OR rename it with a date + "pre-ANGLE" tag. Currently it's the only reason "10 MB regression" even surfaced as a question.
+2. **Why did `wsh` stop being duplicated?** Worth a `git log -p scripts/package-cef-portable.sh` check before the next release to confirm it wasn't accidental removal.
+3. **Track per-version uncompressed sizes in `VERSION_HISTORY.md`?** A single-line "size: XXX MiB" entry per release would make this sort of question answerable without re-extracting ZIPs. ~30 seconds of script work per bump.
+4. **Packaging script's silent failure.** `scripts/package-cef-portable.sh` pipes `powershell Compress-Archive … || true` and then reports `ZIP: (N/A)` when it fails. That's how this session got a portable folder on the desktop with no ZIP next to it. The script should exit non-zero if the ZIP step fails, or fall back to `tar -a -cf` / `pwsh Compress-Archive` explicitly. **Already observed in practice.**
+
+---
+
+## 7. Bottom line for the user
+
+- The 0.33.101 portable is **163 MB compressed / 320 MB extracted**.
+- Compared to "a couple of versions ago": **+10 MiB uncompressed, +~7-8 MiB compressed.**
+- **All of that** traces to one commit on Mar 29 (`8e15fe7`) that added `libEGL.dll` + `libGLESv2.dll` to the bundle. The entire ultra-long-sessions plan added ~0.42 MiB to the Rust sidecar. Nothing suspicious is growing.
+- The GPU DLLs are load-bearing (white flash fix, scroll smoothness, text clarity); removing them would regress rendering quality.
+- **No action needed on size.** One follow-up worth filing: fix the packaging script's silent Compress-Archive failure (§6.4).

--- a/docs/retros/2026-04-12-ultra-long-sessions.md
+++ b/docs/retros/2026-04-12-ultra-long-sessions.md
@@ -1,0 +1,186 @@
+# Ultra-Long Sessions — Verification Report & Retrospective
+
+**Date:** 2026-04-12
+**Plan:** `docs/plans/ultra-long-sessions.md`
+**Status:** COMPLETE — all four phases shipped to `main`
+**Version at completion:** 0.33.100
+**PRs:** #336, #338, #340, #341, #342
+
+---
+
+## 1. Scope
+
+Originally written as a four-phase plan to make AgentMux agent panes survive
+multi-day sessions with hundreds of thousands of streamed events — without
+blowing up RAM, stalling the typing path, or losing history on reconnect.
+
+Four phases as defined in the plan:
+
+| Phase | Theme                         | PR(s)         |
+|-------|-------------------------------|---------------|
+| 1     | Foundation                    | #336          |
+| 2     | Core UX (virtualization etc.) | #338, #340    |
+| 3     | Navigation, archival, digest  | #341          |
+| 4     | Resilience + edge cases       | #342          |
+
+---
+
+## 2. Verification — what shipped per phase
+
+### Phase 1 — Foundation (PR #336)
+
+| Item                                    | Status | Anchor                                                                 |
+|-----------------------------------------|:------:|------------------------------------------------------------------------|
+| 1.1 `blockfile:read_range` pagination   | ✅     | `agentmux-srv/src/server/app_api.rs` (read_range + line_count handlers) |
+| 1.1 `blockfile:line_count` O(1) fast-path via meta | ✅ | same; backed by `session:line_count`                                  |
+| 1.2 WPS ring-buffer cap (`MAX_PERSIST = 4096`) | ✅ | `agentmux-srv/src/backend/wps.rs:53`                                  |
+| 1.2 FileStore LRU eviction (128 MB cap) | ✅     | `agentmux-srv/src/backend/storage/filestore/` (cache layer)            |
+| 1.3 Write-through to FileStore on stdout| ✅     | `agentmux-srv/src/backend/blockcontroller/shell.rs:918-998`            |
+| 1.4 Session metadata (`session:*` meta) | ✅     | `agentmux-srv/src/backend/blockcontroller/session_stats.rs`            |
+
+### Phase 2 — Core UX (PRs #338, #340)
+
+| Item                                     | Status | Anchor                                                                  |
+|------------------------------------------|:------:|-------------------------------------------------------------------------|
+| 2.1 Virtualization via `content-visibility: auto` | ✅ | `frontend/app/view/agent/components/AgentDocumentView.tsx:208`         |
+| 2.2 Paginated history loading on mount   | ✅     | `frontend/app/view/agent/agent-view.tsx` (history load + prepend)       |
+| 2.2 Scroll-top "load older" with RAF position restore | ✅ | same                                                             |
+| 2.3 Reconnect recovery via history reload| ✅     | same                                                                    |
+| 2.4 Timeline minimap w/ 30-bucket density| ✅     | `frontend/app/view/agent/components/TimelineMinimap.tsx`                |
+| 2.4 Bookmarks (Ctrl+B)                   | ✅     | `agent-view.tsx:741` (Ctrl+B handler), `agent-view.tsx:901` (read meta) |
+
+### Phase 3 — Navigation + Archival + Digest (PR #341)
+
+| Item                                           | Status | Anchor                                                                |
+|------------------------------------------------|:------:|-----------------------------------------------------------------------|
+| 3.1 In-session search (Ctrl+F, pane-scoped)    | ✅     | `frontend/app/view/agent/components/AgentSearchBar.tsx`              |
+| 3.3 Session archival (gzip → `~/.agentmux/archives/`) | ✅ | `agentmux-srv/src/backend/session_archive.rs` + archiver sweep in `main.rs` |
+| 3.3 Archive / Restore / Export RPCs            | ✅     | `agentmux-srv/src/server/app_api.rs` (register_session_*)             |
+| 3.3 Frontend buttons in `AgentControlBar`      | ✅     | `frontend/app/view/agent/components/AgentControlBar.tsx`              |
+| 3.4 AI session digest via block's own Claude CLI| ✅    | `app_api.rs` (register_session_digest + invoke_cli_for_digest)        |
+| 3.4 `SessionDigestBanner` collapsible UI       | ✅     | `frontend/app/view/agent/components/SessionDigestBanner.tsx`          |
+
+### Phase 4 — Resilience (PR #342)
+
+| Item                                           | Status | Anchor                                                                |
+|------------------------------------------------|:------:|-----------------------------------------------------------------------|
+| 4.1 500K-line warning banner + one-click Archive| ✅    | `AgentControlBar.tsx` (isLargeSession check)                          |
+| 4.1 SQLite WAL backpressure (already in place) | ✅     | `agentmux-srv/src/backend/storage/filestore/core.rs:69`               |
+| 4.2 Orphaned-session detection (`scan_orphans`)| ✅     | `agentmux-srv/src/backend/blockcontroller/session_recovery.rs`        |
+| 4.2 `session:active_pid` + `session:was_interrupted` meta flags | ✅ | same                                                          |
+| 4.2 Startup scan hooked in main.rs             | ✅     | `main.rs` (after `heal_all_layouts`)                                  |
+| 4.2 Frontend interrupted banner + Dismiss      | ✅     | `AgentControlBar.tsx` (wasInterrupted check)                          |
+| 4.2 `--resume <session_id>` path (pre-existing)| ✅     | `agentmux-srv/src/backend/blockcontroller/subprocess.rs:193-209`      |
+| 4.3 WPS broker fanout correctness (pre-existing)| ✅    | `wps.rs:221-238` (single-mutex publish)                               |
+
+### Intentionally descoped
+
+| Item                                    | Reason |
+|-----------------------------------------|--------|
+| 4.1 Per-block FileStore write rate-limit| SQLite WAL + WPS persist ring buffer already provide correct backpressure. Throttling without a demonstrated saturation issue is premature optimization. |
+| 4.1 Frame-time-adaptive virtualization buffer | `content-visibility: auto` is already browser-adaptive. No evidence of actual frame-time issues after the DOM-size work in PR #334. |
+| 4.3 Explicit snapshot isolation across read_range + live append | Per-operation mutexes are sufficient; explicit isolation would be a large refactor without a demonstrated race. |
+
+---
+
+## 3. What each PR actually delivers in user-visible terms
+
+- **#336 Foundation** — nothing visible yet; unlocks everything else by giving the frontend a paginated read API and a persistent write path.
+- **#338 Pagination + reconnect** — refreshing the pane or reconnecting no longer loses history; older events stay addressable.
+- **#340 Timeline + bookmarks + segmentation** — tiny density strip on the right edge, Ctrl+B to bookmark the current node, bookmarks persist in block meta.
+- **#341 Search + archive + digest** — Ctrl+F opens a pane-scoped search bar. Expanded control bar exposes Archive / Export / Restore buttons. A collapsible banner above the document renders an AI summary of the session on demand.
+- **#342 Resilience** — sessions over 500K lines surface a soft warning with a one-click archive action, and sessions that were running when agentmux-srv crashed/rebooted are flagged on next boot with an "interrupted" banner. The very next message auto-resumes via the existing `--resume` path.
+
+---
+
+## 4. Build / review integrity
+
+Every phase PR went through reagent review on opus-4-6 at high effort. Summary:
+
+| PR   | Review rounds | Issues found by reagent                                                                                            |
+|------|:-------------:|---------------------------------------------------------------------------------------------------------------------|
+| #336 | 1             | clean                                                                                                              |
+| #338 | 1             | `nodeIndexMap` not rebuilt on history prepend (fixed with `documentVersion` signal)                                |
+| #340 | 1             | `read_range` O(N) memory warning — fixed by making `line_count` use meta fast-path; Ctrl+B was global (pane-scoped) |
+| #341 | 3             | (1) stale `home_dir` fallback, (2) meta written *after* FileStore delete (orphan risk), (3) digest prompt via argv (MAX_ARG_STRLEN), (4) `package-lock.json` lockfile drift, (5) tokio child not killed on timeout |
+| #342 | 1             | clean (LGTM on first pass)                                                                                         |
+
+All issues were real bugs caught before merge. The reagent loop paid for itself.
+
+---
+
+## 5. Retrospective — what went well, what hurt, what we learned
+
+### Went well
+- **Phased rollout caught real issues early.** Phase 1 landing before Phase 2 meant the paginated reads were exercised by the foundation tests before the frontend pagination UI depended on them.
+- **Persistent meta flags are a clean pattern.** Using `session:active_pid` + `session:was_interrupted` instead of a new out-of-band IPC surface meant zero new RPC types for Phase 4.2 — the frontend just watches block meta like it does for every other agent feature.
+- **Reagent + Opus-4.6 high-effort is finding subtle bugs I would miss.** The MAX_ARG_STRLEN catch on the digest prompt and the tokio child-drop catch are both things I wouldn't have thought about under time pressure. 3 review rounds on PR #341 saved two follow-up PRs.
+- **Delegating research to an Explore subagent before planning each phase.** The 400-word "what already exists / what needs implementation" brief let me scope each PR tightly without re-reading entire modules.
+
+### Hurt
+- **bump-cli is not syncing `package-lock.json` consistently.** It updated the five Cargo.toml files and `package.json` but left `package-lock.json` stale on every bump this session. Had to manually `npm install --package-lock-only` twice and still hit it in PR #341 review. **Action:** add `package-lock.json` to `.bump.json` targets (or run `npm i --package-lock-only` as part of `bump` post-hook).
+- **Nested git clone under `~/.agentmux/agents/agentx/agentmux/`.** A 3.5 GB pre-SolidJS clone was thrashing I/O and confusing agents inside the pane into thinking the project was React. Unrelated to this plan but cost ~30 min. **Action:** add agent workspaces to gitignore OR make the agent startup code refuse to clone into `$AGENTMUX_DATA_DIR/agents/*/repo`.
+- **Context-window churn across 5 PRs.** Each PR required re-fetching files that had been summarized away. **Action:** when running a multi-PR plan, write a one-page cheatsheet at the top of each PR that records the exact file paths and line numbers touched so future iterations can skip re-exploration.
+- **Review iteration is slow** — each PR took 2–20 min of wall-clock time waiting for reagent. Cumulative wait across 5 PRs was ~1.5 hours. **Action:** none really — this is inherent to the review model, and the catches were worth the wait.
+
+### Surprises
+- **content-visibility: auto is enough.** Phase 2.1 was originally planned to need a full virtualized list implementation. Adding `content-visibility: auto` on each node wrapper + removing the hard cap gave us effectively unlimited DOM size at smooth framerate. Saved us from building a virtualizer.
+- **--resume was already implemented.** Phase 4.2 originally called out `--resume` support as a deliverable; turned out `subprocess.rs:193-209` had been wiring session_id → `--resume` since an earlier PR. Phase 4.2 became a pure UX layer: scan for orphans, surface to user, let existing resume path do the work.
+- **SQLite WAL + WPS ring-buffer already provide backpressure.** Phase 4.1 rate-limiting was descoped once I realized the existing stack handles floods correctly — runaway loops queue in SQLite WAL and get served at disk speed, with WPS ring buffer capping live memory.
+
+### Takeaways for future multi-phase plans
+1. Land foundations (RPC types, meta flags, backend plumbing) in one PR before touching frontend. Reviewers can reason about the API without UI noise.
+2. Surface every backend state change through existing meta rather than new RPC calls where possible — reuses the subscribe/render path for free.
+3. Budget one "reagent round 2" per PR as the default expectation. Round 3 is a signal to split the PR.
+4. Always run `bump verify` + spot-check `package-lock.json` before pushing a bumped commit.
+5. Describe descoped items explicitly in PR body with the reason. Saves reviewer time and documents the decision for future-you.
+
+---
+
+## 6. Test plan for the portable build
+
+Manual verification in the 0.33.100 portable:
+
+**Phase 1–2 (paginated history + virtualization):**
+- [ ] Open an agent pane, run a 10K-line task (e.g. `ls -R /usr`). Confirm typing stays smooth.
+- [ ] Close and re-open the pane. History loads from FileStore.
+- [ ] Scroll to top. Older history pages in (look for loading indicator + preserved scroll position).
+
+**Phase 2.4 (timeline + bookmarks):**
+- [ ] Timeline strip appears on the right edge with density bars.
+- [ ] Ctrl+B bookmarks the current node. Bookmark persists across pane reload.
+
+**Phase 3.1 (search):**
+- [ ] Ctrl+F opens the search bar only in the focused pane.
+- [ ] Typing a query highlights matches; Enter / Shift+Enter cycle.
+- [ ] Esc closes.
+
+**Phase 3.3 (archival):**
+- [ ] Expanded control bar shows Archive / Export buttons when `lineCount > 0`.
+- [ ] Archive moves the session to `~/.agentmux/archives/<blockid>.jsonl.gz` — verify the file exists.
+- [ ] Restore brings the session back.
+- [ ] Export downloads `session-<blockId>-<ts>.jsonl`.
+
+**Phase 3.4 (digest):**
+- [ ] Trigger session digest. Collapsible banner renders with summary text.
+- [ ] Regenerate re-invokes the CLI.
+
+**Phase 4.1 (large-session banner):**
+- [ ] (optional — requires 500K lines) Warning banner appears with one-click archive.
+
+**Phase 4.2 (interrupted-session recovery):**
+- [ ] Start a session, send a message, then kill `agentmux-srv` via Task Manager while the subprocess is running.
+- [ ] Restart portable. The interrupted banner should appear above the control bar.
+- [ ] Send a new message. The session should resume via `--resume` under the hood.
+- [ ] Click Dismiss. The banner should clear.
+
+---
+
+## 7. Follow-ups
+
+Open items that came out of this plan but weren't in scope:
+
+1. **bump-cli package-lock.json drift** — see section 5.
+2. **agent nested-repo workspace** — see section 5.
+3. **WER dump collection** after any crash — configured but no triggers observed during this plan's testing.
+4. **Rate-limit telemetry** — if users ever report runaway-loop saturation, the first step is adding per-block bytes/sec counters to session meta. Not implementing now, but the meta slot is available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.102",
+  "version": "0.33.103",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.102",
+      "version": "0.33.103",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.101",
+  "version": "0.33.102",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.101",
+      "version": "0.33.102",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.100",
+  "version": "0.33.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.100",
+      "version": "0.33.101",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.101",
+  "version": "0.33.102",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.102",
+  "version": "0.33.103",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.100",
+  "version": "0.33.101",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/bump-wrapper.sh
+++ b/scripts/bump-wrapper.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# bump-wrapper.sh — wraps @a5af/bump-cli so package-lock.json actually gets synced.
+#
+# Background: bump-cli's "npm" lockfile strategy runs `npm version` under the
+# hood, which fails with "Unknown error" while bump-cli holds the working tree
+# in a partial state. Because `allowFailure: true` in the default config,
+# bump-cli silently proceeds, leaving package-lock.json pinned to the previous
+# version. PR #341 caught the resulting inconsistency in review.
+#
+# This wrapper runs bump normally, then syncs the lockfile with a direct
+# `npm install --package-lock-only` call, and (if bump created a commit) folds
+# the synced lockfile into the same commit via `git commit --amend`. That
+# single amend is deliberate — it produces a clean, consistent bump commit
+# without leaving an orphaned "lockfile sync" commit trailing behind every
+# version bump.
+#
+# Usage: mirrors bump-cli exactly.
+#   scripts/bump-wrapper.sh patch -m "description" --commit
+#   scripts/bump-wrapper.sh minor --commit
+#   scripts/bump-wrapper.sh 1.2.3 --commit
+#
+# Exit codes match bump-cli: non-zero on any failure, including the lockfile
+# sync. If --commit is not passed, the wrapper skips the amend step and just
+# syncs the lockfile in-place (caller is responsible for staging).
+
+set -euo pipefail
+
+# Pass everything through to the real bump CLI.
+if ! command -v bump >/dev/null 2>&1; then
+    echo "ERROR: bump-cli not installed. Install with: npm install -g @a5af/bump-cli" >&2
+    exit 1
+fi
+
+# Detect whether --commit was requested — controls whether we amend.
+DO_COMMIT=0
+for arg in "$@"; do
+    if [ "$arg" = "--commit" ]; then
+        DO_COMMIT=1
+    fi
+done
+
+# Remember HEAD so we can detect whether bump actually created a commit.
+BEFORE_HEAD=""
+if [ "$DO_COMMIT" -eq 1 ]; then
+    BEFORE_HEAD=$(git rev-parse HEAD 2>/dev/null || echo "")
+fi
+
+# Run the real bump CLI.
+bump "$@"
+
+# Sync package-lock.json directly. --ignore-scripts keeps lifecycle hooks from
+# running during what should be a pure metadata operation.
+echo ""
+echo "bump-wrapper: syncing package-lock.json …"
+npm install --package-lock-only --ignore-scripts >/dev/null 2>&1 || {
+    echo "ERROR: npm install --package-lock-only failed; lockfile is out of sync" >&2
+    exit 1
+}
+
+# Verify the versions now match, just in case.
+PKG_VER=$(node -p "require('./package.json').version")
+LOCK_VER=$(node -p "require('./package-lock.json').version")
+if [ "$PKG_VER" != "$LOCK_VER" ]; then
+    echo "ERROR: version mismatch after sync: package.json=$PKG_VER lockfile=$LOCK_VER" >&2
+    exit 1
+fi
+echo "bump-wrapper: package-lock.json synced to $LOCK_VER"
+
+# If bump committed, amend the lockfile into that same commit.
+if [ "$DO_COMMIT" -eq 1 ]; then
+    AFTER_HEAD=$(git rev-parse HEAD 2>/dev/null || echo "")
+    if [ -n "$BEFORE_HEAD" ] && [ "$BEFORE_HEAD" != "$AFTER_HEAD" ]; then
+        if ! git diff --quiet package-lock.json 2>/dev/null; then
+            git add package-lock.json
+            git commit --amend --no-edit >/dev/null
+            echo "bump-wrapper: folded lockfile into bump commit $(git rev-parse --short HEAD)"
+        fi
+    fi
+fi

--- a/scripts/package-cef-portable.sh
+++ b/scripts/package-cef-portable.sh
@@ -86,9 +86,42 @@ fi
 DIR_SIZE=$(du -sh "$PORTABLE" | cut -f1)
 
 # ZIP
+#
+# Tries pwsh 7 first (Compress-Archive with proper module), then falls back to
+# Windows PowerShell 5, then to `tar -a -cf` (bsdtar on Win10+). If *none*
+# succeed the script exits non-zero instead of silently reporting "N/A", which
+# is how a broken packaging run used to produce a portable folder on the
+# desktop with no ZIP beside it.
 cd "$OUTDIR"
 ZIP_NAME="agentmux-cef-$VERSION-x64-portable.zip"
-powershell -Command "Compress-Archive -Path '$(basename "$PORTABLE")/*' -DestinationPath '$ZIP_NAME' -Force" 2>/dev/null || true
+rm -f "$ZIP_NAME"
+
+portable_basename=$(basename "$PORTABLE")
+zip_made=0
+
+if command -v pwsh >/dev/null 2>&1; then
+    if pwsh -Command "Compress-Archive -Path '${portable_basename}/*' -DestinationPath '$ZIP_NAME' -Force" >/dev/null 2>&1; then
+        zip_made=1
+    fi
+fi
+
+if [ "$zip_made" -eq 0 ]; then
+    if powershell -Command "Compress-Archive -Path '${portable_basename}/*' -DestinationPath '$ZIP_NAME' -Force" >/dev/null 2>&1; then
+        zip_made=1
+    fi
+fi
+
+if [ "$zip_made" -eq 0 ]; then
+    if tar -a -cf "$ZIP_NAME" "$portable_basename" >/dev/null 2>&1; then
+        zip_made=1
+    fi
+fi
+
+if [ "$zip_made" -eq 0 ] || [ ! -f "$ZIP_NAME" ]; then
+    echo "ERROR: failed to create $ZIP_NAME — Compress-Archive (pwsh + powershell) and tar -a both failed" >&2
+    exit 1
+fi
+
 ZIP_SIZE=$(du -sh "$ZIP_NAME" 2>/dev/null | cut -f1 || echo "N/A")
 
 echo ""

--- a/scripts/package-cef-portable.sh
+++ b/scripts/package-cef-portable.sh
@@ -6,6 +6,12 @@
 
 set -euo pipefail
 
+# Resolve the repo root BEFORE any `cd` so later path lookups (e.g. the
+# VERSION_HISTORY.md size-table append below) don't get confused by the
+# script's internal working-directory change.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 VERSION=$(node -p "require('./package.json').version")
 OUTDIR="${1:-$HOME/Desktop}"
 PORTABLE="$OUTDIR/agentmux-cef-$VERSION-x64-portable"
@@ -125,14 +131,11 @@ fi
 ZIP_SIZE=$(du -sh "$ZIP_NAME" 2>/dev/null | cut -f1 || echo "N/A")
 
 # Append compact size row to VERSION_HISTORY.md under the "## Sizes" table
-# if it exists. Skipped silently if the section isn't there — the script
-# is still the one that creates it on first use, but only if the repo root
-# contains a VERSION_HISTORY.md in the first place.
-REPO_ROOT=""
-if [ -f "$(dirname "$0")/../VERSION_HISTORY.md" ]; then
-    REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-fi
-if [ -n "$REPO_ROOT" ] && grep -q "^## Sizes " "$REPO_ROOT/VERSION_HISTORY.md" 2>/dev/null; then
+# if it exists. REPO_ROOT was captured at the top of the script BEFORE the
+# `cd "$OUTDIR"` above, so it still points at the repo root even though cwd
+# is now the output directory. Skipped silently if the file / section
+# isn't there.
+if [ -f "$REPO_ROOT/VERSION_HISTORY.md" ] && grep -q "^## Sizes " "$REPO_ROOT/VERSION_HISTORY.md" 2>/dev/null; then
     DIR_BYTES=$(find "$PORTABLE" -type f -printf '%s\n' 2>/dev/null | awk '{s+=$1} END {print s+0}')
     ZIP_BYTES=$(stat -c '%s' "$ZIP_NAME" 2>/dev/null || echo 0)
     DIR_MIB=$(awk "BEGIN {printf \"%.1f\", $DIR_BYTES/1024/1024}")

--- a/scripts/package-cef-portable.sh
+++ b/scripts/package-cef-portable.sh
@@ -124,6 +124,35 @@ fi
 
 ZIP_SIZE=$(du -sh "$ZIP_NAME" 2>/dev/null | cut -f1 || echo "N/A")
 
+# Append compact size row to VERSION_HISTORY.md under the "## Sizes" table
+# if it exists. Skipped silently if the section isn't there — the script
+# is still the one that creates it on first use, but only if the repo root
+# contains a VERSION_HISTORY.md in the first place.
+REPO_ROOT=""
+if [ -f "$(dirname "$0")/../VERSION_HISTORY.md" ]; then
+    REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+if [ -n "$REPO_ROOT" ] && grep -q "^## Sizes " "$REPO_ROOT/VERSION_HISTORY.md" 2>/dev/null; then
+    DIR_BYTES=$(find "$PORTABLE" -type f -printf '%s\n' 2>/dev/null | awk '{s+=$1} END {print s+0}')
+    ZIP_BYTES=$(stat -c '%s' "$ZIP_NAME" 2>/dev/null || echo 0)
+    DIR_MIB=$(awk "BEGIN {printf \"%.1f\", $DIR_BYTES/1024/1024}")
+    ZIP_MIB=$(awk "BEGIN {printf \"%.1f\", $ZIP_BYTES/1024/1024}")
+    TODAY=$(date +%Y-%m-%d)
+    ROW="| $VERSION | $TODAY | $ZIP_MIB MiB | $DIR_MIB MiB | |"
+
+    # Insert the row immediately after the header separator line of the
+    # Sizes table (the `|---|---|...` line). awk in-place via temp file.
+    awk -v row="$ROW" '
+        /^\| *Version *\| *Date *\| *ZIP/ { in_sizes=1 }
+        { print }
+        in_sizes && /^\|[-:| ]+\|[-:| ]+\|[-:| ]+\|[-:| ]+\|[-:| ]+\|$/ {
+            print row
+            in_sizes=0
+        }
+    ' "$REPO_ROOT/VERSION_HISTORY.md" > "$REPO_ROOT/VERSION_HISTORY.md.tmp" \
+        && mv "$REPO_ROOT/VERSION_HISTORY.md.tmp" "$REPO_ROOT/VERSION_HISTORY.md"
+fi
+
 echo ""
 echo "[SUCCESS] CEF Portable v$VERSION"
 echo "  Directory: $PORTABLE ($DIR_SIZE)"


### PR DESCRIPTION
## Summary

Quick-win bundle from \`specs/SPEC_RETRO_FOLLOWUPS_2026_04_12.md\`. Addresses three open questions from the 2026-04-12 retros with low-risk, config/tooling changes only — no runtime behavior.

### #1 bump-cli lockfile drift

bump-cli's \`"npm"\` lockfile strategy calls \`npm version\` internally, which fails with _"Unknown error"_ inside bump's temporary git state. With \`allowFailure: true\` this was silently swallowed, leaving \`package-lock.json\` at the previous version on every bump — PR #341 caught the resulting inconsistency in review.

- **New** \`scripts/bump-wrapper.sh\` — runs bump, then \`npm install --package-lock-only --ignore-scripts\` directly, verifies version match, and (when \`--commit\`) amends the synced lockfile into bump's own commit so we don't trail orphan sync commits.
- \`.bump.json\` — drop the \`"npm"\` lockfile entry entirely with a breadcrumb comment explaining why; also drop the \`"history"\` section since its template (\`| {{version}}-fork | v0.12.0 | ...\`) has never matched \`VERSION_HISTORY.md\`'s actual format and has been silently failing since March.

### #3 Delete pre-ANGLE CEF ZIP

\`dist/agentmux-cef-portable.zip\` and \`dist/cef-release.zip\` (both 2026-03-29) were the only reason the "+10 MiB regression" phantom appeared in the size audit. Both live under \`dist/\` which is \`.gitignored\`, so this is an untracked cleanup — no commit content beyond their absence.

### #5 Per-version size tracking

- \`scripts/package-cef-portable.sh\` — after a successful package, parse the Sizes table in \`VERSION_HISTORY.md\` and insert a new row with compressed + uncompressed MiB. Silently skipped if the section isn't present.
- \`VERSION_HISTORY.md\` — new \`## Sizes (CEF portable, Windows x64)\` section seeded with 0.33.91, 0.33.102, and the pre-ANGLE baseline so future builds have something to append to.

## Deliberately not in this PR

- **#2 nested-repo runtime warning** and **#4 \`deploy_wsh\` no-op** — both are runtime-behavior changes that modify the \`agentmux-srv\` / \`agentmux-cef\` binaries. They'll land in a separate runtime-behavior PR so this config/tooling bundle can be reviewed and merged fast.
- **#6 packaging script silent ZIP failure** — already fixed in commit \`3390e29\` (merged earlier today as part of 0.33.102).

## Files changed

- \`.bump.json\`
- \`VERSION_HISTORY.md\`
- \`scripts/bump-wrapper.sh\` (new)
- \`scripts/package-cef-portable.sh\`
- \`package-lock.json\` (synced to 0.33.103)

## Test plan

- [x] \`cargo check -p agentmux-srv\` clean
- [ ] Run \`scripts/bump-wrapper.sh patch -m "test" --commit\`, verify \`package-lock.json\` lands in the same commit as the version files.
- [ ] Run \`task cef:package:portable\`, verify a new row appears in \`VERSION_HISTORY.md\`'s Sizes table.
- [ ] Confirm bare \`bump patch\` still works (but without lockfile sync — wrapper is the supported path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)