### PR TITLE
fix: eliminate 45ms keystroke latency in agent composer (use CSS field-sizing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.105"
+version = "0.33.106"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.105"
+version = "0.33.106"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.105"
+version = "0.33.106"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.105"
+version = "0.33.106"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.105"
+version = "0.33.106"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.104"
+version = "0.33.105"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.104"
+version = "0.33.105"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.104"
+version = "0.33.105"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.104"
+version = "0.33.105"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.104"
+version = "0.33.105"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.104"
+version = "0.33.105"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.105"
+version = "0.33.106"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.104"
+version = "0.33.105"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.105"
+version = "0.33.106"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.104"
+version = "0.33.105"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.105"
+version = "0.33.106"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.104"
+version = "0.33.105"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.105"
+version = "0.33.106"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.105"
+version = "0.33.106"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.104"
+version = "0.33.105"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1304,6 +1304,14 @@
                 max-height: 200px;
                 overflow-y: auto;
 
+                // Native auto-grow — browser sizes the textarea to its
+                // content without any JS. Supported in Chromium 123+, which
+                // CEF ships (we're on ~133). Replaces the old JS autoGrow
+                // helper in AgentFooter.tsx that forced a synchronous layout
+                // on every keystroke (22ms per keypress in the agent pane).
+                // See docs/analysis/agent-typing-lag-trace-2026-04-12.md.
+                field-sizing: content;
+
                 &:focus {
                     outline: none;
                     border-color: var(--accent-color);

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -15,15 +15,19 @@ interface AgentFooterProps {
 
 export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // Uncontrolled textarea — DOM owns the value. Reading via ref on send
-    // avoids re-rendering the component tree on every keystroke, which was
-    // causing severe typing lag when the parent's `loading` signal updated
-    // frequently from streaming controller status events.
+    // avoids re-rendering the component tree on every keystroke.
+    //
+    // Auto-resize is handled entirely by CSS (`field-sizing: content` on
+    // .agent-input). No `onInput` handler, no `scrollHeight` read — the
+    // browser grows the textarea natively as text wraps. A prior version of
+    // this file had a JS `autoGrow` helper that did
+    //   el.style.height = "auto"; el.style.height = el.scrollHeight + "px";
+    // which forced a synchronous layout on every keystroke. In the agent
+    // pane (flex column with a large content-visibility:auto document view
+    // above), that layout cost ~22ms per keystroke and blocked character
+    // paint — see docs/analysis/agent-typing-lag-trace-2026-04-12.md for
+    // the full trace analysis.
     let textareaRef: HTMLTextAreaElement | undefined;
-
-    const autoGrow = (el: HTMLTextAreaElement) => {
-        el.style.height = "auto";
-        el.style.height = el.scrollHeight + "px";
-    };
 
     const handleSend = () => {
         if (!textareaRef) return;
@@ -32,7 +36,8 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         if (props.onSendMessage) {
             props.onSendMessage(message);
             textareaRef.value = "";
-            textareaRef.style.height = "auto";
+            // No style reset — browser's field-sizing handles it
+            // automatically when the content empties.
         }
     };
 
@@ -43,12 +48,6 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         }
     };
 
-    const handleInput = (e: Event) => {
-        // Only auto-grow — do NOT update a signal here. Keeping the DOM as
-        // the source of truth means keystrokes don't trigger re-renders.
-        autoGrow(e.target as HTMLTextAreaElement);
-    };
-
     return (
         <div class="agent-footer">
             <div class="agent-input-container">
@@ -56,7 +55,6 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                     ref={textareaRef}
                     class="agent-input"
                     placeholder={`Send message to ${props.agentId}...`}
-                    onInput={handleInput}
                     onKeyDown={handleKeyDown}
                     rows={1}
                 />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.104",
+  "version": "0.33.105",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.104",
+      "version": "0.33.105",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.105",
+  "version": "0.33.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.105",
+      "version": "0.33.106",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.104",
+  "version": "0.33.105",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.105",
+  "version": "0.33.106",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**45ms → 0.1ms keystroke latency.** ~450× improvement, verified with a before-and-after DevTools Performance trace.

Root cause: \`AgentFooter.autoGrow\` was doing the classic forced-sync-layout pattern on every onInput:

\`\`\`ts
el.style.height = "auto";
el.style.height = el.scrollHeight + "px";  // ← read forces sync layout
\`\`\`

In a simple page the \`scrollHeight\` read costs ~0.5ms. In the agent pane (flex column with a \`content-visibility:auto\` document view above the footer) the layout had to propagate the flex container's intrinsic-size recalc through thousands of children, costing **22ms per keystroke** plus another ~22ms for the follow-up render pipeline layout.

## Evidence — 0.33.105 baseline trace

User captured a 10-second DevTools Performance trace while typing in 0.33.105. Analyzed with a plain Node script:

| Event | n | avg | max |
|---|---:|---:|---:|
| \`keydown\` | 34 | 0.36ms | 0.8ms |
| \`keypress\` | 34 | **45.12ms** | **60.0ms** |
| \`textInput\` | 34 | 45.07ms | 59.9ms |
| \`input\` | 34 | 21.75ms | 32.7ms |

- 102 of 118 layouts during the 8-second trace happened **inside keypress events**
- The minified function \`xZ\` (= \`autoGrow\`) accounted for 751ms across 335 self-hits
- 20% of wall time was V8 GC from allocation pressure on the hot path
- \`keydown\` at 0.36ms confirms it's NOT the Ctrl+B/Ctrl+F global listener (ruled out)

Full analysis: \`docs/analysis/agent-typing-lag-trace-2026-04-12.md\` (344 lines).

## Fix

Delete \`autoGrow\` + \`handleInput\` entirely. Let Chromium auto-size the textarea natively via CSS \`field-sizing: content\` — supported since Chromium 123, CEF currently ships ~133, so we're 10 majors ahead.

**Changes:**
- \`frontend/app/view/agent/components/AgentFooter.tsx\` — delete 15 lines of JS, remove \`onInput\` handler
- \`frontend/app/view/agent/agent-view.scss\` — add \`field-sizing: content\` to \`.agent-input\`

Net: +22 / -16 lines.

## Verification — 0.33.106 CDP trace

Built 0.33.106 portable, launched with \`--remote-debugging-port=9222\`, connected via Chrome DevTools Protocol, captured a fresh trace while sending 30 synthetic keystrokes via \`Input.dispatchKeyEvent\`:

| Metric | Before (0.33.105) | After (0.33.106) | Improvement |
|---|---:|---:|---:|
| \`keypress\` avg | 45.12ms | **0.10ms** | **~450×** |
| \`keypress\` max | 60.0ms | 1.24ms | ~48× |
| \`keydown\` avg | 0.36ms | 0.38ms | unchanged (control) |
| \`textInput\` avg | 45.07ms | **not observed** | gone |
| \`input\` avg | 21.75ms | **not observed** | gone |
| Layouts total | 118 / 1521ms | **30 / 16.1ms** | ~95× |

The \`textInput\` and \`input\` events aren't in the new trace because there's no JS listener for them anymore. Chromium still dispatches internally but there's no user code to run.

Verification scripts added:
- \`scripts/capture-trace.cjs\` — general-purpose CDP trace capture (any number of seconds, manual or synthetic input)
- \`scripts/verify-typing-fix.cjs\` — specific PASS/FAIL check against the 5ms keypress target

## Test plan

- [x] TypeScript clean (\`npx tsc --noEmit\`)
- [x] Portable builds cleanly via \`task cef:package:portable\`
- [x] Smoke test passes against new portable (\`node scripts/smoke-test-portable.cjs\`)
- [x] CDP trace confirms keypress avg < 5ms target (actual: 0.10ms)
- [ ] Manual: open an agent pane, type a multi-line message, confirm the textarea still grows naturally as expected (native field-sizing is the replacement for the old JS autogrow)
- [ ] Manual: verify shift-enter newline still works, enter still sends

🤖 Generated with [Claude Code](https://claude.com/claude-code)