### PR TITLE
fix: bookmark/search jump no longer scrolls the entire app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.107"
+version = "0.33.108"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.107"
+version = "0.33.108"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.107"
+version = "0.33.108"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.107"
+version = "0.33.108"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.107"
+version = "0.33.108"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.107"
+version = "0.33.108"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.107"
+version = "0.33.108"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.107"
+version = "0.33.108"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.107"
+version = "0.33.108"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.107"
+version = "0.33.108"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -59,13 +59,34 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
 
     // Scroll to a node by its data-node-id attribute.
     // Exposed to the parent via scrollToNodeRef so BookmarksPanel can call it.
+    //
+    // We deliberately DO NOT use `el.scrollIntoView()` here. scrollIntoView
+    // walks every scrollable ancestor and scrolls each one until the target
+    // is inside its visible region — which in our pane/tab/window nesting
+    // scrolls the outer block frame, pushing the agent pane header and
+    // adjacent pane titles out of the viewport. The symptom is "pane titles
+    // disappear across the entire app when I click a bookmark" — a real bug
+    // reported against 0.33.106.
+    //
+    // Instead, compute the target element's top relative to scrollRef and
+    // set scrollRef.scrollTop directly. That scrolls ONLY the document
+    // container and leaves every ancestor untouched.
+    //
+    // See docs/analysis/agent-pane-rich-features-structure-2026-04-13.md §1.
     const scrollToNode = (nodeId: string) => {
-        const el = scrollRef?.querySelector(`[data-node-id="${nodeId}"]`);
-        if (el) {
-            el.scrollIntoView({ behavior: "smooth", block: "center" });
-            // Disable auto-scroll after a manual jump
-            autoScroll = false;
-        }
+        if (!scrollRef) return;
+        const el = scrollRef.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null;
+        if (!el) return;
+        const elRect = el.getBoundingClientRect();
+        const containerRect = scrollRef.getBoundingClientRect();
+        // Top of el relative to scrollRef's content origin
+        const offsetWithinContainer = elRect.top - containerRect.top + scrollRef.scrollTop;
+        // Center the element in the visible region
+        const centerOffset =
+            offsetWithinContainer - scrollRef.clientHeight / 2 + el.clientHeight / 2;
+        scrollRef.scrollTo({ top: Math.max(0, centerOffset), behavior: "smooth" });
+        // Disable auto-scroll after a manual jump
+        autoScroll = false;
     };
 
     // Expose scrollToNode to the parent on mount

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.107",
+  "version": "0.33.108",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.107",
+      "version": "0.33.108",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.107",
+  "version": "0.33.108",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**Symptom:** set a bookmark, expand the Saved Bookmarks panel, click a bookmark → *the pane titles disappear across the entire app and pane content shifts up*. Same thing can happen with Ctrl+F next/prev.

**Root cause:** \`AgentDocumentView.scrollToNode\` called \`el.scrollIntoView({block: "center"})\`. \`scrollIntoView\` walks every scrollable ancestor of the target and scrolls each one until the target is inside its visible region. In the agent pane, the target is nested:

\`\`\`
<div id="app">                        ← may overflow
  <div class="tab-content">           ← may overflow
    <div class="block-frame">         ← may overflow
      <div class="agent-pane">        ← flex column
        <div class="agent-document">  ← the scroll container we actually want
          <div data-node-id="…">      ← target
\`\`\`

Because one or more of those ancestors has \`overflow: auto\`, the browser happily scrolls the outer block/tab container upward — pushing the agent pane header and every adjacent pane title out of the viewport. That's exactly the reported symptom.

The same function is used by Ctrl+F search navigation (\`searchNext\`, \`searchPrev\`, \`searchOpen\` first-match) through the shared \`scrollToNodeFn\` ref, so this one fix covers all four call sites.

## Fix

Replace \`el.scrollIntoView(...)\` with a \`scrollRef.scrollTo({top})\` call computed from the target's bounding rect relative to the container. That touches **only** \`scrollRef\` and leaves every ancestor untouched.

\`\`\`ts
const scrollToNode = (nodeId: string) => {
    if (!scrollRef) return;
    const el = scrollRef.querySelector(\`[data-node-id="\${nodeId}"]\`) as HTMLElement | null;
    if (!el) return;
    const elRect = el.getBoundingClientRect();
    const containerRect = scrollRef.getBoundingClientRect();
    const offsetWithinContainer = elRect.top - containerRect.top + scrollRef.scrollTop;
    const centerOffset = offsetWithinContainer - scrollRef.clientHeight / 2 + el.clientHeight / 2;
    scrollRef.scrollTo({ top: Math.max(0, centerOffset), behavior: "smooth" });
    autoScroll = false;
};
\`\`\`

## Full analysis

Written during investigation: \`docs/analysis/agent-pane-rich-features-structure-2026-04-13.md\` — covers the specific bug (§1), the broader code-structure pattern that made it easy to ship (§2-3), and the recommended refactor (\`specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md\`, Step 9 being this exact fix).

## Files changed

- \`frontend/app/view/agent/components/AgentDocumentView.tsx\` — scrollToNode body only (+27/-6, mostly comment explaining the bug)

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Build 0.33.108 portable, extract
- [ ] Set a bookmark in a long session, expand bookmarks panel, click it → pane header stays visible, adjacent pane titles stay visible, only the document view scrolls
- [ ] Ctrl+F, type a query, Enter → same assertion
- [ ] Ctrl+F, Shift+Enter to prev → same assertion
- [ ] Verify multiple agent panes open; clicking bookmark in one doesn't disturb the others

🤖 Generated with [Claude Code](https://claude.com/claude-code)