### PR TITLE
refactor: modularize agent-view step 1 — extract AgentPicker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.110"
+version = "0.33.111"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.110"
+version = "0.33.111"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.110"
+version = "0.33.111"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.110"
+version = "0.33.111"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.110"
+version = "0.33.111"
 dependencies = [
  "base64",
  "clap",
@@ -1473,9 +1473,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.110"
+version = "0.33.111"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.110"
+version = "0.33.111"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.110"
+version = "0.33.111"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.110"
+version = "0.33.111"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.110"
+version = "0.33.111"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -15,6 +15,7 @@ import { parseHistoryLines } from "./parseHistoryLines";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
+import { AgentPicker } from "./components/AgentPicker";
 import { AgentSearchBar } from "./components/AgentSearchBar";
 import { BookmarksPanel } from "./components/BookmarksPanel";
 import { SessionDigestBanner } from "./components/SessionDigestBanner";
@@ -26,39 +27,6 @@ import { BlockService } from "@/app/store/services";
 import { getApi, staticTabId } from "@/app/store/global";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import "./agent-view.scss";
-
-// ── useForgeAgents hook ───────────────────────────────────────────────────────
-
-function useForgeAgents(): () => ForgeAgent[] {
-    const [agents, setAgents] = createSignal<ForgeAgent[]>([]);
-
-    onMount(() => {
-        let cancelled = false;
-
-        async function load() {
-            try {
-                const result = await RpcApi.ListForgeAgentsCommand(TabRpcClient);
-                if (!cancelled) setAgents(result ?? []);
-            } catch {
-                // silently ignore
-            }
-        }
-
-        load();
-
-        const unsub = waveEventSubscribe({
-            eventType: "forgeagents:changed",
-            handler: () => load(),
-        });
-
-        onCleanup(() => {
-            cancelled = true;
-            unsub();
-        });
-    });
-
-    return agents;
-}
 
 /**
  * Top-level wrapper — switches between agent picker and presentation view.
@@ -78,99 +46,6 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
 };
 
 AgentViewWrapper.displayName = "AgentViewWrapper";
-
-// ── Agent Picker ────────────────────────────────────────────────────────────────
-
-const AgentPicker = ({ model }: { model: AgentViewModel }): JSX.Element => {
-    const [launching, setLaunching] = createSignal<string | null>(null);
-    const [nodejsError, setNodejsError] = createSignal<string | null>(null);
-    const agents = useForgeAgents();
-
-    const handleSelect = async (agent: ForgeAgent) => {
-        setNodejsError(null);
-        setLaunching(agent.id);
-        try {
-            await model.launchForgeAgent(agent);
-            // Check if launch was blocked by missing Node.js
-            if (model.nodejsError) {
-                setNodejsError(model.nodejsError);
-                model.nodejsError = null;
-            }
-        } catch {
-            // model logs internally
-        } finally {
-            setLaunching(null);
-        }
-    };
-
-    const busy = () => launching() !== null;
-
-    return (
-        <Show
-            when={agents().length > 0}
-            fallback={
-                <div class="agent-view">
-                    <div class="agent-picker-empty">
-                        <div class="agent-picker-empty-icon">{"\u2726"}</div>
-                        <div class="agent-picker-empty-title">No agents configured</div>
-                        <div class="agent-picker-empty-desc">Create an agent in the Forge to get started.</div>
-                        <button class="agent-picker-forge-btn" disabled>
-                            + Create an agent in the Forge
-                        </button>
-                    </div>
-                </div>
-            }
-        >
-            <div class="agent-view">
-                <div class="agent-picker">
-                    <div class="agent-picker-list">
-                        <For each={agents()}>
-                            {(agent) => (
-                                <button
-                                    class={`agent-card${launching() === agent.id ? " agent-card--launching" : ""}`}
-                                    onClick={() => handleSelect(agent)}
-                                    disabled={busy()}
-                                >
-                                    <span class="agent-card-icon">{agent.icon}</span>
-                                    <span class="agent-card-info">
-                                        <span class="agent-card-name">{agent.name}</span>
-                                        <Show when={agent.description}>
-                                            <span class="agent-card-desc">{agent.description}</span>
-                                        </Show>
-                                    </span>
-                                    <Show when={launching() === agent.id}>
-                                        <span class="agent-card-spinner" />
-                                    </Show>
-                                </button>
-                            )}
-                        </For>
-                    </div>
-                    <Show when={nodejsError()}>
-                        <div class="agent-nodejs-notice">
-                            <div class="nodejs-notice-icon">
-                                <i class="fa-solid fa-circle-exclamation" />
-                            </div>
-                            <div class="nodejs-notice-content">
-                                <div class="nodejs-notice-title">Node.js Required</div>
-                                <div class="nodejs-notice-text">{nodejsError()}</div>
-                                <div class="nodejs-notice-hint">
-                                    After installing, restart AgentMux and try again.
-                                </div>
-                            </div>
-                        </div>
-                    </Show>
-                    <div class="agent-picker-footer">
-                        <button class="agent-picker-forge-btn" disabled>
-                            + New agent in Forge
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </Show>
-    );
-};
-
-AgentPicker.displayName = "AgentPicker";
 
 // ── Launch Flow ──────────────────────────────────────────────────────────────────
 

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -1,0 +1,151 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentPicker — shown when an agent pane has no agentId in block meta.
+ * Lists available Forge agents and launches the selected one into the
+ * calling AgentViewModel.
+ *
+ * Extracted from agent-view.tsx as Step 1 of
+ * specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ */
+
+import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import { waveEventSubscribe } from "@/app/store/wps";
+import type { AgentViewModel } from "../agent-model";
+
+// ── useForgeAgents hook ───────────────────────────────────────────────────────
+
+/**
+ * Reactive accessor for the current Forge agent list. Subscribes to
+ * `forgeagents:changed` and refetches when that event fires.
+ */
+export function useForgeAgents(): () => ForgeAgent[] {
+    const [agents, setAgents] = createSignal<ForgeAgent[]>([]);
+
+    onMount(() => {
+        let cancelled = false;
+
+        async function load() {
+            try {
+                const result = await RpcApi.ListForgeAgentsCommand(TabRpcClient);
+                if (!cancelled) setAgents(result ?? []);
+            } catch {
+                // silently ignore
+            }
+        }
+
+        load();
+
+        const unsub = waveEventSubscribe({
+            eventType: "forgeagents:changed",
+            handler: () => load(),
+        });
+
+        onCleanup(() => {
+            cancelled = true;
+            unsub();
+        });
+    });
+
+    return agents;
+}
+
+// ── AgentPicker component ───────────────────────────────────────────────────────
+
+interface AgentPickerProps {
+    model: AgentViewModel;
+}
+
+export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
+    const [launching, setLaunching] = createSignal<string | null>(null);
+    const [nodejsError, setNodejsError] = createSignal<string | null>(null);
+    const agents = useForgeAgents();
+
+    const handleSelect = async (agent: ForgeAgent) => {
+        setNodejsError(null);
+        setLaunching(agent.id);
+        try {
+            await props.model.launchForgeAgent(agent);
+            // Check if launch was blocked by missing Node.js
+            if (props.model.nodejsError) {
+                setNodejsError(props.model.nodejsError);
+                props.model.nodejsError = null;
+            }
+        } catch {
+            // model logs internally
+        } finally {
+            setLaunching(null);
+        }
+    };
+
+    const busy = () => launching() !== null;
+
+    return (
+        <Show
+            when={agents().length > 0}
+            fallback={
+                <div class="agent-view">
+                    <div class="agent-picker-empty">
+                        <div class="agent-picker-empty-icon">{"\u2726"}</div>
+                        <div class="agent-picker-empty-title">No agents configured</div>
+                        <div class="agent-picker-empty-desc">Create an agent in the Forge to get started.</div>
+                        <button class="agent-picker-forge-btn" disabled>
+                            + Create an agent in the Forge
+                        </button>
+                    </div>
+                </div>
+            }
+        >
+            <div class="agent-view">
+                <div class="agent-picker">
+                    <div class="agent-picker-list">
+                        <For each={agents()}>
+                            {(agent) => (
+                                <button
+                                    class={`agent-card${launching() === agent.id ? " agent-card--launching" : ""}`}
+                                    onClick={() => handleSelect(agent)}
+                                    disabled={busy()}
+                                >
+                                    <span class="agent-card-icon">{agent.icon}</span>
+                                    <span class="agent-card-info">
+                                        <span class="agent-card-name">{agent.name}</span>
+                                        <Show when={agent.description}>
+                                            <span class="agent-card-desc">{agent.description}</span>
+                                        </Show>
+                                    </span>
+                                    <Show when={launching() === agent.id}>
+                                        <span class="agent-card-spinner" />
+                                    </Show>
+                                </button>
+                            )}
+                        </For>
+                    </div>
+                    <Show when={nodejsError()}>
+                        <div class="agent-nodejs-notice">
+                            <div class="nodejs-notice-icon">
+                                <i class="fa-solid fa-circle-exclamation" />
+                            </div>
+                            <div class="nodejs-notice-content">
+                                <div class="nodejs-notice-title">Node.js Required</div>
+                                <div class="nodejs-notice-text">{nodejsError()}</div>
+                                <div class="nodejs-notice-hint">
+                                    After installing, restart AgentMux and try again.
+                                </div>
+                            </div>
+                        </div>
+                    </Show>
+                    <div class="agent-picker-footer">
+                        <button class="agent-picker-forge-btn" disabled>
+                            + New agent in Forge
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Show>
+    );
+};
+
+AgentPicker.displayName = "AgentPicker";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.110",
+  "version": "0.33.111",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.110",
+      "version": "0.33.111",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.110",
+  "version": "0.33.111",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

First step of \`specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md\`. Mechanical extract of the picker screen + its \`useForgeAgents\` hook from \`agent-view.tsx\` into a dedicated \`components/AgentPicker.tsx\` file.

## Scope

**New file** — \`frontend/app/view/agent/components/AgentPicker.tsx\` (151 lines):
- \`useForgeAgents\` — the Forge-list hook with \`forgeagents:changed\` subscription
- \`AgentPicker\` — the component that renders the empty-state + card-list UI and launches the selected agent via \`model.launchForgeAgent\`

**Modified** — \`frontend/app/view/agent/agent-view.tsx\`:
- Remove the inline \`useForgeAgents\` function definition
- Remove the inline \`AgentPicker\` component definition
- Add \`import { AgentPicker } from "./components/AgentPicker"\`
- No other changes — \`AgentViewWrapper\`'s \`<Show>\` still uses \`<AgentPicker model={model} />\`

## Line counts

| File | Before | After | Delta |
|---|---:|---:|---:|
| \`agent-view.tsx\` | 1,178 | **1,053** | **−125** |
| \`components/AgentPicker.tsx\` | — | 151 | +151 |
| **Total** | 1,178 | 1,204 | +26 |

The small positive delta is import boilerplate + header comment block in the new file. Net, this is the setup cost for future extractions — subsequent steps reuse the same import structure, so they'll land mostly negative.

## Behavior

**Zero change.** Same render tree, same RPCs, same event subscriptions. \`AgentPicker\` was already well-isolated inside \`agent-view.tsx\` (no shared state with \`AgentPresentationView\`), so this move is purely mechanical.

## SolidJS reactivity

Converted \`AgentPicker\` to the \`(props: AgentPickerProps)\` accessor pattern instead of the destructured \`({ model }: { model: ... })\` it had inline. In this specific case \`model\` is a stable class instance (not a Solid signal) so destructuring would work, but using \`props.model\` keeps the code consistent with the house rule I added in PR #346 after reagent caught the destructure-breaks-reactivity bug in \`ToolBlock\`.

## Remaining modularization steps

From the spec:

2. Launch flow extraction (\`flows/launch-flow.ts\`)
3. \`useLaunchLogs\` hook
4. \`useAgentControllerStatus\` hook
5. \`useHistoryPagination\` hook
6. \`useSessionDigest\` hook
7. \`useBookmarks\` hook
8. \`useInSessionSearch\` hook
9. \`useScrollToNode\` hook (scrollIntoView bug already fixed standalone in PR #347)
10. \`useAgentKeyboard\` hook
11. \`AgentPresentationHeader\` component
12. Cleanup pass, target \`agent-view.tsx\` ≤ 300 lines

Each step is its own PR, shippable standalone. This ordering is load-bearing — later steps depend on earlier ones landing (the hooks need the launch flow extracted first so they can share a cleaner setup).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`scripts/bump-wrapper.sh patch --commit\` worked (0.33.111, lockfile folded)
- [ ] Launch a portable, open an agent pane, pick an agent, confirm the launch flow still works end-to-end
- [ ] Confirm the empty-state UI still renders when no agents are seeded
- [ ] Confirm the Node.js missing-dependency banner still renders on a machine without Node

🤖 Generated with [Claude Code](https://claude.com/claude-code)