### PR TITLE
refactor: modularize agent-view step 2 — extract launch flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.111"
+version = "0.33.112"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.111"
+version = "0.33.112"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.111"
+version = "0.33.112"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.111"
+version = "0.33.112"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.111"
+version = "0.33.112"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.111"
+version = "0.33.112"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.111"
+version = "0.33.112"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.111"
+version = "0.33.112"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.111"
+version = "0.33.112"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.111"
+version = "0.33.112"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -12,6 +12,7 @@ import type { Bookmark, DocumentNode, SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
 import { parseHistoryLines } from "./parseHistoryLines";
+import { runLaunchFlow } from "./flows/launch-flow";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
@@ -47,211 +48,8 @@ export const AgentViewWrapper = ({ model }: { model: AgentViewModel }): JSX.Elem
 
 AgentViewWrapper.displayName = "AgentViewWrapper";
 
-// ── Launch Flow ──────────────────────────────────────────────────────────────────
-
-type LogFn = (tag: string, text: string, level?: "info" | "error" | "warn") => void;
-
-/**
- * Full agent launch flow: CLI detection → auth check → controller registration.
- * Emits terminal-style log lines at each phase.
- *
- * Returns:
- *  "success"     — controller registered, ready
- *  "auth_failed" — login timed out or errored (retry makes sense)
- *  "fatal"       — CLI missing, Docker missing, etc. (retry won't help)
- */
-async function runLaunchFlow(
-    blockId: string,
-    provider: ProviderDefinition | undefined,
-    log: LogFn,
-    setAuthUrl: (url: string | null) => void,
-    isCancelled: () => boolean,
-    setLoginWaiting: (v: boolean) => void,
-    authEnv?: Record<string, string>,
-): Promise<"success" | "auth_failed" | "fatal"> {
-    if (!provider) {
-        log("error", "no provider definition — cannot resolve CLI", "error");
-        return "fatal";
-    }
-
-    const oref = WOS.makeORef("block", blockId);
-
-    // Phase 0: Container agents require a container runtime
-    const blockData = WOS.getWaveObjectAtom<Block>(oref)();
-    const agentMode = blockData?.meta?.agentMode ?? "host";
-    if (agentMode === "container") {
-        log("docker", "container agent — checking for container runtime...");
-        try {
-            const dockerResult = await RpcApi.ResolveCliCommand(TabRpcClient, {
-                provider_id: "docker",
-                cli_command: "docker",
-                npm_package: "",
-                pinned_version: "",
-                windows_install_command: "",
-                unix_install_command: "",
-            }, { timeout: 10000 });
-            log("docker", `found: ${dockerResult.cli_path} (${dockerResult.version})`);
-        } catch {
-            log("docker", "Container runtime not found", "error");
-            log("docker", "Container agents require a compatible container runtime (e.g. Docker) to run.", "error");
-            return "fatal";
-        }
-    }
-
-    // Phase 1: CLI Detection / Installation
-    log("cli", `checking for ${provider.cliCommand}...`);
-    if (provider.pinnedVersion) {
-        log("cli", `if not found locally, will install ${provider.npmPackage}@${provider.pinnedVersion} via npm (this may take 1-2 minutes)...`);
-    }
-
-    // Subscribe to install progress events — backend streams npm/installer output line-by-line
-    const installScope = WOS.makeORef("block", blockId);
-    const unsubInstall = waveEventSubscribe({
-        eventType: "install_progress",
-        scope: installScope,
-        handler: (event: any) => {
-            const msg: string = event?.data?.message ?? "";
-            if (msg) log("install", msg);
-        },
-    });
-
-    let cliResult: ResolveCliResult;
-    try {
-        cliResult = await RpcApi.ResolveCliCommand(TabRpcClient, {
-            provider_id: provider.id,
-            cli_command: provider.cliCommand,
-            npm_package: provider.npmPackage,
-            pinned_version: provider.pinnedVersion,
-            windows_install_command: provider.windowsInstallCommand,
-            unix_install_command: provider.unixInstallCommand,
-            block_id: blockId,
-        }, { timeout: 300000 });
-    } catch (err: any) {
-        unsubInstall();
-        const msg = err?.message ?? String(err);
-        log("cli", msg, "error");
-        log("error", `${provider.cliCommand} not available — install manually or check your internet connection`, "error");
-        return "fatal";
-    }
-    unsubInstall();
-
-    if (cliResult.source === "installed") {
-        log("cli", `installed ${provider.npmPackage} (${cliResult.version})`);
-    } else if (cliResult.source === "local_install") {
-        log("cli", `found: ${cliResult.cli_path} (${cliResult.version}) [local install]`);
-    } else {
-        log("cli", `found: ${cliResult.cli_path} (${cliResult.version})`);
-    }
-
-    // Update block meta with resolved absolute path
-    await RpcApi.SetMetaCommand(TabRpcClient, {
-        oref,
-        meta: { cmd: cliResult.cli_path },
-    });
-
-    // Phase 2: Auth Check → auto-login if not authenticated
-    log("auth", `checking ${provider.cliCommand} authentication...`);
-    let needsLogin = false;
-    try {
-        const authResult = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
-            cli_path: cliResult.cli_path,
-            auth_check_args: provider.authCheckCommand,
-            auth_env: authEnv,
-        }, { timeout: 30000 });
-        if (authResult.authenticated) {
-            const emailPart = authResult.email ? ` as ${authResult.email}` : "";
-            const methodPart = authResult.auth_method ? ` (${authResult.auth_method})` : "";
-            log("auth", `authenticated${emailPart}${methodPart}`);
-        } else {
-            needsLogin = true;
-        }
-    } catch (err: any) {
-        log("auth", `check failed: ${err?.message ?? String(err)}`, "warn");
-        log("auth", "authentication status unknown — will attempt anyway", "warn");
-    }
-
-    if (needsLogin) {
-        log("auth", "not authenticated — starting login flow...");
-        try {
-            // Run from Tauri host (GUI process) so the browser opens correctly on Windows.
-            // Returns immediately after spawning — browser opens, frontend polls for completion.
-            await getApi().runCliLogin(
-                cliResult.cli_path,
-                provider.authLoginCommand,
-                authEnv ?? {},
-            );
-            log("auth", "a browser window should have opened — complete login there");
-
-            // Poll until authenticated, cancelled, or timed out (5 minutes)
-            log("auth", "waiting for login to complete...");
-            setLoginWaiting(true);
-            const deadline = Date.now() + 5 * 60 * 1000;
-            let authenticated = false;
-            while (!isCancelled() && Date.now() < deadline) {
-                await new Promise<void>((r) => setTimeout(r, 2000));
-                if (isCancelled()) break;
-                try {
-                    const recheckResult = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
-                        cli_path: cliResult.cli_path,
-                        auth_check_args: provider.authCheckCommand,
-                        auth_env: authEnv,
-                    }, { timeout: 10000 });
-                    if (recheckResult.authenticated) {
-                        const emailPart = recheckResult.email ? ` as ${recheckResult.email}` : "";
-                        log("auth", `authenticated${emailPart}`);
-                        authenticated = true;
-                        break;
-                    }
-                } catch {
-                    // keep polling on transient RPC errors
-                }
-            }
-            setLoginWaiting(false);
-
-            // Always clear auth URL after the login attempt
-            setAuthUrl(null);
-
-            if (isCancelled()) {
-                return "auth_failed";
-            }
-
-            if (!authenticated) {
-                log("auth", "login timed out after 5 minutes", "error");
-                log("auth", `retry: click the button below, or run '${provider.cliCommand} ${provider.authLoginCommand.join(" ")}' manually`, "warn");
-                return "auth_failed";
-            }
-        } catch (err: any) {
-            setLoginWaiting(false);
-            setAuthUrl(null);
-            log("auth", `login failed: ${err?.message ?? String(err)}`, "error");
-            log("auth", `run: ${provider.cliCommand} ${provider.authLoginCommand.join(" ")}`, "warn");
-            return "auth_failed";
-        }
-    }
-
-    // Phase 3: Controller Registration
-    log("controller", "registering subprocess controller...");
-    try {
-        await RpcApi.ControllerResyncCommand(TabRpcClient, {
-            tabid: staticTabId(),
-            blockid: blockId,
-            forcerestart: false,
-        });
-        const rts = await BlockService.GetControllerStatus(blockId);
-        const status = rts?.shellprocstatus ?? "init";
-        log("controller", `status: ${status}`);
-        if (status === "init") {
-            log("agent", "ready — type a message below to start");
-        } else if (status === "done") {
-            log("agent", "previous turn complete — send a message to continue");
-        }
-    } catch (err: any) {
-        log("controller", `resync failed: ${err?.message ?? String(err)}`, "warn");
-        log("agent", "ready — type a message below to start");
-    }
-
-    return "success";
-}
+// Launch flow lives in `flows/launch-flow.ts` — Step 2 of
+// specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
 
 // ── Presentation View ───────────────────────────────────────────────────────────
 
@@ -397,12 +195,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         const prov = provider();
         try {
             const authEnv = await buildAuthEnv(prov);
-            const result = await runLaunchFlow(
-                model.blockId, prov, log, setAuthUrl,
-                () => loginCancelled,
+            const result = await runLaunchFlow({
+                blockId: model.blockId,
+                provider: prov,
+                log,
+                setAuthUrl,
+                isCancelled: () => loginCancelled,
                 setLoginWaiting,
                 authEnv,
-            );
+            });
             if (result === "success") {
                 setAgentReady(true);
             } else if (result === "auth_failed" && !loginCancelled) {

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -1,0 +1,240 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * launch-flow — the full agent launch sequence extracted from agent-view.tsx.
+ *
+ * Step 2 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ *
+ * Phases:
+ *   0. Container agents require a container runtime (docker/podman/…).
+ *      Skipped for host agents.
+ *   1. CLI detection/installation — resolve the provider's cli_command, with
+ *      optional npm install if not found and pinnedVersion is set. Subscribes
+ *      to `install_progress` events so the caller's log sink sees each npm
+ *      line as it happens.
+ *   2. Auth check — calls the provider's check-auth command. If unauthenticated,
+ *      spawns the login command via the Tauri host (so the browser opens
+ *      correctly on Windows), then polls with 2s cadence until authenticated,
+ *      cancelled, or 5 minutes elapse.
+ *   3. Controller registration — ControllerResync on the tab, read status, log
+ *      "ready" or "done" depending on whether there's a prior turn.
+ *
+ * The caller provides a log sink, a cancellation accessor, and callbacks for
+ * two pieces of external state (`authUrl`, `loginWaiting`). All other state
+ * is derived from the block_id + provider definition.
+ *
+ * Return values:
+ *   - "success"     — controller registered, ready for user input
+ *   - "auth_failed" — login timed out, cancelled, or erred (retry makes sense)
+ *   - "fatal"       — CLI missing, docker missing, provider unknown (retry won't help)
+ */
+
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import { waveEventSubscribe } from "@/app/store/wps";
+import * as WOS from "@/app/store/wos";
+import { BlockService } from "@/app/store/services";
+import { getApi, staticTabId } from "@/app/store/global";
+import type { ProviderDefinition } from "../providers";
+
+export type LogFn = (tag: string, text: string, level?: "info" | "error" | "warn") => void;
+
+export interface LaunchFlowOptions {
+    blockId: string;
+    provider: ProviderDefinition | undefined;
+    log: LogFn;
+    setAuthUrl: (url: string | null) => void;
+    isCancelled: () => boolean;
+    setLoginWaiting: (v: boolean) => void;
+    authEnv?: Record<string, string>;
+}
+
+export type LaunchFlowResult = "success" | "auth_failed" | "fatal";
+
+export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlowResult> {
+    const { blockId, provider, log, setAuthUrl, isCancelled, setLoginWaiting, authEnv } = opts;
+
+    if (!provider) {
+        log("error", "no provider definition — cannot resolve CLI", "error");
+        return "fatal";
+    }
+
+    const oref = WOS.makeORef("block", blockId);
+
+    // Phase 0: Container agents require a container runtime
+    const blockData = WOS.getWaveObjectAtom<Block>(oref)();
+    const agentMode = blockData?.meta?.agentMode ?? "host";
+    if (agentMode === "container") {
+        log("docker", "container agent — checking for container runtime...");
+        try {
+            const dockerResult = await RpcApi.ResolveCliCommand(TabRpcClient, {
+                provider_id: "docker",
+                cli_command: "docker",
+                npm_package: "",
+                pinned_version: "",
+                windows_install_command: "",
+                unix_install_command: "",
+            }, { timeout: 10000 });
+            log("docker", `found: ${dockerResult.cli_path} (${dockerResult.version})`);
+        } catch {
+            log("docker", "Container runtime not found", "error");
+            log("docker", "Container agents require a compatible container runtime (e.g. Docker) to run.", "error");
+            return "fatal";
+        }
+    }
+
+    // Phase 1: CLI Detection / Installation
+    log("cli", `checking for ${provider.cliCommand}...`);
+    if (provider.pinnedVersion) {
+        log("cli", `if not found locally, will install ${provider.npmPackage}@${provider.pinnedVersion} via npm (this may take 1-2 minutes)...`);
+    }
+
+    // Subscribe to install progress events — backend streams npm/installer output line-by-line
+    const installScope = WOS.makeORef("block", blockId);
+    const unsubInstall = waveEventSubscribe({
+        eventType: "install_progress",
+        scope: installScope,
+        handler: (event: any) => {
+            const msg: string = event?.data?.message ?? "";
+            if (msg) log("install", msg);
+        },
+    });
+
+    let cliResult: ResolveCliResult;
+    try {
+        cliResult = await RpcApi.ResolveCliCommand(TabRpcClient, {
+            provider_id: provider.id,
+            cli_command: provider.cliCommand,
+            npm_package: provider.npmPackage,
+            pinned_version: provider.pinnedVersion,
+            windows_install_command: provider.windowsInstallCommand,
+            unix_install_command: provider.unixInstallCommand,
+            block_id: blockId,
+        }, { timeout: 300000 });
+    } catch (err: any) {
+        unsubInstall();
+        const msg = err?.message ?? String(err);
+        log("cli", msg, "error");
+        log("error", `${provider.cliCommand} not available — install manually or check your internet connection`, "error");
+        return "fatal";
+    }
+    unsubInstall();
+
+    if (cliResult.source === "installed") {
+        log("cli", `installed ${provider.npmPackage} (${cliResult.version})`);
+    } else if (cliResult.source === "local_install") {
+        log("cli", `found: ${cliResult.cli_path} (${cliResult.version}) [local install]`);
+    } else {
+        log("cli", `found: ${cliResult.cli_path} (${cliResult.version})`);
+    }
+
+    // Update block meta with resolved absolute path
+    await RpcApi.SetMetaCommand(TabRpcClient, {
+        oref,
+        meta: { cmd: cliResult.cli_path },
+    });
+
+    // Phase 2: Auth Check → auto-login if not authenticated
+    log("auth", `checking ${provider.cliCommand} authentication...`);
+    let needsLogin = false;
+    try {
+        const authResult = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
+            cli_path: cliResult.cli_path,
+            auth_check_args: provider.authCheckCommand,
+            auth_env: authEnv,
+        }, { timeout: 30000 });
+        if (authResult.authenticated) {
+            const emailPart = authResult.email ? ` as ${authResult.email}` : "";
+            const methodPart = authResult.auth_method ? ` (${authResult.auth_method})` : "";
+            log("auth", `authenticated${emailPart}${methodPart}`);
+        } else {
+            needsLogin = true;
+        }
+    } catch (err: any) {
+        log("auth", `check failed: ${err?.message ?? String(err)}`, "warn");
+        log("auth", "authentication status unknown — will attempt anyway", "warn");
+    }
+
+    if (needsLogin) {
+        log("auth", "not authenticated — starting login flow...");
+        try {
+            // Run from Tauri host (GUI process) so the browser opens correctly on Windows.
+            // Returns immediately after spawning — browser opens, frontend polls for completion.
+            await getApi().runCliLogin(
+                cliResult.cli_path,
+                provider.authLoginCommand,
+                authEnv ?? {},
+            );
+            log("auth", "a browser window should have opened — complete login there");
+
+            // Poll until authenticated, cancelled, or timed out (5 minutes)
+            log("auth", "waiting for login to complete...");
+            setLoginWaiting(true);
+            const deadline = Date.now() + 5 * 60 * 1000;
+            let authenticated = false;
+            while (!isCancelled() && Date.now() < deadline) {
+                await new Promise<void>((r) => setTimeout(r, 2000));
+                if (isCancelled()) break;
+                try {
+                    const recheckResult = await RpcApi.CheckCliAuthCommand(TabRpcClient, {
+                        cli_path: cliResult.cli_path,
+                        auth_check_args: provider.authCheckCommand,
+                        auth_env: authEnv,
+                    }, { timeout: 10000 });
+                    if (recheckResult.authenticated) {
+                        const emailPart = recheckResult.email ? ` as ${recheckResult.email}` : "";
+                        log("auth", `authenticated${emailPart}`);
+                        authenticated = true;
+                        break;
+                    }
+                } catch {
+                    // keep polling on transient RPC errors
+                }
+            }
+            setLoginWaiting(false);
+
+            // Always clear auth URL after the login attempt
+            setAuthUrl(null);
+
+            if (isCancelled()) {
+                return "auth_failed";
+            }
+
+            if (!authenticated) {
+                log("auth", "login timed out after 5 minutes", "error");
+                log("auth", `retry: click the button below, or run '${provider.cliCommand} ${provider.authLoginCommand.join(" ")}' manually`, "warn");
+                return "auth_failed";
+            }
+        } catch (err: any) {
+            setLoginWaiting(false);
+            setAuthUrl(null);
+            log("auth", `login failed: ${err?.message ?? String(err)}`, "error");
+            log("auth", `run: ${provider.cliCommand} ${provider.authLoginCommand.join(" ")}`, "warn");
+            return "auth_failed";
+        }
+    }
+
+    // Phase 3: Controller Registration
+    log("controller", "registering subprocess controller...");
+    try {
+        await RpcApi.ControllerResyncCommand(TabRpcClient, {
+            tabid: staticTabId(),
+            blockid: blockId,
+            forcerestart: false,
+        });
+        const rts = await BlockService.GetControllerStatus(blockId);
+        const status = rts?.shellprocstatus ?? "init";
+        log("controller", `status: ${status}`);
+        if (status === "init") {
+            log("agent", "ready — type a message below to start");
+        } else if (status === "done") {
+            log("agent", "previous turn complete — send a message to continue");
+        }
+    } catch (err: any) {
+        log("controller", `resync failed: ${err?.message ?? String(err)}`, "warn");
+        log("agent", "ready — type a message below to start");
+    }
+
+    return "success";
+}

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -14,7 +14,7 @@
  *      to `install_progress` events so the caller's log sink sees each npm
  *      line as it happens.
  *   2. Auth check — calls the provider's check-auth command. If unauthenticated,
- *      spawns the login command via the Tauri host (so the browser opens
+ *      spawns the login command via the CEF host (so the browser opens
  *      correctly on Windows), then polls with 2s cadence until authenticated,
  *      cancelled, or 5 minutes elapse.
  *   3. Controller registration — ControllerResync on the tab, read status, log
@@ -159,7 +159,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
     if (needsLogin) {
         log("auth", "not authenticated — starting login flow...");
         try {
-            // Run from Tauri host (GUI process) so the browser opens correctly on Windows.
+            // Run from the CEF host (GUI process) so the browser opens correctly on Windows.
             // Returns immediately after spawning — browser opens, frontend polls for completion.
             await getApi().runCliLogin(
                 cliResult.cli_path,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.111",
+  "version": "0.33.112",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.111",
+      "version": "0.33.112",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.111",
+  "version": "0.33.112",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 2 of \`specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md\`. Extract the 200-line \`runLaunchFlow\` function from \`agent-view.tsx\` into a dedicated \`flows/launch-flow.ts\` file and refactor its call signature to a single options object.

## Scope

**New file** — \`frontend/app/view/agent/flows/launch-flow.ts\` (240 lines):
- \`LogFn\` type export
- \`LaunchFlowOptions\`, \`LaunchFlowResult\` types
- \`runLaunchFlow(opts: LaunchFlowOptions)\` — byte-identical body to what was inline, packaged in its own module with its own imports

**Modified** — \`frontend/app/view/agent/agent-view.tsx\`:
- Remove inline \`runLaunchFlow\` function (191 lines)
- Remove inline \`LogFn\` type (1 line)
- Add \`import { runLaunchFlow } from "./flows/launch-flow"\`
- Update the one call site from 7 positional args to an options object

Positional-to-options migration:

\`\`\`ts
// Before
const result = await runLaunchFlow(
    model.blockId, prov, log, setAuthUrl,
    () => loginCancelled, setLoginWaiting, authEnv,
);

// After
const result = await runLaunchFlow({
    blockId: model.blockId,
    provider: prov,
    log,
    setAuthUrl,
    isCancelled: () => loginCancelled,
    setLoginWaiting,
    authEnv,
});
\`\`\`

## Line counts

| File | Before | After | Delta |
|---|---:|---:|---:|
| \`agent-view.tsx\` | 1,053 | **854** | **−199** |
| \`flows/launch-flow.ts\` | — | 240 | +240 |
| **Total** | 1,053 | 1,094 | +41 |

The +41 is the header comment block + type exports in the new file. Subsequent steps will land mostly negative.

## Progress toward target

| Step | agent-view.tsx | Delta |
|---|---:|---:|
| 0. baseline | 1,178 | — |
| 1. AgentPicker extracted (#351) | 1,053 | −125 |
| 2. launch flow extracted (**this PR**) | 854 | −199 |
| Target | ≤300 | −554 to go |

## Behavior change

**Zero.** The launch flow body is identical — only the parameter binding changed. All \`RpcApi\` calls, \`waveEventSubscribe\` subscriptions, state transitions, and log sink invocations are in the same order with the same arguments.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`scripts/bump-wrapper.sh patch --commit\` worked (0.33.112, lockfile folded)
- [ ] Launch a portable, create a new agent pane via the picker, confirm the launch flow works end-to-end:
  - [ ] CLI resolution succeeds
  - [ ] Auth check either skips (already authenticated) or opens the browser login flow
  - [ ] Controller registration completes and "ready" log line appears
- [ ] Confirm a container agent still gets the \`docker\` resolution phase
- [ ] Confirm \`canRetry\` + retry button path works on auth failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)