### PR TITLE
refactor: modularize agent-view step 3 — useLaunchLogs hook

### DIFF
--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -13,6 +13,7 @@ import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-
 import { useAgentStream } from "./useAgentStream";
 import { parseHistoryLines } from "./parseHistoryLines";
 import { runLaunchFlow } from "./flows/launch-flow";
+import { useLaunchLogs } from "./hooks/useLaunchLogs";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
@@ -84,12 +85,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const [documentVersion, setDocumentVersion] = createSignal(0);
     const bumpDocumentVersion = () => setDocumentVersion((v) => v + 1);
 
-    // Accumulated terminal-style log lines
-    type LogLine = { tag: string; text: string; level?: "info" | "error" | "warn" };
-    const [logLines, setLogLines] = createSignal<LogLine[]>([]);
-    const log = (tag: string, text: string, level?: "info" | "error" | "warn") => {
-        setLogLines((prev) => [...prev, { tag, text, level: level ?? "info" }]);
-    };
+    // Accumulated terminal-style log lines — managed by useLaunchLogs hook.
+    // `logLines` is the reactive accessor; `log` is the append function
+    // that matches the LogFn signature expected by runLaunchFlow().
+    const launchLogs = useLaunchLogs();
+    const logLines = launchLogs.lines;
+    const log = launchLogs.append;
 
     // OAuth URL — shown prominently with a copy button when login is needed
     const [authUrl, setAuthUrl] = createSignal<string | null>(null);

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -9,18 +9,12 @@
 
 import { createEffect, createSignal, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
 import type { SignalPair } from "../state";
-import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+import type { DocumentNode, DocumentState, LogLine, SubagentLinkNode } from "../types";
 import { AgentMessageBlock } from "./AgentMessageBlock";
 import { MarkdownBlock } from "./MarkdownBlock";
 import { SubagentLinkBlock } from "./SubagentLinkBlock";
 import { ToolBlock } from "./ToolBlock";
 import { ContextMenuModel } from "@/app/store/contextmenu";
-
-export interface LogLine {
-    tag: string;        // "agent", "cli", "auth", "env", "error", etc.
-    text: string;
-    level?: "info" | "error" | "warn";
-}
 
 interface AgentDocumentViewProps {
     documentAtom: SignalPair<DocumentNode[]>;

--- a/frontend/app/view/agent/hooks/useLaunchLogs.ts
+++ b/frontend/app/view/agent/hooks/useLaunchLogs.ts
@@ -1,0 +1,42 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useLaunchLogs — terminal-style log line accumulator used during the
+ * agent launch flow.
+ *
+ * Step 3 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ *
+ * Returns:
+ *   - `lines` — reactive accessor for the current LogLine[]
+ *   - `append` — add one line. Matches the `LogFn` signature used by
+ *     `runLaunchFlow` in flows/launch-flow.ts, so the caller can pass
+ *     `append` directly as the `log` option.
+ *   - `clear` — reset the log buffer (used on retry)
+ *
+ * No RPCs, no subscriptions, no side effects — this is a pure
+ * createSignal wrapper. The only reason it's a hook at all is so the
+ * three log-management pieces (state, append, clear) live together
+ * instead of being scattered across agent-view.tsx.
+ */
+
+import { createSignal, type Accessor } from "solid-js";
+import type { LogLine } from "../types";
+
+export interface UseLaunchLogs {
+    lines: Accessor<LogLine[]>;
+    append: (tag: string, text: string, level?: "info" | "error" | "warn") => void;
+    clear: () => void;
+}
+
+export function useLaunchLogs(): UseLaunchLogs {
+    const [lines, setLines] = createSignal<LogLine[]>([]);
+
+    const append = (tag: string, text: string, level?: "info" | "error" | "warn") => {
+        setLines((prev) => [...prev, { tag, text, level: level ?? "info" }]);
+    };
+
+    const clear = () => setLines([]);
+
+    return { lines, append, clear };
+}

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -9,6 +9,18 @@
  */
 
 /**
+ * A single terminal-style log line emitted during the agent launch flow
+ * (CLI resolution, install progress, auth check, login poll, controller
+ * registration). Collected into an array by `useLaunchLogs` and rendered
+ * at the top of `AgentDocumentView` until the agent is ready.
+ */
+export interface LogLine {
+    tag: string; // "agent", "cli", "auth", "env", "error", "install", etc.
+    text: string;
+    level?: "info" | "error" | "warn";
+}
+
+/**
  * Initialization question asked by the CLI during startup
  */
 export interface InitQuestion {


### PR DESCRIPTION
## Summary

Step 3 of \`specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md\`. Extract the inline log buffer (\`logLines\` signal + \`log\` helper) from \`agent-view.tsx\` into a \`hooks/useLaunchLogs.ts\` hook, and move the duplicated \`LogLine\` type into \`types.ts\` as the canonical definition.

## Honest framing

**This step is structural prep, not a line reduction.** \`agent-view.tsx\` actually goes from 1,053 → 1,054 lines (+1) because the new hook call + import takes the same room as the inline code I removed. The wins are architectural:

1. \`LogLine\` is now defined **once** (in \`types.ts\`) instead of twice (in \`agent-view.tsx\` AND \`AgentDocumentView.tsx\` as separate definitions with the same shape).
2. The \`hooks/\` directory is created and ready for steps 4-10. Each subsequent hook will have the same shape and the same kind of plumbing.
3. The log buffer is now a unit-testable function instead of a closure inside an 850-line component function.

The modularization spec's per-step estimates were rough. Step 3 was estimated at −15 lines but landed at +1. Steps 4-8 (which extract bigger feature blocks: auth, history, digest, bookmarks, search) are where the real line drops happen.

## Files

| File | Change |
|---|---|
| \`hooks/useLaunchLogs.ts\` | **new** — \`useLaunchLogs()\` returns \`{ lines, append, clear }\`. \`append\` matches the \`LogFn\` signature so callers can pass it directly to \`runLaunchFlow\`. |
| \`types.ts\` | **+9** — add \`LogLine\` interface as canonical export |
| \`components/AgentDocumentView.tsx\` | **−5** — remove duplicate inline \`LogLine\` interface; import from \`../types\` |
| \`agent-view.tsx\` | **+1** — replace 6-line inline log buffer with 5-line hook wiring + 1-line import |

## Progress so far

| Milestone | agent-view.tsx | Delta |
|---|---:|---:|
| Session start | 1,178 | — |
| Step 1 (AgentPicker) — #351 ✅ | 1,053 | −125 |
| Step 2 (launch flow) — #352 (open) | 854 | −199 |
| Step 3 (launch logs) — **this PR** | 855† | +1 |
| Steps 4-12 estimated | ~400 | −455 |

† This PR is based on current main (without #352), so its delta is calculated against 1,053 not 854. After #352 merges, #353 rebases automatically: agent-view.tsx will be 855 (854 from #352 + 1 from #353).

## Behavior change

**Zero.** Same log buffer semantics, same accessor name (\`logLines\`), same append signature (\`log\`), same render in \`AgentDocumentView\`. The rest of the file references \`logLines\` and \`log\` exactly as before — only the source of truth moved.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`scripts/bump-wrapper.sh patch --commit\` worked (0.33.112, lockfile folded)
- [ ] Launch a portable, create a fresh agent pane, watch the launch flow log lines accumulate as before
- [ ] Verify the existing \`agent-status-log\` UI in \`AgentDocumentView\` still renders the lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)