### PR TITLE
refactor: modularize agent-view step 5 — useHistoryPagination hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.112"
+version = "0.33.113"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.112"
+version = "0.33.113"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.112"
+version = "0.33.113"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.112"
+version = "0.33.113"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.112"
+version = "0.33.113"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.112"
+version = "0.33.113"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.112"
+version = "0.33.113"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.112"
+version = "0.33.113"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.112"
+version = "0.33.113"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.112"
+version = "0.33.113"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -14,6 +14,7 @@ import { useAgentStream } from "./useAgentStream";
 import { parseHistoryLines } from "./parseHistoryLines";
 import { runLaunchFlow } from "./flows/launch-flow";
 import { useLaunchLogs } from "./hooks/useLaunchLogs";
+import { useHistoryPagination } from "./hooks/useHistoryPagination";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
@@ -62,13 +63,33 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     const agentAtoms = createMemo(() => createAgentAtoms(model.blockId));
 
-    // ── History pagination state ────────────────────────────────────────────────
-    // These track the window of lines we've loaded from the persisted blockfile.
-    // historyOffset = the line index where the currently-loaded slice starts.
-    // historyTotal  = total lines in the file (from session:line_count meta).
-    const [historyOffset, setHistoryOffset] = createSignal(0);
-    const [historyTotal, setHistoryTotal] = createSignal(0);
-    const [loadingOlder, setLoadingOlder] = createSignal(false);
+    // Accumulated terminal-style log lines — managed by useLaunchLogs hook.
+    // `logLines` is the reactive accessor; `log` is the append function
+    // that matches the LogFn signature expected by runLaunchFlow().
+    // Declared early so subsequent hooks (history, digest, controller
+    // status) can take it as a dependency.
+    const launchLogs = useLaunchLogs();
+    const logLines = launchLogs.lines;
+    const log = launchLogs.append;
+
+    // History pagination — owns historyOffset/historyTotal/loadingOlder,
+    // documentVersion, loadOlder handler, and the initial async history
+    // load that fires on hook mount. See hooks/useHistoryPagination.ts.
+    //
+    // documentVersion is bumped on every external document mutation
+    // (initial load + every loadOlder prepend). useAgentStream subscribes
+    // to it and rebuilds its dedup index after the document is reshaped.
+    const history = useHistoryPagination({
+        blockId: model.blockId,
+        documentAtom: agentAtoms().documentAtom,
+        outputFormat,
+        log,
+    });
+    const historyOffset = history.historyOffset;
+    const historyTotal = history.historyTotal;
+    const loadingOlder = history.loadingOlder;
+    const loadOlder = history.loadOlder;
+    const documentVersion = history.documentVersion;
 
     // ── Session digest ──────────────────────────────────────────────────────────
     // Shows a collapsible AI-generated summary when the user returns to a stale
@@ -77,20 +98,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const [digestGeneratedAt, setDigestGeneratedAt] = createSignal<number | null>(null);
     const [digestLoading, setDigestLoading] = createSignal(false);
     const [digestDismissed, setDigestDismissed] = createSignal(false);
-
-    // Bumped on every external document mutation (history load, prepend).
-    // useAgentStream watches this and rebuilds its internal nodeIdSet +
-    // nodeIndexMap so live-stream updates continue targeting the right
-    // node indices after the document has been reshaped from outside.
-    const [documentVersion, setDocumentVersion] = createSignal(0);
-    const bumpDocumentVersion = () => setDocumentVersion((v) => v + 1);
-
-    // Accumulated terminal-style log lines — managed by useLaunchLogs hook.
-    // `logLines` is the reactive accessor; `log` is the append function
-    // that matches the LogFn signature expected by runLaunchFlow().
-    const launchLogs = useLaunchLogs();
-    const logLines = launchLogs.lines;
-    const log = launchLogs.append;
 
     // OAuth URL — shown prominently with a copy button when login is needed
     const [authUrl, setAuthUrl] = createSignal<string | null>(null);
@@ -122,42 +129,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         }
     };
 
-    // Load the previous page of history (prepend to document).
-    // Called by AgentDocumentView when the user scrolls near the top.
-    const loadOlder = async (): Promise<void> => {
-        const currentOffset = historyOffset();
-        if (currentOffset === 0) return; // already at the beginning
-        if (loadingOlder()) return;
-
-        setLoadingOlder(true);
-        try {
-            const newOffset = Math.max(0, currentOffset - 200);
-            const loadLimit = currentOffset - newOffset;
-
-            const resp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
-                block_id: model.blockId,
-                filename: "output",
-                offset: newOffset,
-                limit: loadLimit,
-            }, { timeout: 15000 });
-
-            const newNodes = parseHistoryLines(resp.lines ?? [], outputFormat());
-            if (newNodes.length > 0) {
-                const [, setDoc] = agentAtoms().documentAtom;
-                setDoc((prev) => [...newNodes, ...prev]);
-                // Notify useAgentStream to rebuild its index map so live
-                // updates target the correct nodes after the prepend.
-                bumpDocumentVersion();
-            }
-
-            setHistoryOffset(newOffset);
-            log("history", `loaded ${newNodes.length} older messages (offset ${newOffset})`);
-        } catch (err: any) {
-            log("history", `failed to load older messages: ${err?.message ?? String(err)}`, "warn");
-        } finally {
-            setLoadingOlder(false);
-        }
-    };
+    // loadOlder + initial-history-load are owned by useHistoryPagination
+    // (local aliases declared above).
 
     // Fetch (or regenerate) the session digest via the session:digest RPC.
     // `force=true` bypasses the cache and re-invokes the Claude CLI.
@@ -243,67 +216,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         log("agent", `${name} selected (provider: ${provName})`);
         if (cwd) log("env", `working directory: ${cwd}`);
 
-        // Load persisted session history before starting the live stream.
-        // We do this asynchronously so the UI isn't blocked, but we fire it
-        // immediately so history appears as early as possible.
-        (async () => {
-            try {
-                const countResp = await RpcApi.BlockfileLineCountCommand(TabRpcClient, {
-                    block_id: model.blockId,
-                    filename: "output",
-                }, { timeout: 5000 });
-
-                const total = countResp?.count ?? 0;
-                if (total > 0) {
-                    const pageSize = 200;
-                    const offset = Math.max(0, total - pageSize);
-                    const limit = total - offset;
-
-                    const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
-                        block_id: model.blockId,
-                        filename: "output",
-                        offset,
-                        limit,
-                    }, { timeout: 15000 });
-
-                    const nodes = parseHistoryLines(rangeResp.lines ?? [], outputFormat());
-                    if (nodes.length > 0) {
-                        const [doc, setDoc] = agentAtoms().documentAtom;
-                        // Prepend history to whatever is already in the
-                        // document. If useAgentStream has already captured
-                        // live events during the async history load, we
-                        // must not discard them. Dedupe by id — history
-                        // nodes and live nodes can overlap briefly during
-                        // a reconnect where an in-flight turn is also
-                        // visible in the persisted ring buffer.
-                        setDoc((prev) => {
-                            if (prev.length === 0) return nodes;
-                            const seen = new Set(prev.map((n) => n.id));
-                            const historyFresh = nodes.filter((n) => !seen.has(n.id));
-                            return [...historyFresh, ...prev];
-                        });
-                        // Notify useAgentStream to rebuild its nodeIdSet
-                        // and nodeIndexMap from the merged document so
-                        // subsequent live updates target correct indices.
-                        bumpDocumentVersion();
-                    }
-
-                    // Store pagination state for subsequent loadOlder() calls.
-                    // `resp.total` from the backend is the actual available
-                    // line count (clamped to the event ring buffer window),
-                    // not the all-time session:line_count. Use it so the
-                    // frontend never asks for offsets the backend can't serve.
-                    const available = rangeResp.total ?? total;
-                    setHistoryOffset(offset);
-                    setHistoryTotal(available);
-
-                    log("history", `loaded ${nodes.length} of ${available} previous messages`);
-                }
-            } catch (err: any) {
-                // Non-fatal — fresh session or backend not ready yet
-                log("history", `could not load history: ${err?.message ?? String(err)}`, "warn");
-            }
-        })();
+        // Initial history load is owned by useHistoryPagination's own
+        // onMount — fires automatically when the hook mounts. No work
+        // here. See hooks/useHistoryPagination.ts.
 
         // ── Session digest auto-trigger ─────────────────────────────────────────
         // Decide whether to show (or generate) a digest on pane open.

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -1,0 +1,182 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useHistoryPagination — owns the persisted-session history slice that
+ * sits above the live stream in the agent document.
+ *
+ * Step 5 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ *
+ * On mount the hook fires an async initial load: read `session:line_count`
+ * for the block, fetch the trailing 200 lines, prepend them to the
+ * document atom, and store the resulting offset for later page-up calls.
+ * The hook NEVER blocks the UI — failures are non-fatal and just log a
+ * warning. Live-stream events keep flowing through useAgentStream
+ * regardless of whether history is loaded.
+ *
+ * Subsequent page-up calls (the user scrolling near the top of the
+ * document view) call `loadOlder()` which fetches the previous 200-line
+ * page and prepends it. Each prepend bumps `documentVersion`, which
+ * useAgentStream reads to rebuild its dedup set + index map so live
+ * updates target the right node positions after the document is
+ * re-shaped from outside.
+ *
+ * Returns:
+ *   - `historyOffset` — line index where the loaded slice begins
+ *   - `historyTotal`  — actual available line count (clamped to the
+ *                       backend's event ring buffer window, NOT the
+ *                       all-time `session:line_count`)
+ *   - `loadingOlder`  — true while a page-up fetch is in flight
+ *   - `loadOlder`     — async handler the document view calls when the
+ *                       user scrolls near the top
+ *   - `documentVersion` — bumped on every external document mutation;
+ *                         useAgentStream subscribes to this
+ */
+
+import { createSignal, onMount, type Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import type { SignalPair } from "../state";
+import type { DocumentNode } from "../types";
+import { parseHistoryLines } from "../parseHistoryLines";
+
+export type LogFn = (tag: string, text: string, level?: "info" | "error" | "warn") => void;
+
+export interface UseHistoryPaginationOptions {
+    blockId: string;
+    documentAtom: SignalPair<DocumentNode[]>;
+    /**
+     * Accessor for the document's stream-event format, e.g.
+     * "claude-stream-json", "codex-json", etc. Passed reactively because
+     * the format may not be available at hook-mount time (block meta
+     * loads asynchronously).
+     */
+    outputFormat: Accessor<string>;
+    log: LogFn;
+}
+
+export interface UseHistoryPagination {
+    historyOffset: Accessor<number>;
+    historyTotal: Accessor<number>;
+    loadingOlder: Accessor<boolean>;
+    loadOlder: () => Promise<void>;
+    documentVersion: Accessor<number>;
+}
+
+const PAGE_SIZE = 200;
+
+export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHistoryPagination {
+    const [historyOffset, setHistoryOffset] = createSignal(0);
+    const [historyTotal, setHistoryTotal] = createSignal(0);
+    const [loadingOlder, setLoadingOlder] = createSignal(false);
+
+    // Bumped on every external document mutation (initial history load +
+    // every loadOlder prepend). useAgentStream reads this and rebuilds
+    // its internal nodeIdSet + nodeIndexMap so live-stream updates
+    // continue targeting the right node indices after the document has
+    // been reshaped from outside.
+    const [documentVersion, setDocumentVersion] = createSignal(0);
+    const bumpDocumentVersion = () => setDocumentVersion((v) => v + 1);
+
+    const [doc, setDoc] = opts.documentAtom;
+
+    /**
+     * Load the previous page of history and prepend to the document.
+     * Called by AgentDocumentView when the user scrolls near the top.
+     * Idempotent at the start-of-history boundary (returns immediately
+     * if `historyOffset === 0`). Guarded against concurrent re-entry.
+     */
+    const loadOlder = async (): Promise<void> => {
+        const currentOffset = historyOffset();
+        if (currentOffset === 0) return; // already at the beginning
+        if (loadingOlder()) return;
+
+        setLoadingOlder(true);
+        try {
+            const newOffset = Math.max(0, currentOffset - PAGE_SIZE);
+            const loadLimit = currentOffset - newOffset;
+
+            const resp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                block_id: opts.blockId,
+                filename: "output",
+                offset: newOffset,
+                limit: loadLimit,
+            }, { timeout: 15000 });
+
+            const newNodes = parseHistoryLines(resp.lines ?? [], opts.outputFormat());
+            if (newNodes.length > 0) {
+                setDoc((prev) => [...newNodes, ...prev]);
+                bumpDocumentVersion();
+            }
+
+            setHistoryOffset(newOffset);
+            opts.log("history", `loaded ${newNodes.length} older messages (offset ${newOffset})`);
+        } catch (err: any) {
+            opts.log("history", `failed to load older messages: ${err?.message ?? String(err)}`, "warn");
+        } finally {
+            setLoadingOlder(false);
+        }
+    };
+
+    // Initial load — async, non-blocking, fires immediately on mount.
+    // Reads the latest PAGE_SIZE lines and prepends them. Dedupes by id
+    // against any live events that may have arrived in the meantime
+    // during a reconnect (where in-flight turns can briefly appear in
+    // both the persisted ring buffer and the live stream).
+    onMount(() => {
+        (async () => {
+            try {
+                const countResp = await RpcApi.BlockfileLineCountCommand(TabRpcClient, {
+                    block_id: opts.blockId,
+                    filename: "output",
+                }, { timeout: 5000 });
+
+                const total = countResp?.count ?? 0;
+                if (total === 0) return;
+
+                const offset = Math.max(0, total - PAGE_SIZE);
+                const limit = total - offset;
+
+                const rangeResp = await RpcApi.BlockfileReadRangeCommand(TabRpcClient, {
+                    block_id: opts.blockId,
+                    filename: "output",
+                    offset,
+                    limit,
+                }, { timeout: 15000 });
+
+                const nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
+                if (nodes.length > 0) {
+                    setDoc((prev) => {
+                        if (prev.length === 0) return nodes;
+                        const seen = new Set(prev.map((n) => n.id));
+                        const historyFresh = nodes.filter((n) => !seen.has(n.id));
+                        return [...historyFresh, ...prev];
+                    });
+                    bumpDocumentVersion();
+                }
+
+                // `resp.total` from the backend is the actual available
+                // line count clamped to the event ring buffer window —
+                // NOT the all-time session:line_count meta. Use it so
+                // the frontend never asks for offsets the backend can't
+                // serve.
+                const available = rangeResp.total ?? total;
+                setHistoryOffset(offset);
+                setHistoryTotal(available);
+
+                opts.log("history", `loaded ${nodes.length} of ${available} previous messages`);
+            } catch (err: any) {
+                // Non-fatal — fresh session or backend not ready yet
+                opts.log("history", `could not load history: ${err?.message ?? String(err)}`, "warn");
+            }
+        })();
+    });
+
+    return {
+        historyOffset,
+        historyTotal,
+        loadingOlder,
+        loadOlder,
+        documentVersion,
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.112",
+  "version": "0.33.113",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.112",
+      "version": "0.33.113",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.112",
+  "version": "0.33.113",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 5 of \`specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md\`. Extract all the persisted-history pagination state and logic from \`agent-view.tsx\` into a dedicated \`hooks/useHistoryPagination.ts\` hook. Biggest single-step reduction so far at **−85 lines**.

## Scope

**New file** — \`hooks/useHistoryPagination.ts\` (182 lines):

State + functions:
- \`historyOffset\` / \`historyTotal\` / \`loadingOlder\` signals
- \`documentVersion\` signal + \`bumpDocumentVersion\` helper (internal)
- \`loadOlder()\` — handler the document view calls when the user scrolls near the top
- **Initial async history load** — fires automatically on hook mount via internal \`onMount()\`. Reads \`session:line_count\`, fetches the trailing 200 lines via \`BlockfileReadRangeCommand\`, dedupes against any in-flight live events, and prepends to the document atom.

Returns: \`{ historyOffset, historyTotal, loadingOlder, loadOlder, documentVersion }\`

**Modified** — \`agent-view.tsx\`:
- Remove \`historyOffset\` / \`historyTotal\` / \`loadingOlder\` signal declarations
- Remove \`documentVersion\` signal + \`bumpDocumentVersion\` helper
- Remove the inline \`loadOlder\` function (35 lines)
- Remove the **60-line initial-history-load IIFE** that lived inside \`onMount\`
- Add \`useHistoryPagination\` hook call with 5 local aliases
- Move \`useLaunchLogs\` declaration earlier so \`log\` is available as a dependency
- Add the hook import

## Line counts

| File | Before | After | Delta |
|---|---:|---:|---:|
| \`agent-view.tsx\` | 855 | **770** | **−85** |
| \`hooks/useHistoryPagination.ts\` | — | 182 | +182 |
| **Total** | 855 | 952 | +97 |

## Cumulative trajectory

| Step | agent-view.tsx | Cumulative delta | Status |
|---|---:|---:|---|
| 0. baseline | 1,178 | — | — |
| 1. AgentPicker — #351 | 1,053 | −125 | **merged** |
| 2. launch flow — #352 | 854 | −324 | **merged** |
| 3. useLaunchLogs — #353 | 855 | −323 | **merged** |
| 4. controller status — #354 | 820 | −358 | open (rebased) |
| 5. useHistoryPagination — **this PR** | 735 | −443 | open |
| 6-12 estimated | ~400 | −778 | queued |

After #354 + #355 land sequentially, agent-view.tsx will be approximately **735 lines**, down from **1,178** at session start. That's a **38% reduction** with seven more extraction steps remaining.

## Behavior change

**Zero.** Same blockfile RPCs in the same order, same id-dedupe semantics on the initial load, same scroll-near-top trigger contract from the document view. The async IIFE moved from inline-in-onMount to inside the hook's own \`onMount\` — same SolidJS lifecycle attachment point, same effective execution timing.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`scripts/bump-wrapper.sh patch --commit\` worked (0.33.113, lockfile folded)
- [ ] Open a portable, open an existing agent pane with persisted history
  - [ ] Initial load fires within ~200ms of mount
  - [ ] "loaded N of M previous messages" log line appears
  - [ ] Document shows the trailing 200 lines (or all of them if fewer than 200)
  - [ ] Live stream events from useAgentStream still arrive after the initial load
- [ ] Scroll to top of the document view
  - [ ] loadingOlder spinner shows briefly
  - [ ] Older 200 lines prepend
  - [ ] Scroll position is preserved (no jump)
  - [ ] historyOffset moves backward correctly
- [ ] Open a fresh agent pane (no history)
  - [ ] Initial load no-ops gracefully (count === 0)
  - [ ] No "could not load history" warning unless backend is actually down

🤖 Generated with [Claude Code](https://claude.com/claude-code)