### PR TITLE
refactor: modularize agent-view step 7 — useBookmarks hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.114"
+version = "0.33.115"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.114"
+version = "0.33.115"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.114"
+version = "0.33.115"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.114"
+version = "0.33.115"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.114"
+version = "0.33.115"
 dependencies = [
  "base64",
  "clap",
@@ -2063,7 +2063,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2123,9 +2123,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3071,7 +3071,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.3",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.114"
+version = "0.33.115"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.114"
+version = "0.33.115"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.114"
+version = "0.33.115"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.114"
+version = "0.33.115"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.114"
+version = "0.33.115"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -16,6 +16,7 @@ import { runLaunchFlow } from "./flows/launch-flow";
 import { useLaunchLogs } from "./hooks/useLaunchLogs";
 import { useSessionDigest } from "./hooks/useSessionDigest";
 import { useHistoryPagination } from "./hooks/useHistoryPagination";
+import { useBookmarks } from "./hooks/useBookmarks";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
@@ -423,23 +424,25 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     // ── Bookmarks ───────────────────────────────────────────────────────────────
 
-    // Read bookmarks reactively from block meta ("agent:bookmarks").
-    const bookmarks = createMemo<Bookmark[]>(() => {
-        const raw = block()?.meta?.["agent:bookmarks"];
-        if (!Array.isArray(raw)) return [];
-        return raw as Bookmark[];
-    });
-
-    // Derived set of bookmarked nodeIds for O(1) look-up in the renderer.
-    const bookmarkedNodeIds = createMemo<Set<string>>(
-        () => new Set(bookmarks().map((b) => b.nodeId)),
-    );
-
-    // Whether the bookmarks panel is visible.
-    const [showBookmarks, setShowBookmarks] = createSignal(false);
-
     // Mutable ref to the scrollToNode function exposed by AgentDocumentView.
     let scrollToNodeFn: ((nodeId: string) => void) | null = null;
+
+    // Bookmarks — owns reactive list, derived id set, panel visibility,
+    // and CRUD callbacks. See hooks/useBookmarks.ts.
+    const bookmarksHook = useBookmarks({
+        blockId: model.blockId,
+        block,
+        log,
+        jumpTo: (nodeId) => scrollToNodeFn?.(nodeId),
+    });
+    const bookmarks = bookmarksHook.bookmarks;
+    const bookmarkedNodeIds = bookmarksHook.bookmarkedNodeIds;
+    const showBookmarks = bookmarksHook.visible;
+    const setShowBookmarks = bookmarksHook.setVisible;
+    const handleBookmark = bookmarksHook.add;
+    const handleBookmarkDelete = bookmarksHook.remove;
+    const handleBookmarkRename = bookmarksHook.rename;
+    const handleBookmarkJump = bookmarksHook.jump;
     // Mutable ref to the scrollToBottom function exposed by AgentDocumentView.
     // Called by AgentFooter's onTyping when the user starts composing.
     let scrollToBottomFn: (() => void) | null = null;
@@ -519,70 +522,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         return idx >= 0 && idx < matches.length ? matches[idx] : null;
     });
 
-    const saveBookmarks = async (next: Bookmark[]): Promise<void> => {
-        await RpcApi.SetMetaCommand(TabRpcClient, {
-            oref: WOS.makeORef("block", model.blockId),
-            meta: { "agent:bookmarks": next },
-        });
-    };
-
-    /** Extract plain text preview from a DocumentNode (≤80 chars). */
-    const nodePreview = (node: DocumentNode): string => {
-        let raw = "";
-        switch (node.type) {
-            case "markdown":    raw = node.content; break;
-            case "user_message": raw = node.message; break;
-            case "tool":        raw = node.summary || node.tool; break;
-            case "agent_message": raw = node.summary || node.message; break;
-            case "section":     raw = node.title; break;
-            case "subagent_link": raw = node.slug || node.subagentId; break;
-        }
-        return raw.replace(/\s+/g, " ").trim().slice(0, 80);
-    };
-
-    const handleBookmark = (node: DocumentNode): void => {
-        const current = bookmarks();
-        const existingIdx = current.findIndex((b) => b.nodeId === node.id);
-        let next: Bookmark[];
-        if (existingIdx >= 0) {
-            // Remove existing bookmark
-            next = current.filter((_, i) => i !== existingIdx);
-        } else {
-            const preview = nodePreview(node);
-            const label = preview.slice(0, 60) || node.id;
-            const newBookmark: Bookmark = {
-                id: crypto.randomUUID(),
-                nodeId: node.id,
-                createdAt: Date.now(),
-                label,
-                preview,
-            };
-            next = [...current, newBookmark];
-            // Open the panel on first bookmark
-            setShowBookmarks(true);
-        }
-        saveBookmarks(next).catch((err) => {
-            log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
-        });
-    };
-
-    const handleBookmarkDelete = (id: string): void => {
-        const next = bookmarks().filter((b) => b.id !== id);
-        saveBookmarks(next).catch((err) => {
-            log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
-        });
-    };
-
-    const handleBookmarkRename = (id: string, label: string): void => {
-        const next = bookmarks().map((b) => (b.id === id ? { ...b, label } : b));
-        saveBookmarks(next).catch((err) => {
-            log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
-        });
-    };
-
-    const handleBookmarkJump = (nodeId: string): void => {
-        if (scrollToNodeFn) scrollToNodeFn(nodeId);
-    };
+    // Bookmark CRUD + jump owned by useBookmarks (aliases declared above).
 
     // Per-pane zoom: read term:zoom from block meta (same key as terminal panes)
     const zoomFactor = createMemo(() => {

--- a/frontend/app/view/agent/hooks/useBookmarks.ts
+++ b/frontend/app/view/agent/hooks/useBookmarks.ts
@@ -1,0 +1,158 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useBookmarks — owns the bookmark CRUD state for the agent pane.
+ *
+ * Step 7 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ *
+ * Bookmarks are stored as block meta under "agent:bookmarks" (a
+ * Bookmark[] JSON array). The hook provides reactive accessors for
+ * the list + the derived nodeId set, and CRUD callbacks that
+ * persist via SetMetaCommand.
+ *
+ * The hook does NOT own the scroll-to-node implementation — that
+ * lives in AgentDocumentView (Step 9 useScrollToNode will formalize
+ * that). Callers pass a `jumpTo(nodeId)` callback which the hook's
+ * `jump` handler invokes.
+ *
+ * Returns:
+ *   - bookmarks         — reactive Bookmark[] from block meta
+ *   - bookmarkedNodeIds — Set<string> of nodeIds, O(1) lookup
+ *   - visible           — whether the bookmarks panel is shown
+ *   - setVisible        — toggle the panel
+ *   - add(node)         — toggle a bookmark (add if missing, remove if present)
+ *   - remove(id)        — delete by bookmark id
+ *   - rename(id, label) — change a bookmark's label
+ *   - jump(nodeId)      — call the parent's scroll-to-node function
+ */
+
+import { createMemo, createSignal, type Accessor, type Setter } from "solid-js";
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import * as WOS from "@/app/store/wos";
+import type { Bookmark, DocumentNode } from "../types";
+
+export type LogFn = (tag: string, text: string, level?: "info" | "error" | "warn") => void;
+
+export interface UseBookmarksOptions {
+    blockId: string;
+    block: Accessor<{ meta?: Record<string, unknown> } | undefined>;
+    log: LogFn;
+    /**
+     * Called when the user clicks a bookmark. The hook doesn't own
+     * the scroll target — pass the parent's scrollToNodeFn here.
+     * Optional because bookmarks can exist without scrolling support
+     * (e.g. during a brief window before the document view mounts).
+     */
+    jumpTo?: (nodeId: string) => void;
+}
+
+export interface UseBookmarks {
+    bookmarks: Accessor<Bookmark[]>;
+    bookmarkedNodeIds: Accessor<Set<string>>;
+    visible: Accessor<boolean>;
+    /** Full SolidJS Setter — accepts both `(true)` and `((prev) => !prev)`. */
+    setVisible: Setter<boolean>;
+    add: (node: DocumentNode) => void;
+    remove: (id: string) => void;
+    rename: (id: string, label: string) => void;
+    jump: (nodeId: string) => void;
+}
+
+const META_KEY = "agent:bookmarks";
+
+/** Extract a short plain-text preview from any document node (≤80 chars). */
+function nodePreview(node: DocumentNode): string {
+    let raw = "";
+    switch (node.type) {
+        case "markdown":      raw = node.content; break;
+        case "user_message":  raw = node.message; break;
+        case "tool":          raw = node.summary || node.tool; break;
+        case "agent_message": raw = node.summary || node.message; break;
+        case "section":       raw = node.title; break;
+        case "subagent_link": raw = node.slug || node.subagentId; break;
+    }
+    return raw.replace(/\s+/g, " ").trim().slice(0, 80);
+}
+
+export function useBookmarks(opts: UseBookmarksOptions): UseBookmarks {
+    // Reactive read from block meta. Recomputes when the block atom
+    // changes (e.g. after SetMetaCommand mutations propagate via WPS).
+    const bookmarks = createMemo<Bookmark[]>(() => {
+        const raw = opts.block()?.meta?.[META_KEY];
+        if (!Array.isArray(raw)) return [];
+        return raw as Bookmark[];
+    });
+
+    // Derived id set for the renderer's O(1) "is this node bookmarked"
+    // checks. Re-derives only when bookmarks() changes.
+    const bookmarkedNodeIds = createMemo<Set<string>>(
+        () => new Set(bookmarks().map((b) => b.nodeId)),
+    );
+
+    const [visible, setVisible] = createSignal(false);
+
+    /** Persist the bookmark array via SetMetaCommand. */
+    const save = async (next: Bookmark[]): Promise<void> => {
+        await RpcApi.SetMetaCommand(TabRpcClient, {
+            oref: WOS.makeORef("block", opts.blockId),
+            meta: { [META_KEY]: next },
+        });
+    };
+
+    const add = (node: DocumentNode): void => {
+        const current = bookmarks();
+        const existingIdx = current.findIndex((b) => b.nodeId === node.id);
+        let next: Bookmark[];
+        if (existingIdx >= 0) {
+            // Toggle: remove an existing bookmark
+            next = current.filter((_, i) => i !== existingIdx);
+        } else {
+            const preview = nodePreview(node);
+            const label = preview.slice(0, 60) || node.id;
+            const newBookmark: Bookmark = {
+                id: crypto.randomUUID(),
+                nodeId: node.id,
+                createdAt: Date.now(),
+                label,
+                preview,
+            };
+            next = [...current, newBookmark];
+            // Open the panel on first bookmark so the user sees it
+            setVisible(true);
+        }
+        save(next).catch((err) => {
+            opts.log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    const remove = (id: string): void => {
+        const next = bookmarks().filter((b) => b.id !== id);
+        save(next).catch((err) => {
+            opts.log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    const rename = (id: string, label: string): void => {
+        const next = bookmarks().map((b) => (b.id === id ? { ...b, label } : b));
+        save(next).catch((err) => {
+            opts.log("bookmark", `failed to save: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    const jump = (nodeId: string): void => {
+        opts.jumpTo?.(nodeId);
+    };
+
+    return {
+        bookmarks,
+        bookmarkedNodeIds,
+        visible,
+        setVisible,
+        add,
+        remove,
+        rename,
+        jump,
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.114",
+  "version": "0.33.115",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.114",
+      "version": "0.33.115",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.114",
+  "version": "0.33.115",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 7 of \`specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md\`. Extract bookmark CRUD state and handlers from \`agent-view.tsx\` into a dedicated \`hooks/useBookmarks.ts\` hook.

## Scope

**New file** — \`hooks/useBookmarks.ts\` (~150 lines):

State + functions:
- \`bookmarks\` — reactive accessor reading block meta \`agent:bookmarks\`
- \`bookmarkedNodeIds\` — derived \`Set<string>\` for O(1) renderer lookup
- \`visible\` / \`setVisible\` — panel visibility, typed as \`Setter<boolean>\` so the existing Ctrl+B functional updater works
- \`add(node)\` — toggle (remove if existing, otherwise add)
- \`remove(id)\` — delete by id
- \`rename(id, label)\` — update label
- \`jump(nodeId)\` — calls the parent's \`jumpTo\` callback

Private helper: \`nodePreview(node)\` — extract ≤80-char text snippet from any DocumentNode.

**Modified** — \`agent-view.tsx\`:
- Remove inline \`bookmarks\` createMemo + \`bookmarkedNodeIds\` memo + \`showBookmarks\` signal
- Remove inline \`saveBookmarks\` + \`nodePreview\` + 4 handler functions
- Add \`useBookmarks\` hook call with 8 local aliases
- Add the hook import

## Line counts

| File | Before | After | Delta |
|---|---:|---:|---:|
| \`agent-view.tsx\` | 714 | **654** | **−60** |
| \`hooks/useBookmarks.ts\` | — | 150 | +150 |
| **Total** | 714 | 804 | +90 |

## Cumulative trajectory

| Step | PR | agent-view.tsx | State |
|---|---|---:|---|
| 0 baseline | — | 1,178 | — |
| 1 AgentPicker | #351 | 1,053 | **merged** |
| 2 launch flow | #352 | 854 | **merged** |
| 3 useLaunchLogs | #353 | 855 | **merged** |
| 4 controller status | #354 | 718 | open (rebased + dead-import fixed) |
| 5 useHistoryPagination | #355 | 770 | **merged** |
| 6 useSessionDigest | #356 | 714 | **merged** |
| 7 useBookmarks | **this PR** | **654** | open |
| 8-12 estimated | — | ~400 | queued |

## Behavior change

**Zero.** Same persistence path (\`SetMetaCommand\`), same bookmark schema, same panel-open-on-first-create UX, same Ctrl+B hotkey wired to \`setShowBookmarks\`. The bookmark functions just live in their own file now.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`scripts/bump-wrapper.sh patch --commit\` worked (0.33.115, lockfile folded)
- [ ] Open a portable, open an agent pane with some agent activity
- [ ] Right-click a node → "Bookmark this message" → bookmark added
- [ ] Click the bookmark in the panel → scroll jumps to that node
- [ ] Rename the bookmark → label persists across pane reload
- [ ] Delete the bookmark → it's gone after reload
- [ ] Ctrl+B toggles the panel open/closed (uses functional updater)

🤖 Generated with [Claude Code](https://claude.com/claude-code)