### PR TITLE
refactor: modularize agent-view step 8 — useInSessionSearch hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.115"
+version = "0.33.116"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.115"
+version = "0.33.116"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.115"
+version = "0.33.116"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.115"
+version = "0.33.116"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.115"
+version = "0.33.116"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.115"
+version = "0.33.116"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.115"
+version = "0.33.116"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.115"
+version = "0.33.116"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.115"
+version = "0.33.116"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.115"
+version = "0.33.116"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -16,6 +16,7 @@ import { runLaunchFlow } from "./flows/launch-flow";
 import { useLaunchLogs } from "./hooks/useLaunchLogs";
 import { useSessionDigest } from "./hooks/useSessionDigest";
 import { useHistoryPagination } from "./hooks/useHistoryPagination";
+import { useInSessionSearch } from "./hooks/useInSessionSearch";
 import { useBookmarks } from "./hooks/useBookmarks";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
@@ -447,82 +448,22 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // Called by AgentFooter's onTyping when the user starts composing.
     let scrollToBottomFn: (() => void) | null = null;
 
-    // ── In-session search ───────────────────────────────────────────────────────
-    // Searches over the currently-loaded document slice only. Searching the
-    // full persisted history would require a backend blockfile:search RPC —
-    // out of scope for this PR.
-
-    const [searchVisible, setSearchVisible] = createSignal(false);
-    /** Node IDs whose text content matches the active query. */
-    const [searchMatches, setSearchMatches] = createSignal<string[]>([]);
-    /** 0-based index into searchMatches. -1 when there are no matches. */
-    const [searchCurrentIndex, setSearchCurrentIndex] = createSignal(-1);
-
-    /** Extract searchable plain text from any document node. */
-    const nodeSearchText = (node: DocumentNode): string => {
-        switch (node.type) {
-            case "markdown":      return node.content;
-            case "user_message":  return node.message;
-            case "agent_message": return node.message;
-            case "tool":          return node.tool + " " + JSON.stringify(node.params ?? {});
-            case "section":       return node.title;
-            case "subagent_link": return node.slug + " " + node.subagentId;
-            default:              return "";
-        }
-    };
-
-    const performSearch = (query: string) => {
-        if (!query.trim()) {
-            setSearchMatches([]);
-            setSearchCurrentIndex(-1);
-            return;
-        }
-        const q = query.toLowerCase();
-        const [doc] = agentAtoms().documentAtom;
-        const matches: string[] = [];
-        for (const node of doc()) {
-            if (nodeSearchText(node).toLowerCase().includes(q)) {
-                matches.push(node.id);
-            }
-        }
-        setSearchMatches(matches);
-        const newIndex = matches.length > 0 ? 0 : -1;
-        setSearchCurrentIndex(newIndex);
-        if (newIndex >= 0 && scrollToNodeFn) {
-            scrollToNodeFn(matches[0]);
-        }
-    };
-
-    const searchNext = () => {
-        const matches = searchMatches();
-        if (matches.length === 0) return;
-        const next = (searchCurrentIndex() + 1) % matches.length;
-        setSearchCurrentIndex(next);
-        if (scrollToNodeFn) scrollToNodeFn(matches[next]);
-    };
-
-    const searchPrev = () => {
-        const matches = searchMatches();
-        if (matches.length === 0) return;
-        const prev = (searchCurrentIndex() - 1 + matches.length) % matches.length;
-        setSearchCurrentIndex(prev);
-        if (scrollToNodeFn) scrollToNodeFn(matches[prev]);
-    };
-
-    const searchClose = () => {
-        setSearchVisible(false);
-        setSearchMatches([]);
-        setSearchCurrentIndex(-1);
-    };
-
-    /** Node id of the currently highlighted search result, or null. */
-    const searchHighlightId = createMemo<string | null>(() => {
-        const matches = searchMatches();
-        const idx = searchCurrentIndex();
-        return idx >= 0 && idx < matches.length ? matches[idx] : null;
+    // In-session search — owns matches, current index, navigation, highlight.
+    // Searches over the currently-loaded document slice only. See
+    // hooks/useInSessionSearch.ts.
+    const search = useInSessionSearch({
+        document: agentAtoms().documentAtom[0],
+        jumpTo: (nodeId) => scrollToNodeFn?.(nodeId),
     });
-
-    // Bookmark CRUD + jump owned by useBookmarks (aliases declared above).
+    const searchVisible = search.visible;
+    const setSearchVisible = search.setVisible;
+    const searchCurrentIndex = search.currentIndex;
+    const searchMatchCount = search.matchCount;
+    const performSearch = search.performSearch;
+    const searchNext = search.next;
+    const searchPrev = search.prev;
+    const searchClose = search.close;
+    const searchHighlightId = search.highlightId;
 
     // Per-pane zoom: read term:zoom from block meta (same key as terminal panes)
     const zoomFactor = createMemo(() => {
@@ -598,7 +539,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 onPrev={searchPrev}
                 onClose={searchClose}
                 matchIndex={searchCurrentIndex}
-                matchCount={() => searchMatches().length}
+                matchCount={searchMatchCount}
             />
 
             <Show when={!digestDismissed()}>

--- a/frontend/app/view/agent/hooks/useInSessionSearch.ts
+++ b/frontend/app/view/agent/hooks/useInSessionSearch.ts
@@ -1,0 +1,142 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useInSessionSearch — owns the Ctrl+F search state for the agent
+ * pane: query results, current match index, navigation, highlight.
+ *
+ * Step 8 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ *
+ * Searches over the currently-loaded document slice only. Searching
+ * the full persisted history would require a backend
+ * blockfile:search RPC — out of scope for this hook.
+ *
+ * Returns:
+ *   - visible          — whether the search bar is shown
+ *   - setVisible       — toggle the bar (Setter so the Ctrl+F handler
+ *                        can use functional updaters)
+ *   - matches          — current matched node IDs
+ *   - currentIndex     — 0-based index into matches; -1 when none
+ *   - matchCount       — derived: matches().length
+ *   - highlightId      — derived: matches[currentIndex] or null
+ *   - performSearch    — run a fresh query
+ *   - next             — cycle to next match
+ *   - prev             — cycle to previous match
+ *   - close            — clear matches and hide the bar
+ *
+ * Like useBookmarks, this hook doesn't own scroll. Callers pass a
+ * `jumpTo(nodeId)` callback that gets invoked on every navigation.
+ */
+
+import { createMemo, createSignal, type Accessor, type Setter } from "solid-js";
+import type { DocumentNode } from "../types";
+
+export interface UseInSessionSearchOptions {
+    /**
+     * Reactive accessor for the document slice to search over.
+     * Pass the document atom's read accessor.
+     */
+    document: Accessor<DocumentNode[]>;
+    /**
+     * Called with the matched node id when the user navigates to a
+     * result (initial match, next, prev). Optional — search can
+     * function without a scroll target.
+     */
+    jumpTo?: (nodeId: string) => void;
+}
+
+export interface UseInSessionSearch {
+    visible: Accessor<boolean>;
+    setVisible: Setter<boolean>;
+    matches: Accessor<string[]>;
+    currentIndex: Accessor<number>;
+    matchCount: Accessor<number>;
+    highlightId: Accessor<string | null>;
+    performSearch: (query: string) => void;
+    next: () => void;
+    prev: () => void;
+    close: () => void;
+}
+
+/** Extract searchable plain text from any document node. */
+function nodeSearchText(node: DocumentNode): string {
+    switch (node.type) {
+        case "markdown":      return node.content;
+        case "user_message":  return node.message;
+        case "agent_message": return node.message;
+        case "tool":          return node.tool + " " + JSON.stringify(node.params ?? {});
+        case "section":       return node.title;
+        case "subagent_link": return node.slug + " " + node.subagentId;
+        default:              return "";
+    }
+}
+
+export function useInSessionSearch(opts: UseInSessionSearchOptions): UseInSessionSearch {
+    const [visible, setVisible] = createSignal(false);
+    const [matches, setMatches] = createSignal<string[]>([]);
+    const [currentIndex, setCurrentIndex] = createSignal(-1);
+
+    const matchCount = createMemo(() => matches().length);
+
+    const highlightId = createMemo<string | null>(() => {
+        const m = matches();
+        const idx = currentIndex();
+        return idx >= 0 && idx < m.length ? m[idx] : null;
+    });
+
+    const performSearch = (query: string) => {
+        if (!query.trim()) {
+            setMatches([]);
+            setCurrentIndex(-1);
+            return;
+        }
+        const q = query.toLowerCase();
+        const result: string[] = [];
+        for (const node of opts.document()) {
+            if (nodeSearchText(node).toLowerCase().includes(q)) {
+                result.push(node.id);
+            }
+        }
+        setMatches(result);
+        const newIndex = result.length > 0 ? 0 : -1;
+        setCurrentIndex(newIndex);
+        if (newIndex >= 0) {
+            opts.jumpTo?.(result[0]);
+        }
+    };
+
+    const next = () => {
+        const m = matches();
+        if (m.length === 0) return;
+        const n = (currentIndex() + 1) % m.length;
+        setCurrentIndex(n);
+        opts.jumpTo?.(m[n]);
+    };
+
+    const prev = () => {
+        const m = matches();
+        if (m.length === 0) return;
+        const p = (currentIndex() - 1 + m.length) % m.length;
+        setCurrentIndex(p);
+        opts.jumpTo?.(m[p]);
+    };
+
+    const close = () => {
+        setVisible(false);
+        setMatches([]);
+        setCurrentIndex(-1);
+    };
+
+    return {
+        visible,
+        setVisible,
+        matches,
+        currentIndex,
+        matchCount,
+        highlightId,
+        performSearch,
+        next,
+        prev,
+        close,
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.115",
+  "version": "0.33.116",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.115",
+      "version": "0.33.116",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.115",
+  "version": "0.33.116",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 8 of `specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md`. Extract the Ctrl+F in-session search state from `agent-view.tsx` into a dedicated `hooks/useInSessionSearch.ts` hook.

## Scope

**New file** — `hooks/useInSessionSearch.ts` (142 lines):

State managed:
- `visible` / `setVisible` (`Setter<boolean>` so the Ctrl+F handler can use functional updaters)
- `matches` — `string[]` of matching node ids
- `currentIndex` — 0-based, `-1` when there are no matches
- `matchCount` — derived memo over `matches`
- `highlightId` — derived memo: `matches[currentIndex]` or `null`

Functions exposed:
- `performSearch(query)` — run a fresh query
- `next()` / `prev()` — cycle through matches
- `close()` — clear matches and hide the bar

Private helper `nodeSearchText(node)` moved into the hook.

**Caller contract:** like `useBookmarks`, this hook doesn't own scroll. Callers pass a `jumpTo(nodeId)` callback that fires on every navigation (initial match, next, prev).

**Modified** — `agent-view.tsx`:
- Remove ~75 lines of inline signals + functions (search state, `nodeSearchText`, `performSearch`, `searchNext`, `searchPrev`, `searchClose`, `searchHighlightId` memo)
- Add ~16-line hook call + aliases to preserve existing call sites
- Add the hook import
- Swap `matchCount={() => searchMatches().length}` to `matchCount={searchMatchCount}` — one fewer closure allocation per render

## Line counts

| File | Before | After | Delta |
|---|---:|---:|---:|
| `agent-view.tsx` | 654 | **595** | **−59** |
| `hooks/useInSessionSearch.ts` | — | 142 | +142 |

## Behavior change

**Zero.** Same search algorithm (case-insensitive substring over `nodeSearchText`), same cycling, same jump-to-node behavior. Only the source of the state moved.

## Test plan

- [x] `npx tsc --noEmit` — clean on agent-view.tsx and the new hook
- [ ] Launch portable, open agent pane with some content
- [ ] Ctrl+F opens the search bar
- [ ] Typing a query highlights the first match and scrolls to it
- [ ] Enter / Shift-Enter cycles forward / backward
- [ ] Escape closes the bar and clears the highlight
- [ ] Match count display reflects current position

🤖 Generated with [Claude Code](https://claude.com/claude-code)