### PR TITLE
refactor: modularize agent-view step 11 — AgentPresentationHeader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.119"
+version = "0.33.120"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.119"
+version = "0.33.120"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.119"
+version = "0.33.120"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.119"
+version = "0.33.120"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.119"
+version = "0.33.120"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.119"
+version = "0.33.120"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.119"
+version = "0.33.120"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.119"
+version = "0.33.120"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.119"
+version = "0.33.120"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.119"
+version = "0.33.120"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -23,6 +23,7 @@ import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
 import { AgentPicker } from "./components/AgentPicker";
+import { AgentPresentationHeader } from "./components/AgentPresentationHeader";
 import { AgentSearchBar } from "./components/AgentSearchBar";
 import { BookmarksPanel } from "./components/BookmarksPanel";
 import { SessionDigestBanner } from "./components/SessionDigestBanner";
@@ -502,13 +503,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             style={{ zoom: zoomFactor() }}
             onContextMenu={handleContextMenu}
         >
-            <div class="agent-pres-header">
-                <span class="agent-pres-icon">{block()?.meta?.["agentIcon"] ?? "\u26A1"}</span>
-                <span class="agent-pres-name">{block()?.meta?.["agentName"] ?? provider()?.displayName ?? agentId}</span>
-                <button class="agent-pres-back" onClick={handleBack} title="Back to agents">
-                    {"\u2715"}
-                </button>
-            </div>
+            <AgentPresentationHeader
+                block={block}
+                provider={provider}
+                agentId={agentId}
+                onBack={handleBack}
+            />
 
             <AgentControlBar
                 blockId={model.blockId}

--- a/frontend/app/view/agent/components/AgentPresentationHeader.tsx
+++ b/frontend/app/view/agent/components/AgentPresentationHeader.tsx
@@ -1,0 +1,40 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentPresentationHeader — the top strip of the agent pane: icon,
+ * name, and the "back to picker" close button.
+ *
+ * Step 11 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ *
+ * Pulled out of agent-view.tsx to keep the presentation component
+ * focused on composition and let the header own its own rendering +
+ * fallback logic for the display name.
+ */
+
+import type { Accessor, JSX } from "solid-js";
+import type { ProviderDefinition } from "../providers";
+
+interface AgentPresentationHeaderProps {
+    block: Accessor<{ meta?: Record<string, any> } | undefined>;
+    provider: Accessor<ProviderDefinition | undefined>;
+    agentId: string;
+    onBack: () => void;
+}
+
+export const AgentPresentationHeader = (props: AgentPresentationHeaderProps): JSX.Element => {
+    const icon = () => props.block()?.meta?.["agentIcon"] ?? "\u26A1";
+    const name = () => props.block()?.meta?.["agentName"] ?? props.provider()?.displayName ?? props.agentId;
+
+    return (
+        <div class="agent-pres-header">
+            <span class="agent-pres-icon">{icon()}</span>
+            <span class="agent-pres-name">{name()}</span>
+            <button class="agent-pres-back" onClick={props.onBack} title="Back to agents">
+                {"\u2715"}
+            </button>
+        </div>
+    );
+};
+
+AgentPresentationHeader.displayName = "AgentPresentationHeader";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.119",
+  "version": "0.33.120",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.119",
+      "version": "0.33.120",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.119",
+  "version": "0.33.120",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 11 of \`specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md\`. Extract the \`.agent-pres-header\` JSX block (icon + name + close button) from \`agent-view.tsx\` into its own component.

## Scope

**New file** — \`components/AgentPresentationHeader.tsx\` (~45 lines):
- Takes \`{ block, provider, agentId, onBack }\`
- Owns the display-name fallback chain: \`agentName\` meta → provider display name → raw \`agentId\`
- Owns the icon fallback: \`agentIcon\` meta → lightning bolt (\`\u26A1\`)
- Renders the close button that invokes \`onBack\`

**Modified** — \`agent-view.tsx\`:
- Replace the 5-line inline JSX header block with \`<AgentPresentationHeader>\`
- Add the component import

## Behavior change

**Zero.** Same markup, same classes, same fallback chains.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Launch portable, agent pane shows icon + name + close button
- [ ] Close button still returns to the agent picker
- [ ] Agents with an \`agentIcon\` meta show their custom icon; others show the lightning bolt
- [ ] Agents without \`agentName\` fall back to the provider display name

## Version

Bumped to **0.33.120** to leap past parallel PRs #354, #359, #360.

🤖 Generated with [Claude Code](https://claude.com/claude-code)