### PR TITLE
refactor: modularize agent-view step 12 — cleanup pass to 297 lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.120"
+version = "0.33.121"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.120"
+version = "0.33.121"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.120"
+version = "0.33.121"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.120"
+version = "0.33.121"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.120"
+version = "0.33.121"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.120"
+version = "0.33.121"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.120"
+version = "0.33.121"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.120"
+version = "0.33.121"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.120"
+version = "0.33.121"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.120"
+version = "0.33.121"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -2,23 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { writeText as clipboardWriteText } from "@/util/clipboard";
-import { createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createMemo, onMount, Show, type JSX } from "solid-js";
 import type { AgentViewModel } from "./agent-model";
-import { buildRuntimeArgs, getRuntimeConfig } from "./buildRuntimeArgs";
-import { getProvider, type ProviderDefinition } from "./providers";
+import { getProvider } from "./providers";
 import { createAgentAtoms } from "./state";
-import type { Bookmark, DocumentNode, SubagentLinkNode } from "./types";
+import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
-import { parseHistoryLines } from "./parseHistoryLines";
-import { runLaunchFlow } from "./flows/launch-flow";
 import { useLaunchLogs } from "./hooks/useLaunchLogs";
 import { useSessionDigest } from "./hooks/useSessionDigest";
 import { useHistoryPagination } from "./hooks/useHistoryPagination";
+import { useAgentControllerStatus } from "./hooks/useAgentControllerStatus";
 import { useInSessionSearch } from "./hooks/useInSessionSearch";
 import { useBookmarks } from "./hooks/useBookmarks";
 import { useScrollToNode } from "./hooks/useScrollToNode";
 import { useAgentKeyboard } from "./hooks/useAgentKeyboard";
+import { useSubagentEvents } from "./hooks/useSubagentEvents";
+import { useControllerStatusEvents } from "./hooks/useControllerStatusEvents";
+import { useAgentCommands } from "./hooks/useAgentCommands";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
@@ -27,12 +28,6 @@ import { AgentPresentationHeader } from "./components/AgentPresentationHeader";
 import { AgentSearchBar } from "./components/AgentSearchBar";
 import { BookmarksPanel } from "./components/BookmarksPanel";
 import { SessionDigestBanner } from "./components/SessionDigestBanner";
-import { RpcApi } from "@/app/store/wshclientapi";
-import { TabRpcClient } from "@/app/store/wshrpcutil";
-import { waveEventSubscribe } from "@/app/store/wps";
-import * as WOS from "@/app/store/wos";
-import { BlockService } from "@/app/store/services";
-import { getApi, staticTabId } from "@/app/store/global";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import "./agent-view.scss";
 
@@ -68,232 +63,42 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     const agentAtoms = createMemo(() => createAgentAtoms(model.blockId));
 
-    // Accumulated terminal-style log lines — managed by useLaunchLogs hook.
-    // `logLines` is the reactive accessor; `log` is the append function
-    // that matches the LogFn signature expected by runLaunchFlow().
-    // Declared early so subsequent hooks (history, digest, controller
-    // status) can take it as a dependency.
-    const launchLogs = useLaunchLogs();
-    const logLines = launchLogs.lines;
-    const log = launchLogs.append;
+    // Log buffer — the LogFn is passed down to every hook that needs it.
+    const { lines: logLines, append: log } = useLaunchLogs();
 
-    // History pagination — owns historyOffset/historyTotal/loadingOlder,
-    // documentVersion, loadOlder handler, and the initial async history
-    // load that fires on hook mount. See hooks/useHistoryPagination.ts.
-    //
-    // documentVersion is bumped on every external document mutation
-    // (initial load + every loadOlder prepend). useAgentStream subscribes
-    // to it and rebuilds its dedup index after the document is reshaped.
+    // History pagination: owns the document slice, loadingOlder state,
+    // loadOlder handler, and documentVersion (bumped on every external
+    // document mutation so useAgentStream can rebuild its dedup index).
     const history = useHistoryPagination({
         blockId: model.blockId,
         documentAtom: agentAtoms().documentAtom,
         outputFormat,
         log,
     });
-    const historyOffset = history.historyOffset;
-    const historyTotal = history.historyTotal;
-    const loadingOlder = history.loadingOlder;
-    const loadOlder = history.loadOlder;
-    const documentVersion = history.documentVersion;
 
-    // Session digest — owns summary/generatedAt/loading/dismissed signals,
-    // the fetch RPC wrapper, and the auto-trigger that decides whether to
-    // surface or generate a digest on pane open. See hooks/useSessionDigest.ts.
-    const digest = useSessionDigest({
-        blockId: model.blockId,
-        block,
-        log,
-    });
-    const digestSummary = digest.summary;
-    const digestGeneratedAt = digest.generatedAt;
-    const digestLoading = digest.loading;
-    const digestDismissed = digest.dismissed;
-    const fetchDigest = digest.fetch;
-    const dismissDigest = digest.dismiss;
+    // Session digest banner state + auto-trigger.
+    const digest = useSessionDigest({ blockId: model.blockId, block, log });
 
-    // OAuth URL — shown prominently with a copy button when login is needed
-    const [authUrl, setAuthUrl] = createSignal<string | null>(null);
-    // Whether to show the retry button (after auth_failed)
-    const [canRetry, setCanRetry] = createSignal(false);
-    // Whether the launch flow is currently running
-    const [flowRunning, setFlowRunning] = createSignal(false);
-    // Whether the agent is ready (launch complete, controller registered)
-    const [agentReady, setAgentReady] = createSignal(false);
-    // Show spinner during launch and until agent is ready.
-    // createMemo ensures derived value is cached and only re-evaluates
-    // when underlying signals change — not on every caller read.
-    const isLoading = createMemo(() => flowRunning() || !agentReady());
-    // Whether we're specifically in the login-polling phase
-    const [loginWaiting, setLoginWaiting] = createSignal(false);
-    // Mutable flag for cancelling the polling loop (set by cancel or onCleanup)
-    let loginCancelled = false;
-
-    // Build auth env for a given provider
-    const buildAuthEnv = async (prov: ReturnType<typeof provider>): Promise<Record<string, string> | undefined> => {
-        if (!prov?.authConfigDirEnvVar || !prov?.authDirName) return undefined;
-        try {
-            const authDir = await getApi().ensureAuthDir(prov.id);
-            const env: Record<string, string> = { [prov.authConfigDirEnvVar]: authDir };
-            if (prov.authExtraEnv) Object.assign(env, prov.authExtraEnv);
-            return env;
-        } catch {
-            return undefined; // non-fatal — fall back to default auth dir
-        }
-    };
-
-    // loadOlder + initial-history-load are owned by useHistoryPagination
-    // (local aliases declared above).
-
-    // fetchDigest + dismissDigest are owned by useSessionDigest
-    // (local aliases declared above).
-
-    // Runs the full launch flow; can be triggered at mount time or via retry.
-    const startLaunchFlow = async () => {
-        if (flowRunning()) return;
-        loginCancelled = false;
-        setFlowRunning(true);
-        setCanRetry(false);
-        const prov = provider();
-        try {
-            const authEnv = await buildAuthEnv(prov);
-            const result = await runLaunchFlow({
-                blockId: model.blockId,
-                provider: prov,
-                log,
-                setAuthUrl,
-                isCancelled: () => loginCancelled,
-                setLoginWaiting,
-                authEnv,
-            });
-            if (result === "success") {
-                setAgentReady(true);
-            } else if (result === "auth_failed" && !loginCancelled) {
-                setCanRetry(true);
-                setAgentReady(true); // clear spinner so retry button is usable
-            }
-        } catch (err: any) {
-            log("error", err?.message ?? String(err), "error");
-            setAgentReady(true); // clear spinner on error
-        } finally {
-            setFlowRunning(false);
-        }
-    };
-
-    // Cancel login: stop polling and kill the background CLI process.
-    const cancelLogin = () => {
-        loginCancelled = true;
-        getApi().cancelCliLogin().catch(() => {});
-        log("auth", "login cancelled", "warn");
-    };
-
-    // If the pane is closed while login is in progress, cancel and kill the CLI process.
-    onCleanup(() => {
-        if (loginWaiting()) {
-            loginCancelled = true;
-            getApi().cancelCliLogin().catch(() => {});
-        }
-    });
+    // Auth + launch flow state and the onCleanup that kills the CLI
+    // if the pane closes mid-login.
+    const status = useAgentControllerStatus({ blockId: model.blockId, provider, log });
 
     onMount(() => {
         const name = block()?.meta?.["agentName"] ?? agentId;
-        const prov = provider();
-        const provName = prov?.displayName ?? providerKey();
+        const provName = provider()?.displayName ?? providerKey();
         const cwd = block()?.meta?.["cmd:cwd"] ?? "";
-
         log("agent", `${name} selected (provider: ${provName})`);
         if (cwd) log("env", `working directory: ${cwd}`);
-
-        // Initial history load is owned by useHistoryPagination's own
-        // onMount — fires automatically when the hook mounts. No work
-        // here. See hooks/useHistoryPagination.ts.
-
-        // Session digest auto-trigger is owned by useSessionDigest's
-        // own onMount (see hooks/useSessionDigest.ts).
-
-        // Full launch flow: CLI resolution → auth check → controller registration
-        startLaunchFlow();
-
-        // Subscribe to status changes
-        const unsub = waveEventSubscribe({
-            eventType: "controllerstatus",
-            scope: WOS.makeORef("block", model.blockId),
-            handler: (event) => {
-                const status = (event as any)?.data?.shellprocstatus;
-                if (status === "running") {
-                    log("subprocess", "spawned, waiting for response...");
-                } else if (status === "done") {
-                    const exitCode = (event as any)?.data?.shellprocexitcode;
-                    if (exitCode != null && exitCode !== 0) {
-                        log("subprocess", `exited with code ${exitCode}`, "error");
-                    } else {
-                        log("subprocess", "turn complete");
-                    }
-                }
-            },
-        });
-        onCleanup(() => unsub());
-
-        // Subscribe to subagent:spawned events — render clickable links
-        const unsubSpawned = waveEventSubscribe({
-            eventType: "subagent:spawned",
-            handler: (event: WaveEvent) => {
-                const data = event?.data as any;
-                if (!data?.agentId) return;
-
-                const linkNode: SubagentLinkNode = {
-                    type: "subagent_link",
-                    id: `subagent_${data.agentId}`,
-                    subagentId: data.agentId,
-                    slug: data.slug ?? "",
-                    parentAgent: data.parentAgent ?? "",
-                    sessionId: data.sessionId ?? "",
-                    status: "active",
-                    model: data.model ?? null,
-                };
-
-                const [, setDoc] = agentAtoms().documentAtom;
-                setDoc((prev) => [...prev, linkNode]);
-                log("subagent", `spawned: ${data.slug || data.agentId}`);
-            },
-        });
-        onCleanup(() => unsubSpawned());
-
-        // Subscribe to subagent:completed — update link status
-        const unsubCompleted = waveEventSubscribe({
-            eventType: "subagent:completed",
-            handler: (event: WaveEvent) => {
-                const data = event?.data as any;
-                if (!data?.agentId) return;
-
-                const nodeId = `subagent_${data.agentId}`;
-                const [, setDoc] = agentAtoms().documentAtom;
-                setDoc((prev) =>
-                    prev.map((n) =>
-                        n.id === nodeId && n.type === "subagent_link"
-                            ? { ...n, status: "completed" as const }
-                            : n
-                    )
-                );
-            },
-        });
-        onCleanup(() => unsubCompleted());
-
-        // Ctrl+B / Ctrl+F handling is owned by useAgentKeyboard (called
-        // at the top level below — hooks can't mount inside onMount).
+        status.startLaunchFlow();
     });
 
-    // Pane-scoped Ctrl+B / Ctrl+F listener. See hooks/useAgentKeyboard.ts.
-    useAgentKeyboard({
-        blockId: model.blockId,
-        onToggleBookmarks: () => setShowBookmarks((v) => !v),
-        onToggleSearch: () => {
-            // Second Ctrl+F press closes and clears state.
-            if (searchVisible()) {
-                searchClose();
-            } else {
-                setSearchVisible(true);
-            }
-        },
+    // Log controllerstatus events as they stream in.
+    useControllerStatusEvents({ blockId: model.blockId, log });
+
+    // Subagent event subscriptions. See hooks/useSubagentEvents.ts.
+    useSubagentEvents({
+        documentAtom: agentAtoms().documentAtom,
+        log,
     });
 
     // Subscribe to subprocess output and parse into DocumentNodes.
@@ -306,158 +111,62 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         documentAtom: agentAtoms().documentAtom,
         streamingStateAtom: agentAtoms().streamingStateAtom,
         enabled: true,
-        documentVersion,
+        documentVersion: history.documentVersion,
     });
 
-    // Send user message
-    const handleSendMessage = async (message: string) => {
-        // Add user message as a document node so it appears in the chat
-        const [, setDocument] = agentAtoms().documentAtom;
-        setDocument((prev) => [
-            ...prev,
-            {
-                type: "user_message",
-                id: `user_${Date.now()}`,
-                message,
-                timestamp: Date.now(),
-                collapsed: false,
-                summary: "",
-            } as DocumentNode,
-        ]);
-
-        // Intercept interactive-only slash commands that don't work in
-        // stream-json mode. These require TTY/browser interaction.
-        const trimmed = message.trim();
-        if (trimmed === "/login") {
-            const prov = provider();
-            const cliPath = block()?.meta?.["cmd"] ?? "";
-            if (!prov || !cliPath) {
-                log("error", "/login: provider or CLI path not available", "error");
-                return;
-            }
-            log("auth", "running /login via GUI flow...");
-            try {
-                const authEnv: Record<string, string> = {};
-                const envMeta = block()?.meta?.["cmd:env"];
-                if (envMeta && typeof envMeta === "object") {
-                    for (const [k, v] of Object.entries(envMeta)) {
-                        if (typeof v === "string") authEnv[k] = v;
-                    }
-                }
-                const url = await getApi().runCliLogin(cliPath, prov.authLoginCommand, authEnv);
-                if (url) {
-                    setAuthUrl(url);
-                    log("auth", `OAuth URL captured — browser should open automatically`);
-                    log("auth", `if it didn't, copy the URL from the box above`);
-                } else {
-                    log("auth", "a browser window should have opened — complete login there");
-                }
-                log("auth", "run /cost to verify authentication once logged in");
-            } catch (err: any) {
-                log("error", `/login failed: ${err?.message ?? String(err)}`, "error");
-            }
-            return;
-        }
-        if (trimmed === "/clear") {
-            // Frontend-only: clear the document
-            setDocument([]);
-            log("system", "chat cleared");
-            return;
-        }
-
-        // Apply runtime args (permission mode, model, effort) before this turn
-        const prov = provider();
-        if (prov) {
-            const runtimeConfig = getRuntimeConfig(block()?.meta);
-            const baseArgs = prov.controllerType === "persistent" && prov.persistentLaunchArgs
-                ? prov.persistentLaunchArgs
-                : prov.launchArgs;
-            const updatedArgs = buildRuntimeArgs(baseArgs, runtimeConfig);
-            const oref = WOS.makeORef("block", model.blockId);
-            try {
-                await RpcApi.SetMetaCommand(TabRpcClient, {
-                    oref,
-                    meta: { "cmd:args": updatedArgs },
-                });
-            } catch (err) {
-                log("error", `Failed to update runtime args: ${err}`, "error");
-            }
-        }
-
-        RpcApi.AgentInputCommand(TabRpcClient, {
-            blockid: model.blockId,
-            message: message,
-        }).catch((err) => {
-            const errMsg = err?.message ?? String(err);
-            log("error", errMsg, "error");
-        });
-    };
-
-    const handleBack = async () => {
-        const oref = WOS.makeORef("block", model.blockId);
-        try {
-            await RpcApi.SetMetaCommand(TabRpcClient, {
-                oref,
-                meta: {
-                    agentId: null,
-                    agentProvider: null,
-                    agentOutputFormat: null,
-                    agentName: null,
-                    agentIcon: null,
-                    agentCliPath: null,
-                    agentCliArgs: null,
-                    agentBinDir: null,
-                    controller: null,
-                },
-            });
-        } catch {
-            // model logs internally
-        }
-    };
+    // User-message send + /login /clear slash intercepts + back-to-picker.
+    // See hooks/useAgentCommands.ts.
+    const commands = useAgentCommands({
+        blockId: model.blockId,
+        block,
+        provider,
+        documentAtom: agentAtoms().documentAtom,
+        log,
+        setAuthUrl: status.setAuthUrl,
+    });
+    const handleSendMessage = commands.sendMessage;
+    const handleBack = commands.back;
 
     // ── Jump-to-node + Bookmarks ────────────────────────────────────────────────
 
-    // Signal-based jump command. AgentDocumentView reacts to changes via a
-    // createEffect and does the DOM scroll inside its own container — no
-    // mutable refs crossing the component boundary. See hooks/useScrollToNode.ts.
+    // Signal-based jump command. AgentDocumentView reacts via a
+    // createEffect and scrolls inside its own container — no mutable
+    // refs crossing component boundaries. See hooks/useScrollToNode.ts.
     const scroll = useScrollToNode();
 
-    // Bookmarks — owns reactive list, derived id set, panel visibility,
-    // and CRUD callbacks. See hooks/useBookmarks.ts.
-    const bookmarksHook = useBookmarks({
+    // Bookmarks: list, derived id set, panel visibility, CRUD callbacks.
+    const bookmarks = useBookmarks({
         blockId: model.blockId,
         block,
         log,
         jumpTo: scroll.jumpTo,
     });
-    const bookmarks = bookmarksHook.bookmarks;
-    const bookmarkedNodeIds = bookmarksHook.bookmarkedNodeIds;
-    const showBookmarks = bookmarksHook.visible;
-    const setShowBookmarks = bookmarksHook.setVisible;
-    const handleBookmark = bookmarksHook.add;
-    const handleBookmarkDelete = bookmarksHook.remove;
-    const handleBookmarkRename = bookmarksHook.rename;
-    const handleBookmarkJump = bookmarksHook.jump;
-    // Mutable ref to the scrollToBottom function exposed by AgentDocumentView.
-    // Called by AgentFooter's onTyping when the user starts composing.
-    let scrollToBottomFn: (() => void) | null = null;
 
-    // In-session search — owns matches, current index, navigation, highlight.
-    // Searches over the currently-loaded document slice only. See
-    // hooks/useInSessionSearch.ts.
+    // In-session search: matches, navigation, highlight. Searches over
+    // the currently-loaded document slice only.
     const search = useInSessionSearch({
         document: agentAtoms().documentAtom[0],
         jumpTo: scroll.jumpTo,
     });
-    const searchVisible = search.visible;
-    const setSearchVisible = search.setVisible;
-    const searchCurrentIndex = search.currentIndex;
-    const searchMatchCount = search.matchCount;
-    const performSearch = search.performSearch;
-    const searchNext = search.next;
-    const searchPrev = search.prev;
-    const searchClose = search.close;
-    const searchHighlightId = search.highlightId;
+
+    // Mutable ref to the scrollToBottom function exposed by
+    // AgentDocumentView. Called by AgentFooter's onTyping when the user
+    // starts composing.
+    let scrollToBottomFn: (() => void) | null = null;
+
+    // Pane-scoped Ctrl+B / Ctrl+F listener. See hooks/useAgentKeyboard.ts.
+    useAgentKeyboard({
+        blockId: model.blockId,
+        onToggleBookmarks: () => bookmarks.setVisible((v) => !v),
+        onToggleSearch: () => {
+            // Second Ctrl+F press closes and clears state.
+            if (search.visible()) {
+                search.close();
+            } else {
+                search.setVisible(true);
+            }
+        },
+    });
 
     // Per-pane zoom: read term:zoom from block meta (same key as terminal panes)
     const zoomFactor = createMemo(() => {
@@ -516,32 +225,32 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 providerId={provider()?.id ?? ""}
             />
 
-            <Show when={showBookmarks()}>
+            <Show when={bookmarks.visible()}>
                 <BookmarksPanel
-                    bookmarks={bookmarks}
-                    onJump={handleBookmarkJump}
-                    onDelete={handleBookmarkDelete}
-                    onRename={handleBookmarkRename}
+                    bookmarks={bookmarks.bookmarks}
+                    onJump={bookmarks.jump}
+                    onDelete={bookmarks.remove}
+                    onRename={bookmarks.rename}
                 />
             </Show>
 
             <AgentSearchBar
-                visible={searchVisible}
-                onSearch={performSearch}
-                onNext={searchNext}
-                onPrev={searchPrev}
-                onClose={searchClose}
-                matchIndex={searchCurrentIndex}
-                matchCount={searchMatchCount}
+                visible={search.visible}
+                onSearch={search.performSearch}
+                onNext={search.next}
+                onPrev={search.prev}
+                onClose={search.close}
+                matchIndex={search.currentIndex}
+                matchCount={search.matchCount}
             />
 
-            <Show when={!digestDismissed()}>
+            <Show when={!digest.dismissed()}>
                 <SessionDigestBanner
-                    summary={digestSummary}
-                    generatedAt={digestGeneratedAt}
-                    loading={digestLoading}
-                    onDismiss={dismissDigest}
-                    onRegenerate={() => fetchDigest(true)}
+                    summary={digest.summary}
+                    generatedAt={digest.generatedAt}
+                    loading={digest.loading}
+                    onDismiss={digest.dismiss}
+                    onRegenerate={() => digest.fetch(true)}
                 />
             </Show>
 
@@ -549,27 +258,27 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 documentAtom={agentAtoms().documentAtom}
                 documentStateAtom={agentAtoms().documentStateAtom}
                 logLines={logLines}
-                authUrl={authUrl}
+                authUrl={status.authUrl}
                 onSubagentClick={handleSubagentClick}
-                onLoadOlder={loadOlder}
-                loadingOlder={loadingOlder}
-                bookmarkedNodeIds={bookmarkedNodeIds}
-                onBookmark={handleBookmark}
+                onLoadOlder={history.loadOlder}
+                loadingOlder={history.loadingOlder}
+                bookmarkedNodeIds={bookmarks.bookmarkedNodeIds}
+                onBookmark={bookmarks.add}
                 scrollCommand={scroll.command}
                 scrollToBottomRef={(fn) => { scrollToBottomFn = fn; }}
-                highlightNodeId={searchHighlightId}
+                highlightNodeId={search.highlightId}
             />
 
-            <Show when={loginWaiting()}>
+            <Show when={status.loginWaiting()}>
                 <div class="agent-retry-bar">
-                    <button class="agent-retry-btn agent-retry-btn--cancel" onClick={cancelLogin}>
+                    <button class="agent-retry-btn agent-retry-btn--cancel" onClick={status.cancelLogin}>
                         Cancel Login
                     </button>
                 </div>
             </Show>
-            <Show when={canRetry()}>
+            <Show when={status.canRetry()}>
                 <div class="agent-retry-bar">
-                    <button class="agent-retry-btn" onClick={startLaunchFlow}>
+                    <button class="agent-retry-btn" onClick={status.startLaunchFlow}>
                         Retry Login
                     </button>
                 </div>
@@ -577,9 +286,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
             <AgentFooter
                 agentId={agentId}
-                onSendMessage={handleSendMessage}
+                onSendMessage={commands.sendMessage}
                 onTyping={() => scrollToBottomFn?.()}
-                loading={isLoading()}
+                loading={status.isLoading()}
             />
         </div>
     );

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -1,0 +1,158 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useAgentCommands — owns the top-level user-driven handlers for the
+ * agent pane: sending messages (including slash-command intercepts)
+ * and returning to the agent picker.
+ *
+ * Step 12 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ *
+ * Extracted from agent-view.tsx so AgentPresentationView stays focused
+ * on composition + JSX instead of owning several dozen lines of
+ * RPC plumbing.
+ *
+ * Slash commands intercepted:
+ *   - `/login` — runs a GUI OAuth flow via the host API, captures the
+ *                returned URL, and pushes it into `setAuthUrl` so the
+ *                auth box appears above the composer.
+ *   - `/clear` — frontend-only document reset.
+ *
+ * All other messages pass through to the backend via
+ * `RpcApi.AgentInputCommand`, with `cmd:args` updated first so runtime
+ * flags (permission mode, model, effort) take effect on this turn.
+ */
+
+import type { Accessor } from "solid-js";
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import * as WOS from "@/app/store/wos";
+import { getApi } from "@/app/store/global";
+import { buildRuntimeArgs, getRuntimeConfig } from "../buildRuntimeArgs";
+import type { ProviderDefinition } from "../providers";
+import type { SignalPair } from "../state";
+import type { DocumentNode } from "../types";
+import type { LogFn } from "./useAgentControllerStatus";
+
+export interface UseAgentCommandsOptions {
+    blockId: string;
+    block: Accessor<{ meta?: Record<string, any> } | undefined>;
+    provider: Accessor<ProviderDefinition | undefined>;
+    documentAtom: SignalPair<DocumentNode[]>;
+    log: LogFn;
+    setAuthUrl: (url: string | null) => void;
+}
+
+export interface UseAgentCommands {
+    /** Send a user message. Handles `/login` and `/clear` as special cases. */
+    sendMessage: (message: string) => Promise<void>;
+    /** Return to the agent picker by clearing the agent-identity meta keys. */
+    back: () => Promise<void>;
+}
+
+export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommands {
+    const [, setDocument] = opts.documentAtom;
+
+    const runLoginCommand = async (): Promise<void> => {
+        const prov = opts.provider();
+        const cliPath = opts.block()?.meta?.["cmd"] ?? "";
+        if (!prov || !cliPath) {
+            opts.log("error", "/login: provider or CLI path not available", "error");
+            return;
+        }
+        opts.log("auth", "running /login via GUI flow...");
+        try {
+            const authEnv: Record<string, string> = {};
+            const envMeta = opts.block()?.meta?.["cmd:env"];
+            if (envMeta && typeof envMeta === "object") {
+                for (const [k, v] of Object.entries(envMeta)) {
+                    if (typeof v === "string") authEnv[k] = v;
+                }
+            }
+            const url = await getApi().runCliLogin(cliPath, prov.authLoginCommand, authEnv);
+            if (url) {
+                opts.setAuthUrl(url);
+                opts.log("auth", "OAuth URL captured — browser should open automatically");
+                opts.log("auth", "if it didn't, copy the URL from the box above");
+            } else {
+                opts.log("auth", "a browser window should have opened — complete login there");
+            }
+            opts.log("auth", "run /cost to verify authentication once logged in");
+        } catch (err: any) {
+            opts.log("error", `/login failed: ${err?.message ?? String(err)}`, "error");
+        }
+    };
+
+    const sendMessage = async (message: string): Promise<void> => {
+        setDocument((prev) => [
+            ...prev,
+            {
+                type: "user_message",
+                id: `user_${Date.now()}`,
+                message,
+                timestamp: Date.now(),
+                collapsed: false,
+                summary: "",
+            } as DocumentNode,
+        ]);
+
+        const trimmed = message.trim();
+        if (trimmed === "/login") {
+            await runLoginCommand();
+            return;
+        }
+        if (trimmed === "/clear") {
+            setDocument([]);
+            opts.log("system", "chat cleared");
+            return;
+        }
+
+        // Apply runtime args (permission mode, model, effort) before this turn.
+        const prov = opts.provider();
+        if (prov) {
+            const runtimeConfig = getRuntimeConfig(opts.block()?.meta);
+            const baseArgs = prov.controllerType === "persistent" && prov.persistentLaunchArgs
+                ? prov.persistentLaunchArgs
+                : prov.launchArgs;
+            const updatedArgs = buildRuntimeArgs(baseArgs, runtimeConfig);
+            try {
+                await RpcApi.SetMetaCommand(TabRpcClient, {
+                    oref: WOS.makeORef("block", opts.blockId),
+                    meta: { "cmd:args": updatedArgs },
+                });
+            } catch (err) {
+                opts.log("error", `Failed to update runtime args: ${err}`, "error");
+            }
+        }
+
+        RpcApi.AgentInputCommand(TabRpcClient, {
+            blockid: opts.blockId,
+            message,
+        }).catch((err) => {
+            opts.log("error", err?.message ?? String(err), "error");
+        });
+    };
+
+    const back = async (): Promise<void> => {
+        try {
+            await RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: WOS.makeORef("block", opts.blockId),
+                meta: {
+                    agentId: null,
+                    agentProvider: null,
+                    agentOutputFormat: null,
+                    agentName: null,
+                    agentIcon: null,
+                    agentCliPath: null,
+                    agentCliArgs: null,
+                    agentBinDir: null,
+                    controller: null,
+                },
+            });
+        } catch {
+            // model logs internally
+        }
+    };
+
+    return { sendMessage, back };
+}

--- a/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
+++ b/frontend/app/view/agent/hooks/useControllerStatusEvents.ts
@@ -1,0 +1,43 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useControllerStatusEvents — subscribes to the `controllerstatus`
+ * wave event (scoped to one block) and translates shellprocstatus /
+ * shellprocexitcode into log lines.
+ *
+ * Step 12 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ */
+
+import { onCleanup, onMount } from "solid-js";
+import { waveEventSubscribe } from "@/app/store/wps";
+import * as WOS from "@/app/store/wos";
+import type { LogFn } from "./useAgentControllerStatus";
+
+export interface UseControllerStatusEventsOptions {
+    blockId: string;
+    log: LogFn;
+}
+
+export function useControllerStatusEvents(opts: UseControllerStatusEventsOptions): void {
+    onMount(() => {
+        const unsub = waveEventSubscribe({
+            eventType: "controllerstatus",
+            scope: WOS.makeORef("block", opts.blockId),
+            handler: (event) => {
+                const status = (event as any)?.data?.shellprocstatus;
+                if (status === "running") {
+                    opts.log("subprocess", "spawned, waiting for response...");
+                } else if (status === "done") {
+                    const exitCode = (event as any)?.data?.shellprocexitcode;
+                    if (exitCode != null && exitCode !== 0) {
+                        opts.log("subprocess", `exited with code ${exitCode}`, "error");
+                    } else {
+                        opts.log("subprocess", "turn complete");
+                    }
+                }
+            },
+        });
+        onCleanup(() => unsub());
+    });
+}

--- a/frontend/app/view/agent/hooks/useSubagentEvents.ts
+++ b/frontend/app/view/agent/hooks/useSubagentEvents.ts
@@ -1,0 +1,71 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useSubagentEvents — subscribes to subagent:spawned / subagent:completed
+ * wave events and maintains the corresponding SubagentLinkNode entries
+ * in the document.
+ *
+ * Step 12 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
+ *
+ * On `subagent:spawned`: appends a new subagent_link node to the
+ * document with status "active".
+ *
+ * On `subagent:completed`: flips the status of the matching node from
+ * "active" to "completed".
+ */
+
+import { onCleanup, onMount } from "solid-js";
+import { waveEventSubscribe } from "@/app/store/wps";
+import type { SignalPair } from "../state";
+import type { DocumentNode, SubagentLinkNode } from "../types";
+import type { LogFn } from "./useAgentControllerStatus";
+
+export interface UseSubagentEventsOptions {
+    documentAtom: SignalPair<DocumentNode[]>;
+    log: LogFn;
+}
+
+export function useSubagentEvents(opts: UseSubagentEventsOptions): void {
+    const [, setDoc] = opts.documentAtom;
+
+    onMount(() => {
+        const unsubSpawned = waveEventSubscribe({
+            eventType: "subagent:spawned",
+            handler: (event: WaveEvent) => {
+                const data = event?.data as any;
+                if (!data?.agentId) return;
+                const linkNode: SubagentLinkNode = {
+                    type: "subagent_link",
+                    id: `subagent_${data.agentId}`,
+                    subagentId: data.agentId,
+                    slug: data.slug ?? "",
+                    parentAgent: data.parentAgent ?? "",
+                    sessionId: data.sessionId ?? "",
+                    status: "active",
+                    model: data.model ?? null,
+                };
+                setDoc((prev) => [...prev, linkNode]);
+                opts.log("subagent", `spawned: ${data.slug || data.agentId}`);
+            },
+        });
+        onCleanup(() => unsubSpawned());
+
+        const unsubCompleted = waveEventSubscribe({
+            eventType: "subagent:completed",
+            handler: (event: WaveEvent) => {
+                const data = event?.data as any;
+                if (!data?.agentId) return;
+                const nodeId = `subagent_${data.agentId}`;
+                setDoc((prev) =>
+                    prev.map((n) =>
+                        n.id === nodeId && n.type === "subagent_link"
+                            ? { ...n, status: "completed" as const }
+                            : n
+                    )
+                );
+            },
+        });
+        onCleanup(() => unsubCompleted());
+    });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.120",
+  "version": "0.33.121",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.120",
+      "version": "0.33.121",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.120",
+  "version": "0.33.121",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**Final step** of `specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md`.

`agent-view.tsx`: **588 → 297 lines** (−291, −49%). Target was ≤ 300. Below budget.

## What changed

### 1. Wire `useAgentControllerStatus` (rebase-regression fix, ~80 lines)

The hook file existed from PR #354 but `agent-view.tsx` on main was still carrying the inline auth state, `startLaunchFlow`, `cancelLogin`, `buildAuthEnv`, and the login-pending `onCleanup`. This PR finally wires the hook and deletes the inline version.

### 2. Extract subagent event subscriptions into `hooks/useSubagentEvents.ts` (~45 lines)

The `subagent:spawned` and `subagent:completed` wave-event handlers and their document mutations (appending the link node, flipping status to `"completed"`).

### 3. Extract controllerstatus subscription into `hooks/useControllerStatusEvents.ts` (~20 lines)

The `shellprocstatus` / `shellprocexitcode` → log line translation.

### 4. Extract user-message send + slash intercepts + back into `hooks/useAgentCommands.ts` (~100 lines)

`handleSendMessage` was ~80 lines carrying the runtime-args computation, RPC plumbing, and the full `/login` GUI OAuth flow. `handleBack` was another ~15 lines of SetMetaCommand. Both now live in a single 155-line commands hook with one clean public API:

```ts
const commands = useAgentCommands({ blockId, block, provider, documentAtom, log, setAuthUrl });
// commands.sendMessage, commands.back
```

### 5. Remove 14 local aliases

`digestSummary`, `digestLoading`, `historyOffset`, `historyTotal`, `authUrl`, `canRetry`, `bookmarks`, `handleBookmarkJump`, `searchVisible`, `searchNext`, etc. Callers now reference `bookmarks.jump`, `status.authUrl`, `digest.summary`, `search.close` directly in JSX.

### 6. Collapse `onMount`

Drop the no-op comments pointing to owner hooks. What remains is 6 lines: fetch agent name from meta, emit two log lines, kick the launch flow.

### 7. Drop 17 now-dead imports

`RpcApi`, `TabRpcClient`, `WOS`, `BlockService`, `buildRuntimeArgs`, `getRuntimeConfig`, `getApi`, `staticTabId`, `runLaunchFlow`, `parseHistoryLines`, `waveEventSubscribe`, `For`, `createSignal`, `onCleanup`, `Bookmark`, `DocumentNode`.

## New files

- `hooks/useSubagentEvents.ts`
- `hooks/useControllerStatusEvents.ts`
- `hooks/useAgentCommands.ts`

## What `agent-view.tsx` owns now

- The `AgentViewWrapper` picker/presentation switch (~20 lines)
- Local derivations: `providerKey`, `provider`, `outputFormat`, `zoomFactor`, `agentAtoms`
- 10 hook calls — one for each concern
- Two local handlers: `handleSubagentClick`, `handleContextMenu`
- The JSX composition tree

## Behavior change

**Zero.** All state machines, event subscriptions, RPC calls, and UI behaviors are preserved — they're just now in their own files.

## Final cumulative trajectory

| Step | agent-view.tsx |
|---|---:|
| 0. baseline | 1,178 |
| 1. AgentPicker | 1,053 |
| 2. launch flow | 854 |
| 3. useLaunchLogs | — |
| 4. useAgentControllerStatus | — (rebase regression; finally wired in Step 12) |
| 5. useHistoryPagination | — |
| 6. useSessionDigest | — |
| 7. useBookmarks | — |
| 8. useInSessionSearch | — |
| 9. useScrollToNode | — |
| 10. useAgentKeyboard | — |
| 11. AgentPresentationHeader | 588 |
| **12. cleanup pass** | **297** |
| **Target** | **≤ 300** |

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Launch portable build
- [ ] Open agent pane → launch flow runs, logs stream, auth UI appears if needed
- [ ] Send a message → response streams, tool blocks render
- [ ] Ctrl+F / Ctrl+B still work in focused pane
- [ ] Bookmarks create/jump/delete/rename
- [ ] Search: Enter/Shift-Enter cycle matches
- [ ] `/login` slash command opens OAuth flow
- [ ] `/clear` slash command resets the chat
- [ ] Back button returns to the agent picker
- [ ] Close pane mid-login kills the CLI process

bump: **0.33.120 → 0.33.121**

🤖 Generated with [Claude Code](https://claude.com/claude-code)