### PR TITLE
refactor: extract AgentCard + NewAgentCard from AgentPicker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.122"
+version = "0.33.123"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.122"
+version = "0.33.123"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.122"
+version = "0.33.123"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.122"
+version = "0.33.123"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.122"
+version = "0.33.123"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.122"
+version = "0.33.123"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.122"
+version = "0.33.123"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.122"
+version = "0.33.123"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.122"
+version = "0.33.123"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.122"
+version = "0.33.123"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -263,6 +263,20 @@
             background: color-mix(in srgb, var(--accent-color) 6%, transparent);
         }
 
+        &--new {
+            border-style: dashed;
+            background: transparent;
+
+            .agent-card-icon {
+                font-weight: bold;
+                color: var(--secondary-text-color);
+            }
+
+            &:hover:not(:disabled) .agent-card-icon {
+                color: var(--accent-color);
+            }
+        }
+
         .agent-card-icon {
             font-size: 22px;
             flex-shrink: 0;

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -1,0 +1,44 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentCard — a single entry in the agent picker list.
+ *
+ * PR 1 of specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md.
+ *
+ * For now this is a pure extraction of the inline button JSX that lived
+ * inside AgentPicker's <For>. Later PRs add the per-agent Forge /
+ * Identity buttons and the inline settings slide-over.
+ */
+
+import { Show, type JSX } from "solid-js";
+
+interface AgentCardProps {
+    agent: ForgeAgent;
+    launching: boolean;
+    disabled: boolean;
+    onLaunch: (agent: ForgeAgent) => void;
+}
+
+export const AgentCard = (props: AgentCardProps): JSX.Element => {
+    return (
+        <button
+            class={`agent-card${props.launching ? " agent-card--launching" : ""}`}
+            onClick={() => props.onLaunch(props.agent)}
+            disabled={props.disabled}
+        >
+            <span class="agent-card-icon">{props.agent.icon}</span>
+            <span class="agent-card-info">
+                <span class="agent-card-name">{props.agent.name}</span>
+                <Show when={props.agent.description}>
+                    <span class="agent-card-desc">{props.agent.description}</span>
+                </Show>
+            </span>
+            <Show when={props.launching}>
+                <span class="agent-card-spinner" />
+            </Show>
+        </button>
+    );
+};
+
+AgentCard.displayName = "AgentCard";

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -15,6 +15,8 @@ import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
 import { waveEventSubscribe } from "@/app/store/wps";
 import type { AgentViewModel } from "../agent-model";
+import { AgentCard } from "./AgentCard";
+import { NewAgentCard } from "./NewAgentCard";
 
 // ── useForgeAgents hook ───────────────────────────────────────────────────────
 
@@ -104,24 +106,15 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     <div class="agent-picker-list">
                         <For each={agents()}>
                             {(agent) => (
-                                <button
-                                    class={`agent-card${launching() === agent.id ? " agent-card--launching" : ""}`}
-                                    onClick={() => handleSelect(agent)}
+                                <AgentCard
+                                    agent={agent}
+                                    launching={launching() === agent.id}
                                     disabled={busy()}
-                                >
-                                    <span class="agent-card-icon">{agent.icon}</span>
-                                    <span class="agent-card-info">
-                                        <span class="agent-card-name">{agent.name}</span>
-                                        <Show when={agent.description}>
-                                            <span class="agent-card-desc">{agent.description}</span>
-                                        </Show>
-                                    </span>
-                                    <Show when={launching() === agent.id}>
-                                        <span class="agent-card-spinner" />
-                                    </Show>
-                                </button>
+                                    onLaunch={handleSelect}
+                                />
                             )}
                         </For>
+                        <NewAgentCard disabled={busy()} />
                     </div>
                     <Show when={nodejsError()}>
                         <div class="agent-nodejs-notice">

--- a/frontend/app/view/agent/components/NewAgentCard.tsx
+++ b/frontend/app/view/agent/components/NewAgentCard.tsx
@@ -1,0 +1,37 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * NewAgentCard — "+ New agent" tile at the end of the picker list.
+ *
+ * PR 1 of specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md.
+ *
+ * Placeholder for now — clicking is a no-op until PR 2 wires it to
+ * open the ForgePanel in create mode.
+ */
+
+import type { JSX } from "solid-js";
+
+interface NewAgentCardProps {
+    onClick?: () => void;
+    disabled?: boolean;
+}
+
+export const NewAgentCard = (props: NewAgentCardProps): JSX.Element => {
+    return (
+        <button
+            class="agent-card agent-card--new"
+            onClick={() => props.onClick?.()}
+            disabled={props.disabled}
+            title="Create a new agent"
+        >
+            <span class="agent-card-icon">{"\u002B"}</span>
+            <span class="agent-card-info">
+                <span class="agent-card-name">New agent</span>
+                <span class="agent-card-desc">Define a new agent in the Forge</span>
+            </span>
+        </button>
+    );
+};
+
+NewAgentCard.displayName = "NewAgentCard";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.122",
+  "version": "0.33.123",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.122",
+      "version": "0.33.123",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.122",
+  "version": "0.33.123",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR 1 of \`specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md\`. Pure refactor: pull the inline \`<button class=\"agent-card\">\` out of \`AgentPicker\`'s \`<For>\` into its own component, and add a placeholder \`NewAgentCard\` tile at the end of the list.

## Scope

**New files:**
- \`components/AgentCard.tsx\` — the single-agent tile. Takes \`{ agent, launching, disabled, onLaunch }\`. No per-agent settings buttons yet — those come in PR 2.
- \`components/NewAgentCard.tsx\` — the \"+ New agent\" tile. Dashed border, muted \`+\` icon that brightens on hover. \`onClick\` is a no-op for now; PR 2 will wire it to open \`ForgePanel\` in create mode.

**Modified:**
- \`components/AgentPicker.tsx\` — swap the inline \`<button>\` for \`<AgentCard>\`, append \`<NewAgentCard>\` after the \`<For>\`.
- \`agent-view.scss\` — new \`.agent-card--new\` variant (dashed border, muted \`+\`).

## Behavior change

**Zero.** Same launch flow, same busy states, same \"No agents configured\" empty state. The \`+ New agent\` tile is intentionally dead until PR 2.

## Why this is first

Every later PR (buttons + ForgePanel + slide-over) depends on \`AgentCard\` existing as a standalone component — we can't drop settings buttons into an inline \`<button>\` block inside a \`<For>\`. This PR makes the surgery site ready.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Launch portable, open agent pane → see the agent list exactly as before
- [ ] \`+ New agent\` tile appears at the end of the list with dashed border
- [ ] Clicking an existing agent launches it (unchanged)
- [ ] Clicking \`+ New agent\` does nothing visible (placeholder)
- [ ] Hover highlight on \`+ New agent\` brightens the \`+\` icon

bump: 0.33.122 → 0.33.123

🤖 Generated with [Claude Code](https://claude.com/claude-code)