### PR TITLE
feat(agent): per-card Forge button + inline settings panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.123"
+version = "0.33.124"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.123"
+version = "0.33.124"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.123"
+version = "0.33.124"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.123"
+version = "0.33.124"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.123"
+version = "0.33.124"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.124"
+version = "0.33.125"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.124"
+version = "0.33.125"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.124"
+version = "0.33.125"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.124"
+version = "0.33.125"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.124"
+version = "0.33.125"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.123"
+version = "0.33.124"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.124"
+version = "0.33.125"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.124"
+version = "0.33.125"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.123"
+version = "0.33.124"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.124"
+version = "0.33.125"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.123"
+version = "0.33.124"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.123"
+version = "0.33.124"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.124"
+version = "0.33.125"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.124"
+version = "0.33.125"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.123"
+version = "0.33.124"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -277,6 +277,137 @@
             }
         }
 
+        &--disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .agent-card-actions {
+            display: flex;
+            gap: 4px;
+            margin-left: auto;
+            opacity: 0;
+            transition: opacity 0.15s;
+        }
+
+        &:hover .agent-card-actions,
+        &:focus-within .agent-card-actions {
+            opacity: 1;
+        }
+
+        .agent-card-action-btn {
+            width: 26px;
+            height: 26px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0;
+            border: 1px solid var(--border-color);
+            background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
+            border-radius: 4px;
+            color: var(--main-text-color);
+            font-size: 13px;
+            cursor: pointer;
+            transition: all 0.1s;
+
+            &:hover:not(:disabled) {
+                border-color: var(--accent-color);
+                background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+            }
+
+            &:disabled {
+                opacity: 0.4;
+                cursor: not-allowed;
+            }
+        }
+    }
+
+    .agent-card-settings-panel {
+        margin: 4px 0 12px 0;
+        border: 1px solid var(--accent-color);
+        border-radius: 6px;
+        background: color-mix(in srgb, var(--main-bg-color) 95%, transparent);
+        overflow: hidden;
+        max-height: 60vh;
+        display: flex;
+        flex-direction: column;
+
+        .agent-card-settings-header {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 10px;
+            border-bottom: 1px solid var(--border-color);
+            background: color-mix(in srgb, var(--accent-color) 5%, transparent);
+        }
+
+        .agent-card-settings-tabs {
+            display: flex;
+            gap: 4px;
+            flex: 1;
+        }
+
+        .agent-card-settings-tab {
+            padding: 4px 10px;
+            border: 1px solid var(--border-color);
+            background: transparent;
+            color: var(--secondary-text-color);
+            border-radius: 4px;
+            font-size: 12px;
+            cursor: pointer;
+            transition: all 0.1s;
+
+            &:hover:not(.active) {
+                color: var(--main-text-color);
+                border-color: var(--main-text-color);
+            }
+
+            &.active {
+                color: var(--main-text-color);
+                border-color: var(--accent-color);
+                background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+            }
+        }
+
+        .agent-card-settings-close {
+            width: 24px;
+            height: 24px;
+            padding: 0;
+            border: none;
+            background: transparent;
+            color: var(--secondary-text-color);
+            font-size: 14px;
+            cursor: pointer;
+            border-radius: 4px;
+
+            &:hover {
+                color: var(--main-text-color);
+                background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
+            }
+        }
+
+        .agent-card-settings-body {
+            flex: 1;
+            overflow: auto;
+            padding: 8px;
+            min-height: 200px;
+        }
+
+        .agent-card-settings-identity-stub {
+            padding: 20px;
+            color: var(--secondary-text-color);
+            font-size: 13px;
+            text-align: center;
+
+            .agent-card-settings-stub-note {
+                margin-top: 8px;
+                font-size: 11px;
+                opacity: 0.7;
+            }
+        }
+    }
+
+
         .agent-card-icon {
             font-size: 22px;
             flex-shrink: 0;

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -4,11 +4,16 @@
 /**
  * AgentCard — a single entry in the agent picker list.
  *
- * PR 1 of specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md.
+ * PR 2 of specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md
+ * adds the ⚙ Forge and 👤 Identity buttons that expand an inline
+ * settings panel below the card.
  *
- * For now this is a pure extraction of the inline button JSX that lived
- * inside AgentPicker's <For>. Later PRs add the per-agent Forge /
- * Identity buttons and the inline settings slide-over.
+ * Clicking the card body still launches the agent. The buttons call
+ * stopPropagation so they never accidentally trigger launch.
+ *
+ * The card is rendered as a <div role="button"> rather than <button>
+ * so nested action buttons are valid HTML (buttons can't contain
+ * buttons).
  */
 
 import { Show, type JSX } from "solid-js";
@@ -18,14 +23,37 @@ interface AgentCardProps {
     launching: boolean;
     disabled: boolean;
     onLaunch: (agent: ForgeAgent) => void;
+    onOpenForge: (agent: ForgeAgent) => void;
+    onOpenIdentity: (agent: ForgeAgent) => void;
 }
 
 export const AgentCard = (props: AgentCardProps): JSX.Element => {
+    const stopAndRun = (fn: () => void) => (e: MouseEvent) => {
+        e.stopPropagation();
+        fn();
+    };
+
+    const handleCardClick = () => {
+        if (!props.disabled) props.onLaunch(props.agent);
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (props.disabled) return;
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            props.onLaunch(props.agent);
+        }
+    };
+
     return (
-        <button
+        <div
             class={`agent-card${props.launching ? " agent-card--launching" : ""}`}
-            onClick={() => props.onLaunch(props.agent)}
-            disabled={props.disabled}
+            classList={{ "agent-card--disabled": props.disabled }}
+            onClick={handleCardClick}
+            onKeyDown={handleKeyDown}
+            role="button"
+            tabIndex={props.disabled ? -1 : 0}
+            aria-disabled={props.disabled}
         >
             <span class="agent-card-icon">{props.agent.icon}</span>
             <span class="agent-card-info">
@@ -34,10 +62,30 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
                     <span class="agent-card-desc">{props.agent.description}</span>
                 </Show>
             </span>
+            <div class="agent-card-actions">
+                <button
+                    class="agent-card-action-btn"
+                    onClick={stopAndRun(() => props.onOpenForge(props.agent))}
+                    title="Configure this agent in the Forge"
+                    disabled={props.disabled}
+                    type="button"
+                >
+                    {"\u2699"}
+                </button>
+                <button
+                    class="agent-card-action-btn"
+                    onClick={stopAndRun(() => props.onOpenIdentity(props.agent))}
+                    title="Manage this agent's identity"
+                    disabled={props.disabled}
+                    type="button"
+                >
+                    {"\uD83D\uDC64"}
+                </button>
+            </div>
             <Show when={props.launching}>
                 <span class="agent-card-spinner" />
             </Show>
-        </button>
+        </div>
     );
 };
 

--- a/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
+++ b/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
@@ -39,12 +39,20 @@ export const AgentCardSettingsPanel = (props: AgentCardSettingsPanelProps): JSX.
     // so the wave-event subscriptions are cleaned up.
     const forgeModel = new ForgeViewModel(props.blockId, props.nodeModel);
 
+    // Guard for the auto-close effect below. ForgeViewModel initializes
+    // viewAtom to "list" synchronously in its constructor, and createEffect
+    // fires once during component creation (before onMount). Without this
+    // flag the effect would see v === "list" immediately and close the
+    // panel before we've had a chance to call openDetail / startCreate.
+    let mounted = false;
+
     onMount(() => {
         if (props.agent) {
             void forgeModel.openDetail(props.agent);
         } else {
             forgeModel.startCreate();
         }
+        mounted = true;
 
         const handleKey = (e: KeyboardEvent) => {
             if (e.key === "Escape") {
@@ -61,11 +69,13 @@ export const AgentCardSettingsPanel = (props: AgentCardSettingsPanelProps): JSX.
     });
 
     // When the ForgeViewModel view flips back to "list" (e.g. user clicked
-    // the in-panel Back button inside ForgeDetail) we want to close the
-    // whole settings panel — the user explicitly asked to exit.
+    // the in-panel Back button inside ForgeDetail, or saved a create/edit)
+    // we want to close the whole settings panel — the user explicitly
+    // asked to exit. Only fires after mount to avoid the synchronous
+    // initial-run problem described above.
     createEffect(() => {
         const v = forgeModel.viewAtom();
-        if (v === "list") {
+        if (mounted && v === "list") {
             props.onClose();
         }
     });

--- a/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
+++ b/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
@@ -1,0 +1,121 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentCardSettingsPanel — inline settings panel that expands below a
+ * clicked AgentCard. Hosts the Forge and Identity tabs for a single
+ * agent.
+ *
+ * PR 2 of specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md.
+ *
+ * Instantiates a dedicated ForgeViewModel on mount (lifetime = panel
+ * lifetime) and delegates to the existing ForgeDetail / ForgeForm
+ * components. No rewrite of Forge internals — just reuse.
+ *
+ * Identity tab is a stub for now; PR 3 wires the IdentityPanel.
+ */
+
+import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import type { BlockNodeModel } from "@/app/block/blocktypes";
+import { ForgeViewModel } from "@/app/view/forge/forge-model";
+import { ForgeDetail } from "@/app/view/forge/components/ForgeDetail";
+import { ForgeForm } from "@/app/view/forge/components/ForgeForm";
+
+export type SettingsTab = "forge" | "identity";
+
+interface AgentCardSettingsPanelProps {
+    blockId: string;
+    nodeModel: BlockNodeModel;
+    /** The agent being edited. Undefined = create mode (new agent). */
+    agent: ForgeAgent | undefined;
+    initialTab: SettingsTab;
+    onClose: () => void;
+}
+
+export const AgentCardSettingsPanel = (props: AgentCardSettingsPanelProps): JSX.Element => {
+    const [tab, setTab] = createSignal<SettingsTab>(props.initialTab);
+
+    // Dedicated Forge model for this panel session. Disposed on unmount
+    // so the wave-event subscriptions are cleaned up.
+    const forgeModel = new ForgeViewModel(props.blockId, props.nodeModel);
+
+    onMount(() => {
+        if (props.agent) {
+            void forgeModel.openDetail(props.agent);
+        } else {
+            forgeModel.startCreate();
+        }
+
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.preventDefault();
+                props.onClose();
+            }
+        };
+        window.addEventListener("keydown", handleKey);
+        onCleanup(() => window.removeEventListener("keydown", handleKey));
+    });
+
+    onCleanup(() => {
+        forgeModel.dispose();
+    });
+
+    // When the ForgeViewModel view flips back to "list" (e.g. user clicked
+    // the in-panel Back button inside ForgeDetail) we want to close the
+    // whole settings panel — the user explicitly asked to exit.
+    createEffect(() => {
+        const v = forgeModel.viewAtom();
+        if (v === "list") {
+            props.onClose();
+        }
+    });
+
+    return (
+        <div class="agent-card-settings-panel">
+            <div class="agent-card-settings-header">
+                <div class="agent-card-settings-tabs">
+                    <button
+                        class={`agent-card-settings-tab${tab() === "forge" ? " active" : ""}`}
+                        onClick={() => setTab("forge")}
+                    >
+                        {"\u2699"} Forge
+                    </button>
+                    <button
+                        class={`agent-card-settings-tab${tab() === "identity" ? " active" : ""}`}
+                        onClick={() => setTab("identity")}
+                    >
+                        {"\uD83D\uDC64"} Identity
+                    </button>
+                </div>
+                <button
+                    class="agent-card-settings-close"
+                    onClick={() => props.onClose()}
+                    title="Close (Esc)"
+                >
+                    {"\u2715"}
+                </button>
+            </div>
+
+            <div class="agent-card-settings-body">
+                <Show when={tab() === "forge"}>
+                    <Show
+                        when={forgeModel.viewAtom() === "create" || forgeModel.viewAtom() === "edit"}
+                        fallback={<ForgeDetail model={forgeModel} />}
+                    >
+                        <ForgeForm model={forgeModel} />
+                    </Show>
+                </Show>
+                <Show when={tab() === "identity"}>
+                    <div class="agent-card-settings-identity-stub">
+                        <p>Identity settings for this agent will appear here.</p>
+                        <p class="agent-card-settings-stub-note">
+                            Wired in PR 3 of the consolidation spec.
+                        </p>
+                    </div>
+                </Show>
+            </div>
+        </div>
+    );
+};
+
+AgentCardSettingsPanel.displayName = "AgentCardSettingsPanel";

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -93,14 +93,29 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
 
     const openForgeFor = (agent: ForgeAgent) => {
         setCreateMode(false);
+        // Capture the previous tab BEFORE switching — otherwise we can't
+        // tell whether clicking ⚙ on an expanded card means "collapse"
+        // (already on forge) or "switch from identity to forge".
+        const prevTab = expandedTab();
+        const prevId = expandedId();
         setExpandedTab("forge");
-        setExpandedId((prev) => (prev === agent.id && expandedTab() === "forge" ? null : agent.id));
+        if (prevId === agent.id && prevTab === "forge") {
+            setExpandedId(null);
+        } else {
+            setExpandedId(agent.id);
+        }
     };
 
     const openIdentityFor = (agent: ForgeAgent) => {
         setCreateMode(false);
+        const prevTab = expandedTab();
+        const prevId = expandedId();
         setExpandedTab("identity");
-        setExpandedId((prev) => (prev === agent.id && expandedTab() === "identity" ? null : agent.id));
+        if (prevId === agent.id && prevTab === "identity") {
+            setExpandedId(null);
+        } else {
+            setExpandedId(agent.id);
+        }
     };
 
     const openCreateNew = () => {

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -17,6 +17,7 @@ import { waveEventSubscribe } from "@/app/store/wps";
 import type { AgentViewModel } from "../agent-model";
 import { AgentCard } from "./AgentCard";
 import { NewAgentCard } from "./NewAgentCard";
+import { AgentCardSettingsPanel, type SettingsTab } from "./AgentCardSettingsPanel";
 
 // ── useForgeAgents hook ───────────────────────────────────────────────────────
 
@@ -66,6 +67,13 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     const [nodejsError, setNodejsError] = createSignal<string | null>(null);
     const agents = useForgeAgents();
 
+    // Inline settings-panel state: which agent is expanded and which tab
+    // (forge/identity) is active. `null` agentId means "create new" mode.
+    // Session-local only — not persisted to block meta.
+    const [expandedId, setExpandedId] = createSignal<string | null>(null);
+    const [expandedTab, setExpandedTab] = createSignal<SettingsTab>("forge");
+    const [createMode, setCreateMode] = createSignal(false);
+
     const handleSelect = async (agent: ForgeAgent) => {
         setNodejsError(null);
         setLaunching(agent.id);
@@ -81,6 +89,29 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         } finally {
             setLaunching(null);
         }
+    };
+
+    const openForgeFor = (agent: ForgeAgent) => {
+        setCreateMode(false);
+        setExpandedTab("forge");
+        setExpandedId((prev) => (prev === agent.id && expandedTab() === "forge" ? null : agent.id));
+    };
+
+    const openIdentityFor = (agent: ForgeAgent) => {
+        setCreateMode(false);
+        setExpandedTab("identity");
+        setExpandedId((prev) => (prev === agent.id && expandedTab() === "identity" ? null : agent.id));
+    };
+
+    const openCreateNew = () => {
+        setCreateMode(true);
+        setExpandedTab("forge");
+        setExpandedId("__new__");
+    };
+
+    const closePanel = () => {
+        setExpandedId(null);
+        setCreateMode(false);
     };
 
     const busy = () => launching() !== null;
@@ -106,15 +137,40 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     <div class="agent-picker-list">
                         <For each={agents()}>
                             {(agent) => (
-                                <AgentCard
-                                    agent={agent}
-                                    launching={launching() === agent.id}
-                                    disabled={busy()}
-                                    onLaunch={handleSelect}
-                                />
+                                <>
+                                    <AgentCard
+                                        agent={agent}
+                                        launching={launching() === agent.id}
+                                        disabled={busy()}
+                                        onLaunch={handleSelect}
+                                        onOpenForge={openForgeFor}
+                                        onOpenIdentity={openIdentityFor}
+                                    />
+                                    <Show when={expandedId() === agent.id && !createMode()}>
+                                        <AgentCardSettingsPanel
+                                            blockId={props.model.blockId}
+                                            nodeModel={props.model.nodeModel}
+                                            agent={agent}
+                                            initialTab={expandedTab()}
+                                            onClose={closePanel}
+                                        />
+                                    </Show>
+                                </>
                             )}
                         </For>
-                        <NewAgentCard disabled={busy()} />
+                        <NewAgentCard
+                            disabled={busy()}
+                            onClick={openCreateNew}
+                        />
+                        <Show when={expandedId() === "__new__" && createMode()}>
+                            <AgentCardSettingsPanel
+                                blockId={props.model.blockId}
+                                nodeModel={props.model.nodeModel}
+                                agent={undefined}
+                                initialTab="forge"
+                                onClose={closePanel}
+                            />
+                        </Show>
                     </div>
                     <Show when={nodejsError()}>
                         <div class="agent-nodejs-notice">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.123",
+  "version": "0.33.124",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.123",
+      "version": "0.33.124",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.124",
+  "version": "0.33.125",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.124",
+      "version": "0.33.125",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.124",
+  "version": "0.33.125",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.123",
+  "version": "0.33.124",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR 2 of \`specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md\`.

Every agent card in the picker now has **⚙ Forge** and **👤 Identity** buttons. Clicking either expands an inline settings panel below the card, scoped to that specific agent. Clicking the card body still launches — buttons use \`stopPropagation\`.

The \`+ New agent\` tile from PR 1 is now wired to open the same panel in create mode.

## What the user sees

- Hover over any agent card → two small buttons fade in on the right (⚙ for Forge config, 👤 for Identity).
- Click ⚙ → the card expands, revealing a tabbed settings panel with the full Forge Detail view for that agent (soul / agentmd / mcp / env / skills / history).
- Click 👤 → same panel, Identity tab. Currently shows a stub; PR 3 wires the real Identity UI.
- Tab switcher inside the panel header lets you flip between Forge and Identity without collapsing.
- Esc, close button, or clicking another card's ⚙ collapses/swaps the panel.
- \`+ New agent\` tile opens the panel in create mode — \`ForgeForm\` with empty fields.

## Scope

**New file** — \`components/AgentCardSettingsPanel.tsx\` (~110 lines):
- Instantiates a dedicated \`ForgeViewModel\` for its lifetime (per-panel, not per-pane) and disposes it on unmount so the wave-event subscriptions are cleaned up.
- On mount: calls \`forgeModel.openDetail(agent)\` for edit mode, \`forgeModel.startCreate()\` for create mode.
- Renders \`<ForgeDetail>\` or \`<ForgeForm>\` based on \`forgeModel.viewAtom()\` — reuses the existing Forge components unchanged, no rewrite.
- Watches \`viewAtom === \"list\"\` to auto-close the panel after the user hits Back inside ForgeDetail.
- Esc key handler installed in \`onMount\`, removed in \`onCleanup\`.

**Modified** — \`components/AgentCard.tsx\`:
- Rendered as \`<div role=\"button\">\` so nested \`<button>\` action buttons are valid HTML.
- Two action buttons on the right with \`stopPropagation\` handlers.
- Hover-reveal on the action buttons (opacity 0 → 1) so they don't clutter the list at rest.
- \`Enter\` / \`Space\` keyboard support for launching (since we lost the native \`<button>\`).

**Modified** — \`components/AgentPicker.tsx\`:
- New signals: \`expandedId\`, \`expandedTab\`, \`createMode\`.
- \`openForgeFor\` / \`openIdentityFor\` / \`openCreateNew\` / \`closePanel\` handlers.
- Each \`<AgentCard>\` in the list is now followed by a \`<Show when={expandedId() === agent.id}>\` that mounts \`<AgentCardSettingsPanel>\` inline.
- Create mode uses a sentinel \`'__new__'\` id and renders its panel after \`<NewAgentCard>\`.

**Modified** — \`agent-view.scss\`:
- \`.agent-card-actions\` — flex row, hover-reveal via \`opacity\` transition.
- \`.agent-card-action-btn\` — 26×26 square, hover → accent-color border.
- \`.agent-card-settings-panel\` — bordered container, max-height 60vh with internal scroll, tab header, close button.

## Zero Forge rewrite

The existing \`ForgeDetail\`, \`ForgeForm\`, \`ForgeContentSection\`, \`ForgeSkillsPanel\`, \`ForgeHistoryPanel\` components are untouched. They already accept a \`ForgeViewModel\` prop — we just hand them a per-panel instance instead of the one the forge widget used to create. Same atoms, same event subscriptions, same behavior.

## Why a new ForgeViewModel per panel

Each panel creates its own \`ForgeViewModel\`. Reasons:
1. **Isolation**: multiple agent panes open simultaneously shouldn't share Forge edit state.
2. **Lifecycle**: the model's wave-event subscriptions (\`forgeagents:changed\`, \`forgecontent:changed\`, etc.) live with the panel — close the panel, dispose the subscriptions.
3. **Simplicity**: no need to thread a shared model through the agent view tree.

The cost is ~4 wave-event subscriptions per open panel. Negligible.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Launch portable, open agent pane with existing agents
- [ ] Hover over an agent card → ⚙ and 👤 buttons appear
- [ ] Click ⚙ → panel expands below the card with ForgeDetail for that agent
- [ ] Edit the agent's description in the Content section → save → see the change in the card
- [ ] Click 👤 → panel swaps to Identity tab showing the stub
- [ ] Click ⚙ on a different agent → panel target swaps without flashing
- [ ] Esc collapses the panel
- [ ] Click the close button (×) in the panel header → collapses
- [ ] Click \`+ New agent\` → panel opens in create mode with empty ForgeForm
- [ ] Fill in name + provider → save → panel closes, new agent appears in the list
- [ ] Click the card body (not a button) → launches the agent (unchanged)

## Next

- **PR 3** — wire the real \`IdentityPanel\` into the Identity tab (replaces the stub)
- **PR 4** — remove \`defwidget@forge\` and \`defwidget@identity\` from the widget bar, migrate existing panes

bump: 0.33.123 → 0.33.124

🤖 Generated with [Claude Code](https://claude.com/claude-code)