### PR TITLE
feat(agent): wire IdentityPanel into per-agent settings tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.125"
+version = "0.33.126"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.125"
+version = "0.33.126"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.125"
+version = "0.33.126"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.125"
+version = "0.33.126"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.125"
+version = "0.33.126"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.126"
+version = "0.33.127"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.126"
+version = "0.33.127"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.126"
+version = "0.33.127"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.126"
+version = "0.33.127"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.126"
+version = "0.33.127"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.126"
+version = "0.33.127"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.125"
+version = "0.33.126"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.126"
+version = "0.33.127"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.125"
+version = "0.33.126"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.126"
+version = "0.33.127"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.125"
+version = "0.33.126"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.126"
+version = "0.33.127"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.125"
+version = "0.33.126"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.125"
+version = "0.33.126"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.126"
+version = "0.33.127"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -393,18 +393,6 @@
             min-height: 200px;
         }
 
-        .agent-card-settings-identity-stub {
-            padding: 20px;
-            color: var(--secondary-text-color);
-            font-size: 13px;
-            text-align: center;
-
-            .agent-card-settings-stub-note {
-                margin-top: 8px;
-                font-size: 11px;
-                opacity: 0.7;
-            }
-        }
     }
 
 

--- a/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
+++ b/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
@@ -20,6 +20,8 @@ import type { BlockNodeModel } from "@/app/block/blocktypes";
 import { ForgeViewModel } from "@/app/view/forge/forge-model";
 import { ForgeDetail } from "@/app/view/forge/components/ForgeDetail";
 import { ForgeForm } from "@/app/view/forge/components/ForgeForm";
+import { IdentityViewModel } from "@/app/view/identity/identity-model";
+import { IdentityPanel } from "@/app/view/identity/identity-view";
 
 export type SettingsTab = "forge" | "identity";
 
@@ -38,6 +40,11 @@ export const AgentCardSettingsPanel = (props: AgentCardSettingsPanelProps): JSX.
     // Dedicated Forge model for this panel session. Disposed on unmount
     // so the wave-event subscriptions are cleaned up.
     const forgeModel = new ForgeViewModel(props.blockId, props.nodeModel);
+
+    // Dedicated Identity model for the Identity tab. Currently shows the
+    // global account list (same as the old identity widget); per-agent
+    // scoping is deferred to SPEC_FORGE_AGENT_IDENTITY_2026_04_13.md.
+    const identityModel = new IdentityViewModel(props.blockId, props.nodeModel);
 
     // Guard for the auto-close effect below. ForgeViewModel initializes
     // viewAtom to "list" synchronously in its constructor, and createEffect
@@ -66,6 +73,7 @@ export const AgentCardSettingsPanel = (props: AgentCardSettingsPanelProps): JSX.
 
     onCleanup(() => {
         forgeModel.dispose();
+        identityModel.dispose();
     });
 
     // When the ForgeViewModel view flips back to "list" (e.g. user clicked
@@ -116,12 +124,7 @@ export const AgentCardSettingsPanel = (props: AgentCardSettingsPanelProps): JSX.
                     </Show>
                 </Show>
                 <Show when={tab() === "identity"}>
-                    <div class="agent-card-settings-identity-stub">
-                        <p>Identity settings for this agent will appear here.</p>
-                        <p class="agent-card-settings-stub-note">
-                            Wired in PR 3 of the consolidation spec.
-                        </p>
-                    </div>
+                    <IdentityPanel model={identityModel} />
                 </Show>
             </div>
         </div>

--- a/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
+++ b/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
@@ -8,11 +8,14 @@
  *
  * PR 2 of specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md.
  *
- * Instantiates a dedicated ForgeViewModel on mount (lifetime = panel
- * lifetime) and delegates to the existing ForgeDetail / ForgeForm
- * components. No rewrite of Forge internals — just reuse.
+ * Instantiates a dedicated ForgeViewModel and IdentityViewModel
+ * on mount (lifetime = panel lifetime) and delegates to the existing
+ * ForgeDetail / ForgeForm / IdentityPanel components. No rewrite of
+ * Forge or Identity internals — just reuse.
  *
- * Identity tab is a stub for now; PR 3 wires the IdentityPanel.
+ * The Identity tab currently shows the global account list (same
+ * data as the old identity widget). Per-agent scoping is deferred
+ * to SPEC_FORGE_AGENT_IDENTITY_2026_04_13.md.
  */
 
 import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -33,6 +33,17 @@ const STATUS_DOT: Record<string, string> = {
 // ── Root view ────────────────────────────────────────────────────────────────
 
 export function IdentityView(props: ViewComponentProps<IdentityViewModel>): JSX.Element {
+    return <IdentityPanel model={props.model} />;
+}
+
+// ── IdentityPanel — reusable body ────────────────────────────────────────────
+//
+// Takes the model directly (no ViewComponentProps wrapper) so it can be
+// composed inside other views — notably the per-agent settings panel
+// in the agent picker. See
+// specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md (PR 3).
+
+export function IdentityPanel(props: { model: IdentityViewModel }): JSX.Element {
     const model = props.model;
 
     return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.126",
+  "version": "0.33.127",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.126",
+      "version": "0.33.127",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.125",
+  "version": "0.33.126",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.125",
+      "version": "0.33.126",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.126",
+  "version": "0.33.127",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.125",
+  "version": "0.33.126",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR 3 of \`specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md\`. Replaces the stub 'Coming soon' text in the Identity tab (from PR #364) with the real Identity UI.

## Scope

**Modified** — \`frontend/app/view/identity/identity-view.tsx\`:
- Export a new \`IdentityPanel({ model })\` component that takes the model directly (no \`ViewComponentProps\` wrapper).
- Existing \`IdentityView\` becomes a one-line shell that delegates to \`<IdentityPanel model={props.model} />\`. The \`identity\` widget still works identically.

**Modified** — \`frontend/app/view/agent/components/AgentCardSettingsPanel.tsx\`:
- Instantiate a dedicated \`IdentityViewModel\` alongside the existing per-panel \`ForgeViewModel\`.
- Dispose both on unmount.
- Swap the stub \`<div>\` in the Identity tab for \`<IdentityPanel model={identityModel} />\`.

**Modified** — \`frontend/app/view/agent/agent-view.scss\`:
- Drop the now-unused \`.agent-card-settings-identity-stub\` class.

## Behavior change

- Clicking the 👤 Identity button on any agent card now opens the full Identity management UI inline: Accounts tab with create/edit/delete, Assignments tab, add-account form overlay.
- The old \`identity\` widget is untouched and still works. PR 4 removes it.

## Scope note

This PR wires the existing **global** identity UI into the per-agent tab. Per-agent scoping (showing only the accounts assigned to *this* agent, assignment toggling from the agent card) is deferred to \`SPEC_FORGE_AGENT_IDENTITY_2026_04_13.md\`. For now the user sees the full account list no matter which agent they clicked 👤 on — it's the same data, just a different entry point.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Launch portable, open agent pane
- [ ] Click 👤 on an agent card → panel expands with real IdentityPanel (Accounts/Assignments tabs)
- [ ] Click \"+ Add\" → account form overlay opens
- [ ] Create a GitHub account → appears in the Accounts list
- [ ] Switch to Assignments tab → see it populated
- [ ] Close panel → open again → state preserved (panel still alive)
- [ ] Click 👤 on a different agent → same UI (global scope for now)
- [ ] Old \`identity\` widget still opens and works independently

## Next

- **PR 4** — remove \`defwidget@forge\` + \`defwidget@identity\`, migrate existing panes

bump: 0.33.125 → 0.33.126

🤖 Generated with [Claude Code](https://claude.com/claude-code)