### PR TITLE
feat(agent): remove Forge + Identity widgets from the widget bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.127"
+version = "0.33.128"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.127"
+version = "0.33.128"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.127"
+version = "0.33.128"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.127"
+version = "0.33.128"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.127"
+version = "0.33.128"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.127"
+version = "0.33.128"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.127"
+version = "0.33.128"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.127"
+version = "0.33.128"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.127"
+version = "0.33.128"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -17,30 +17,6 @@
             }
         }
     },
-    "defwidget@forge": {
-        "display:order": 2,
-        "icon": "hammer",
-        "color": "#a78bfa",
-        "label": "forge",
-        "description": "Create and manage your agents",
-        "blockdef": {
-            "meta": {
-                "view": "forge"
-            }
-        }
-    },
-    "defwidget@identity": {
-        "display:order": 3,
-        "icon": "id-card",
-        "color": "#a78bfa",
-        "label": "identity",
-        "description": "External account and credential management",
-        "blockdef": {
-            "meta": {
-                "view": "identity"
-            }
-        }
-    },
     "defwidget@swarm": {
         "display:order": 4,
         "display:hidden": true,

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.127"
+version = "0.33.128"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -12,10 +12,8 @@ import {
 import { LauncherViewModel } from "@/app/view/launcher/launcher";
 import { SysinfoViewModel } from "@/app/view/sysinfo/sysinfo";
 import { AgentViewModel } from "@/app/view/agent";
-import { ForgeViewModel } from "@/app/view/forge/forge";
 import { SubagentViewModel } from "@/app/view/subagent/subagent";
 import { SwarmViewModel } from "@/app/view/swarm/swarm";
-import { IdentityViewModel } from "@/app/view/identity/identity";
 import { ErrorBoundary } from "@/element/errorboundary";
 import { CenteredDiv } from "@/element/quickelems";
 import { NodeModel, useDebouncedNodeInnerRect } from "@/layout/index";
@@ -44,17 +42,22 @@ BlockRegistry.set("sysinfo", SysinfoViewModel as any);
 BlockRegistry.set("help", HelpViewModel as any);
 BlockRegistry.set("launcher", LauncherViewModel as any);
 BlockRegistry.set("agent", AgentViewModel as any);
-BlockRegistry.set("forge", ForgeViewModel as any);
 BlockRegistry.set("subagent", SubagentViewModel as any);
 BlockRegistry.set("swarm", SwarmViewModel as any);
-BlockRegistry.set("identity", IdentityViewModel as any);
 
 function makeViewModel(blockId: string, blockView: string, nodeModel: NodeModel): ViewModel {
-    const ctor = BlockRegistry.get(blockView);
+    // Consolidation migration: the forge and identity widgets have been
+    // merged into the agent picker's per-card settings panel. Any saved
+    // pane with view: "forge" or view: "identity" now renders as an
+    // agent pane — the user sees the picker with the ⚙ / 👤 buttons and
+    // can find the same functionality there.
+    // See specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md (PR 4).
+    const effectiveView = (blockView === "forge" || blockView === "identity") ? "agent" : blockView;
+    const ctor = BlockRegistry.get(effectiveView);
     if (ctor != null) {
         return new ctor(blockId, nodeModel as any);
     }
-    return makeDefaultViewModel(blockId, blockView);
+    return makeDefaultViewModel(blockId, effectiveView);
 }
 
 function getViewElem(

--- a/frontend/app/store/command-registry.ts
+++ b/frontend/app/store/command-registry.ts
@@ -114,27 +114,11 @@ export function registerDefaultCommands(): void {
             createBlock({ meta: { view: "agent", controller: "cmd", cmd: "", "cmd:args": [], "cmd:interactive": true, "cmd:runonstart": false } }),
     });
     commandRegistry.register({
-        id: "open:forge",
-        label: "Open Forge",
-        category: "Open",
-        icon: "hammer",
-        iconColor: "#a78bfa",
-        execute: () => createBlock({ meta: { view: "forge" } }),
-    });
-    commandRegistry.register({
         id: "open:sysinfo",
         label: "Open System Info",
         category: "Open",
         icon: "chart-line",
         execute: () => createBlock({ meta: { view: "sysinfo" } }),
-    });
-    commandRegistry.register({
-        id: "open:identity",
-        label: "Open Identity",
-        category: "Open",
-        icon: "id-card",
-        iconColor: "#a78bfa",
-        execute: () => createBlock({ meta: { view: "identity" } }),
     });
     commandRegistry.register({
         id: "open:help",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.127",
+  "version": "0.33.128",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.127",
+      "version": "0.33.128",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.127",
+  "version": "0.33.128",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**Final PR** of \`specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md\`. The forge and identity widgets are now accessible via the per-agent buttons inside the agent picker (shipped in PRs #364 and #365). This PR removes the top-level entries.

## Changes

**\`agentmux-srv/src/config/widgets.json\`**
- Drop \`defwidget@forge\` and \`defwidget@identity\` entries.
- Widget bar now shows: \`agent\`, \`swarm\` (hidden), \`terminal\`, \`sysinfo\`, \`settings\`, \`help\`, \`devtools\`.

**\`frontend/app/block/block.tsx\`**
- Drop \`ForgeViewModel\` and \`IdentityViewModel\` imports + \`BlockRegistry\` registrations.
- **Migration shim** in \`makeViewModel\`: saved panes with \`view: \"forge\"\` or \`view: \"identity\"\` now resolve to \`view: \"agent\"\`. Users with those panes open see the agent picker (with the ⚙/👤 buttons on each card) instead of a broken pane.

**\`frontend/app/store/command-registry.ts\`**
- Remove the \`open:forge\` and \`open:identity\` palette commands.

## Not deleted

- \`frontend/app/view/forge/\` — still referenced by \`AgentCardSettingsPanel\` which imports \`ForgeViewModel\` from \`forge-model.ts\` and \`ForgeDetail\` / \`ForgeForm\` from \`components/\`. The directory stays, just not as a top-level view.
- \`frontend/app/view/identity/\` — same reason (\`AgentCardSettingsPanel\` imports \`IdentityViewModel\` from \`identity-model.ts\` and \`IdentityPanel\` from \`identity-view.tsx\`).

## Zero backend change

All RPCs (\`ListForgeAgentsCommand\`, \`CreateForgeAgentCommand\`, identity account RPCs, etc.) are unchanged. The data model is untouched.

## Consolidation summary (4 PRs)

| PR | What |
|---|---|
| #363 | Extract \`AgentCard\` + \`NewAgentCard\` |
| #364 | Per-card ⚙ Forge button + inline settings panel + create mode |
| #365 | Wire real \`IdentityPanel\` into the Identity tab |
| **this** | Remove the widgets + migrate existing panes |

## Test plan

- [x] \`npx tsc --noEmit\` clean on all touched files
- [ ] Launch portable, open widget bar → no forge, no identity entries
- [ ] Command palette → \"Open Forge\" / \"Open Identity\" are gone
- [ ] Open agent pane → picker shows agent list with per-card buttons (unchanged from PR #364)
- [ ] Click ⚙ on an agent → Forge panel still works
- [ ] Click 👤 on an agent → Identity panel still works
- [ ] **Migration:** create a fresh pane, manually set its \`meta.view = \"forge\"\` via the block service, reload → pane renders as an agent pane (picker), NOT as a broken/empty pane
- [ ] Same for \`view: \"identity\"\`

## Follow-up

- \`SPEC_FORGE_AGENT_IDENTITY_2026_04_13.md\` — scope the Identity panel to just the accounts assigned to the clicked agent, add assignment toggle inside the panel.
- Eventual deletion of \`forge-view.tsx\` / \`identity-view.tsx\` shells once we're confident no saved layouts reference them.

bump: 0.33.127 → 0.33.128

🤖 Generated with [Claude Code](https://claude.com/claude-code)