### PR TITLE
fix(agent): restore tool hover-expand via Portal to escape paint containment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.133"
+version = "0.33.134"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.133"
+version = "0.33.134"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.133"
+version = "0.33.134"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.133"
+version = "0.33.134"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.133"
+version = "0.33.134"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.132"
+version = "0.33.133"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.132"
+version = "0.33.133"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.132"
+version = "0.33.133"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.132"
+version = "0.33.133"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.132"
+version = "0.33.133"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.133"
+version = "0.33.134"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.132"
+version = "0.33.133"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.132"
+version = "0.33.133"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.133"
+version = "0.33.134"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.133"
+version = "0.33.134"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.132"
+version = "0.33.133"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.132"
+version = "0.33.133"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.133"
+version = "0.33.134"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.132"
+version = "0.33.133"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.133"
+version = "0.33.134"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -782,40 +782,18 @@
             cursor: text;
         }
 
-        // Overlay mode — applied when the block is expanded via hover or
-        // pin (but NOT when running/failed forces it expanded). The content
-        // floats on top of whatever is below in document flow so the
-        // surrounding tools/messages don't get pushed down.
+        // Overlay mode is implemented via a <Portal> to document.body so
+        // the overlay escapes the `content-visibility: auto` paint
+        // containment on `.agent-document-node-wrapper`. Without the
+        // portal, the absolute-positioned overlay would be paint-clipped
+        // at the wrapper's edge and invisible on hover.
         //
-        // The overlay is still a DOM descendant of `.agent-tool-block`, so
-        // `mouseenter`/`mouseleave` on the parent cover both the summary
-        // row and the floating content without any timers or tolerance.
-        &.overlay-mode .agent-tool-content {
-            position: absolute;
-            top: 100%;
-            left: 0;
-            right: 0;
-            z-index: 20;
-            background: var(--main-bg-color);
-            border: 1px solid var(--border-color);
-            border-top: none;
-            border-radius: 0 0 3px 3px;
-            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
-            max-height: min(400px, 60vh);
-            overflow-y: auto;
-            padding: 6px 10px 8px 20px;
-        }
-
-        // Flip variant — when JS detects <400px of room below the block
-        // in its scroll container, the overlay opens UP instead of DOWN.
-        &.overlay-mode.overlay-up .agent-tool-content {
-            top: auto;
-            bottom: 100%;
-            border-top: 1px solid var(--border-color);
-            border-bottom: none;
-            border-radius: 3px 3px 0 0;
-            box-shadow: 0 -6px 20px rgba(0, 0, 0, 0.35);
-        }
+        // See .agent-tool-content--portal below for the portaled element's
+        // visual styling (background, border, shadow, z-index).
+        //
+        // The inline `.agent-tool-content` rule above still applies when
+        // the block is force-expanded (running/failed) — those render
+        // inline in the document flow, not in the portal.
 
         .agent-tool-loading {
             color: var(--secondary-text-color);
@@ -2544,5 +2522,35 @@
         opacity: 0.6;
         font-style: italic;
         color: var(--secondary-text-color);
+    }
+}
+
+// Portal-rendered tool overlay — lives at document.body level so it escapes
+// paint containment on .agent-document-node-wrapper (content-visibility).
+// Positioning is handled inline in the ToolBlock render (fixed, top/left/width
+// computed from the summary row's rect on hover). This rule is top-level
+// rather than nested inside .agent-view because SolidJS <Portal> mounts to
+// document.body by default.
+.agent-tool-content--portal {
+    z-index: 200;
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0 0 3px 3px;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+    max-height: min(400px, 60vh);
+    overflow-y: auto;
+    padding: 6px 10px 8px 20px;
+    cursor: default;
+    user-select: text;
+    font-family: var(--fixed-font, monospace);
+    font-size: 12px;
+    color: var(--main-text-color);
+
+    // Flip variant — overlay opens upward when there isn't enough room
+    // below the block. Swap the border-radius so the rounded side is on
+    // top of the overlay (adjacent to where the summary row is).
+    &.overlay-up {
+        border-radius: 3px 3px 0 0;
+        box-shadow: 0 -6px 20px rgba(0, 0, 0, 0.35);
     }
 }

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -29,7 +29,8 @@
  */
 
 import clsx from "clsx";
-import { Show, createSignal, type JSX } from "solid-js";
+import { Show, createEffect, createSignal, onCleanup, type JSX } from "solid-js";
+import { Portal } from "solid-js/web";
 import { createBlock } from "@/store/global";
 import type { ToolNode } from "../types";
 import { BashOutputViewer } from "./BashOutputViewer";
@@ -71,12 +72,21 @@ const OVERLAY_MAX_HEIGHT_PX = 400;
 
 export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     const [hovered, setHovered] = createSignal(false);
-    // `true` when the overlay should pop UP above the summary row instead of
-    // down below it. Decided on each mouseenter by measuring against the
-    // scroll parent — not reactive to layout changes, just a one-time check
-    // at hover time. Recomputed on every mouseenter so scrolling between
-    // hovers picks up the new position.
+    // Position of the collapsed row in viewport coordinates, recomputed on
+    // mouseenter. The overlay is rendered via a <Portal> to document.body to
+    // escape the paint containment imposed by .agent-document-node-wrapper's
+    // `content-visibility: auto` — otherwise the absolute-positioned overlay
+    // gets clipped at the wrapper's edge and the hover expansion is invisible.
+    const [overlayRect, setOverlayRect] = createSignal<{
+        left: number;
+        right: number;
+        top: number;    // used when overlayUp = false (drop down below the row)
+        bottom: number; // used when overlayUp = true  (pop up above the row)
+        width: number;
+    } | null>(null);
     const [overlayUp, setOverlayUp] = createSignal(false);
+
+    let blockRef: HTMLDivElement | undefined;
 
     // Force-expand rules — override hover/pin when the user must see content.
     // `failed` stays expanded so errors are immediately visible.
@@ -94,26 +104,78 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
 
     const statusIcon = (): string => STATUS_ICON[props.node.status] || "•";
 
-    const handleMouseEnter = (e: MouseEvent) => {
-        // Measure room BEFORE flipping the overlay class — the measurement
-        // is done on the collapsed block (1-line height), so `blockRect.bottom`
-        // is the start-of-overlay position. If there's <400px between that
-        // and the scroll parent's bottom, flip up.
-        const block = e.currentTarget as HTMLElement;
-        const blockRect = block.getBoundingClientRect();
-        const scrollParent = findScrollParent(block);
+    const measure = () => {
+        if (!blockRef) return;
+        const blockRect = blockRef.getBoundingClientRect();
+        const scrollParent = findScrollParent(blockRef);
         const parentBottom = scrollParent
             ? scrollParent.getBoundingClientRect().bottom
             : window.innerHeight;
         const spaceBelow = parentBottom - blockRect.bottom;
         setOverlayUp(spaceBelow < OVERLAY_MAX_HEIGHT_PX);
+        setOverlayRect({
+            left: blockRect.left,
+            right: window.innerWidth - blockRect.right,
+            top: blockRect.bottom,
+            bottom: window.innerHeight - blockRect.top,
+            width: blockRect.width,
+        });
+    };
+
+    // Hover-leave is deferred by a microtask so that mouseleave on the
+    // summary block followed by mouseenter on the portal overlay doesn't
+    // cause a visible collapse. The portal is rendered to document.body,
+    // not as a DOM descendant of the block — a direct onMouseLeave →
+    // setHovered(false) would momentarily hide the overlay as the cursor
+    // transits the one-pixel gap between the summary row and the portal.
+    let leavePending = 0;
+    const handleMouseEnter = () => {
+        if (leavePending) {
+            clearTimeout(leavePending);
+            leavePending = 0;
+        }
+        measure();
         setHovered(true);
     };
 
     const handleMouseLeave = () => {
-        setHovered(false);
-        // overlayUp stays — it'll be recomputed on next mouseenter
+        if (leavePending) clearTimeout(leavePending);
+        leavePending = window.setTimeout(() => {
+            leavePending = 0;
+            setHovered(false);
+        }, 0);
     };
+
+    onCleanup(() => {
+        if (leavePending) clearTimeout(leavePending);
+    });
+
+    // Reposition the portal overlay on scroll so a pinned overlay stays
+    // anchored to its block. Only attached while overlayMode() is active
+    // to avoid one listener per tool block in the document.
+    let scrollParentRef: HTMLElement | null = null;
+    const handleScroll = () => measure();
+
+    createEffect(() => {
+        const active = overlayMode();
+        if (active && blockRef) {
+            scrollParentRef = findScrollParent(blockRef);
+            scrollParentRef?.addEventListener("scroll", handleScroll, { passive: true });
+            window.addEventListener("resize", handleScroll, { passive: true });
+        } else if (scrollParentRef) {
+            scrollParentRef.removeEventListener("scroll", handleScroll);
+            window.removeEventListener("resize", handleScroll);
+            scrollParentRef = null;
+        }
+    });
+
+    onCleanup(() => {
+        if (scrollParentRef) {
+            scrollParentRef.removeEventListener("scroll", handleScroll);
+            window.removeEventListener("resize", handleScroll);
+            scrollParentRef = null;
+        }
+    });
 
     // Render tool-specific content — only evaluated when expanded.
     const renderToolContent = (): JSX.Element => {
@@ -190,8 +252,30 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         }
     };
 
+    // Overlay style — only meaningful when overlayMode() is true. Computed
+    // from overlayRect() which is set during handleMouseEnter / handleScroll.
+    const overlayStyle = (): Record<string, string> => {
+        const r = overlayRect();
+        if (!r) return { display: "none" };
+        if (overlayUp()) {
+            return {
+                position: "fixed",
+                left: `${r.left}px`,
+                width: `${r.width}px`,
+                bottom: `${r.bottom}px`,
+            };
+        }
+        return {
+            position: "fixed",
+            left: `${r.left}px`,
+            width: `${r.width}px`,
+            top: `${r.top}px`,
+        };
+    };
+
     return (
         <div
+            ref={blockRef}
             class={clsx("agent-tool-block", {
                 collapsed: !expanded(),
                 expanded: expanded(),
@@ -231,10 +315,32 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 </Show>
                 <span class="agent-tool-ellipsis">…</span>
             </div>
-            <Show when={expanded()}>
+            {/* Inline content for persistent force-expanded states
+                (running/failed) — paints inside the document flow. */}
+            <Show when={expanded() && !overlayMode()}>
                 <div class="agent-tool-content" onClick={(e) => e.stopPropagation()}>
                     {renderToolContent()}
                 </div>
+            </Show>
+            {/* Overlay content for hover/pin — rendered via <Portal> so it
+                escapes the `.agent-document-node-wrapper`'s paint containment
+                (content-visibility: auto). Without the portal, the overlay
+                gets clipped at the wrapper's edge and hover expansion is
+                invisible. */}
+            <Show when={overlayMode()}>
+                <Portal>
+                    <div
+                        class={clsx("agent-tool-content", "agent-tool-content--portal", {
+                            "overlay-up": overlayUp(),
+                        })}
+                        style={overlayStyle()}
+                        onClick={(e) => e.stopPropagation()}
+                        onMouseEnter={() => setHovered(true)}
+                        onMouseLeave={handleMouseLeave}
+                    >
+                        {renderToolContent()}
+                    </div>
+                </Portal>
             </Show>
         </div>
     );

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -335,7 +335,13 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                         })}
                         style={overlayStyle()}
                         onClick={(e) => e.stopPropagation()}
-                        onMouseEnter={() => setHovered(true)}
+                        // Use handleMouseEnter (not an inline setHovered(true))
+                        // so the pending leavePending timeout from the block's
+                        // mouseleave is cleared. Otherwise the timeout fires
+                        // on the next tick after the portal's mouseenter
+                        // has set hovered=true, flipping it back to false
+                        // and collapsing the overlay mid-transit.
+                        onMouseEnter={handleMouseEnter}
                         onMouseLeave={handleMouseLeave}
                     >
                         {renderToolContent()}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.133",
+  "version": "0.33.134",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.133",
+      "version": "0.33.134",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.132",
+  "version": "0.33.133",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.132",
+      "version": "0.33.133",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.132",
+  "version": "0.33.133",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.133",
+  "version": "0.33.134",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Item #6 of \`specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md\`. Restores the broken tool-block hover-expand.

## Symptom

Hovering a collapsed tool block fired the hover highlight but the expanded content never appeared. Click-to-pin was equally broken — the \`.pinned\` class got set but nothing rendered.

## Root cause

\`.agent-document-node-wrapper\` (from the ultra-long-session perf work) has \`content-visibility: auto\`, which implicitly applies \`contain: layout paint style\`. **Paint containment clips rendering to the padding box** of the wrapper. The overlay in \`.agent-tool-block\` was \`position: absolute; top: 100%\` — a valid escape from the block's box, but then *still inside the wrapper's paint-contained box*. So the overlay painted into a clipped area and was invisible.

This is a regression that landed when \`content-visibility\` was added for ultra-long-session rendering. The hover UX was fine before that optimization; paint clipping killed it silently.

## Fix

Render the hover/pin overlay through a SolidJS \`<Portal>\` to \`document.body\`, escaping the paint containment entirely.

- \`position: fixed\` with \`top\` / \`left\` / \`width\` computed from the summary row's \`getBoundingClientRect\` on \`mouseenter\`.
- Position recomputed on scroll (listener attached only while \`overlayMode\` is active — **one listener per currently-visible overlay**, not per tool block in the document).
- \`overlayUp\` flip variant (opens upward when \`<400px\` below) preserved.

## Hover-sticky across the DOM gap

The portal is a sibling of \`document.body\`, not a descendant of \`.agent-tool-block\`. Moving the cursor from the summary row into the overlay crosses a DOM boundary that fires \`mouseleave\` on the block. To avoid a visible collapse during transit:

1. \`handleMouseLeave\` defers \`setHovered(false)\` via \`setTimeout(0)\`.
2. The portal's own \`onMouseEnter\` clears the pending timeout and re-asserts \`hovered=true\`.
3. If the cursor leaves both the block and the portal, the timeout fires on the next tick and the overlay collapses.

## Force-expanded states unaffected

\`running\` and \`failed\` tools still render inline via the existing \`.agent-tool-content\` div. They're persistent, not transient, and their inline position is inside the block's own painting context (the block itself is a normal flow child). Only hover/pin transients go through the portal.

## SCSS

- Drop the old \`.overlay-mode .agent-tool-content\` absolute-positioned rule — no longer used.
- New top-level \`.agent-tool-content--portal\` rule (z-index 200, background, border, shadow, max-height, overflow). Lives outside \`.agent-view\` because \`<Portal>\` mounts to \`document.body\`.
- \`.overlay-up\` flip variant preserves border-radius + shadow for upward-opening.

## Test plan

- [x] Frontend build clean
- [ ] Launch portable, open agent pane with completed tool blocks
- [ ] Hover over a tool block → expanded content appears immediately
- [ ] Move cursor from block into the expanded overlay → overlay stays open
- [ ] Move cursor out of overlay → overlay collapses
- [ ] Click a tool block → pins open, cursor can leave, overlay stays
- [ ] Click again → unpins
- [ ] Scroll the document while pinned → pinned overlay follows the source row (stays anchored)
- [ ] Hover a tool block near the bottom of the scroll area → overlay flips upward
- [ ] Open a long session (1000+ document nodes) → hover still works on scroll-virtualized nodes (the bug)
- [ ] Running tools still render their inline content (force-expanded)
- [ ] Failed tools still render their inline error content (force-expanded)

bump: 0.33.130 → 0.33.131

🤖 Generated with [Claude Code](https://claude.com/claude-code)