### PR TITLE
feat(agent): remove stale '+ New agent in Forge' footer button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.130"
+version = "0.33.131"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.130"
+version = "0.33.131"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.130"
+version = "0.33.131"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.130"
+version = "0.33.131"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.130"
+version = "0.33.131"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -468,32 +468,6 @@
         }
     }
 
-    .agent-picker-footer {
-        flex-shrink: 0;
-        padding-top: 4px;
-        border-top: 1px solid var(--border-color);
-    }
-
-    .agent-picker-forge-btn {
-        width: 100%;
-        padding: 8px;
-        background: transparent;
-        border: 1px dashed var(--border-color);
-        border-radius: 6px;
-        color: var(--secondary-text-color);
-        font-size: 12px;
-        cursor: not-allowed;
-        transition: all 0.15s;
-
-        &:not(:disabled) {
-            cursor: pointer;
-            &:hover {
-                border-color: var(--accent-color);
-                color: var(--accent-color);
-            }
-        }
-    }
-
     // === Picker Empty State ===
     .agent-picker-empty {
         display: flex;

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -139,10 +139,19 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     <div class="agent-picker-empty">
                         <div class="agent-picker-empty-icon">{"\u2726"}</div>
                         <div class="agent-picker-empty-title">No agents configured</div>
-                        <div class="agent-picker-empty-desc">Create an agent in the Forge to get started.</div>
-                        <button class="agent-picker-forge-btn" disabled>
-                            + Create an agent in the Forge
-                        </button>
+                        <div class="agent-picker-empty-desc">
+                            Click the <strong>+ New agent</strong> tile below to create one.
+                        </div>
+                        <NewAgentCard onClick={openCreateNew} />
+                        <Show when={expandedId() === "__new__" && createMode()}>
+                            <AgentCardSettingsPanel
+                                blockId={props.model.blockId}
+                                nodeModel={props.model.nodeModel}
+                                agent={undefined}
+                                initialTab="forge"
+                                onClose={closePanel}
+                            />
+                        </Show>
                     </div>
                 </div>
             }
@@ -201,11 +210,6 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                             </div>
                         </div>
                     </Show>
-                    <div class="agent-picker-footer">
-                        <button class="agent-picker-forge-btn" disabled>
-                            + New agent in Forge
-                        </button>
-                    </div>
                 </div>
             </div>
         </Show>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.130",
+  "version": "0.33.131",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.130",
+      "version": "0.33.131",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.130",
+  "version": "0.33.131",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Item #2 of \`specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md\`. Drop the disabled-placeholder '+ New agent in Forge' buttons that predated the consolidation work.

## Scope

**\`AgentPicker.tsx\`:**
- **Empty-state fallback**: replace the dead button with \`<NewAgentCard onClick={openCreateNew} />\` + the create-mode settings panel. Users with no agents can now actually create one from the pane — previously the empty state pointed them at a dead button.
- **Populated state**: delete the \`<div class=\"agent-picker-footer\">\` wrapper and its disabled button entirely. The \`+ New agent\` tile at the end of the card list handles creation.

**\`agent-view.scss\`:**
- Delete \`.agent-picker-footer\` and \`.agent-picker-forge-btn\` rules. No other callers.

## Behavior change

Only in the empty state: the dead button becomes a working \`NewAgentCard\` tile. Everywhere else this is pure cleanup.

## Test plan

- [x] Frontend build clean
- [ ] Launch with zero agents → empty state shows '+ New agent' tile → click → settings panel opens → create → agent appears in list
- [ ] Launch with existing agents → no footer button at the bottom → the '+ New agent' tile is the only create path (unchanged)

bump: 0.33.131 → 0.33.132

🤖 Generated with [Claude Code](https://claude.com/claude-code)