### PR TITLE
feat(agent): move AgentControlBar below the composer hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.130"
+version = "0.33.131"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.130"
+version = "0.33.131"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.130"
+version = "0.33.131"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.130"
+version = "0.33.131"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.130"
+version = "0.33.131"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.130"
+version = "0.33.131"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -573,11 +573,23 @@
     }
 
     // === Control Bar ===
+    // Anchored to the bottom of the pane below AgentFooter (see
+    // SPEC_AGENT_PANE_FOLLOWUPS item #7). Border on top so it reads
+    // as a sub-footer visually separated from the composer above.
     .agent-control-bar {
-        border-bottom: 1px solid var(--border-color);
+        border-top: 1px solid var(--border-color);
         background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
         flex-shrink: 0;
         font-size: 11px;
+    }
+
+    // Composer region wraps AgentFooter + AgentControlBar at the pane
+    // bottom. Flex column so the footer sits above the control bar
+    // and the two read as a single unit.
+    .agent-composer-region {
+        display: flex;
+        flex-direction: column;
+        flex-shrink: 0;
     }
 
     .agent-interrupted-banner {

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -219,12 +219,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 onBack={handleBack}
             />
 
-            <AgentControlBar
-                blockId={model.blockId}
-                blockAtom={block}
-                providerId={provider()?.id ?? ""}
-            />
-
             <Show when={bookmarks.visible()}>
                 <BookmarksPanel
                     bookmarks={bookmarks.bookmarks}
@@ -284,12 +278,19 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 </div>
             </Show>
 
-            <AgentFooter
-                agentId={agentId}
-                onSendMessage={commands.sendMessage}
-                onTyping={() => scrollToBottomFn?.()}
-                loading={status.isLoading()}
-            />
+            <div class="agent-composer-region">
+                <AgentFooter
+                    agentId={agentId}
+                    onSendMessage={commands.sendMessage}
+                    onTyping={() => scrollToBottomFn?.()}
+                    loading={status.isLoading()}
+                />
+                <AgentControlBar
+                    blockId={model.blockId}
+                    blockAtom={block}
+                    providerId={provider()?.id ?? ""}
+                />
+            </div>
         </div>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.130",
+  "version": "0.33.131",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.130",
+      "version": "0.33.131",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.130",
+  "version": "0.33.131",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Item #7 of \`specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md\`. Move the permission-mode / model / effort control bar from its old slot (between the pane header and the document) to a new slot below \`AgentFooter\`.

The control bar is a per-turn setting that's rarely touched; putting it above the document ate vertical space from the message list. Anchoring it to the bottom keeps it one glance away but out of the primary reading area.

## Changes

**\`agent-view.tsx\`:**
- Delete the \`<AgentControlBar>\` mount that sat above the bookmarks panel.
- Wrap \`<AgentFooter>\` + \`<AgentControlBar>\` in a new \`<div class=\"agent-composer-region\">\` at the bottom of the pane. Flex column so the footer stacks above the control bar and the two read as a single unit.

**\`agent-view.scss\`:**
- Flip \`.agent-control-bar\` border from \`border-bottom\` to \`border-top\` so it visually anchors to the composer above it.
- New \`.agent-composer-region\` rule — \`display: flex; flex-direction: column; flex-shrink: 0\`. The wrapper stays at its natural height, doesn't flex-grow into the document area.

## Behavior change

Layout only. Same controls, same expand/collapse state, same runtime-flag wiring. The user's action to flip permission mode / model / effort is identical; only its physical position changes.

## Test plan

- [x] Frontend build clean
- [ ] Open agent pane → pane header, then document, then composer, then control bar at the bottom
- [ ] Expand the control bar header → body opens, pushing up (or positioning itself above the footer cleanly, TBD during visual check)
- [ ] Change permission mode / model / effort → still takes effect on next turn
- [ ] Resize the pane → control bar stays anchored to the bottom, document flexes

bump: 0.33.131 → 0.33.132

🤖 Generated with [Claude Code](https://claude.com/claude-code)