### PR TITLE
fix(agent): scroll to bottom after user_message is appended

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.131"
+version = "0.33.132"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.131"
+version = "0.33.132"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.131"
+version = "0.33.132"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.131"
+version = "0.33.132"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.131"
+version = "0.33.132"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.131"
+version = "0.33.132"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.131"
+version = "0.33.132"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.131"
+version = "0.33.132"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.131"
+version = "0.33.132"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.131"
+version = "0.33.132"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -113,6 +113,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         documentVersion: history.documentVersion,
     });
 
+    // Mutable ref to the scrollToBottom function exposed by
+    // AgentDocumentView. Called by AgentFooter's onTyping when the user
+    // starts composing AND by useAgentCommands.onSent after the user's
+    // message has been appended to the document (SPEC_AGENT_PANE_FOLLOWUPS
+    // item #1). Declared here so both useAgentCommands and the JSX below
+    // can close over the same reference; assigned once AgentDocumentView
+    // mounts via scrollToBottomRef.
+    let scrollToBottomFn: (() => void) | null = null;
+
     // User-message send + /login /clear slash intercepts + back-to-picker.
     // See hooks/useAgentCommands.ts.
     const commands = useAgentCommands({
@@ -123,6 +132,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         log,
         setAuthUrl: status.setAuthUrl,
         backToPicker: () => model.backToPicker(),
+        // Scroll the user's own message into view after Enter. The hook
+        // defers this to the next animation frame so the mounted node is
+        // included in scrollHeight. See SPEC_AGENT_PANE_FOLLOWUPS item #1.
+        onSent: () => scrollToBottomFn?.(),
     });
     const handleSendMessage = commands.sendMessage;
 
@@ -147,11 +160,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         document: agentAtoms().documentAtom[0],
         jumpTo: scroll.jumpTo,
     });
-
-    // Mutable ref to the scrollToBottom function exposed by
-    // AgentDocumentView. Called by AgentFooter's onTyping when the user
-    // starts composing.
-    let scrollToBottomFn: (() => void) | null = null;
 
     // Pane-scoped Ctrl+B / Ctrl+F listener. See hooks/useAgentKeyboard.ts.
     useAgentKeyboard({

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -48,6 +48,16 @@ export interface UseAgentCommandsOptions {
      * place (AgentViewModel). See SPEC_AGENT_PANE_FOLLOWUPS item #8.
      */
     backToPicker: () => Promise<void>;
+    /**
+     * Called on the next animation frame after a user_message is
+     * appended to the document via `sendMessage`. AgentPresentationView
+     * wires this to the AgentDocumentView's `scrollToBottomFn` so the
+     * user's own message is guaranteed visible when they press Enter.
+     * Without this, the auto-scroll effect may be skipped if `autoScroll`
+     * was flipped off during the composer's own growth.
+     * See SPEC_AGENT_PANE_FOLLOWUPS item #1.
+     */
+    onSent?: () => void;
 }
 
 export interface UseAgentCommands {
@@ -102,6 +112,15 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
                 summary: "",
             } as DocumentNode,
         ]);
+
+        // Defer the scroll-to-bottom by one animation frame so the
+        // user_message node has a chance to mount in the DOM before the
+        // scroll math runs. Calling it synchronously lands the scroll
+        // ABOVE the new message because scrollHeight doesn't include the
+        // unmounted node yet. See SPEC_AGENT_PANE_FOLLOWUPS item #1.
+        if (opts.onSent) {
+            requestAnimationFrame(() => opts.onSent?.());
+        }
 
         const trimmed = message.trim();
         if (trimmed === "/login") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.131",
+  "version": "0.33.132",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.131",
+      "version": "0.33.132",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.131",
+  "version": "0.33.132",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Item #1 of \`specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md\`. Fix the user's own message being hidden below the fold after pressing Enter.

## Symptom

Type a message → press Enter → the message node is appended to the document, but the viewport doesn't move. The user usually sees only the composer, with their own message off-screen until the agent's response starts streaming (which triggers the next auto-scroll via the document-length effect).

## Root cause

\`AgentDocumentView\`'s auto-scroll effect is gated on an \`autoScroll\` boolean that gets flipped by \`handleScroll\`. The typing path resets it to true via \`jumpToBottom\`, but between composer growth (long lines) and the actual Enter, a scroll event can run \`handleScroll\` and flip \`autoScroll\` off again. By the time the new \`user_message\` node arrives in the document, the effect sees \`autoScroll=false\` and skips the scroll.

## Fix

Give \`useAgentCommands\` a new optional \`onSent\` callback. The hook fires it on the next animation frame after \`setDocument\` appends the \`user_message\` node. The RAF is necessary because:

- \`setDocument\` schedules a SolidJS \`<For>\` re-render;
- the new DOM node mounts on the next tick;
- calling \`scrollToBottomFn\` synchronously would read \`scrollHeight\` BEFORE the mount and scroll to a position ABOVE the new node.

\`AgentPresentationView\` wires \`onSent\` to the same \`scrollToBottomFn\` that \`onTyping\` uses. \`jumpToBottom\` in \`AgentDocumentView\` unconditionally re-enables \`autoScroll\` and calls \`scrollTo(0, MAX_SAFE_INTEGER)\`, so the new message is guaranteed visible regardless of what the flag was before.

## Files

- **\`hooks/useAgentCommands.ts\`** — new \`onSent\` option. Fire inside a RAF after the document mutation in \`sendMessage\`.
- **\`agent-view.tsx\`** — hoist the \`scrollToBottomFn\` \`let\` declaration above the \`useAgentCommands\` call so the \`onSent\` closure can safely capture it. Pass \`onSent: () => scrollToBottomFn?.()\` to the hook.

## Test plan

- [x] Frontend build clean
- [ ] Launch portable, open agent pane
- [ ] Type a short message → Enter → message visible immediately, composer still focused
- [ ] Type a multi-line message (Shift-Enter several times) → Enter → full message visible, composer still focused
- [ ] Scroll up in the document first, then type → Enter → viewport jumps back to bottom with the new message visible (\`autoScroll\` gets re-enabled)
- [ ] Typing without pressing Enter still scrolls to bottom (existing \`onTyping\` behavior unchanged)
- [ ] \`/clear\` and \`/login\` slash commands still work — onSent fires in both paths but is harmless when the document is cleared or untouched

bump: 0.33.131 → 0.33.132

🤖 Generated with [Claude Code](https://claude.com/claude-code)