### PR TITLE
feat(agent): Esc in composer — clear text or stop agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.134"
+version = "0.33.131"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.134"
+version = "0.33.131"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.134"
+version = "0.33.131"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.134"
+version = "0.33.131"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.134"
+version = "0.33.131"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.131"
+version = "0.33.135"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.131"
+version = "0.33.135"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.131"
+version = "0.33.135"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.131"
+version = "0.33.135"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.131"
+version = "0.33.135"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.131"
+version = "0.33.135"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.134"
+version = "0.33.131"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.131"
+version = "0.33.135"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.134"
+version = "0.33.131"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.134"
+version = "0.33.131"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.131"
+version = "0.33.135"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.134"
+version = "0.33.131"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.131"
+version = "0.33.135"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.134"
+version = "0.33.131"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.131"
+version = "0.33.135"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -287,6 +287,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     agentId={agentId}
                     onSendMessage={commands.sendMessage}
                     onTyping={() => scrollToBottomFn?.()}
+                    onStopAgent={commands.stopAgent}
                     loading={status.isLoading()}
                 />
                 <AgentControlBar

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -17,6 +17,13 @@ interface AgentFooterProps {
      * per animation frame regardless of how many keystrokes queued up.
      */
     onTyping?: () => void;
+    /**
+     * Called on Esc when the textarea is empty (or whitespace only). The
+     * parent sends SIGINT to the agent CLI process — equivalent to Ctrl+C
+     * in a terminal. With text in the textarea, Esc clears instead.
+     * See SPEC_AGENT_PANE_FOLLOWUPS item #9.
+     */
+    onStopAgent?: () => void;
     loading?: boolean;
 }
 
@@ -74,6 +81,23 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
             handleSend();
+            return;
+        }
+        if (e.key === "Escape") {
+            // Esc semantics (SPEC_AGENT_PANE_FOLLOWUPS item #9):
+            //  - textarea has text → clear it, stay focused
+            //  - textarea is empty → send SIGINT to the agent CLI
+            if (!textareaRef) return;
+            if (textareaRef.value.trim().length > 0) {
+                e.preventDefault();
+                textareaRef.value = "";
+                // Kick the RAF-debounced typing scroll so the footer's
+                // auto-grow collapses and the document stays anchored.
+                props.onTyping?.();
+            } else {
+                e.preventDefault();
+                props.onStopAgent?.();
+            }
         }
     };
 
@@ -89,7 +113,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                     rows={1}
                 />
                 <div class="agent-input-hint">
-                    <span>Enter to send • Shift+Enter for newline</span>
+                    <span>Enter to send • Shift+Enter for newline • Esc to clear / stop</span>
                     <Show when={props.loading}>
                         <span class="agent-loading-spinner">
                             <span class="agent-spinner-dot" />

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -65,6 +65,14 @@ export interface UseAgentCommands {
     sendMessage: (message: string) => Promise<void>;
     /** Return to the agent picker by clearing the agent-identity meta keys. */
     back: () => Promise<void>;
+    /**
+     * Send SIGINT to the currently running agent CLI process. Invoked
+     * from the composer's Esc handler when the textarea is empty —
+     * equivalent to Ctrl+C in a terminal. Silently no-ops if the
+     * controller rejects the signal (e.g. no process running).
+     * See SPEC_AGENT_PANE_FOLLOWUPS item #9.
+     */
+    stopAgent: () => void;
 }
 
 export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommands {
@@ -165,5 +173,14 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         await opts.backToPicker();
     };
 
-    return { sendMessage, back };
+    const stopAgent = (): void => {
+        RpcApi.ControllerInputCommand(TabRpcClient, {
+            blockid: opts.blockId,
+            signame: "SIGINT",
+        }).catch((err) => {
+            opts.log("warn", `stop failed: ${err?.message ?? String(err)}`, "warn");
+        });
+    };
+
+    return { sendMessage, back, stopAgent };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.134",
+  "version": "0.33.131",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.134",
+      "version": "0.33.131",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.131",
+  "version": "0.33.135",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.131",
+      "version": "0.33.135",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.134",
+  "version": "0.33.131",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.131",
+  "version": "0.33.135",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Item #9 of \`specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md\`. Add Esc as a keybinding in the agent composer:

- **Textarea has text** → Esc clears it, cursor stays in the composer.
- **Textarea is empty** → Esc sends SIGINT to the agent CLI process. Same effect as Ctrl+C in a terminal.

Uses the existing \`ControllerInputCommand\` RPC with the \`signame\` field — the backend (\`BlockInputUnion::signal\` in \`blockcontroller\`) already supports raw signal delivery. No backend change.

## Changes

**\`components/AgentFooter.tsx\`:**
- New \`onStopAgent?: () => void\` prop.
- \`handleKeyDown\`: new Escape branch. Trimmed-length check picks clear vs stop. Clearing also fires \`props.onTyping\` so the RAF-debounced auto-scroll runs and the composer's \`field-sizing\` collapses back to one row.
- Hint line updated: \`Enter to send • Shift+Enter for newline • Esc to clear / stop\`

**\`hooks/useAgentCommands.ts\`:**
- New \`stopAgent()\` on \`UseAgentCommands\`. Dispatches \`ControllerInputCommand({ blockid, signame: \"SIGINT\" })\`. Warns (not errors) on failure — the pane frame's back button is a backstop.

**\`agent-view.tsx\`:**
- Pass \`commands.stopAgent\` as \`AgentFooter\`'s \`onStopAgent\` prop.

## Test plan

- [x] Frontend build clean
- [ ] Open agent pane, type a message → Esc → textarea clears, focus stays
- [ ] Empty composer + running agent → Esc → agent stops (SIGINT reaches the CLI)
- [ ] Empty composer + idle agent → Esc → warning log, no crash
- [ ] Hint line reflects the new binding
- [ ] Enter still sends (unchanged)
- [ ] Shift+Enter still inserts newline (unchanged)

bump: 0.33.131 → 0.33.132

🤖 Generated with [Claude Code](https://claude.com/claude-code)