### PR TITLE
feat(agent): one-line running tools + one-line errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.135"
+version = "0.33.136"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.135"
+version = "0.33.136"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.135"
+version = "0.33.136"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.135"
+version = "0.33.136"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.135"
+version = "0.33.136"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.136"
+version = "0.33.137"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.136"
+version = "0.33.137"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.136"
+version = "0.33.137"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.136"
+version = "0.33.137"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.136"
+version = "0.33.137"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.136"
+version = "0.33.137"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.135"
+version = "0.33.136"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.136"
+version = "0.33.137"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.135"
+version = "0.33.136"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.136"
+version = "0.33.137"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.135"
+version = "0.33.136"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.135"
+version = "0.33.136"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.136"
+version = "0.33.137"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.135"
+version = "0.33.136"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.136"
+version = "0.33.137"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -75,7 +75,24 @@
     .agent-status-line {
         color: var(--secondary-text-color);
         opacity: 0.7;
-        white-space: pre-wrap;
+        // One-line collapsed by default — errors and warnings often include
+        // stack traces or long diagnostic blobs that wrap into many lines
+        // and dominate the pane. Hover expands to pre-wrap so the user can
+        // read the full text without the pane feeling like a wall of red.
+        // See SPEC_AGENT_PANE_FOLLOWUPS item #5.
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+        cursor: default;
+        transition: background 0.1s;
+
+        &:hover {
+            white-space: pre-wrap;
+            overflow: visible;
+            text-overflow: clip;
+            background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+        }
 
         &--error {
             color: var(--error-color);

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -9,13 +9,21 @@
  *
  * Behavior:
  *   - Collapsed (default): one line showing status icon + tool name + ellipsis.
- *     No wrapping, no content rendered inside.
- *   - Hover: expands instantly on mouseenter, collapses instantly on mouseleave.
+ *     Applies to ALL statuses — running, success, and failed.
+ *     Running tools show a ⏳ spinner in the summary; failed tools show ✗.
+ *     No content body is rendered in the document flow.
+ *   - Hover: expands via the portal overlay on mouseenter, collapses
+ *     on mouseleave. The portal escapes the `content-visibility: auto`
+ *     paint containment on .agent-document-node-wrapper (see PR #367).
  *   - Click: pins the expanded state. A pinned-open block stays open even
  *     after the mouse leaves. Clicking again unpins.
- *   - Force-expanded regardless of hover/pin state:
- *       * status === "running" — actively executing
- *       * status === "failed"  — user needs to see the error
+ *
+ * Prior behavior removed in SPEC_AGENT_PANE_FOLLOWUPS items #4 + #5:
+ *   running and failed states used to force-expand inline, taking 2+ lines
+ *   per tool. That violated the explicit one-line rule in
+ *   docs/specs/tool-collapse.md and the user's feedback memory. Now all
+ *   statuses collapse by default; progress and error content are still
+ *   accessible via hover/pin.
  *
  * SolidJS reactivity note:
  *   Props are accessed via `props.X` (never destructured in the function

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -88,19 +88,22 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
 
     let blockRef: HTMLDivElement | undefined;
 
-    // Force-expand rules — override hover/pin when the user must see content.
-    // `failed` stays expanded so errors are immediately visible.
-    // `running` stays expanded so the user can watch progress.
-    const forceExpanded = () =>
-        props.node.status === "running" || props.node.status === "failed";
+    // Collapsed-by-default for every status. Running, success, and failed
+    // all get the same one-line treatment (SPEC_AGENT_PANE_FOLLOWUPS items
+    // #4 and #5). Hover reveals the body via the portal overlay; click
+    // pins it open. Progress + error content are still accessible — just
+    // not always-on visually.
+    //
+    // The running state shows a spinner in the collapsed summary; the
+    // failed state shows a red ✗. Both indicate what's happening without
+    // consuming vertical space from the pane.
+    const expanded = () => props.pinned || hovered();
 
-    const expanded = () => props.pinned || hovered() || forceExpanded();
-
-    // Overlay mode applies ONLY for transient (hover) and explicit (pinned)
-    // expansion — NOT for persistent state (running/failed). Persistent state
-    // stays inline so the user can scroll past it. See
-    // specs/SPEC_TOOL_OVERLAY_AND_SCROLL_ON_TYPE_2026_04_13.md §2.5.
-    const overlayMode = () => (hovered() || props.pinned) && !forceExpanded();
+    // All transient / pinned expansion now goes through the portal overlay.
+    // Nothing renders inline in the document flow anymore — so we don't
+    // need a separate `overlayMode` predicate; every expansion IS overlay
+    // mode. Kept as an accessor for parity with the existing SCSS hooks.
+    const overlayMode = () => hovered() || props.pinned;
 
     const statusIcon = (): string => STATUS_ICON[props.node.status] || "•";
 
@@ -315,19 +318,11 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 </Show>
                 <span class="agent-tool-ellipsis">…</span>
             </div>
-            {/* Inline content for persistent force-expanded states
-                (running/failed) — paints inside the document flow. */}
-            <Show when={expanded() && !overlayMode()}>
-                <div class="agent-tool-content" onClick={(e) => e.stopPropagation()}>
-                    {renderToolContent()}
-                </div>
-            </Show>
-            {/* Overlay content for hover/pin — rendered via <Portal> so it
-                escapes the `.agent-document-node-wrapper`'s paint containment
-                (content-visibility: auto). Without the portal, the overlay
-                gets clipped at the wrapper's edge and hover expansion is
-                invisible. */}
-            <Show when={overlayMode()}>
+            {/* All expansion now routes through the portal overlay — running,
+                failed, success all collapse by default (SPEC_AGENT_PANE_FOLLOWUPS
+                items #4 and #5). The portal escapes the paint containment on
+                `.agent-document-node-wrapper` (content-visibility: auto). */}
+            <Show when={expanded()}>
                 <Portal>
                     <div
                         class={clsx("agent-tool-content", "agent-tool-content--portal", {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.136",
+  "version": "0.33.137",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.136",
+      "version": "0.33.137",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.135",
+  "version": "0.33.136",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.135",
+      "version": "0.33.136",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.135",
+  "version": "0.33.136",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.136",
+  "version": "0.33.137",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Items #4 and #5 of \`specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md\`, bundled since they share the same one-line rule and touch the same files.

## Item #4 — running/failed tools collapse to one line

**Before:** the \`running\` and \`failed\` states were **force-expanded**. Their content body rendered inline in the document flow, eating 2+ lines per tool even though the user's explicit rule is \"tools should be one line.\"

**After:** all statuses collapse by default. Hover reveals the body via the portal overlay (same path success tools already used after PR #367).

Progress + error information is still accessible:
- **Running:** ⏳ spinner in the summary, tool name visible, hover reveals the \"Running...\" body and any in-flight output.
- **Failed:** ✗ red status icon in the summary, tool name visible, hover reveals the full error payload.

Also simplifies the render: every expansion routes through the portal now, no more separate inline vs overlay branches. Removed the \`forceExpanded\` predicate entirely.

## Item #5 — error log lines collapse to one line

**Before:** \`.agent-status-line\` used \`white-space: pre-wrap\` — long error text wrapped into as many lines as it needed. A stack trace or a diagnostic blob could easily take 10–20 lines in the pane's log area.

**After:** CSS-only fix on \`.agent-status-line\`:
- \`white-space: nowrap; overflow: hidden; text-overflow: ellipsis\` at rest.
- Hover expands to \`pre-wrap\`.
- Subtle background tint on hover so it's obvious the line is interactive.

Applies to all log line levels (info/warn/error), but the practical impact is on error/warn since those are the ones that wrap.

## Scope

**\`ToolBlock.tsx\`:**
- Drop \`forceExpanded\` accessor.
- \`expanded()\` = \`props.pinned || hovered()\` only.
- \`overlayMode()\` = \`hovered() || props.pinned\` (simplified — no more \`!forceExpanded\` guard).
- Drop the inline \`.agent-tool-content\` \`<Show>\` block — only the portal overlay renders expanded content now.

**\`agent-view.scss\`:**
- \`.agent-status-line\` → one-line clamp at rest, hover expands.

## Behavior change

- \`running\` / \`failed\` tools that were always showing their body are now collapsed until you hover.
- Long error log lines are one line until you hover.
- Success tools are unchanged (already collapsed since PR #346).
- Non-error log lines are unchanged behaviorally — they were already short enough to not wrap in practice.

## Test plan

- [x] \`task build:frontend\` clean
- [ ] Trigger a running tool → it shows one line with the ⏳ spinner, not a two-line block
- [ ] Hover the running tool → portal overlay expands with the 'Running...' body
- [ ] Trigger a failing tool (e.g. \`cat /nonexistent\`) → it shows one line with the ✗ icon
- [ ] Hover the failed tool → portal overlay shows the full error output
- [ ] Generate an error log line → appears as one line with ellipsis in the pane header
- [ ] Hover the error line → expands to show the full text
- [ ] Success tools unchanged

bump: 0.33.135 → 0.33.136

🤖 Generated with [Claude Code](https://claude.com/claude-code)