### PR TITLE
feat(agent): auto-login captures OAuth URL from runCliLogin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.137"
+version = "0.33.138"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.137"
+version = "0.33.138"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.137"
+version = "0.33.138"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.137"
+version = "0.33.138"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.137"
+version = "0.33.138"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.137"
+version = "0.33.138"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.137"
+version = "0.33.138"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.137"
+version = "0.33.138"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.137"
+version = "0.33.138"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.137"
+version = "0.33.138"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -161,12 +161,26 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
         try {
             // Run from the CEF host (GUI process) so the browser opens correctly on Windows.
             // Returns immediately after spawning — browser opens, frontend polls for completion.
-            await getApi().runCliLogin(
+            //
+            // The host API may return an OAuth URL string captured from the
+            // CLI's stdout (Claude Code does this reliably; other providers
+            // may not). When available, push it into setAuthUrl so the
+            // auth-url box renders above the composer with a Copy button —
+            // the user can paste the URL into their browser manually if the
+            // auto-open didn't fire or got blocked. See
+            // SPEC_AGENT_PANE_FOLLOWUPS item #3.
+            const loginUrl = await getApi().runCliLogin(
                 cliResult.cli_path,
                 provider.authLoginCommand,
                 authEnv ?? {},
             );
-            log("auth", "a browser window should have opened — complete login there");
+            if (loginUrl) {
+                setAuthUrl(loginUrl);
+                log("auth", "OAuth URL captured — browser should open automatically");
+                log("auth", "if it didn't, copy the URL from the box above");
+            } else {
+                log("auth", "a browser window should have opened — complete login there");
+            }
 
             // Poll until authenticated, cancelled, or timed out (5 minutes)
             log("auth", "waiting for login to complete...");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.137",
+  "version": "0.33.138",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.137",
+      "version": "0.33.138",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.137",
+  "version": "0.33.138",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**Final** item of \`specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md\` (item #3). Fills a one-line gap in the already-implemented auto-login flow.

## Context

The auto-login path was already in place before this PR: Phase 2 of \`runLaunchFlow\` calls \`getApi().runCliLogin\` automatically when \`CheckCliAuthCommand\` reports the CLI isn't authenticated. It then polls every 2s for up to 5 minutes, falling back to the existing Retry Login button on timeout or cancellation. The \`loginWaiting\` state is already set during the poll, and \`setAuthUrl(null)\` is already cleared after the flow ends.

**The gap:** \`runCliLogin\`'s return value (the OAuth URL it captures from the CLI's stdout) was being discarded. So when Claude Code emits the URL to stdout, we had it in memory but never showed it in the UI.

## Fix

Capture the return value and pass it to \`setAuthUrl\` when truthy:

\`\`\`ts
const loginUrl = await getApi().runCliLogin(cliPath, prov.authLoginCommand, authEnv ?? {});
if (loginUrl) {
    setAuthUrl(loginUrl);
    log(\"auth\", \"OAuth URL captured — browser should open automatically\");
    log(\"auth\", \"if it didn't, copy the URL from the box above\");
} else {
    log(\"auth\", \"a browser window should have opened — complete login there\");
}
\`\`\`

The existing auth-url box UI (above the composer, with a Copy button) now renders during the launch-flow auto-login path. Previously it only showed up for the manual \`/login\` slash command.

## Behavior

- **Provider emits URL to stdout (Claude Code):** URL appears in the auth-url box, user can copy it if the browser auto-open didn't work.
- **Provider doesn't emit a URL:** existing \`a browser window should have opened\` log line still fires. Unchanged.
- **Successful login:** browser opens, user completes OAuth, 2s poll detects authenticated, pane transitions to running. Unchanged.
- **Login timeout / cancel:** Retry Login button shows. Unchanged.

## Resume safety

The spec calls out that auto-login shouldn't fire during resume. Already handled: \`CheckCliAuthCommand\` short-circuits on cached credentials, so \`needsLogin\` stays \`false\` and the auto-login block doesn't execute. No new gate needed.

## No backend change

Pure frontend one-liner. \`getApi().runCliLogin\` already returned the URL — we just started listening.

## Test plan

- [x] \`task build:frontend\` clean
- [ ] Fresh pane, no cached credentials: launch an agent → auto-login triggers → browser opens → URL appears in the auth box above the composer
- [ ] Same scenario, manually close the browser before completing login: URL visible in pane, click Copy, paste into a new browser, complete login → pane transitions to running
- [ ] Re-open the same pane after successful login: cached credential detected → Phase 2 short-circuits → no auto-login, straight to running
- [ ] Running → logout via \`/login\` again → URL still captured by the manual path (unchanged from before)

## Followups complete

With this PR, all 9 items from \`specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md\` ship:

| # | Item | PR |
|---:|---|---|
| 1 | Send scroll-to-bottom | #371 |
| 2 | Remove stale \"+ New agent in Forge\" footer | #368 |
| 3 | Auto-login captures OAuth URL | **this** |
| 4 | Tool \`running\` state one-line | #373 |
| 5 | Errors one-line | #373 |
| 6 | Tool hover-expand Portal fix | #367 |
| 7 | Move AgentControlBar below composer | #370 |
| 8 | Remove in-pane header; use frame title | #369 |
| 9 | Esc in composer — clear / stop | #372 |

bump: 0.33.137 → 0.33.138

🤖 Generated with [Claude Code](https://claude.com/claude-code)