### PR TITLE
feat(cef): show recovery page on render-process termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.139"
+version = "0.33.140"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.139"
+version = "0.33.140"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.139"
+version = "0.33.140"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.139"
+version = "0.33.140"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.139"
+version = "0.33.140"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.138"
+version = "0.33.139"
 dependencies = [
  "agentmux-common",
  "axum 0.8.8",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.138"
+version = "0.33.139"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.138"
+version = "0.33.139"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.138"
+version = "0.33.139"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -90,7 +90,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.138"
+version = "0.33.139"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.138"
+version = "0.33.139"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.139"
+version = "0.33.140"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -364,6 +364,205 @@ impl AgentMuxHandler {
         let uri = CefString::from(data_uri.as_str());
         frame.load_url(Some(&uri));
     }
+
+    /// Render-process terminated — typically OOM, a renderer-side panic, or
+    /// some native bug inside CEF/Chromium. Without this hook the window
+    /// just turns white. We log the cause and replace the white page with
+    /// a recovery HTML page that offers Reload / Quit buttons.
+    ///
+    /// See specs/SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md (PR 1).
+    fn on_render_process_terminated(
+        &mut self,
+        browser: Option<&mut Browser>,
+        status: TerminationStatus,
+        error_code: i32,
+        error_string: Option<&CefString>,
+    ) {
+        let reason = if status == TerminationStatus::PROCESS_OOM {
+            "out of memory"
+        } else if status == TerminationStatus::PROCESS_CRASHED {
+            "renderer process crashed"
+        } else if status == TerminationStatus::ABNORMAL_TERMINATION {
+            "abnormal termination"
+        } else {
+            "renderer process terminated"
+        };
+
+        let detail = error_string.map(CefString::to_string).unwrap_or_default();
+        tracing::error!(
+            target: "crash",
+            kind = "renderer_terminated",
+            reason,
+            error_code,
+            detail = %detail,
+            "{}", reason,
+        );
+
+        // Build the recovery page. Plain HTML+CSS, no JS dependencies, so
+        // it renders even if the frontend bundle is dead. The Reload button
+        // calls history.go(0), which forces a navigation refresh from the
+        // current URL — for a `data:` URL that won't go anywhere, but the
+        // host injects a real frontend URL via load_url() once the user
+        // triggers it via the JS bridge `window.__AGENTMUX_RECOVER__`.
+        // (For now the JS bridge is not wired; users see Reload as a
+        // visual affordance and can use the system Quit / close window
+        // buttons to exit cleanly.)
+        let detail_block = if detail.is_empty() {
+            String::new()
+        } else {
+            format!("<p class=\"detail\"><code>{}</code></p>", html_escape(&detail))
+        };
+
+        let html = format!(
+            r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>AgentMux — Recovery</title>
+    <style>
+        :root {{
+            color-scheme: dark;
+        }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #1e1e2e;
+            color: #cdd6f4;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            padding: 24px;
+            box-sizing: border-box;
+        }}
+        .recovery {{
+            text-align: center;
+            max-width: 540px;
+            padding: 36px;
+            background: #181825;
+            border: 1px solid #313244;
+            border-radius: 10px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+        }}
+        .icon {{
+            font-size: 36px;
+            line-height: 1;
+            margin-bottom: 12px;
+        }}
+        h1 {{
+            color: #f9e2af;
+            font-size: 22px;
+            margin: 0 0 6px 0;
+        }}
+        .reason {{
+            color: #a6adc8;
+            font-size: 14px;
+            margin: 0 0 20px 0;
+            font-style: italic;
+        }}
+        p {{
+            color: #bac2de;
+            line-height: 1.55;
+            margin: 0 0 12px 0;
+            font-size: 14px;
+        }}
+        .detail code {{
+            display: inline-block;
+            background: #313244;
+            color: #f38ba8;
+            padding: 6px 10px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-family: ui-monospace, 'Cascadia Code', Menlo, Consolas, monospace;
+            word-break: break-all;
+            text-align: left;
+            max-width: 100%;
+        }}
+        .actions {{
+            display: flex;
+            gap: 10px;
+            justify-content: center;
+            margin-top: 24px;
+            flex-wrap: wrap;
+        }}
+        button {{
+            padding: 10px 22px;
+            border: 1px solid #45475a;
+            border-radius: 6px;
+            background: #313244;
+            color: #cdd6f4;
+            cursor: pointer;
+            font-size: 13px;
+            font-family: inherit;
+            transition: background 0.1s, border-color 0.1s;
+        }}
+        button:hover {{
+            background: #45475a;
+            border-color: #585b70;
+        }}
+        button.primary {{
+            background: #89b4fa;
+            color: #1e1e2e;
+            border-color: #89b4fa;
+            font-weight: 600;
+        }}
+        button.primary:hover {{
+            background: #74a0f8;
+            border-color: #74a0f8;
+        }}
+        .footer {{
+            color: #6c7086;
+            font-size: 11px;
+            margin-top: 18px;
+            font-family: ui-monospace, monospace;
+        }}
+    </style>
+</head>
+<body>
+    <div class="recovery" role="alertdialog" aria-labelledby="title">
+        <div class="icon">⚠</div>
+        <h1 id="title">AgentMux hit a problem</h1>
+        <p class="reason">Reason: {reason_safe}</p>
+        {detail_block}
+        <p>Your open sessions are saved on disk. Reloading should bring you back where you left off.</p>
+        <div class="actions">
+            <button class="primary" onclick="location.reload()">Reload window</button>
+            <button onclick="window.close()">Quit</button>
+        </div>
+        <div class="footer">error_code={error_code}</div>
+    </div>
+</body>
+</html>"#,
+            reason_safe = html_escape(reason),
+            detail_block = detail_block,
+            error_code = error_code,
+        );
+
+        // Load the recovery page in the main frame of the dead browser.
+        // The renderer subprocess will be re-spawned by CEF when we
+        // navigate, so the new page mounts in a fresh process.
+        if let Some(b) = browser {
+            if let Some(frame) = b.main_frame() {
+                let b64 = cef::base64_encode(Some(html.as_bytes()));
+                let b64_str = CefString::from(&b64).to_string();
+                let data_uri = format!("data:text/html;base64,{}", b64_str);
+                let uri = CefString::from(data_uri.as_str());
+                frame.load_url(Some(&uri));
+            }
+        }
+    }
+}
+
+/// Minimal HTML escape for the recovery page. Only the characters that
+/// would break the `format!`-templated string need attention; the input
+/// (CEF status enum + cef-provided error string) is trusted but may
+/// contain `&` / `<` / `>` in some failure modes.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
 }
 
 // ---------------------------------------------------------------------------
@@ -390,6 +589,10 @@ wrap_client! {
 
         fn load_handler(&self) -> Option<LoadHandler> {
             Some(AgentMuxLoadHandler::new(self.inner.clone()))
+        }
+
+        fn request_handler(&self) -> Option<RequestHandler> {
+            Some(AgentMuxRequestHandler::new(self.inner.clone()))
         }
     }
 }
@@ -512,6 +715,33 @@ wrap_load_handler! {
         ) {
             let mut inner = self.inner.lock();
             inner.on_load_error(browser, frame, error_code, error_text, failed_url);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RequestHandler — render-process termination (white-screen recovery)
+// ---------------------------------------------------------------------------
+//
+// We only override `on_render_process_terminated` here. Everything else
+// inherits the default (no-op) implementations from the cef-rs trait.
+// See SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md (PR 1).
+
+wrap_request_handler! {
+    struct AgentMuxRequestHandler {
+        inner: Arc<Mutex<AgentMuxHandler>>,
+    }
+
+    impl RequestHandler {
+        fn on_render_process_terminated(
+            &self,
+            browser: Option<&mut Browser>,
+            status: TerminationStatus,
+            error_code: ::std::os::raw::c_int,
+            error_string: Option<&CefString>,
+        ) {
+            let mut inner = self.inner.lock();
+            inner.on_render_process_terminated(browser, status, error_code, error_string);
         }
     }
 }

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -398,21 +398,39 @@ impl AgentMuxHandler {
             "{}", reason,
         );
 
-        // Build the recovery page. Plain HTML+CSS, no JS dependencies, so
-        // it renders even if the frontend bundle is dead. The Reload button
-        // calls history.go(0), which forces a navigation refresh from the
-        // current URL — for a `data:` URL that won't go anywhere, but the
-        // host injects a real frontend URL via load_url() once the user
-        // triggers it via the JS bridge `window.__AGENTMUX_RECOVER__`.
-        // (For now the JS bridge is not wired; users see Reload as a
-        // visual affordance and can use the system Quit / close window
-        // buttons to exit cleanly.)
+        // Resolve the real frontend URL so the Reload button can navigate
+        // back to the live app instead of reloading the recovery page
+        // itself. Matches the format used by
+        // commands::window::resolve_frontend_base_url and its callers
+        // (see window.rs:400, window.rs:430, drag.rs:294 — all use the
+        // same ipc_port / ipc_token query params).
+        let base_url = crate::commands::window::resolve_frontend_base_url(self.ipc_port);
+        let separator = if base_url.contains('?') { "&" } else { "?" };
+        let app_url = format!(
+            "{}{}ipc_port={}&ipc_token={}",
+            base_url, separator, self.ipc_port, self.state.ipc_token
+        );
+
         let detail_block = if detail.is_empty() {
             String::new()
         } else {
             format!("<p class=\"detail\"><code>{}</code></p>", html_escape(&detail))
         };
 
+        // Build the recovery page. Plain HTML+CSS, no JS dependencies
+        // beyond a single click handler, so it renders even if the
+        // frontend bundle is dead. The Reload button navigates directly
+        // to the real app URL (NOT location.reload() — that would just
+        // re-render the same data: URL). CEF will spawn a fresh renderer
+        // subprocess for the navigation.
+        //
+        // NOTE on ipc_token exposure: the token is already present in
+        // the live app URL that was loaded before the crash (it's in
+        // the location bar for the dead renderer's process). Embedding
+        // it in the recovery HTML that runs inside the same browser
+        // doesn't extend its reach — the HTML is ephemeral, not
+        // persisted to disk, and `window.close()` or the next crash
+        // clears it.
         let html = format!(
             r#"<!DOCTYPE html>
 <html lang="en">
@@ -524,18 +542,27 @@ impl AgentMuxHandler {
         <h1 id="title">AgentMux hit a problem</h1>
         <p class="reason">Reason: {reason_safe}</p>
         {detail_block}
-        <p>Your open sessions are saved on disk. Reloading should bring you back where you left off.</p>
+        <p>Your open sessions are saved on disk. Reloading will bring you back where you left off.</p>
         <div class="actions">
-            <button class="primary" onclick="location.reload()">Reload window</button>
+            <button class="primary" id="reload-btn">Reload window</button>
             <button onclick="window.close()">Quit</button>
         </div>
         <div class="footer">error_code={error_code}</div>
     </div>
+    <script>
+        // The Reload button navigates to the live app URL (not
+        // location.reload, which would just re-render this data: page).
+        // The URL is injected by the host at HTML-build time.
+        document.getElementById('reload-btn').addEventListener('click', function() {{
+            location.href = {app_url_js};
+        }});
+    </script>
 </body>
 </html>"#,
             reason_safe = html_escape(reason),
             detail_block = detail_block,
             error_code = error_code,
+            app_url_js = js_string_literal(&app_url),
         );
 
         // Load the recovery page in the main frame of the dead browser.
@@ -551,6 +578,33 @@ impl AgentMuxHandler {
             }
         }
     }
+}
+
+/// Quote a string as a JavaScript string literal — escape backslashes,
+/// quotes, and newlines so it's safe to embed inside `<script>` via
+/// `format!`. Used by the recovery page to inject the app URL for the
+/// Reload button's navigation target.
+fn js_string_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '<' => out.push_str("\\u003c"), // defense against </script> injection
+            '>' => out.push_str("\\u003e"),
+            '&' => out.push_str("\\u0026"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
 }
 
 /// Minimal HTML escape for the recovery page. Only the characters that

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.139"
+version = "0.33.140"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.138"
+version = "0.33.139"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.138"
+version = "0.33.139"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.139"
+version = "0.33.140"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.139"
+version = "0.33.140"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.138"
+version = "0.33.139"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.138"
+version = "0.33.139"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.139"
+version = "0.33.140"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/docs/analysis/agent-pane-spec-verification-2026-04-13.md
+++ b/docs/analysis/agent-pane-spec-verification-2026-04-13.md
@@ -1,0 +1,271 @@
+# Agent Pane — Spec Verification Report
+
+**Date:** 2026-04-13
+**Author:** AgentA
+**Verified against `main` HEAD:** `0e795dfe` (post-PR #371 merge)
+**In-flight (approved, unmerged):** PR #367 (item #6), PR #372 (item #9)
+
+Scope: three specs that govern the current agent pane surface:
+
+1. `specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md` — 12-step decomposition of `agent-view.tsx`
+2. `specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md` — 4-PR merge of Forge + Identity into the agent pane
+3. `specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md` — 9 follow-up items raised after the consolidation landed
+
+For each spec I walked its stated deliverables and checked the current code. Findings below are grouped by spec; each item is marked **✓ delivered**, **⚠ partial** (shipped but with a caveat), **⧗ pending** (work in progress), or **✗ missing**.
+
+---
+
+## 1. SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md — 12 steps
+
+### 1.1 Line count target
+
+Spec §5: "After Step 12, `wc -l frontend/app/view/agent/agent-view.tsx` must be ≤ 300."
+
+- **On main:** 302 lines.
+- **Verdict:** **⚠ partial** — overshoots the target by 2 lines. Not a functional regression, but worth noting as a budget creep. Most likely culprit: the `agent-composer-region` wrapper introduced in PR #370 (spec-followups item #7) added 2–3 lines of JSX. Trivial to reclaim on any subsequent cleanup pass; not urgent.
+
+### 1.2 Hook extractions
+
+| Step | Hook | File | Present? | Notes |
+|---|---|---|---|---|
+| 3 | `useLaunchLogs` | `hooks/useLaunchLogs.ts` | ✓ | Wired in `agent-view.tsx:76` |
+| 4 | `useAgentControllerStatus` | `hooks/useAgentControllerStatus.ts` | ✓ | 156 lines, wired at `agent-view.tsx:83` |
+| 5 | `useHistoryPagination` | `hooks/useHistoryPagination.ts` | ✓ | 182 lines |
+| 6 | `useSessionDigest` | `hooks/useSessionDigest.ts` | ✓ | 115 lines |
+| 7 | `useBookmarks` | `hooks/useBookmarks.ts` | ✓ | 158 lines |
+| 8 | `useInSessionSearch` | `hooks/useInSessionSearch.ts` | ✓ | 142 lines |
+| 9 | `useScrollToNode` | `hooks/useScrollToNode.ts` | ✓ | Signal-based jump command |
+| 10 | `useAgentKeyboard` | `hooks/useAgentKeyboard.ts` | ✓ | Ctrl+B / Ctrl+F, pane-scoped |
+| 12 | `useSubagentEvents` | `hooks/useSubagentEvents.ts` | ✓ | spawned / completed subscriptions |
+| 12 | `useControllerStatusEvents` | `hooks/useControllerStatusEvents.ts` | ✓ | shellprocstatus → log |
+| 12 | `useAgentCommands` | `hooks/useAgentCommands.ts` | ✓ | 169 lines |
+
+All hook files present, all imports wired. **✓ delivered** for the hook layer.
+
+### 1.3 Component extractions
+
+| Step | Component | File | Present? |
+|---|---|---|---|
+| 1 | `AgentPicker` + `useForgeAgents` | `components/AgentPicker.tsx` | ✓ |
+| 11 | `AgentPresentationHeader` | `components/AgentPresentationHeader.tsx` | **✗ file deleted** |
+
+The header component was intentionally removed in the followups spec item #8 (PR #369) in favor of driving the pane frame title from `block.meta.agentName` / `agentIcon` via `AgentViewModel.viewName` / `viewIcon`. The modularization spec's original intent (move the header into its own file) was honored; the subsequent decision to delete it is documented in the followups spec. **✓ delivered** by the combination of steps 11 (extract) and followups #8 (delete).
+
+### 1.4 `scrollIntoView` ancestor-leakage bug (Step 9)
+
+Spec §4: The pane-titles-disappearing bug caused by `scrollIntoView` walking every scrollable ancestor. Fix: compute target offset inside `AgentDocumentView` and call `scrollRef.scrollTo({ top: ... })` directly.
+
+- **On main:** `AgentDocumentView.tsx:62` retains the comment explaining the bug; `:86` uses `scrollRef.scrollTo({ top: Math.max(0, centerOffset), behavior: "smooth" })`; `:117` uses `scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "instant" })` for the jumpToBottom path. **✓ delivered.**
+
+### 1.5 Mutable ref elimination
+
+Spec §3.3: "No mutable refs crossing component boundaries. `let scrollToNodeFn: ((id: string) => void) | null = null` is removed."
+
+- **On main:** `agent-view.tsx` still declares `let scrollToBottomFn: (() => void) | null = null` (line ~114). Used by both `AgentFooter.onTyping` and `useAgentCommands.onSent` to scroll on composer activity.
+- **Verdict:** **⚠ partial** — the `scrollToNodeFn` the spec called out specifically is gone (replaced by `useScrollToNode`'s signal command). But a **second** mutable ref, `scrollToBottomFn`, still exists for the scroll-on-type path, and `onSent` reuses it. The spec's anti-pattern rule is technically still violated by the second ref. Either rename the comment to acknowledge the one remaining ref, or port it to a signal-based command too (a `useScrollToBottom` hook mirroring `useScrollToNode`). Not a functional bug — the ref works — but a loose end against the stated invariant.
+
+### 1.6 `AgentNotificationStack` deferral
+
+Spec §5: "`AgentNotificationStack` component. Referenced in the target structure but deferred to a separate PR."
+
+- **On main:** still deferred. Banners (`SessionDigestBanner`, login-waiting, can-retry) are rendered inline in `agent-view.tsx` via `<Show>` blocks.
+- **Verdict:** **✗ missing** — explicitly out of scope per the spec. No action needed; flagged here for completeness.
+
+### 1.7 Cumulative trajectory
+
+Spec §4.12 table predicts `agent-view.tsx: 1,178 → ~250` after cleanup. Actual: **302**. 52 lines over the optimistic estimate, 2 lines over the hard cap. Within acceptable drift.
+
+---
+
+## 2. SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md — 4 PRs
+
+### 2.1 Per-card Forge + Identity buttons
+
+Spec §4.1: Each agent card gets ⚙ Forge and 👤 Identity buttons. Clicking opens an inline panel scoped to that agent.
+
+- **On main:** `components/AgentCard.tsx` renders `.agent-card-action-btn` buttons with ⚙ and 👤 glyphs. `AgentPicker.tsx` owns `expandedId` / `expandedTab` / `createMode` signals and conditionally mounts `<AgentCardSettingsPanel>` under the target card. **✓ delivered.**
+
+### 2.2 `+ New agent` tile
+
+Spec §4.3: A "+ New agent" tile at the end of the picker list opens the settings panel in create mode (empty `ForgeForm`).
+
+- **On main:** `components/NewAgentCard.tsx` renders a dashed-border tile. `AgentPicker.openCreateNew` sets `createMode=true` and `expandedId="__new__"` to trigger the create-mode panel. **✓ delivered.**
+
+### 2.3 Inline settings panel with tab switcher
+
+Spec §5: `AgentCardSettingsPanel` renders `ForgeDetail` / `ForgeForm` for the Forge tab and `IdentityPanel` for the Identity tab. Tab switcher in the panel header.
+
+- **On main:** `AgentCardSettingsPanel.tsx` exists (137 lines). Imports `ForgeViewModel`, `ForgeDetail`, `ForgeForm`, `IdentityViewModel`, `IdentityPanel`. Instantiates both view models per-panel, disposes on unmount, renders `<IdentityPanel model={identityModel} />` in the Identity tab. **✓ delivered.**
+
+### 2.4 Panel auto-close on ForgeDetail back
+
+Spec §5: "When the ForgeViewModel view flips back to 'list' (user clicked Back inside ForgeDetail) we want to close the whole settings panel."
+
+- **On main:** `AgentCardSettingsPanel.tsx` has a `createEffect` watching `forgeModel.viewAtom()` with a `mounted` guard (from the PR #364 reagent fix). **✓ delivered.**
+
+### 2.5 Widget bar cleanup
+
+Spec §7.4: Remove `defwidget@forge` and `defwidget@identity` from `agentmux-srv/src/config/widgets.json`.
+
+- **On main (`agentmux-srv/src/config/widgets.json`):** widget bar contains `agent`, `swarm` (hidden), `terminal`, `sysinfo`, `settings`, `help`, `devtools`. No `forge`, no `identity`. **✓ delivered.**
+
+### 2.6 BlockRegistry cleanup
+
+Spec §7.4: Unregister `ForgeView` and `IdentityView` in `frontend/app/block/block.tsx`.
+
+- **On main:** registered views are `term`, `cpuplot`, `sysinfo`, `help`, `launcher`, `agent`, `subagent`, `swarm`. **✓ delivered.**
+
+### 2.7 Saved-pane migration shim
+
+Spec §7.4: "Saved panes with `view: \"forge\"` or `view: \"identity\"` now resolve to `view: \"agent\"`."
+
+- **On main (`frontend/app/block/block.tsx:55`):** `const effectiveView = (blockView === "forge" || blockView === "identity") ? "agent" : blockView;` in `makeViewModel`. **✓ delivered.**
+
+### 2.8 Command palette cleanup
+
+Spec §7.4: Remove `open:forge` and `open:identity` palette commands.
+
+- **On main (`frontend/app/store/command-registry.ts`):** neither command exists. **✓ delivered.**
+
+### 2.9 `ForgeViewModel` / `IdentityViewModel` survival for per-panel use
+
+Spec §6: "Each panel creates its own `ForgeViewModel` — isolation, lifecycle, simplicity."
+
+- **On main:** `forge-model.ts` / `identity-model.ts` still exist in the `view/forge/` and `view/identity/` directories. `AgentCardSettingsPanel` instantiates both per-panel and calls `.dispose()` on unmount. **✓ delivered.**
+
+### 2.10 Identity per-agent scoping
+
+Spec §7 (PR 3): "This PR wires the existing **global** identity UI into the per-agent tab. Per-agent scoping is deferred to `SPEC_FORGE_AGENT_IDENTITY_2026_04_13.md`."
+
+- **On main:** Identity tab shows the global account list for any agent the user clicks 👤 on. Per-agent assignment filtering not implemented. **✗ missing (deferred)** — per the spec, this is intentional. No action needed here.
+
+---
+
+## 3. SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md — 9 items
+
+### 3.1 Item #1 — Send scroll-to-bottom fix
+
+- **PR:** #371 (merged)
+- **Verification:** `useAgentCommands.ts` has `onSent?` in options (line 60), fires `requestAnimationFrame(() => opts.onSent?.())` after `setDocument` (line 121–122). `agent-view.tsx` wires `onSent: () => scrollToBottomFn?.()` to the hook. **✓ delivered.**
+
+### 3.2 Item #2 — Remove stale "+ New agent in Forge" footer
+
+- **PR:** #368 (merged)
+- **Verification:** `grep -rn "agent-picker-forge-btn\|agent-picker-footer" frontend/app/view/agent/` returns **zero matches**. `AgentPicker.tsx` empty-state fallback now renders a live `<NewAgentCard onClick={openCreateNew} />`. **✓ delivered.**
+
+### 3.3 Item #3 — Auto-login on first open
+
+- **Status:** **⧗ pending** — not started. Requires changes inside `launch-flow.ts` Phase 2. Spec marks this as highest risk; scheduled to ship last.
+
+### 3.4 Item #4 — Tool `running` state on one line
+
+- **Status:** **⧗ pending** — not started. Blocked on item #6 (#367 PR) landing so the ToolBlock edits merge into known-good state.
+
+### 3.5 Item #5 — Errors on one line
+
+- **Status:** **⧗ pending** — not started. Planned to bundle with item #4 since both touch the same SCSS region.
+
+### 3.6 Item #6 — Tool hover-expand regression (Portal to escape paint containment)
+
+- **PR:** #367 (approved, not merged)
+- **Code delivered:**
+  - `ToolBlock.tsx` imports `Portal` from `solid-js/web`
+  - Overlay content rendered via `<Portal>` with `position: fixed` computed from the block's `getBoundingClientRect` on mouseenter
+  - Scroll listener attached while `overlayMode()` is active, reposition on scroll/resize
+  - Deferred `leavePending` timeout for hover-sticky across the DOM gap
+  - Portal `onMouseEnter` now routes through `handleMouseEnter` (clears the pending leave) — caught by reagent on first review, fixed in second push
+- **SCSS:** new top-level `.agent-tool-content--portal` rule (z-index 200, background, border, shadow, max-height) outside `.agent-view` since the portal mounts to `document.body`
+- **Verdict:** **⧗ pending** but ready to merge. Needs re-review after my latest push (0.33.134).
+
+### 3.7 Item #7 — Move AgentControlBar below the composer
+
+- **PR:** #370 (merged)
+- **Verification:** `agent-view.tsx` wraps `<AgentFooter>` + `<AgentControlBar>` in a `.agent-composer-region` flex column at the bottom of the pane. `.agent-control-bar` SCSS uses `border-top` (not `border-bottom`) to read as a sub-footer. **✓ delivered.**
+
+### 3.8 Item #8 — Remove in-pane header; use frame title
+
+- **PR:** #369 (merged)
+- **Verification:**
+  - `AgentPresentationHeader.tsx` file does not exist on main
+  - `AgentViewModel` has reactive `viewName` / `viewIcon` reading `block.meta.agentName` / `agentIcon` (agent-model.ts:38–54)
+  - `AgentViewModel.endIconButtons()` returns a back-arrow `IconButtonDecl` when `agentId` is set; click routes through `this.backToPicker()` (agent-model.ts:56–69)
+  - `AgentViewModel.backToPicker` method exists and is the single source of truth; `useAgentCommands.back()` delegates via the `backToPicker` option
+  - `.agent-pres-*` SCSS rules removed
+  - **✓ delivered.**
+
+### 3.9 Item #9 — Esc in composer (clear / stop)
+
+- **PR:** #372 (approved, not merged)
+- **Code delivered:**
+  - `AgentFooter.handleKeyDown` has an `Escape` branch: clears if `textareaRef.value.trim()` non-empty, else calls `props.onStopAgent?.()`
+  - Hint line updated to `Enter to send • Shift+Enter for newline • Esc to clear / stop`
+  - `useAgentCommands.stopAgent()` calls `RpcApi.ControllerInputCommand({ blockid, signame: "SIGINT" })`; backend `BlockInputUnion::signal` path accepts it
+  - `agent-view.tsx` passes `onStopAgent={commands.stopAgent}` to AgentFooter
+- **Verdict:** **⧗ pending** but ready to merge after rebase past #371's version collision (re-bumped to 0.33.133).
+
+---
+
+## 4. Summary table
+
+| Spec | Total items | ✓ delivered | ⚠ partial | ⧗ pending | ✗ missing (deferred) |
+|---|---:|---:|---:|---:|---:|
+| Modularization | 12 steps + 5 cross-cutting | 14 | 2 (line count, one mutable ref) | 0 | 1 (AgentNotificationStack) |
+| Forge/Identity consolidation | 10 deliverables | 9 | 0 | 0 | 1 (per-agent identity scoping) |
+| Pane followups | 9 items | 4 (#1 #2 #7 #8) | 0 | 5 (#3 #4 #5 #6 #9) | 0 |
+
+**Ship state:** 27 of 31 verifiable deliverables **shipped**. 2 **partial** (minor, line-count + one remaining ref), 5 **pending** (3 approved awaiting merge, 2 not started), 2 **explicitly deferred** to separate specs.
+
+---
+
+## 5. Gaps and loose ends
+
+### 5.1 `agent-view.tsx` is 302 lines, 2 over the ≤300 target
+
+Not urgent. Options to reclaim:
+- Inline the `agent-composer-region` div class name without the wrapping `<div>` (use `classList` on an existing node — but there's no natural parent).
+- Collapse a few multi-line JSX props into single lines.
+- Accept the 2-line overshoot and update the spec target.
+
+Recommendation: accept the overshoot. The spec target was an aspirational budget, not a hard contract; the code is structurally clean and reducing by two lines for its own sake would be wasted work.
+
+### 5.2 Second mutable ref (`scrollToBottomFn`) survives the modularization spec's "no mutable refs" rule
+
+The spec called out `scrollToNodeFn` specifically and replaced it with `useScrollToNode`. The same pattern (`scrollToBottomFn: (() => void) | null = null`) is still in `agent-view.tsx` for the scroll-on-type + scroll-on-send paths. Spec §3.3 says "no mutable refs crossing component boundaries" — this technically violates the rule.
+
+**Fix (optional):** introduce a `useScrollToBottom` hook mirroring `useScrollToNode`. Its `command()` accessor changes any time the consumer calls `jumpToBottom()`. `AgentDocumentView` reads it in an effect and invokes its internal `jumpToBottom` function. Consumers get `scroll.jumpToBottom()` instead of `scrollToBottomFn?.()`.
+
+Not urgent. The current ref works; this is purely a consistency cleanup.
+
+### 5.3 `AgentHeader.tsx` (not the presentation header) is dead code
+
+`frontend/app/view/agent/components/AgentHeader.tsx` exists on main but is not imported anywhere. Predates the modularization effort. Different from `AgentPresentationHeader.tsx` which was deleted in PR #369.
+
+**Recommendation:** delete it in a later cleanup pass. Not blocking.
+
+### 5.4 Followups items #3 / #4 / #5 still ahead of us
+
+Spec says ship ordering is `#6 → #2 → #8 → #7 → #1 → #9 → #4+#5 → #3`. Items #6 and #9 are approved but not yet merged. Items #4 and #5 are not started; they were intentionally blocked on #6 landing first so the ToolBlock state is stable. Item #3 (auto-login) is the last and riskiest.
+
+**Recommendation:** wait for #367 and #372 to be re-reviewed and merged. Then ship #4 + #5 bundled (one PR that touches `ToolBlock.tsx` + a small SCSS block for errors), then #3 as a standalone PR.
+
+### 5.5 Identity per-agent scoping is still the global list
+
+Explicitly deferred to `SPEC_FORGE_AGENT_IDENTITY_2026_04_13.md`. The UI is already wired inside the agent pane — that spec's work will change what data the `IdentityPanel` shows (only assigned accounts for the clicked agent), not where it renders.
+
+**Recommendation:** address when someone has the appetite to touch the identity model. Not blocking any current work.
+
+---
+
+## 6. Regressions (none observed)
+
+I checked every item the specs promised and cross-referenced against the current code. No delivered item is broken; no behavior from prior specs has been lost. The followup items still in flight are tracked with PR numbers and have review signal (#367 and #372 are approved).
+
+---
+
+## 7. Conclusion
+
+The agent pane consolidation work (modularization + forge/identity merge + first wave of followups) is in a consistent shape. Four of the nine followup items remain: three pending/ready (#6, #9 approved; #4+#5 blocked on #6), one riskiest last (#3).
+
+No emergency, no hidden regression. Two minor cleanups (line count, second mutable ref) can be deferred or skipped entirely. The specs match the code; the code matches the specs.
+
+Continue when ready.

--- a/docs/analysis/crashes-2026-04-13.md
+++ b/docs/analysis/crashes-2026-04-13.md
@@ -1,0 +1,152 @@
+# Crash Post-Mortem — 2026-04-13
+
+**Author:** AgentA
+**Build:** v0.33.130 portable (`~/Desktop/agentmux-cef-0.33.130-x64-portable/`)
+**Scope:** two crash signatures in a single long-running session launched ~15:31 PDT 2026-04-13, reported by the user while the graceful-crash-handling spec was being drafted.
+**Current state:** all three processes (launcher, host, sidecar) **still alive** in `tasklist` at the time of this write — but log output has been frozen for hours. See "Finding 2" below.
+
+---
+
+## Process inventory (at report time)
+
+```
+agentmux.exe                 15196   3,572 K    ← launcher
+agentmux-cef-0.33.130.exe    14732 103,300 K    ← host (main/UI thread)
+agentmux-srv-0.33.130-win    22804  23,324 K    ← sidecar
+agentmux-srv-0.33.130-win     3880   7,192 K    ← sidecar crash-monitor child
+agentmux-cef-0.33.130.exe    29480  30,112 K    ← CEF subprocess
+agentmux-cef-0.33.130.exe    26308  16,380 K    ← CEF subprocess
+agentmux-cef-0.33.130.exe    36764  22,616 K    ← CEF subprocess
+```
+
+Nothing has been terminated. The launcher is waiting on the host PID, the host is waiting on... something. Neither the CEF host nor the sidecar has logged a single line since ~23:36 PDT even though the host binary is still loaded in memory (WS=100 MB).
+
+---
+
+## Timeline
+
+| Local (PDT) | UTC | Event |
+|---|---|---|
+| 15:31:33 | 2026-04-13T22:31:33Z | Launcher spawns v0.33.130 host (`agentmux-launcher.log`: last `spawning` line) |
+| 15:31:33 | 22:31:33 | Host tracing pipeline starts — first memory heartbeat |
+| 15:31:33 | 22:31:33 | Sidecar starts, crash-handler installed |
+| 15:31:34 | 22:31:34 | **WS conn A (conn_id 8d6dfbae)** connects, immediately disconnects 0.3s later — short-lived handshake/reload, nothing unusual |
+| 15:31:34 | 22:31:34 | **WS conn B (conn_id b32df86e)** connects — main session |
+| 16:50:24 | **23:50:24** | **WS conn B disconnects.** No reconnect. **← Crash #1** |
+| 16:59 | 23:59:53 | Last line in 04-13 host log (daily file rollover) |
+| 17:00 | 00:00:13 (04-14) | First line in 04-14 host log — same process, just a new daily file |
+| 17:31 onwards (hourly) | 00:31 UTC etc. | Sidecar keeps writing its once-an-hour `session archiver sweep complete` line |
+| 23:31:33 | 06:31:33 (04-14) | **Last sidecar line** — a normal hourly session archiver sweep |
+| 23:36:14 | **06:36:14** (04-14) | **Last host memory heartbeat.** System memory at 31% load, 22 GB available — **NOT an OOM**. **← Crash #2** |
+| — | — | Both processes still resident in memory per `tasklist`, no log output since. Launcher has not written an `exited with code N` line for v0.33.130, so as far as it knows, the host PID is still alive. |
+
+Memory heartbeat `ws_mb` stayed at 91.8, `commit_mb` at 38.6 for the full 8-hour run. `page_faults` climbed from ~35k to ~117k monotonically — no resets, no spikes. **Not a memory pressure event.**
+
+---
+
+## Crash #1 — CEF renderer subprocess died (the "white screen")
+
+**Signature:**
+
+- Sidecar log `agentmuxsrv-v0.33.130.log.2026-04-13`: `"WebSocket client disconnected","conn_id":"b32df86e-9ff1-4751-9e74-0648d41573f1"` at **22:30:24 UTC** (16:50:24 PDT).
+- Host log `agentmux-host-v0.33.130.log.2026-04-13`: **continues writing memory heartbeats every 20 seconds** after the WS drop, all the way through the 04-14 file rollover.
+- No CEF render-process termination dump in `%LOCALAPPDATA%\CrashDumps\` (dumps there are for full process crashes; CEF subprocess deaths go to CEF's own Crashpad).
+- No `chrome.exe.*.dmp` from the actual session (the only `chrome.exe` dump in WER is from 18:18 PDT and belongs to a different Chrome instance — probably the user's regular browser).
+- `load_pct` at the time was 35–38%. **Plenty of RAM.** Not an OOM at the OS level. Whatever killed the renderer was a Chromium-internal condition — V8 OOM inside the renderer's own address space, a JS panic, an imported-module failure, or similar.
+
+**What the user saw:**
+
+The renderer subprocess was painting the frontend. When it died, CEF did **nothing** — it left the last paint on screen and didn't attempt to reload or show an error. The user sees a white/static screen. The host's IPC channel to the renderer is dead, so no JS runs, no RPC reaches anything.
+
+**Why we currently have no recovery:**
+
+`agentmux-cef/src/client.rs` has a `CefLoadHandler::on_load_error` implementation (the gray dev-server-not-running recovery page) but **no `CefRequestHandler`** — so no `on_render_process_terminated` callback ever fires on our side. This is exactly the hole the graceful-crash-handling spec (PR #375) plugs.
+
+**Post-mortem lesson:** the 78-minute run before the drop is not unusually long. Whatever killed the renderer is almost certainly a memory-pressure condition in the renderer's **own** V8/Blink heap (which is capped per-process, independent of system RAM) — long agent sessions accumulate DOM nodes and JS objects even with `content-visibility: auto`. This was briefly addressed in PR #222 (FileStore cache OOM, v0.32.78) but that was the sidecar side, not the renderer.
+
+---
+
+## Crash #2 — Host process (and heartbeat) hung
+
+**Signature:**
+
+- Host memory heartbeat **stops emitting** at 06:36:14 UTC 04-14 (23:36:14 PDT 04-13).
+- Sidecar hourly session archiver sweep **stops emitting** at 06:31:33 UTC 04-14 (23:31:33 PDT 04-13) — about 5 minutes earlier. The next hourly sweep never fires.
+- **Both processes are still in `tasklist`** at report time. Neither has exited. The launcher's log has no `exited with code N` line for v0.33.130, so the launcher hasn't detected host death either.
+- No exception dump in `%LOCALAPPDATA%\CrashDumps\`. The sidecar's `C:\CrashDumps\agentmuxsrv\` dir contains only the `monitor.sock` file — no dump.
+- System memory load at the last heartbeat: **31% (22 GB free)**. Not an OOM.
+
+**Interpretation:**
+
+This is a **hang**, not a crash. All threads in the host process (UI thread, memory heartbeat thread, tracing subscriber thread, IPC dispatcher) have stopped making forward progress. A typical cause for the heartbeat thread in particular — the **only** thread in the host that runs an infinite loop independent of UI input — is either:
+
+1. A global lock contention: some other thread is holding a lock that `tracing::info!` or the file appender needs, and `mem-heartbeat` is blocked waiting for it. All tracing calls use the same subscriber, so one slow sink drain can back-pressure everything.
+2. The OS has suspended the process (Windows Task Manager → "Suspend process", or a debugger is attached).
+3. A kernel-mode driver bug that paused the process (rare but happens with GPU/display driver bugs, which CEF exercises heavily).
+
+The sidecar stopping 5 minutes **earlier** than the host rules out a clean "OS suspended both processes at the same instant" theory — they stopped independently. The sidecar's last line is a session-archiver sweep; the host's last line is a memory heartbeat. The gap suggests **a slow, cascading failure** — first the sidecar gets wedged, then the host follows ~5 minutes later.
+
+**What the user saw:**
+
+UI was already dead from crash #1 (16:50 PDT). Between 16:50 and 23:36 the user either left the pane white on screen or closed the window. The host didn't get `on_before_close` (no graceful shutdown lines in the log). The process just gradually stopped doing anything. After 23:36, the window may or may not be visible depending on whether the user had already minimized or moved on; nothing on screen would reflect that the backend is effectively dead.
+
+**Why we currently have no recovery:**
+
+- No "hung process watchdog": the launcher waits on the host PID, not on the host's *liveness*. If the host goes zombie but keeps its PID, the launcher will wait forever.
+- No sidecar-side ping: the sidecar doesn't have a deadman's switch — once the host stops making RPCs, the sidecar just sits idle.
+- No user-facing signal: there's no banner saying "backend hasn't spoken in N minutes."
+
+---
+
+## How the in-flight crash-handling spec addresses these
+
+Cross-referencing against `specs/SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md`:
+
+| Symptom | Spec item | PR status |
+|---|---|---|
+| Crash #1 (renderer dies, white screen) | Step 1: `CefRequestHandler::on_render_process_terminated` + recovery HTML page | **PR #375 open** — landed but not merged yet |
+| Crash #1 if CEF doesn't fire the callback (e.g. unhandled JS panic) | Step 2: frontend `<ErrorBoundary>` + `window.onerror` / `onunhandledrejection` | Not started |
+| Crash #2 (host hangs, sidecar quiet) — **no spec item yet** | — | **Gap.** See recommendation below. |
+| "Backend hasn't spoken in N seconds" UI | Step 4: backend disconnect banner + reconnect logic | Not started — would partially cover crash #1's symptom from the user's side |
+| Proactive OOM warning before the crash | Step 5: memory warning banner | Not started — wouldn't have helped today (system had 22 GB free) |
+| Post-mortem log of crash context | Step 6: crash context + ring buffer of recent lines | Not started |
+
+## Gap: host-hang detection
+
+The spec in its current form assumes **crashes that terminate a process** — it catches render-process termination, unhandled JS, sidecar exit. It does **not** catch the case where the host keeps its PID but stops executing anything (crash #2).
+
+**Proposed addition** — a "host liveness watchdog" as a new step in the spec:
+
+- **Where:** agentmux-srv side (the only process we can be sure stays alive when the host hangs — and we saw today that even the sidecar can wedge, so this isn't bulletproof either, but it's the best we've got).
+- **What:** a dedicated thread that wakes once per minute, checks the time since the last inbound WebSocket message, and if it exceeds 5 minutes **with the host process still registered**, logs a hang warning and optionally kills the host PID so the launcher can re-spawn it.
+- **Caveat:** if the user intentionally minimized the window or locked their screen, the renderer legitimately goes quiet. The watchdog needs to distinguish "user idle" from "renderer wedged." The simplest heuristic: the host's memory heartbeat is **independent of UI activity** and runs every 20s. If the sidecar can observe that heartbeats have stopped (via a new `host:alive` wave event, or by checking the host log's mtime), it can be confident the host is wedged rather than idle.
+
+I'd write this up as a new follow-up item to the graceful-crash spec — **Step 7: host-hang watchdog** — but not block the current PR chain on it.
+
+---
+
+## Immediate action
+
+1. **Leave the current processes alone** — they're harmless zombies. The user can kill them via Task Manager by PID if they want the memory back:
+   ```
+   taskkill /PID 15196 /F   ← launcher
+   taskkill /PID 14732 /F   ← host
+   ```
+   (Taskkill by PID only, never by image name — other AgentMux instances may be running.)
+2. **PR #375** (render-process recovery page) directly addresses crash #1. Keep it in flight.
+3. **Add Step 7 to the spec** — host-hang watchdog. Separate PR after step 1 merges.
+4. **Investigate the renderer V8 budget** — separate line of work, but PR #222 pattern (heap audit + fix) would reduce the frequency of crash #1 not just its symptoms. Not urgent if the recovery page gets the user unstuck in seconds.
+
+---
+
+## Artifacts
+
+- Host logs:
+  - `~/.agentmux/logs/agentmux-host-v0.33.130.log.2026-04-13` — 419 KB, 1202 INFO lines
+  - `~/.agentmux/logs/agentmux-host-v0.33.130.log.2026-04-14` — 657 KB, 2314 INFO lines (last at 06:36:14 UTC)
+- Sidecar logs:
+  - `~/.agentmux/logs/agentmuxsrv-v0.33.130.log.2026-04-13` — 128 KB
+  - `~/.agentmux/logs/agentmuxsrv-v0.33.130.log.2026-04-14` — 1,743 B (7 hourly sweeps)
+- Launcher log: `~/.agentmux/logs/agentmux-launcher.log` — no exit line for v0.33.130
+- No WER crash dumps for this session (only pre-existing dumps from earlier versions)
+- No CEF Crashpad dumps for this session (only old WebView2 dumps from March)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.138",
+  "version": "0.33.139",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.138",
+      "version": "0.33.139",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.139",
+  "version": "0.33.140",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.139",
+      "version": "0.33.140",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.139",
+  "version": "0.33.140",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.138",
+  "version": "0.33.139",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md
+++ b/specs/SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md
@@ -1,0 +1,528 @@
+# SPEC — Agent Pane Follow-ups (post-consolidation)
+
+**Date:** 2026-04-13
+**Status:** Draft
+**Owner:** AgentA
+**Branches / PRs:** TBD
+
+Four small UX fixes surfaced during real use of the consolidated agent pane (after 0.33.130). Each is a standalone PR so they can land independently.
+
+---
+
+## 1. Scroll-to-bottom on send: user's own message is hidden
+
+### Observation
+
+User types into the composer and presses Enter. Their message is appended to the document as a `user_message` node, but the viewport doesn't move — so the message the user just sent is often off-screen at the bottom, and they only see it once the agent starts streaming a response (which triggers the next auto-scroll).
+
+### Root cause
+
+`AgentFooter` currently only calls `onTyping` on `input` events, which RAF-debounces a scroll-to-bottom via `AgentDocumentView.jumpToBottom`. On Enter, it calls `onSendMessage(message)` but does **not** fire `onTyping`, so there's no explicit scroll trigger after send.
+
+`AgentDocumentView`'s auto-scroll effect *should* fire when the document length changes (the new `user_message` node), but it's gated on `autoScroll`, which is set to `false` any time the user manually scrolls away from the bottom. Between the typing jump-to-bottom (which forces `autoScroll = true`) and the actual send, a `scroll` event can re-run `handleScroll` and flip `autoScroll` off if the composer grew and briefly moved the scroll position.
+
+Either way, by the time the `user_message` node is committed to the DOM, auto-scroll may be off, so the effect's scroll-to-bottom is skipped. Result: the message is hidden below the fold.
+
+### Fix
+
+Explicitly scroll to bottom **after** `sendMessage` has mutated the document. The append is synchronous inside `useAgentCommands.sendMessage`, but the DOM node for the new `user_message` is created in the next render tick. So the correct sequence is:
+
+1. Append the `user_message` node (already happens in `useAgentCommands.sendMessage`).
+2. Fire the RPC to the backend (unchanged).
+3. **On the next animation frame**, call `scrollToBottomFn?.()` — which is the same `jumpToBottom` that `onTyping` already uses (unconditional, forces `autoScroll = true` again).
+
+### Implementation
+
+- **`useAgentCommands.sendMessage`** takes a new optional `onSent?: () => void` callback and calls it after the document mutation, wrapped in a `requestAnimationFrame`.
+- **`agent-view.tsx`** passes `() => scrollToBottomFn?.()` as the `onSent` callback when constructing the hook.
+- `AgentFooter` is unchanged — it just calls `onSendMessage` and clears the textarea as before.
+
+Alternative considered: fire `onSent` synchronously inside `sendMessage` before the RPC. Rejected because the DOM node for the new `user_message` isn't mounted yet in the same tick — the scroll math would land above the new message. A single RAF defers to after the SolidJS render pass.
+
+### Risk
+
+Very low. One extra RAF per send, scrolls only if `scrollToBottomFn` is captured (which it always is for the presentation view).
+
+---
+
+## 2. Remove stale "+ New agent in Forge" footer button
+
+### Observation
+
+The agent picker has a disabled placeholder button at the bottom:
+
+```
+[ + New agent in Forge ]
+```
+
+It's inside `.agent-picker-footer` in `AgentPicker.tsx` and has been disabled forever. The empty-state fallback (when no agents are configured) has the same dead button. With the consolidation work, creating a new agent is now done via the `+ New agent` tile that sits *in the card list* and opens the inline settings panel in create mode. The footer button is pure noise.
+
+### Fix
+
+- Delete the `.agent-picker-footer` wrapper from `AgentPicker.tsx` (both in the success path and the empty-state fallback).
+- Delete the corresponding `.agent-picker-forge-btn` SCSS rules from `agent-view.scss` if they're not referenced elsewhere.
+- The empty-state UI still works — the existing `+ New agent` tile (PR #363) handles the create path from any state.
+
+### Risk
+
+None. Dead UI.
+
+---
+
+## 3. Auto-trigger login flow when the agent isn't authenticated
+
+### Observation
+
+First time a user opens an agent pane and the CLI reports "not logged in," the current flow:
+
+1. `startLaunchFlow` runs the auth check.
+2. CLI returns `auth_failed`.
+3. `useAgentControllerStatus` sets `canRetry(true)`.
+4. The UI shows a **Retry Login** button.
+5. User has to notice the button, click it.
+
+That's two clicks (open the pane, click Retry) to reach the thing the user obviously wants (logging in so the agent works). The retry button itself doesn't actually trigger the OAuth browser flow — it re-runs the `startLaunchFlow`, which re-runs the auth check, which fails again, and so on.
+
+### Desired behavior
+
+On first open, if the auth check fails, automatically run the provider's `/login` command (the same thing the `/login` slash command invokes from `useAgentCommands.runLoginCommand`). That command opens the OAuth browser, captures the returned URL into `setAuthUrl`, and transitions the pane into the `loginWaiting` state that's already rendered by the existing UI.
+
+### Fix
+
+Inside `runLaunchFlow`'s auth-check phase (launch-flow.ts), when the check reports unauthenticated, instead of returning `"auth_failed"` and letting the caller decide, run the provider's login command directly and then poll the check-auth command with the existing 2s cadence / 5-minute timeout loop. This is **already** what the flow does for some providers via the `login` step — verify it actually runs, and if not, wire it in.
+
+Specifically:
+- **`launch-flow.ts`**, Phase 2 (auth check): if the check-auth exit code / stdout indicates unauthenticated AND the provider has an `authLoginCommand` defined, automatically invoke it via `getApi().runCliLogin(cliPath, prov.authLoginCommand, authEnv)` — same call the manual `/login` slash command uses.
+- If the login command emits an OAuth URL, push it into `setAuthUrl` so the existing auth UI banner shows it.
+- Poll check-auth every 2s until it reports authenticated, cancelled, or 5 min elapses.
+- On success, continue to Phase 3 (controller registration).
+- On failure/timeout, fall back to the existing `auth_failed` path so the user still sees the Retry Login button — the manual path remains as a backstop.
+
+### Constraint
+
+**Don't auto-trigger during resume.** If the block already has `agentReady = true` from a prior session (i.e. the pane was reopened after a successful launch), skip the auto-login. Only run on first launch per pane. The `agentReady` signal in `useAgentControllerStatus` is the right gate — `startLaunchFlow` already early-returns if `flowRunning`; add a similar check for `agentReady` to skip the flow entirely when the pane is coming back from hydration.
+
+Actually simpler: the flow already handles "already authenticated" correctly — the check-auth command returns success on a cached credential, Phase 2 short-circuits, Phase 3 runs, done. No extra gate needed. The auto-login triggers only when the check actually says "no cached credential".
+
+### Risk
+
+Medium. The OAuth browser flow has historically been finicky — see `docs/AGENT_AUTH_STATE_MACHINES.md` and PR #357. Auto-triggering it means one bug there becomes one wrong auto-click for every user. Mitigations:
+- **Keep the manual Retry Login button as a backstop** for when auto-login fails or times out.
+- **Log each phase transition** to the launch-logs sink, so users can see what happened.
+- **Only auto-login for providers that have `authLoginCommand` defined** — providers without it fall back to the old flow.
+
+### Implementation notes
+
+- `runLaunchFlow` already accepts a `setAuthUrl` callback and a `setLoginWaiting` callback. All the plumbing is in place — this is about *when* the login kicks off, not *how*.
+- The existing `cancelLogin` path must still work during the auto-login phase so the user can bail out.
+
+---
+
+## 4. Tool blocks "running" state takes two lines — should be one
+
+### Observation
+
+Tool blocks have a collapsed-by-default state that the user explicitly asked to be strictly one line (see PR #346 and the existing feedback memory in `~/.claude/projects/C--Systems/memory/feedback_agent_pane_tool_display.md`). When a tool is in the `running` status, it currently takes two lines — icon + name + status on the first line, and the tool parameter summary on the second. At rest (status `success` / `failed`), hover expansion collapses it correctly.
+
+### Root cause
+
+`ToolBlock.tsx` has a branch that renders `running` tools with an always-expanded parameter row so the user can see what the tool is actively doing. This predates the one-line rule. The parameter row is what breaks the height invariant.
+
+### Fix
+
+Collapse the running-state representation to a single line. Options:
+
+1. **Append a spinner + truncated params to the summary line.** The summary already has the tool icon and name; add a spinner glyph and the first ~40 chars of the param text, ellipsized. Hover expansion still reveals the full params + any output.
+2. **Replace the param row with a subtle progress indicator.** A left-edge pulse or bottom border that animates while `running`, no extra height.
+
+Go with option 1 — it keeps the information density the user expects (you can see WHAT is running) while honoring the one-line rule.
+
+### Implementation
+
+- **`ToolBlock.tsx`**: in the `running` branch, remove the separate param row. Extend the summary text with a short truncation of the tool's `params` object — roughly what the current `nodeSearchText` helper produces for a `tool` node, clamped to ~40 chars.
+- Add a spinner glyph (`⏳` is already used as `STATUS_ICONS.running` in `types.ts`) to the left of the status — it's already there, just make sure it's on the summary line not a separate row.
+- **Hover expansion** still shows the full param object + in-flight output, so nothing is lost.
+- **Verify the CSS** — `.agent-tool-block` may have a min-height rule that assumes a two-line layout for running tools; relax to one line.
+
+### Risk
+
+Low. Localised change in one component. The existing hover-to-expand + click-to-pin UX is untouched.
+
+---
+
+---
+
+## 5. Errors collapse to one line by default
+
+### Observation
+
+Error content in the pane currently sprawls across many lines:
+
+- **Launch log errors** (tag `[error]` emitted via `log("error", ...)` into the terminal-style log area) render full stack traces or long error messages, each on a wrapped line in `.agent-status-log` / `.agent-status-line--error`.
+- **Failed tool blocks** show the error payload in an expanded body (`.exit-error` / `.has-error` in the SCSS) by default, not collapsed.
+- **Agent-reported errors** inside text blocks wrap naturally into as many lines as the message takes.
+
+This violates the same one-line rule tool blocks already follow (PR #346 / the user's feedback memory). The pane feels noisy when anything goes wrong.
+
+### Fix
+
+Every error should render as a **single line by default**, with the same hover-expand / click-to-pin affordances that tool blocks use. Specifically:
+
+**Launch log errors** (`LogLine` with `level === "error"`):
+
+- Collapse the error text to a single line, truncated to the pane width with ellipsis.
+- Add a 1-line `.agent-status-line--error--collapsed` variant that sets `white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%`.
+- On hover, reveal the full text — either by switching `white-space: pre-wrap` or by rendering a floating tooltip with the full message.
+- Click to pin open (same pattern as tool blocks).
+
+**Failed tool blocks:**
+
+- Already collapse by default per the existing one-line rule — verify and fix if status `failed` currently bypasses the collapsed-by-default path.
+- The error payload is shown inside the expanded body on hover; the collapsed summary line already includes the ✗ status icon and tool name.
+- If `ToolBlock.tsx` has special-case always-expanded logic for `failed` (mirroring the `running` bug in item #4 above), remove it.
+
+**Agent-reported errors inside text blocks:**
+
+- Out of scope for this pass — agent output is markdown and wrapping is intentional. Only in-pane status/log/tool errors get the one-line treatment.
+
+### Implementation
+
+- **`AgentDocumentView.tsx`** — the `.agent-status-line` rendering loop: for `level === "error"` lines, apply a collapsed variant class and wire hover/click handlers that toggle an "expanded" set (local signal in the component, keyed by line index).
+- **`agent-view.scss`** — add the `.agent-status-line--error--collapsed` rule (`white-space: nowrap; overflow: hidden; text-overflow: ellipsis`) and an `--expanded` variant that unsets the clamp.
+- **`ToolBlock.tsx`** — audit the `failed` branch. If it renders the error body always-expanded, route it through the same collapsed-by-default path used by `success` (parallel fix to item #4 for `running`).
+- **Persistence** — error expansion state is session-local, not stored in block meta. Same as tool pin state in the current design.
+
+### Alternative considered
+
+Show errors as a 1-line summary with a ⚠ icon and a **count** when multiple errors arrive in a burst (e.g. "3 errors — hover to view"). Rejected — adds aggregation UX that doesn't exist today and the user explicitly asked for "same 1-line scheme as the others", not a new scheme.
+
+### Risk
+
+Low. Localised to three files. The only semantic question is whether click-to-pin is needed for error log lines or if hover-to-expand is enough — start with hover-only and add pin if users ask for it.
+
+---
+
+## 6. Tool hover-expand is broken — shows only the hover highlight, no expanded body
+
+### Observation
+
+User hovers over a (collapsed) tool block and the hover style fires (border/background changes) but the expanded content never appears. Expanded content should show the full params + result inline or as an overlay.
+
+This is a regression relative to PR #346, which explicitly implemented hover-to-expand + click-to-pin semantics in `ToolBlock.tsx`. The docblock at `ToolBlock.tsx:5-29` still describes the intended behavior.
+
+### Root cause (hypotheses, to verify before implementing)
+
+`ToolBlock.tsx:73-99` implements the hover expansion like this:
+
+```ts
+const [hovered, setHovered] = createSignal(false);
+const forceExpanded = () => props.node.status === "failed" || props.node.status === "running";
+const expanded = () => props.pinned || hovered() || forceExpanded();
+const overlayMode = () => (hovered() || props.pinned) && !forceExpanded();
+```
+
+And `<Show when={expanded()}>` wraps the body. So the content IS computed. Likely failure modes:
+
+1. **`setHovered` never fires.** The `onMouseEnter` / `onMouseLeave` handlers were dropped during PR #348 ("tool hover overlay + scroll-on-type") which reorganized the overlay rendering. Grep for `setHovered` — if it's not called anywhere, the signal stays `false` and `hovered()` never toggles.
+2. **Overlay positioning is wrong so the expanded body mounts off-screen.** PR #348 introduced absolute-positioned overlay mode (`overlayMode()`). If `position.top` / `position.left` are computed from `blockRect` but the measurements fire before the first render, the overlay lands at `(0, 0)` or negative coordinates and is clipped by `overflow: hidden` on an ancestor.
+3. **`<Show>` is evaluated inside a `classList` context, not a JSX child.** Unlikely — line 234 shows `<Show when={expanded()}>` is a JSX child.
+4. **Pointer-events gap**: the overlay wrapper has `pointer-events: none` and the expanded content has nothing to receive the hover, so as soon as the mouse moves into the gap between the collapsed row and the overlay, `onMouseLeave` fires, the state flips back to collapsed, and you never see the body.
+
+My guess is **#1 or #4**. Need to read the current `ToolBlock.tsx` fully and trace the event handlers.
+
+### Fix
+
+1. **Verify `setHovered` is wired to `onMouseEnter` / `onMouseLeave` on the outer wrapper.** If missing, add them. If they fire on a child element that the mouse can leave en route to the overlay, hoist them to the wrapper that encompasses both the collapsed row and the expanded area.
+2. **Ensure the expanded overlay is hover-sticky.** The simplest hover-sticky pattern: the wrapper has `onMouseLeave` with a small (50–100 ms) delay, or the collapsed row and the overlay share a single wrapper that scopes the hover.
+3. **Log or temporarily render `hovered()` as a debug border color** during development to confirm the signal is toggling.
+4. If #4 is the cause, give the overlay `pointer-events: auto` so moving the mouse into the overlay keeps hover active.
+
+### Why this is separate from #4 (tool running one-line)
+
+Item #4 is about the *running* branch rendering two lines at rest. Item #6 is about hover expansion being completely broken for ALL tool states that should support it (`success`, in particular — the at-rest default). They touch the same file but are independent bugs; fix #6 first because it blocks the hover UX entirely.
+
+### Risk
+
+Low-to-medium. The symptom is a regression in established behavior, so there's a known-good state to aim for. Risk is misdiagnosis — always fire up the pane and verify the signal transitions before shipping.
+
+### Out of scope
+
+- Redesigning the hover → pin UX — keep the current contract.
+- Switching to a click-only expansion model — the user explicitly wants hover-to-expand.
+
+---
+
+---
+
+## 7. Move the runtime options dropdown below the composer hint
+
+### Observation
+
+The `AgentControlBar` (permission mode · model · effort) currently sits **above** the document view, between the header and the message list:
+
+```
+┌ AgentPresentationHeader ─────────────────────┐
+│ ⚡ claude-sonnet                         [✕] │
+├──────────────────────────────────────────────┤
+│ [AgentControlBar — Permission │ Model │ ...] │  ← now here
+├──────────────────────────────────────────────┤
+│  (document view — messages + tool blocks)   │
+├──────────────────────────────────────────────┤
+│  composer textarea                           │
+│  Enter to send • Shift+Enter for newline     │
+└──────────────────────────────────────────────┘
+```
+
+It should live **below** the composer hint line instead:
+
+```
+┌ AgentPresentationHeader ─────────────────────┐
+│ ⚡ claude-sonnet                         [✕] │
+├──────────────────────────────────────────────┤
+│  (document view — messages + tool blocks)   │
+├──────────────────────────────────────────────┤
+│  composer textarea                           │
+│  Enter to send • Shift+Enter for newline     │
+│  [AgentControlBar — Permission │ Model │ ...] │  ← moves here
+└──────────────────────────────────────────────┘
+```
+
+Rationale: the controls are **per-turn settings** (permission mode, model, effort) — always available but rarely touched. Putting them above the document eats vertical space from the messages (the thing the user actually looks at). Placing them below the composer keeps them one glance away but out of the primary reading area.
+
+### Fix
+
+`agent-view.tsx` composes the layout. Move the `<AgentControlBar>` element out of its current slot (after the header) and drop it into the composer region — structurally a sibling of `<AgentFooter>`, rendered immediately after it.
+
+Simplest implementation: wrap `<AgentFooter>` and `<AgentControlBar>` together in a `.agent-composer-region` container so they're visually one unit at the bottom.
+
+```tsx
+// agent-view.tsx — approximate target
+<AgentPresentationHeader ... />
+<Show when={bookmarks.visible()}>
+  <BookmarksPanel ... />
+</Show>
+<AgentSearchBar ... />
+<Show when={!digest.dismissed()}>
+  <SessionDigestBanner ... />
+</Show>
+<AgentDocumentView ... />
+<Show when={status.loginWaiting()}>...</Show>
+<Show when={status.canRetry()}>...</Show>
+
+<div class="agent-composer-region">
+  <AgentFooter ... />
+  <AgentControlBar ... />  {/* now here, not up top */}
+</div>
+```
+
+### SCSS adjustments
+
+- `.agent-control-bar` currently has top-of-pane styling (border-bottom, maybe top margin). Flip to a top-border on the bottom variant so it reads as a sub-footer rather than a sub-header.
+- The collapsible-body transitions upward into the composer area — verify `max-height` / `overflow` still behave correctly when the bar is anchored to the bottom.
+- The header row with the `[ ⚙ Permission │ Model │ Effort ]` chevron-toggle pattern stays the same; only the vertical position changes.
+
+### Risk
+
+Low. The control bar is self-contained — it reads block meta via RPC, has its own collapsed/expanded state, doesn't reach into document view. Moving its mount point is a JSX reorder + a SCSS border flip.
+
+One thing to verify: when `AgentControlBar` was placed above the document, expanding its body pushed the document down (flex-column natural behavior). When it's below the composer, expanding should push the composer UP (or the control body expands downward from the top-border). Both are fine; just pick one and make sure the max-height animation doesn't feel wrong.
+
+### Out of scope
+
+- Redesigning the controls (permission mode enum, model list, effort levels). Unchanged.
+- Adding new controls. Unchanged.
+- Making the control bar dockable (user can choose top/bottom). Overkill.
+
+---
+
+---
+
+## 8. Remove the in-pane `AgentPresentationHeader`; use the pane frame's title instead
+
+### Observation
+
+Inside the agent pane we render an `AgentPresentationHeader` strip at the very top:
+
+```
+┌─────────────────────────────────────┐
+│ [agent] claude-sonnet          [✕]  │  ← AgentPresentationHeader
+├─────────────────────────────────────┤
+│ pane header (block frame)           │  ← existing block chrome
+├─────────────────────────────────────┤
+```
+
+But the block frame already has its own title area that shows the view name + icon. The in-pane header duplicates that information, eating vertical space.
+
+### Current state
+
+- `AgentViewModel` in `agent-model.ts` sets `viewName = () => "Agent"` and `viewIcon = () => "sparkles"` — both static. The block frame therefore displays "Agent" / sparkles regardless of which forge agent is launched.
+- `AgentPresentationHeader` (44 lines, `components/AgentPresentationHeader.tsx`) renders the icon + name from `block.meta.agentName` / `agentIcon` and the `✕ Back to agents` button.
+- Pane title doesn't update as the user picks an agent because `viewName` never reads the meta.
+
+### Fix
+
+**Drive the pane's title from the launched agent's name/icon**, and delete the in-pane header entirely.
+
+1. **Make `viewName` / `viewIcon` reactive** to `block.meta.agentName` / `agentIcon`:
+   ```ts
+   // agent-model.ts
+   this.viewName = () => {
+       const meta = this.blockAtom()?.meta;
+       return meta?.["agentName"] ?? "Agent";
+   };
+   this.viewIcon = () => {
+       const meta = this.blockAtom()?.meta;
+       return meta?.["agentIcon"] ?? "sparkles";
+   };
+   ```
+   The `blockAtom` is already a `SignalAtom<Block>` — SolidJS will re-evaluate these accessors when the meta changes after launch.
+2. **Delete `<AgentPresentationHeader>` from `agent-view.tsx`.**
+3. **Delete `components/AgentPresentationHeader.tsx`** — no other callers.
+4. **Delete the `.agent-pres-header` / `.agent-pres-icon` / `.agent-pres-name` / `.agent-pres-back` SCSS rules** from `agent-view.scss`.
+
+### The `✕ Back to agents` button
+
+The header was the only entry point for "exit this agent session and return to the picker." We lose that UI when we delete the header. Options:
+
+1. **Block frame header icons.** `ViewModel` exposes a `viewText: () => string | HeaderElem[]` that can include interactive elements. Add a small back-arrow icon there so the pane frame shows it next to the title.
+2. **Context menu on the pane header** — right-click → "Back to agents." Less discoverable; reject.
+3. **Keyboard shortcut only** (e.g. `Ctrl+Shift+B`). Too hidden.
+4. **Command palette action** — "Agent: Back to picker." Good as a secondary path but not as the only one.
+
+Go with **option 1** (block frame header icon) as primary + **option 4** as a secondary affordance.
+
+For option 1, the exact implementation depends on `HeaderElem`'s existing vocabulary — check `frontend/types/custom.d.ts` for whether it supports click-able icons, or if we need a new variant. If it doesn't, fall back to placing a small back button inside the control bar row (from item #7) as a stopgap.
+
+### Alternative considered
+
+**Keep the header but shrink it to a narrow breadcrumb row.** Rejected — the user's explicit guidance is "we'll be using the pane's title for that." Two sources of truth for the agent identity is the exact thing they're calling out.
+
+### Implementation notes
+
+- The `handleBack` action (currently in `useAgentCommands.back()` and called from the header's `onBack` prop) stays exactly the same — it still clears `agentId` + related meta keys so the view falls back to the picker via `AgentViewWrapper`. Just the caller changes.
+- After removal, `agent-view.tsx`'s JSX is simpler by ~6 lines.
+- Verify the pane frame rerenders its title when `meta.agentName` changes — the existing WOS atom subscription should handle it automatically. Test by launching an agent and watching the frame title flip.
+
+### Risk
+
+Low. Delete operation + one accessor wire-up. The one thing to verify is that the back action remains reachable via SOME UI surface (header icon OR command palette) before this PR ships — losing the `✕` without a replacement would trap the user in the agent view.
+
+### Out of scope
+
+- Redesigning the block frame chrome.
+- Adding per-agent colors to the pane title.
+- Making the pane title editable in place.
+
+---
+
+## 9. Estimated cost
+
+| # | Feature | File(s) | Est. time | Review rounds |
+|---:|---|---|---:|---:|
+| 1 | Send scroll-to-bottom | `useAgentCommands.ts`, `agent-view.tsx` | 15 min | 0–1 |
+| 2 | Remove footer button | `AgentPicker.tsx`, `agent-view.scss` | 5 min | 0 |
+| 3 | Auto-login | `launch-flow.ts` | 30 min | 1–2 |
+| 4 | Tool `running` one-line | `ToolBlock.tsx`, `agent-view.scss` | 15 min | 0–1 |
+| 5 | Errors one-line | `AgentDocumentView.tsx`, `ToolBlock.tsx`, `agent-view.scss` | 20 min | 0–1 |
+| 6 | Fix tool hover-expand regression | `ToolBlock.tsx` | 30 min | 0–1 |
+| 7 | Move control bar to bottom | `agent-view.tsx`, `agent-view.scss` | 15 min | 0–1 |
+| 8 | Remove in-pane header; use frame title | `agent-model.ts`, `agent-view.tsx`, `agent-view.scss` (delete) | 20 min | 0–1 |
+| 9 | Esc = clear / stop agent | `AgentFooter.tsx`, `useAgentCommands.ts`, `agent-view.tsx` | 15 min | 0–1 |
+
+Total: ~165 min of coding, 1–8 review rounds. Ship as separate PRs; **bundle #4 + #6** (both ToolBlock), and keep the rest standalone.
+
+---
+
+## 9. Esc key in the composer: clear if text, stop the agent if empty
+
+### Observation
+
+The composer currently only listens for Enter (send) and Shift-Enter (newline). There's no way to cancel a message you've started typing without selecting-all and deleting, and no way to stop an agent mid-turn without finding the right UI affordance elsewhere.
+
+### Desired behavior
+
+Two Esc semantics, chosen by the current textarea state:
+
+1. **If the textarea has text:** Esc clears it. Cursor stays in the composer, ready for the next message.
+2. **If the textarea is empty (or whitespace only):** Esc sends a **stop signal** to the running agent process — same as Ctrl+C would in a terminal. Claude Code supports this via a SIGINT to the CLI process.
+
+The two behaviors are mutually exclusive per keypress, so one handler is enough.
+
+### Fix
+
+**`AgentFooter.tsx`** — extend `handleKeyDown`:
+
+```ts
+const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+        return;
+    }
+    if (e.key === "Escape") {
+        e.preventDefault();
+        if (textareaRef && textareaRef.value.trim().length > 0) {
+            textareaRef.value = "";
+            // Fire onTyping so the composer resets its auto-grow
+            props.onTyping?.();
+        } else {
+            props.onStopAgent?.();
+        }
+    }
+};
+```
+
+**`AgentFooter` props** — add `onStopAgent?: () => void`. If unset, Esc on empty is a no-op (defensive).
+
+**`agent-view.tsx`** — wire `onStopAgent` to a new `commands.stopAgent()` (item below) so the composer doesn't reach into the model directly.
+
+**`useAgentCommands.ts`** — add a `stopAgent()` method that sends a SIGINT to the CLI process via the existing `RpcApi.ControllerInputCommand(TabRpcClient, { blockid, signame: "SIGINT" })` path. This is already documented in the memory file for terminal I/O and used by the terminal view, so the RPC exists.
+
+### Hint line
+
+Update the composer hint to reflect the new binding:
+
+```
+Enter to send • Shift+Enter for newline • Esc to clear / stop
+```
+
+### Risk
+
+Low. Esc is an obvious UX improvement. The only subtle concern: the composer is inside a pane and Esc might conflict with something at the window level (e.g. closing a modal). `e.preventDefault()` only blocks default, not propagation — if we need to stop propagation too, add `e.stopPropagation()`. Check if any ancestor listens for Esc.
+
+### Out of scope
+
+- Graceful stop (`/stop` slash command, soft shutdown, etc.). Esc sends SIGINT — equivalent to Ctrl+C. If the agent ignores SIGINT on certain platforms, that's a separate fix.
+- Esc cancelling the OAuth login flow — already handled by the existing `cancelLogin` button.
+- Visual "stopping..." indicator — out of scope; the existing subprocess-done log line covers it.
+
+---
+
+## 10. Ordering
+
+**#6 first** (hover is broken; blocks all tool-expansion UX — restore it before touching anything else in ToolBlock) → **#2** (dead code, zero risk) → **#8** (remove in-pane header, atomic deletion) → **#7** (control bar move, layout-only) → **#1** (send scroll, trivial) → **#9** (Esc key handling) → **#4 + #5 bundled** (one-line rule for running tools + errors) → **#3 last** (auto-login, biggest surface area).
+
+Reasoning: #6 is a regression gating other tool UX, fix it before anything else in that file. #7 is a pure layout reorder with no behavior change, ship it early so the test builds reflect the new layout. #3 is riskiest and ships last.
+
+## 10. Success criteria
+
+After all nine:
+
+- Pressing Enter in the composer scrolls the document so the user's own message is visible, every time.
+- The picker has no `+ New agent in Forge` button at the bottom. The `+ New agent` tile in the list is the only way to create one.
+- Opening an agent pane for the first time (no cached credentials) opens the OAuth browser flow automatically. The user completes login in the browser; the agent pane transitions to the running state without a manual click.
+- Tool blocks in `running` state are exactly one line tall, matching the existing success/failed rule. Hover still expands to show params + output.
+- Error log lines and failed tool blocks render as a single line at rest. Hover reveals the full error text. The pane is calm when something goes wrong, not sprawling.
+- Hovering a collapsed tool block expands it to show the full params + result (or routes through overlay mode per PR #348). Click to pin still works.
+- The runtime control bar (permission mode · model · effort) sits **below** the composer hint line, not above the document view. Expanding it reveals the controls without covering the messages.
+- The in-pane `AgentPresentationHeader` is gone. The block frame's title shows the launched agent's name + icon (reactive to `block.meta.agentName` / `agentIcon`). A "back to picker" action is reachable from at least one surface (block header icon or command palette).
+- Pressing Esc in the composer with text clears the textarea. Pressing Esc with an empty composer sends a SIGINT to the agent CLI process. The hint line reflects both bindings.
+
+## 11. Out of scope
+
+- Redesigning the auth state machine — just auto-trigger the existing flow.
+- Adding a progress indicator to running tools beyond the existing spinner — option 2 above is rejected.
+- Touching the slash-command dispatcher (`/login`, `/clear`) — unchanged.
+- Error aggregation / count badges — rejected above; keep it simple.
+- Wrapping agent-generated text output (markdown) — agent text stays as-is.
+- Any backend change — these are all frontend/UX fixes.

--- a/specs/SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md
+++ b/specs/SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md
@@ -1,0 +1,359 @@
+# SPEC — Graceful Crash Handling
+
+**Date:** 2026-04-13
+**Status:** Draft
+**Owner:** AgentA
+**Trigger:** Reported 2026-04-13: VSCode and AgentMux both hit OOM; AgentMux silently turned white with no error, no recovery UI, nothing actionable for the user.
+
+---
+
+## 1. The problem
+
+When something goes catastrophically wrong in AgentMux — OOM, renderer crash, sidecar exit, fatal JS error — the user currently sees **nothing**:
+
+- The window turns white (renderer process terminated, nothing left to paint).
+- No toast, no dialog, no recovery UI.
+- Closing the window requires Task Manager or the title-bar close button.
+- Restarting loses whatever wasn't persisted in block files.
+- No clear indication *what* crashed: CEF host? sidecar? frontend JS?
+
+For a local dev tool this is tolerable. For a daily driver that runs agent sessions for hours it isn't. Every crash becomes a silent failure plus a question ("what just happened?").
+
+## 2. What a crash actually looks like
+
+Four distinct failure modes, each with a different visible symptom and a different fix:
+
+### 2.1 CEF renderer process crash (the white screen)
+
+**Cause:** OOM in the Chromium renderer, a native-code bug inside CEF, or a JS execution panic that somehow takes out the whole V8 isolate.
+
+**Symptom:** the window stays up (chrome, title bar, window decorations visible) but the content area turns white. No JS runs. No IPC reaches the host.
+
+**Detection:** CEF fires `CefRequestHandler::OnRenderProcessTerminated` on the host process. It's a C++ callback available via the rust-cef bindings we already use. We do **not** currently implement it.
+
+**What we can do:** the host still has full control — it can navigate the browser to an in-memory HTML error page, it can prompt the user, it can reload the document in-place. The sidecar is untouched so block state is preserved.
+
+### 2.2 Sidecar (`agentmux-srv`) crash
+
+**Cause:** Rust panic, OOM in the server process, GPU backend issue, exit code 1 on some path we missed.
+
+**Symptom:** the WebSocket to the frontend drops. The frontend keeps running but every RPC times out and every subscribed event stops firing. Right now the UI just... sits there with stale data.
+
+**Detection:** the WebSocket client already fires `onclose` / `onerror` events — we have them wired somewhere for reconnect logic but not for user-visible notification.
+
+**What we can do:** show a banner at the top of the window ("Backend disconnected — reconnecting..."), attempt reconnect with backoff, show a "Restart backend" button after N failed attempts.
+
+### 2.3 Fatal JS error in the frontend
+
+**Cause:** unhandled promise rejection, circular dependency, a SolidJS effect that throws inside a `createEffect`, a missing import.
+
+**Symptom:** depends on where. Sometimes the UI partially renders and then freezes. Sometimes a white screen. Sometimes a single pane goes blank while the rest works.
+
+**Detection:** `window.onerror` and `window.onunhandledrejection` catch most of these. We already have a `showStartupError()` function in `frontend/wave.ts` but it's only called from the initial bootstrap path — **no runtime error boundary** catches failures after the app is up.
+
+**What we can do:** install a top-level error boundary via SolidJS `<ErrorBoundary>`; install a global `window.onerror` listener; render a persistent notice ("Something broke — reload to recover") with a reload button.
+
+### 2.4 Pane-local errors (single pane crashes)
+
+**Cause:** a single ViewModel throws, a single agent process hits a bug, a block file gets corrupted.
+
+**Symptom:** one pane goes blank or shows stale content; the rest of the app works fine.
+
+**Detection:** wrap each block's `<ErrorBoundary>` around the view component.
+
+**What we can do:** show a per-pane "This pane crashed. Reload?" placeholder that offers to re-create the view model. Other panes stay untouched.
+
+## 3. Existing infrastructure we can reuse
+
+- **Memory heartbeat** (`agentmux-cef/src/memory_heartbeat.rs`, v0.33.62): already logs system + per-process memory every 20s to the `mem_heartbeat` tracing target. We can surface this to the user as a warning ("memory usage at 92%, consider restarting") BEFORE a crash, not just as a post-mortem log trail.
+- **WER crash dumps**: already configured per the memory file — dumps land in `%LOCALAPPDATA%\CrashDumps\` on sidecar crashes.
+- **`showStartupError()`** (`frontend/wave.ts:132`): existing UI for showing a fullscreen error message with a `<pre>` block. Reusable for runtime errors with small tweaks.
+- **WebSocket `onclose` / `onerror`**: already fire on backend disconnect. Need to be routed to UI, not just logged.
+- **`CefLifeSpanHandler`** (`agentmux-cef/src/client.rs:467`): already implemented. Adding `CefRequestHandler` (for `OnRenderProcessTerminated`) is the same pattern.
+
+## 4. Goals
+
+1. **No silent white screens.** Every fatal state renders *something* the user can read, click, and recover from.
+2. **Preserve work when we can.** Block state lives on disk (files under `~/.agentmux/`); a CEF renderer crash shouldn't lose it. A sidecar crash shouldn't either. Only a full machine kill loses in-flight text in the composer.
+3. **One-click recovery.** The user always has a button: "Reload", "Restart", "Quit cleanly". No Task Manager required.
+4. **Proactive OOM warning.** When memory usage crosses a threshold (say 85% of physical RAM OR 80% of per-process limit), warn the user *before* the crash, so they can save and restart on their terms.
+5. **Telemetry trail.** Every crash writes a line to the host log with the failure mode, the memory state from the most recent heartbeat, and the last 20 log lines. Makes post-mortems actionable.
+
+## 5. Non-goals
+
+- **Automatic recovery.** We don't try to silently relaunch a crashed renderer; that masks bugs. The user always sees a notice.
+- **Persisting composer draft text.** Out of scope for this spec. (Could be a separate follow-up.)
+- **Crash reporter sending dumps to a server.** Local logs only; no network telemetry.
+- **Supporting every obscure CEF failure.** Focus on the four categories in §2.
+
+## 6. Design
+
+### 6.1 CEF renderer-terminated handler (the biggest win)
+
+**New file:** `agentmux-cef/src/request_handler.rs` implementing `CefRequestHandler`. Wire it from `client.rs` alongside the existing `LifeSpanHandler` / `LoadHandler` / etc.
+
+```rust
+// Sketch — not final signature
+impl RequestHandler {
+    fn on_render_process_terminated(
+        &self,
+        browser: Option<&mut Browser>,
+        status: TerminationStatus,
+        error_code: i32,
+        error_string: Option<&CefString>,
+    ) {
+        let reason = match status {
+            TS_PROCESS_CRASHED => "crashed",
+            TS_PROCESS_OOM => "out of memory",
+            TS_ABNORMAL_TERMINATION => "abnormal termination",
+            TS_KILLED => "killed",
+            _ => "unknown",
+        };
+
+        tracing::error!(
+            target: "cef",
+            status = ?status,
+            error_code,
+            error = ?error_string,
+            "render process terminated: {}", reason,
+        );
+
+        // Log the last memory heartbeat snapshot for context
+        memory_heartbeat::log_current_state("render_terminated");
+
+        // Navigate the browser to a built-in recovery page instead of
+        // leaving it white. The page is bundled into the binary at
+        // compile time (include_str!) so it works even if the frontend
+        // can't load.
+        if let Some(b) = browser {
+            b.get_main_frame()
+                .expect("main frame")
+                .load_url(&CefString::from(RECOVERY_PAGE_URL));
+        }
+    }
+}
+```
+
+**The recovery page** is an `agentmux://recovery` custom-scheme URL (we already handle `agentmux://` for frontend assets) or a `data:` URL if simpler. It renders:
+
+```
+╔════════════════════════════════════════╗
+║  ⚠  AgentMux hit a problem             ║
+║                                        ║
+║  Reason: out of memory                 ║
+║  Memory at crash: 92% (14.8/16 GB)     ║
+║                                        ║
+║  Your open sessions are still saved.   ║
+║  Reload to continue where you left off.║
+║                                        ║
+║  [Reload window]  [Show logs]  [Quit]  ║
+╚════════════════════════════════════════╝
+```
+
+**Buttons:**
+- **Reload window** → `browser.reload()` triggers a fresh navigate to the app URL; frontend bootstraps again, sidecar is untouched, sessions resume from disk.
+- **Show logs** → opens `%LOCALAPPDATA%/ai.agentmux.cef.*/logs/` in Explorer via a custom protocol hook.
+- **Quit** → posts a close message to the host.
+
+The recovery page is plain HTML+CSS, no JS dependencies, bundled with `include_str!` into the host binary so it renders even if the webserver and the sidecar are both dead.
+
+### 6.2 Sidecar disconnect banner
+
+**New file:** `frontend/app/ui/BackendStatusBanner.tsx`. Mounts in the top-level layout (`wave.ts` or wherever the root `<div>` lives).
+
+Reads from a new signal `backendState` (in `frontend/app/store/global.ts` or similar):
+
+```ts
+type BackendState =
+    | { kind: "connected" }
+    | { kind: "connecting"; since: number; attempt: number }
+    | { kind: "disconnected"; since: number; lastError?: string; canRestart: boolean };
+```
+
+The WebSocket client already has `onclose` / `onerror`. Wire them to set the signal:
+- First disconnect → `connecting` with exponential backoff (1s, 2s, 4s, 8s, max 30s).
+- After 3 failed reconnects → `disconnected` with a "Restart backend" button.
+
+Banner renders as a thin strip above the title bar:
+
+```
+─────────────────────────────────────
+ ⚠ Backend disconnected — reconnecting (attempt 3)    [Restart backend]
+─────────────────────────────────────
+```
+
+**Restart backend button:** sends a message to the CEF host via the existing IPC channel (`window.cefHost` or whatever we call it). The host re-spawns `agentmux-srv` with the same args. On success the frontend reconnects automatically.
+
+### 6.3 Frontend error boundary + global handlers
+
+**New file:** `frontend/app/ui/ErrorBoundary.tsx`. A SolidJS component that wraps the root tree. Renders a fallback UI when its child throws during render or effect.
+
+**Global listeners** installed once in `wave.ts`:
+
+```ts
+window.addEventListener("error", (e) => {
+    logFatal("window.error", e.error?.stack ?? e.message);
+    showRuntimeError(e.message);
+});
+window.addEventListener("unhandledrejection", (e) => {
+    logFatal("unhandled_promise", String(e.reason));
+    showRuntimeError(String(e.reason));
+});
+```
+
+`showRuntimeError(message)` renders an overlay on top of the app (not a full-screen takeover — the existing app might still be usable) with:
+- Error message (truncated to first 500 chars)
+- "Reload window" button
+- "Dismiss" button (lets the user try to continue)
+- "Copy details" button (for bug reports)
+
+### 6.4 Per-pane error boundary
+
+Wrap each `<BlockFrame>`'s view component in a SolidJS `<ErrorBoundary>`. On error, show:
+
+```
+┌──────────────────────────────────┐
+│ This pane encountered an error.  │
+│                                  │
+│ Error: <short message>           │
+│                                  │
+│ [Reload pane]  [Close]  [Logs]   │
+└──────────────────────────────────┘
+```
+
+**Reload pane:** disposes the current view model and re-creates it from the block's saved meta. Works because view models are all stateless-on-meta by design.
+**Close:** removes the pane from the layout.
+**Logs:** opens the logs directory.
+
+### 6.5 Proactive OOM warning
+
+Memory heartbeat fires every 20s. Add a threshold check:
+
+- **System physical memory load > 85%:** emit a `mem_warning` tracing event with severity `warn`.
+- **Any AgentMux process (host/srv/renderer) > 80% of per-process 4GB limit:** emit with severity `error`.
+
+The host exposes these events over IPC to the frontend via a `system:memory_warning` wave event. A new `MemoryWarningBanner` component renders a thin orange strip:
+
+```
+⚠ Memory usage 89% — consider restarting AgentMux before it crashes   [Restart]
+```
+
+The banner auto-dismisses when memory drops below 80%.
+
+### 6.6 Crash context in logs
+
+Every crash path writes one structured log line via the existing `tracing` pipeline:
+
+```rust
+tracing::error!(
+    target: "crash",
+    kind = "renderer_oom",
+    memory_pct = 92,
+    last_heartbeat = %last_heartbeat_json,
+    last_20_log_lines = %recent_logs_json,
+    "crash detected",
+);
+```
+
+The `last_heartbeat_json` is captured from the memory heartbeat module's most recent sample. The `last_20_log_lines` is captured from an in-memory ring buffer that `tracing`'s subscriber already has access to (need to add a small `recent_logs` layer).
+
+## 7. Files to add / modify
+
+### New files
+
+- `agentmux-cef/src/request_handler.rs` — `CefRequestHandler` impl with `on_render_process_terminated`.
+- `agentmux-cef/assets/recovery.html` — bundled static HTML for the recovery page (or generated inline).
+- `agentmux-cef/src/recent_logs.rs` — small ring buffer `tracing` layer keeping the last N log entries in memory.
+- `frontend/app/ui/BackendStatusBanner.tsx` — disconnect banner + restart button.
+- `frontend/app/ui/MemoryWarningBanner.tsx` — proactive OOM warning.
+- `frontend/app/ui/RuntimeErrorOverlay.tsx` — overlay for `window.error` / `unhandledrejection`.
+- `frontend/app/ui/PaneErrorBoundary.tsx` — per-pane SolidJS `<ErrorBoundary>` wrapper.
+
+### Modified files
+
+- `agentmux-cef/src/client.rs` — wire the new `RequestHandler`.
+- `agentmux-cef/src/memory_heartbeat.rs` — add threshold check, emit `mem_warning` event.
+- `agentmux-cef/src/main.rs` — register the `recent_logs` tracing layer.
+- `frontend/wave.ts` — install global `error` / `unhandledrejection` listeners, wire `backendState` signal to WebSocket lifecycle.
+- `frontend/app/store/global.ts` — new `backendState` atom.
+- `frontend/app/block/blockframe.tsx` (or wherever block view components mount) — wrap in `<PaneErrorBoundary>`.
+- `frontend/app/store/websocket.ts` (or current WS client location) — emit backend-state transitions on connect/close/error.
+
+## 8. Implementation order (incremental, each shippable)
+
+1. **CEF render-process-terminated handler + recovery HTML page.** Highest user-facing impact. Fixes the white screen directly.
+2. **Frontend `<ErrorBoundary>` + global `onerror` / `onunhandledrejection`.** Catches JS-layer failures that aren't renderer crashes.
+3. **Per-pane `<ErrorBoundary>`.** Prevents single-pane failures from taking out the whole app.
+4. **Backend disconnect banner + reconnect logic.** Fixes the stale-UI-after-sidecar-crash case.
+5. **Memory warning banner.** Proactive; ships after the reactive fixes so we know what a typical memory timeline looks like.
+6. **Crash context logging (recent_logs ring buffer).** Diagnostic; nice-to-have once the user-visible pieces are in place.
+
+Each step is one PR. The first two fix the reported problem entirely.
+
+## 9. Estimated cost
+
+| Step | Files | Est. time | Review rounds |
+|---|---|---:|---:|
+| 1. CEF RequestHandler + recovery HTML | 3 new, 1 modified | 2 h | 1–2 |
+| 2. Frontend ErrorBoundary + global handlers | 2 new, 1 modified | 1 h | 0–1 |
+| 3. Per-pane ErrorBoundary | 1 new, 1 modified | 45 min | 0–1 |
+| 4. Backend disconnect banner | 1 new, 2 modified | 90 min | 1 |
+| 5. Memory warning banner | 1 new, 2 modified | 60 min | 0–1 |
+| 6. Crash context logging | 1 new, 1 modified | 45 min | 0–1 |
+
+**Total:** ~6.5 hours of coding, 2–7 review rounds.
+
+## 10. Risks and open questions
+
+### 10.1 `OnRenderProcessTerminated` bindings
+
+Need to verify our `cef-rs` binding crate exposes `RequestHandler::on_render_process_terminated`. If not, we may need to add it or use a different hook. Check with a grep before scheduling step 1.
+
+### 10.2 Recovery page URL scheme
+
+We already use `agentmux://app/...` (or similar) for the bundled frontend. Check if the custom scheme handler can serve a second route `/recovery.html` from an `include_str!` blob, or if we need a `data:` URL. `data:` URLs work everywhere and don't require scheme handler changes — probably the simpler path.
+
+### 10.3 Reload button vs. navigate
+
+When the user clicks "Reload", `browser.reload()` might re-use the crashed renderer context. Need to verify. If so, use `load_url(original_url)` instead to force a fresh load.
+
+### 10.4 Banner real estate
+
+Three possible top-of-window banners (backend disconnect, memory warning, runtime error overlay). Stack them? Show one at a time with a priority? Start with a simple vertical stack and see if it gets ugly in practice.
+
+### 10.5 Sidecar restart UX
+
+The "Restart backend" button calls the CEF host to re-spawn `agentmux-srv`. What happens to any open block controllers that were mid-run when the sidecar died? Probably they're just gone and the user starts fresh turns. Document this limitation in the banner text.
+
+### 10.6 Error boundary and SolidJS HMR
+
+In dev mode with Vite HMR, a file edit triggers hot reload which might look like an error to `<ErrorBoundary>`. Verify the boundary doesn't fire spuriously during dev. If it does, gate the boundary on `import.meta.env.PROD`.
+
+## 11. Success criteria
+
+After all 6 steps:
+
+- **CEF renderer OOM / crash:** the window shows a recovery page with reload/quit/logs buttons instead of going white.
+- **Sidecar exit:** a banner appears at the top of the app within 2 seconds; the user can click Restart Backend to re-spawn the sidecar without restarting the host.
+- **Unhandled JS error:** an overlay appears with the error message and a reload button; the rest of the app stays interactive if possible.
+- **Single pane crash:** only that pane shows an error card; other panes keep working; the user can reload the pane to recover.
+- **Memory warning:** at 85% system memory or 80% per-process, an orange banner appears offering to restart the app before the inevitable crash.
+- **Every crash is diagnosable:** the host log shows the failure mode, memory state, and last 20 log lines without the user having to ask.
+
+## 12. Out of scope
+
+- **Persisting in-flight composer text to disk.** Separate spec if worth it.
+- **Crash reporter backend for telemetry.** Local logs only.
+- **Process isolation per pane** (Chromium's site isolation for different blocks). Too invasive; relies on CEF internals.
+- **Automatic sidecar restart on every disconnect.** We show a button; user decides. Silent relaunch masks real bugs.
+- **Improving WER crash dump quality.** Already configured.
+- **Reducing OOM root causes** (document trimming, heap limits in V8, smarter content-visibility). Separate work; orthogonal to "when it crashes, handle it gracefully."
+
+## 13. Relationship to existing work
+
+- **PR #222 (0.32.78)** — FileStore cache OOM fix. Addresses one root cause. This spec addresses the *symptom* when any OOM occurs.
+- **Memory heartbeat (0.33.62)** — logs a post-mortem timeline. This spec surfaces it to the user proactively and in crash recovery.
+- **WER crash dumps** — already in place for sidecar native crashes. This spec complements the dump with a user-visible notice.
+- **Startup error UI** (`showStartupError` in `wave.ts`) — already exists for bootstrap failures. This spec extends the same visual treatment to runtime failures.
+
+Nothing in this spec conflicts with shipped work. It's all additive: new handlers, new banners, new error boundaries on top of a stable foundation.


### PR DESCRIPTION
## Summary

Step 1 of \`specs/SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md\`. Implements the **highest-impact fix** identified in the spec: when the CEF renderer process dies (OOM, native bug, abnormal termination) the window goes white with no UI. This PR catches the termination via \`CefRequestHandler\` and replaces the dead page with a self-contained recovery HTML page.

## Background

A user-visible incident on 2026-04-13: VSCode and AgentMux both hit OOM. AgentMux's window turned white with no error message, no recovery option, no clean exit path. The spec breaks the problem into 4 crash modes; this PR addresses the **renderer crash** mode (the white-screen one), which is the most common and the most user-visible.

## What this PR does

**\`agentmux-cef/src/client.rs\`:**

1. **New \`AgentMuxRequestHandler\` wrap_request_handler! block.** Mirrors the existing \`AgentMuxLifeSpanHandler\` / \`AgentMuxLoadHandler\` pattern — wraps a shared \`AgentMuxHandler\` and routes the single \`on_render_process_terminated\` callback to it.

2. **New \`AgentMuxHandler::on_render_process_terminated\` method:**
   - Logs the termination via \`tracing::error!(target: \"crash\", kind = \"renderer_terminated\", reason, error_code, detail)\` so the failure shows up grep-able in host logs.
   - Builds a self-contained recovery HTML page (plain HTML + CSS, **no JS dependencies**) showing:
     - The failure reason (\"out of memory\", \"renderer process crashed\", etc.)
     - The cef-provided detail string in a code block (if present)
     - An explanatory message that sessions are saved on disk
     - **Reload window** button (calls \`location.reload()\`) and **Quit** button (calls \`window.close()\`)
   - Loads the page as a \`data:text/html;base64,...\` URL on the dead browser's main frame. CEF re-spawns the renderer subprocess for the navigation, so the recovery page mounts in a fresh process.

3. **Added the request_handler() method to the \`wrap_client!\` impl block** — alongside the existing display/keyboard/life_span/load handlers.

4. **\`html_escape()\` helper** for the reason/detail strings. cef-provided strings are trusted in practice but may contain \`&\` / \`<\` / \`>\` in some failure modes; defense in depth.

## Visual design

```
┌──────────────────────────────────────┐
│              ⚠                       │
│   AgentMux hit a problem             │
│   Reason: out of memory              │
│                                      │
│   Your open sessions are saved on    │
│   disk. Reloading should bring you   │
│   back where you left off.           │
│                                      │
│   [ Reload window ]   [ Quit ]       │
│                                      │
│   error_code=-2                      │
└──────────────────────────────────────┘
```

Catppuccin-styled dark theme matching the rest of the app's chrome. Self-contained — works even if the frontend bundle and the sidecar are both dead.

## What this PR does NOT do

Subsequent steps in the spec are separate PRs:
- Frontend \`<ErrorBoundary>\` + global \`onerror\` / \`onunhandledrejection\` handlers (PR 2)
- Per-pane \`<ErrorBoundary>\` (PR 3)
- Backend disconnect banner + reconnect logic (PR 4)
- Proactive memory warning banner (PR 5)
- Crash context logging (PR 6)

## Verification

- [x] \`cargo check -p agentmux-cef\` clean — 13 warnings, all pre-existing, zero errors. The new \`RequestHandler\` and \`on_render_process_terminated\` compile against the cef-rs 146.1.0 bindings.
- [ ] Manual test: \`task cef:package:portable\`, extract, then trigger an OOM (e.g. allocate huge JS string in a long-running pane). Window should show the recovery page instead of going white.
- [ ] Manual test: trigger a renderer crash via \`chrome://crash\` (CEF supports it). Same expected behavior.
- [ ] Logs: \`muxlog host crash\` should show the structured error line with \`kind=renderer_terminated\` and the reason.

## Reused infrastructure

- Same \`data:\` URL + \`base64_encode\` pattern as the existing \`on_load_error\` recovery page in this file (lines 307–366).
- Same \`Arc<Mutex<AgentMuxHandler>>\` routing pattern as every other CEF handler in this file.
- \`TerminationStatus\` enum from cef-rs 146.1.0 — verified \`PROCESS_OOM\`, \`PROCESS_CRASHED\`, \`ABNORMAL_TERMINATION\` are all present in the Windows binding.

bump: 0.33.138 → 0.33.139

🤖 Generated with [Claude Code](https://claude.com/claude-code)