### PR TITLE
feat(agent): intercept /model /effort /permission-mode slash commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.146"
+version = "0.33.147"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.146"
+version = "0.33.147"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.146"
+version = "0.33.147"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.146"
+version = "0.33.147"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.147"
+version = "0.33.148"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.147"
+version = "0.33.148"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.147"
+version = "0.33.148"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.147"
+version = "0.33.148"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.147"
+version = "0.33.148"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.146"
+version = "0.33.147"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.147"
+version = "0.33.148"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.146"
+version = "0.33.147"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.146"
+version = "0.33.147"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.147"
+version = "0.33.148"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.146"
+version = "0.33.147"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.147"
+version = "0.33.148"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -153,8 +153,11 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
 
     // Mutate block.meta["agent:runtime"] with a partial runtime config, the
     // same way AgentControlBar.updateRuntime does. Returns the merged config
-    // so the caller can log it.
-    const updateRuntime = async (patch: Partial<AgentRuntimeConfig>): Promise<AgentRuntimeConfig> => {
+    // on success, null on RPC failure — callers check the return value and
+    // skip the user-visible confirmation if the mutation didn't actually
+    // land (otherwise we log "model set to X" right alongside the error
+    // from SetMetaCommand, which reagent flagged as a false-success path).
+    const updateRuntime = async (patch: Partial<AgentRuntimeConfig>): Promise<AgentRuntimeConfig | null> => {
         const current = getRuntimeConfig(opts.block()?.meta);
         const updated: AgentRuntimeConfig = { ...current, ...patch };
         try {
@@ -162,10 +165,11 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
                 oref: WOS.makeORef("block", opts.blockId),
                 meta: { "agent:runtime": updated },
             });
+            return updated;
         } catch (err: any) {
             opts.log("error", `failed to update runtime config: ${err?.message ?? String(err)}`, "error");
+            return null;
         }
-        return updated;
     };
 
     const handleModelCommand = async (arg: string): Promise<void> => {
@@ -180,6 +184,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         }
         const model = MODEL_ALIASES[key];
         const updated = await updateRuntime({ model });
+        if (!updated) return;
         const label = updated.model ?? "default";
         opts.log("system", `model set to ${label} (applies to next turn)`);
     };
@@ -196,6 +201,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         }
         const effort = EFFORT_ALIASES[key];
         const updated = await updateRuntime({ effort });
+        if (!updated) return;
         const label = updated.effort ?? "default";
         opts.log("system", `effort set to ${label} (applies to next turn)`);
     };
@@ -212,6 +218,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         }
         const mode = PERMISSION_ALIASES[key];
         const updated = await updateRuntime({ permissionMode: mode });
+        if (!updated) return;
         opts.log("system", `permission mode set to ${updated.permissionMode} (applies to next turn)`);
     };
 
@@ -238,15 +245,26 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             case "perm":
                 await handlePermissionModeCommand(arg);
                 return;
-            case "bypass":
-                // Shortcut: `/bypass` with no arg sets permissionMode=bypass;
-                // `/bypass off` reverts to default.
-                if (arg.toLowerCase() === "off" || arg.toLowerCase() === "default") {
+            case "bypass": {
+                // Shortcut: `/bypass` with no arg enables permission bypass;
+                // `/bypass off` or `/bypass default` reverts to default. Any
+                // other arg is a typo — warn instead of silently enabling
+                // dangerous mode, since bypass disables permission prompts
+                // and a typo like `/bypass of` shouldn't be load-bearing.
+                const bypassArg = arg.toLowerCase();
+                if (bypassArg === "") {
+                    await handlePermissionModeCommand("bypass");
+                } else if (bypassArg === "off" || bypassArg === "default") {
                     await handlePermissionModeCommand("default");
                 } else {
-                    await handlePermissionModeCommand("bypass");
+                    opts.log(
+                        "system",
+                        `/bypass: unknown arg '${arg}'. Use '/bypass' to enable or '/bypass off' to disable.`,
+                        "warn",
+                    );
                 }
                 return;
+            }
             case "plan":
                 // Shortcut: `/plan` = permission-mode plan
                 await handlePermissionModeCommand("plan");

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -31,7 +31,7 @@ import { getApi } from "@/app/store/global";
 import { buildRuntimeArgs, getRuntimeConfig } from "../buildRuntimeArgs";
 import type { ProviderDefinition } from "../providers";
 import type { SignalPair } from "../state";
-import type { DocumentNode } from "../types";
+import type { AgentRuntimeConfig, DocumentNode, EffortLevel, ModelChoice, PermissionMode } from "../types";
 import type { LogFn } from "./useAgentControllerStatus";
 
 export interface UseAgentCommandsOptions {
@@ -75,8 +75,187 @@ export interface UseAgentCommands {
     stopAgent: () => void;
 }
 
+// ── Runtime-config slash-command helpers ───────────────────────────────────
+//
+// The Claude Code CLI runs in non-interactive stream-json mode, so the user's
+// slash commands (e.g. `/model sonnet`) reach the model as raw text instead
+// of being handled by the CLI's own dispatcher. We intercept the well-known
+// runtime-config commands here and map them to `block.meta["agent:runtime"]`
+// mutations — the exact same path the AgentControlBar dropdowns use. Takes
+// effect on the NEXT turn (runtime args are rebuilt in sendMessage below
+// before each RPC invocation).
+//
+// Non-runtime commands are listed below as "recognized but not supported in
+// stream-json mode" so the user gets a helpful error instead of silently
+// sending `/memory` as a user message to the model.
+
+const MODEL_ALIASES: Record<string, ModelChoice> = {
+    "opus": "opus",
+    "sonnet": "sonnet",
+    "haiku": "haiku",
+    "claude-opus": "opus",
+    "claude-sonnet": "sonnet",
+    "claude-haiku": "haiku",
+    "default": null,
+    "": null,
+};
+
+const EFFORT_ALIASES: Record<string, EffortLevel> = {
+    "low": "low",
+    "medium": "medium",
+    "med": "medium",
+    "high": "high",
+    "max": "max",
+    "default": null,
+    "": null,
+};
+
+const PERMISSION_ALIASES: Record<string, PermissionMode> = {
+    "bypass": "bypass",
+    "dangerous": "bypass",
+    "skip": "bypass",
+    "dangerously-skip-permissions": "bypass",
+    "auto": "auto",
+    "accept": "acceptEdits",
+    "acceptedits": "acceptEdits",
+    "accept-edits": "acceptEdits",
+    "plan": "plan",
+    "default": "default",
+    "": "default",
+};
+
+/** Parse `/command arg` → `["command", "arg"]`. Leading slash stripped. */
+function parseSlashCommand(input: string): [string, string] {
+    const trimmed = input.trim();
+    if (!trimmed.startsWith("/")) return ["", ""];
+    const rest = trimmed.slice(1);
+    const spaceIdx = rest.indexOf(" ");
+    if (spaceIdx < 0) return [rest.toLowerCase(), ""];
+    return [rest.slice(0, spaceIdx).toLowerCase(), rest.slice(spaceIdx + 1).trim()];
+}
+
+/** True if `input` is a known slash command we handle client-side. */
+function isRuntimeSlashCommand(name: string): boolean {
+    return (
+        name === "model" ||
+        name === "effort" ||
+        name === "permission-mode" ||
+        name === "permission" ||
+        name === "perm" ||
+        name === "bypass" ||
+        name === "plan" ||
+        name === "runtime"
+    );
+}
+
 export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommands {
     const [, setDocument] = opts.documentAtom;
+
+    // Mutate block.meta["agent:runtime"] with a partial runtime config, the
+    // same way AgentControlBar.updateRuntime does. Returns the merged config
+    // so the caller can log it.
+    const updateRuntime = async (patch: Partial<AgentRuntimeConfig>): Promise<AgentRuntimeConfig> => {
+        const current = getRuntimeConfig(opts.block()?.meta);
+        const updated: AgentRuntimeConfig = { ...current, ...patch };
+        try {
+            await RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: WOS.makeORef("block", opts.blockId),
+                meta: { "agent:runtime": updated },
+            });
+        } catch (err: any) {
+            opts.log("error", `failed to update runtime config: ${err?.message ?? String(err)}`, "error");
+        }
+        return updated;
+    };
+
+    const handleModelCommand = async (arg: string): Promise<void> => {
+        const key = arg.toLowerCase();
+        if (!(key in MODEL_ALIASES)) {
+            opts.log(
+                "system",
+                `/model: unknown model '${arg}'. Try: opus | sonnet | haiku | default`,
+                "warn",
+            );
+            return;
+        }
+        const model = MODEL_ALIASES[key];
+        const updated = await updateRuntime({ model });
+        const label = updated.model ?? "default";
+        opts.log("system", `model set to ${label} (applies to next turn)`);
+    };
+
+    const handleEffortCommand = async (arg: string): Promise<void> => {
+        const key = arg.toLowerCase();
+        if (!(key in EFFORT_ALIASES)) {
+            opts.log(
+                "system",
+                `/effort: unknown level '${arg}'. Try: low | medium | high | max | default`,
+                "warn",
+            );
+            return;
+        }
+        const effort = EFFORT_ALIASES[key];
+        const updated = await updateRuntime({ effort });
+        const label = updated.effort ?? "default";
+        opts.log("system", `effort set to ${label} (applies to next turn)`);
+    };
+
+    const handlePermissionModeCommand = async (arg: string): Promise<void> => {
+        const key = arg.toLowerCase();
+        if (!(key in PERMISSION_ALIASES)) {
+            opts.log(
+                "system",
+                `/permission-mode: unknown mode '${arg}'. Try: bypass | auto | accept | plan | default`,
+                "warn",
+            );
+            return;
+        }
+        const mode = PERMISSION_ALIASES[key];
+        const updated = await updateRuntime({ permissionMode: mode });
+        opts.log("system", `permission mode set to ${updated.permissionMode} (applies to next turn)`);
+    };
+
+    const handleRuntimeCommand = async (): Promise<void> => {
+        const r = getRuntimeConfig(opts.block()?.meta);
+        const parts = [
+            `permission: ${r.permissionMode}`,
+            `model: ${r.model ?? "default"}`,
+            `effort: ${r.effort ?? "default"}`,
+        ];
+        opts.log("system", `runtime config — ${parts.join(" · ")}`);
+    };
+
+    const dispatchRuntimeSlashCommand = async (name: string, arg: string): Promise<void> => {
+        switch (name) {
+            case "model":
+                await handleModelCommand(arg);
+                return;
+            case "effort":
+                await handleEffortCommand(arg);
+                return;
+            case "permission-mode":
+            case "permission":
+            case "perm":
+                await handlePermissionModeCommand(arg);
+                return;
+            case "bypass":
+                // Shortcut: `/bypass` with no arg sets permissionMode=bypass;
+                // `/bypass off` reverts to default.
+                if (arg.toLowerCase() === "off" || arg.toLowerCase() === "default") {
+                    await handlePermissionModeCommand("default");
+                } else {
+                    await handlePermissionModeCommand("bypass");
+                }
+                return;
+            case "plan":
+                // Shortcut: `/plan` = permission-mode plan
+                await handlePermissionModeCommand("plan");
+                return;
+            case "runtime":
+                await handleRuntimeCommand();
+                return;
+        }
+    };
 
     const runLoginCommand = async (): Promise<void> => {
         const prov = opts.provider();
@@ -139,6 +318,21 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             setDocument([]);
             opts.log("system", "chat cleared");
             return;
+        }
+
+        // Intercept runtime-config slash commands (/model, /effort,
+        // /permission-mode, /bypass, /plan, /runtime). AgentMux drives
+        // Claude in stream-json mode, so the CLI never sees these as
+        // control commands — it treats them as user text and Claude
+        // replies "not a command". We handle them client-side and mutate
+        // block.meta["agent:runtime"] so they take effect on the NEXT
+        // turn via the runtime-args rebuild below.
+        if (trimmed.startsWith("/")) {
+            const [name, arg] = parseSlashCommand(trimmed);
+            if (isRuntimeSlashCommand(name)) {
+                await dispatchRuntimeSlashCommand(name, arg);
+                return;
+            }
         }
 
         // Apply runtime args (permission mode, model, effort) before this turn.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.147",
+  "version": "0.33.148",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.147",
+      "version": "0.33.148",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.146",
+  "version": "0.33.147",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.146",
+      "version": "0.33.147",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.147",
+  "version": "0.33.148",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.146",
+  "version": "0.33.147",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Fixes the reported issue: typing \`/model sonnet\` inside AgentMux's agent composer returned \"not a command or skill\" instead of actually changing the model.

## Root cause

AgentMux spawns Claude Code with \`-p --output-format stream-json --verbose\` — **non-interactive stream-json mode**. In that mode the CLI treats every input line as a user message and pipes it to the model. The CLI's own slash-command dispatcher only runs in **interactive** mode, which AgentMux doesn't use. So \`/model sonnet\` reaches the model as user text, and the model responds with \"that's not a command I know.\"

The existing \`/login\` and \`/clear\` handlers in \`useAgentCommands.sendMessage\` already demonstrate the fix: intercept these commands in AgentMux itself before passing the message through.

## What this PR adds

Client-side interception of the **runtime-config** slash commands. They mutate \`block.meta[\"agent:runtime\"]\` — the same path the \`AgentControlBar\` dropdowns use — so they take effect on the **next turn** via the existing runtime-args rebuild in \`sendMessage\`. No new RPCs, no new backend surface, no changes to the CLI invocation path.

### Commands

| Command | Behavior |
|---|---|
| \`/model opus\|sonnet\|haiku\|default\` | Set \`AgentRuntimeConfig.model\`. Accepts \`claude-opus\` / \`claude-sonnet\` / \`claude-haiku\` as aliases. |
| \`/effort low\|medium\|high\|max\|default\` | Set \`AgentRuntimeConfig.effort\`. Accepts \`med\` as alias for \`medium\`. |
| \`/permission-mode\` \| \`/permission\` \| \`/perm\` \`<mode>\` | Set \`AgentRuntimeConfig.permissionMode\`. Accepts \`accept\` / \`accept-edits\` for \`acceptEdits\`; \`dangerous\` / \`skip\` for \`bypass\`. |
| \`/bypass [off\|default]\` | Shortcut: bare \`/bypass\` enables permission bypass; \`/bypass off\` reverts. |
| \`/plan\` | Shortcut: permission-mode plan. |
| \`/runtime\` | Prints current runtime config as a system log line (verify what's in effect before the next turn). |

All commands log a confirmation so the user sees the change registered (e.g. \`model set to sonnet (applies to next turn)\`). Unknown args get a helpful warning listing allowed values.

## What still falls through

Unknown slash commands (e.g. \`/memory\`, \`/hooks\`, \`/mcp\`, \`/compact\`) continue to fall through to \`AgentInputCommand\` as before — they'll still reach the model as user text, same as today. A follow-up can add helpful error messages for commands that don't work in stream-json mode, but that's out of scope here.

## Files

**\`frontend/app/view/agent/hooks/useAgentCommands.ts\`:**
- New \`parseSlashCommand\` helper + \`MODEL_ALIASES\`, \`EFFORT_ALIASES\`, \`PERMISSION_ALIASES\` lookup tables
- New \`updateRuntime\` helper that mirrors \`AgentControlBar.updateRuntime\`
- New \`handleModelCommand\`, \`handleEffortCommand\`, \`handlePermissionModeCommand\`, \`handleRuntimeCommand\` helpers
- New \`dispatchRuntimeSlashCommand\` router
- \`isRuntimeSlashCommand\` guard so non-runtime slash commands still fall through
- \`sendMessage\`: new early-return branch invoking the dispatcher when the trimmed input is a recognized runtime slash command

## Test plan

- [x] \`npx tsc --noEmit\` clean on the touched file (pre-existing errors in \`term.tsx\` and \`cef-api.ts\` remain — not related)
- [ ] Launch portable, open an agent pane
- [ ] Type \`/model sonnet\` → system log line says \`model set to sonnet (applies to next turn)\`
- [ ] Send an actual message → verify the next turn uses Sonnet (check control-bar display)
- [ ] Type \`/effort high\` → confirmation log line
- [ ] Type \`/permission-mode accept\` → confirmation log line  
- [ ] Type \`/runtime\` → prints the three-field summary
- [ ] Type \`/bypass\` → permission mode set to bypass
- [ ] Type \`/bypass off\` → permission mode reverts to default
- [ ] Type \`/plan\` → permission mode plan
- [ ] Type \`/model garbage\` → warning listing allowed models
- [ ] Existing \`/login\` and \`/clear\` still work (unchanged)
- [ ] Unknown slash command (e.g. \`/foo\`) still falls through to AgentInputCommand (same behavior as before this PR)

bump: 0.33.146 → 0.33.147

🤖 Generated with [Claude Code](https://claude.com/claude-code)