### PR TITLE
refactor(agent): slash command registry scaffolding (Step 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.148"
+version = "0.33.149"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.148"
+version = "0.33.149"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.148"
+version = "0.33.149"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.148"
+version = "0.33.149"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.149"
+version = "0.33.150"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.149"
+version = "0.33.150"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.149"
+version = "0.33.150"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.149"
+version = "0.33.150"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.145 | 2026-04-14 | 155.0 MiB | 318.8 MiB | |
 | 0.33.142 | 2026-04-14 | 155.0 MiB | 318.8 MiB | |
 | 0.33.122 | 2026-04-13 | 155.5 MiB | 319.9 MiB | |
 | 0.33.110 | 2026-04-13 | 155.5 MiB | 319.9 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.149"
+version = "0.33.150"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.148"
+version = "0.33.149"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.149"
+version = "0.33.150"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.148"
+version = "0.33.149"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.148"
+version = "0.33.149"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.149"
+version = "0.33.150"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.149"
+version = "0.33.150"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.148"
+version = "0.33.149"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/commands/dispatch.ts
+++ b/frontend/app/view/agent/commands/dispatch.ts
@@ -1,0 +1,151 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * dispatchSlashCommand — the single entry point for handling `/cmd arg`
+ * composer input.
+ *
+ * Step 1 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md.
+ *
+ * The caller (useAgentCommands.sendMessage) passes the raw composer input
+ * and a context bundle. The dispatcher:
+ *
+ *   1. Parses the input into a command name + argument string.
+ *   2. Looks up the command in the registry.
+ *      - Unknown → "passthrough" (caller falls through to AgentInputCommand).
+ *   3. Validates the argument against the command's arg contract.
+ *      - Missing required enum arg → error (picker UI lands in step 2).
+ *      - Missing required freeform → error with placeholder hint.
+ *      - Enum value mismatch → error listing allowed values.
+ *   4. Invokes the handler with the validated arg.
+ *   5. Formats the result:
+ *      - "ok" → log the success message (if any) at info level
+ *      - "error" → log at warn level
+ *      - "passthrough" → caller falls through
+ *
+ * Handlers are pure async functions — they return a SlashResult and the
+ * dispatcher centralizes all user-visible logging. This is intentional:
+ * handlers shouldn't decide where to render, and they shouldn't know
+ * about the launch-log sink.
+ */
+
+import { parseSlashCommand } from "./parse";
+import type { SlashCommand, SlashCommandContext, SlashResult } from "./types";
+import type { SlashCommandRegistry } from "./registry";
+
+export type DispatchOutcome =
+    | { kind: "handled" } // command ran (ok or error) — do NOT fall through
+    | { kind: "passthrough" }; // no matching command — caller sends as user message
+
+/**
+ * Dispatch a slash command. Always returns either "handled" (caller
+ * returns immediately from sendMessage) or "passthrough" (caller
+ * proceeds to AgentInputCommand).
+ */
+export async function dispatchSlashCommand(
+    input: string,
+    registry: SlashCommandRegistry,
+    ctx: SlashCommandContext,
+): Promise<DispatchOutcome> {
+    const [name, arg] = parseSlashCommand(input);
+    if (!name) return { kind: "passthrough" };
+
+    const cmd = registry.lookup(name);
+    if (!cmd) return { kind: "passthrough" };
+
+    const result = await runValidatedHandler(cmd, arg, ctx);
+    formatResult(cmd, result, ctx);
+    return { kind: "handled" };
+}
+
+/**
+ * Validate the arg against the command's arg contract, then invoke the
+ * handler. Returns the handler's SlashResult (or a validation-error
+ * result if the arg didn't pass).
+ *
+ * Picker UX (enum with missing required arg) is not yet implemented —
+ * that lands in step 2 of the spec. For now, bare `/model` returns an
+ * error that lists the choices, matching PR #378's behavior.
+ */
+async function runValidatedHandler(
+    cmd: SlashCommand,
+    arg: string,
+    ctx: SlashCommandContext,
+): Promise<SlashResult> {
+    if (cmd.arg.kind === "none") {
+        return cmd.handler(ctx, "");
+    }
+
+    if (cmd.arg.kind === "enum") {
+        if (arg === "") {
+            if (cmd.arg.required) {
+                // TODO step 2 — open picker here. For now, fall through to
+                // listing the choices as an error (same UX as PR #378).
+                return {
+                    kind: "error",
+                    message: `/${cmd.name} requires an argument. Try: ${cmd.arg.choices
+                        .map((c) => c.value)
+                        .join(" | ")}`,
+                };
+            }
+            return cmd.handler(ctx, "");
+        }
+        const match = cmd.arg.choices.find(
+            (c) => c.value.toLowerCase() === arg.toLowerCase(),
+        );
+        if (!match) {
+            return {
+                kind: "error",
+                message: `/${cmd.name}: unknown value '${arg}'. Try: ${cmd.arg.choices
+                    .map((c) => c.value)
+                    .join(" | ")}`,
+            };
+        }
+        return cmd.handler(ctx, match.value);
+    }
+
+    if (cmd.arg.kind === "freeform") {
+        if (arg === "" && cmd.arg.required) {
+            return {
+                kind: "error",
+                message: `/${cmd.name} requires an argument: ${cmd.arg.placeholder}`,
+            };
+        }
+        return cmd.handler(ctx, arg);
+    }
+
+    // kind === "dynamic" — picker lands in step 2; for now require an explicit arg.
+    if (arg === "") {
+        return {
+            kind: "error",
+            message: `/${cmd.name} requires an argument: ${cmd.arg.placeholder}`,
+        };
+    }
+    return cmd.handler(ctx, arg);
+}
+
+/**
+ * Centralized result logging. Handlers never call ctx.log directly;
+ * they return a SlashResult and the dispatcher decides how to surface it.
+ */
+function formatResult(
+    cmd: SlashCommand,
+    result: SlashResult,
+    ctx: SlashCommandContext,
+): void {
+    if (result.kind === "ok") {
+        if (result.message) {
+            ctx.log("system", result.message);
+        }
+        return;
+    }
+    if (result.kind === "error") {
+        ctx.log("system", result.message, "warn");
+        return;
+    }
+    // passthrough from a handler is a noop here — the dispatcher returns
+    // handled:true, so the caller is about to suppress AgentInputCommand.
+    // Handlers returning passthrough is an escape hatch; at present no
+    // registered command does.
+    ctx.log("system", `/${cmd.name}: passthrough requested (ignored)`, "warn");
+}

--- a/frontend/app/view/agent/commands/global/clear.ts
+++ b/frontend/app/view/agent/commands/global/clear.ts
@@ -1,0 +1,22 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * /clear — frontend-only document reset. Does not touch the backend
+ * session or cancel the running CLI process; just empties the visible
+ * document so the pane looks fresh.
+ */
+
+import type { SlashCommand, SlashResult } from "../types";
+
+export const clearCommand: SlashCommand = {
+    name: "clear",
+    category: "session",
+    description: "Clear the visible document (frontend-only)",
+    arg: { kind: "none" },
+    handler: async (ctx): Promise<SlashResult> => {
+        const [, setDocument] = ctx.documentAtom;
+        setDocument([]);
+        return { kind: "ok", message: "chat cleared" };
+    },
+};

--- a/frontend/app/view/agent/commands/global/index.ts
+++ b/frontend/app/view/agent/commands/global/index.ts
@@ -1,0 +1,21 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Global slash commands — always available regardless of provider.
+ * The registry factory (commands/registry.ts) calls this first, then
+ * overlays any provider-scoped commands.
+ */
+
+import type { SlashCommandRegistry } from "../registry";
+import { clearCommand } from "./clear";
+import { loginCommand } from "./login";
+import { RUNTIME_COMMANDS } from "./runtime";
+
+export function registerGlobalCommands(registry: SlashCommandRegistry): void {
+    for (const cmd of RUNTIME_COMMANDS) {
+        registry.register(cmd);
+    }
+    registry.register(loginCommand);
+    registry.register(clearCommand);
+}

--- a/frontend/app/view/agent/commands/global/login.ts
+++ b/frontend/app/view/agent/commands/global/login.ts
@@ -1,0 +1,55 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * /login — run a GUI OAuth flow via the host API, capture the returned
+ * URL, and push it into ctx.setAuthUrl so the auth box appears above
+ * the composer.
+ *
+ * Migrated from useAgentCommands.runLoginCommand (PR #378 era). Unlike
+ * pure commands, /login logs progress directly via ctx.log because the
+ * auth flow is multi-step and uses an "auth"-level log channel that
+ * the dispatcher's single-result formatter doesn't model. This is
+ * intentional — centralized result logging is the common case; /login
+ * is the exception. See spec §4.4 dispatcher note.
+ */
+
+import { getApi } from "@/app/store/global";
+import type { SlashCommand, SlashResult } from "../types";
+
+export const loginCommand: SlashCommand = {
+    name: "login",
+    category: "auth",
+    description: "Authenticate with the active provider (OAuth in browser)",
+    arg: { kind: "none" },
+    availability: "any-agent",
+    handler: async (ctx): Promise<SlashResult> => {
+        const prov = ctx.provider();
+        const cliPath = ctx.block()?.meta?.["cmd"] ?? "";
+        if (!prov || !cliPath) {
+            return { kind: "error", message: "/login: provider or CLI path not available" };
+        }
+        ctx.log("auth", "running /login via GUI flow...");
+        try {
+            const authEnv: Record<string, string> = {};
+            const envMeta = ctx.block()?.meta?.["cmd:env"];
+            if (envMeta && typeof envMeta === "object") {
+                for (const [k, v] of Object.entries(envMeta)) {
+                    if (typeof v === "string") authEnv[k] = v;
+                }
+            }
+            const url = await getApi().runCliLogin(cliPath, prov.authLoginCommand, authEnv);
+            if (url) {
+                ctx.setAuthUrl(url);
+                ctx.log("auth", "OAuth URL captured — browser should open automatically");
+                ctx.log("auth", "if it didn't, copy the URL from the box above");
+            } else {
+                ctx.log("auth", "a browser window should have opened — complete login there");
+            }
+            ctx.log("auth", "run /cost to verify authentication once logged in");
+            return { kind: "ok" };
+        } catch (err: any) {
+            return { kind: "error", message: `/login failed: ${err?.message ?? String(err)}` };
+        }
+    },
+};

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -1,0 +1,226 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Runtime-config slash commands: /model /effort /permission-mode /bypass
+ * /plan /runtime. Migrated from the inline switch in
+ * useAgentCommands.sendMessage (PR #378) into the registry.
+ *
+ * Step 1 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md —
+ * behavior is intentionally identical to #378. Enum/picker work lands
+ * in step 2.
+ */
+
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import * as WOS from "@/app/store/wos";
+import { getRuntimeConfig } from "../../buildRuntimeArgs";
+import type { AgentRuntimeConfig, EffortLevel, ModelChoice, PermissionMode } from "../../types";
+import type { SlashCommand, SlashCommandContext, SlashResult } from "../types";
+
+// Alias tables — preserved from PR #378 so `/model claude-sonnet` and
+// `/effort med` keep working. Step 2 replaces these with picker enums.
+const MODEL_ALIASES: Record<string, ModelChoice> = {
+    "opus": "opus",
+    "sonnet": "sonnet",
+    "haiku": "haiku",
+    "claude-opus": "opus",
+    "claude-sonnet": "sonnet",
+    "claude-haiku": "haiku",
+    "default": null,
+    "": null,
+};
+
+const EFFORT_ALIASES: Record<string, EffortLevel> = {
+    "low": "low",
+    "medium": "medium",
+    "med": "medium",
+    "high": "high",
+    "max": "max",
+    "default": null,
+    "": null,
+};
+
+const PERMISSION_ALIASES: Record<string, PermissionMode> = {
+    "bypass": "bypass",
+    "dangerous": "bypass",
+    "skip": "bypass",
+    "dangerously-skip-permissions": "bypass",
+    "auto": "auto",
+    "accept": "acceptEdits",
+    "acceptedits": "acceptEdits",
+    "accept-edits": "acceptEdits",
+    "plan": "plan",
+    "default": "default",
+    "": "default",
+};
+
+/**
+ * Mutate block.meta["agent:runtime"] with a partial runtime config.
+ * Returns the merged config on success, null on RPC failure — callers
+ * check and skip the success message if the mutation didn't land.
+ */
+async function updateRuntime(
+    ctx: SlashCommandContext,
+    patch: Partial<AgentRuntimeConfig>,
+): Promise<AgentRuntimeConfig | null> {
+    const current = getRuntimeConfig(ctx.block()?.meta);
+    const updated: AgentRuntimeConfig = { ...current, ...patch };
+    try {
+        await RpcApi.SetMetaCommand(TabRpcClient, {
+            oref: WOS.makeORef("block", ctx.blockId),
+            meta: { "agent:runtime": updated },
+        });
+        return updated;
+    } catch (err: any) {
+        return null;
+    }
+}
+
+export const modelCommand: SlashCommand = {
+    name: "model",
+    category: "runtime",
+    description: "Change the active model (applies to next turn)",
+    arg: { kind: "freeform", placeholder: "opus | sonnet | haiku | default", required: false },
+    availability: "any-agent",
+    handler: async (ctx, arg): Promise<SlashResult> => {
+        const key = arg.toLowerCase();
+        if (!(key in MODEL_ALIASES)) {
+            return {
+                kind: "error",
+                message: `/model: unknown model '${arg}'. Try: opus | sonnet | haiku | default`,
+            };
+        }
+        const model = MODEL_ALIASES[key];
+        const updated = await updateRuntime(ctx, { model });
+        if (!updated) {
+            return { kind: "error", message: "failed to update runtime config" };
+        }
+        const label = updated.model ?? "default";
+        return { kind: "ok", message: `model set to ${label} (applies to next turn)` };
+    },
+};
+
+export const effortCommand: SlashCommand = {
+    name: "effort",
+    category: "runtime",
+    description: "Change reasoning effort level (applies to next turn)",
+    arg: { kind: "freeform", placeholder: "low | medium | high | max | default", required: false },
+    availability: "any-agent",
+    handler: async (ctx, arg): Promise<SlashResult> => {
+        const key = arg.toLowerCase();
+        if (!(key in EFFORT_ALIASES)) {
+            return {
+                kind: "error",
+                message: `/effort: unknown level '${arg}'. Try: low | medium | high | max | default`,
+            };
+        }
+        const effort = EFFORT_ALIASES[key];
+        const updated = await updateRuntime(ctx, { effort });
+        if (!updated) {
+            return { kind: "error", message: "failed to update runtime config" };
+        }
+        const label = updated.effort ?? "default";
+        return { kind: "ok", message: `effort set to ${label} (applies to next turn)` };
+    },
+};
+
+export const permissionModeCommand: SlashCommand = {
+    name: "permission-mode",
+    aliases: ["permission", "perm"],
+    category: "runtime",
+    description: "Change permission mode (applies to next turn)",
+    arg: { kind: "freeform", placeholder: "bypass | auto | accept | plan | default", required: false },
+    availability: "any-agent",
+    handler: async (ctx, arg): Promise<SlashResult> => {
+        const key = arg.toLowerCase();
+        if (!(key in PERMISSION_ALIASES)) {
+            return {
+                kind: "error",
+                message: `/permission-mode: unknown mode '${arg}'. Try: bypass | auto | accept | plan | default`,
+            };
+        }
+        const mode = PERMISSION_ALIASES[key];
+        const updated = await updateRuntime(ctx, { permissionMode: mode });
+        if (!updated) {
+            return { kind: "error", message: "failed to update runtime config" };
+        }
+        return {
+            kind: "ok",
+            message: `permission mode set to ${updated.permissionMode} (applies to next turn)`,
+        };
+    },
+};
+
+export const bypassCommand: SlashCommand = {
+    name: "bypass",
+    category: "runtime",
+    description: "Enable permission bypass for the next turn (dangerous)",
+    // Shortcut: bare `/bypass` enables; `/bypass off` or `/bypass default`
+    // reverts. Any other arg is a typo — warn instead of silently enabling.
+    arg: { kind: "freeform", placeholder: "(empty) | off | default", required: false },
+    availability: "any-agent",
+    handler: async (ctx, arg): Promise<SlashResult> => {
+        const key = arg.toLowerCase();
+        let patch: Partial<AgentRuntimeConfig>;
+        if (key === "") {
+            patch = { permissionMode: "bypass" };
+        } else if (key === "off" || key === "default") {
+            patch = { permissionMode: "default" };
+        } else {
+            return {
+                kind: "error",
+                message: `/bypass: unknown arg '${arg}'. Use '/bypass' to enable or '/bypass off' to disable.`,
+            };
+        }
+        const updated = await updateRuntime(ctx, patch);
+        if (!updated) {
+            return { kind: "error", message: "failed to update runtime config" };
+        }
+        return {
+            kind: "ok",
+            message: `permission mode set to ${updated.permissionMode} (applies to next turn)`,
+        };
+    },
+};
+
+export const planCommand: SlashCommand = {
+    name: "plan",
+    category: "runtime",
+    description: "Switch to plan mode (no tool execution)",
+    arg: { kind: "none" },
+    availability: "any-agent",
+    handler: async (ctx): Promise<SlashResult> => {
+        const updated = await updateRuntime(ctx, { permissionMode: "plan" });
+        if (!updated) {
+            return { kind: "error", message: "failed to update runtime config" };
+        }
+        return { kind: "ok", message: "permission mode set to plan (applies to next turn)" };
+    },
+};
+
+export const runtimeCommand: SlashCommand = {
+    name: "runtime",
+    category: "runtime",
+    description: "Show current runtime config (permission / model / effort)",
+    arg: { kind: "none" },
+    availability: "any-agent",
+    handler: async (ctx): Promise<SlashResult> => {
+        const r = getRuntimeConfig(ctx.block()?.meta);
+        const parts = [
+            `permission: ${r.permissionMode}`,
+            `model: ${r.model ?? "default"}`,
+            `effort: ${r.effort ?? "default"}`,
+        ];
+        return { kind: "ok", message: `runtime config — ${parts.join(" · ")}` };
+    },
+};
+
+export const RUNTIME_COMMANDS: SlashCommand[] = [
+    modelCommand,
+    effortCommand,
+    permissionModeCommand,
+    bypassCommand,
+    planCommand,
+    runtimeCommand,
+];

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -55,15 +55,20 @@ const PERMISSION_ALIASES: Record<string, PermissionMode> = {
     "": "default",
 };
 
+type RuntimeUpdateResult =
+    | { ok: true; updated: AgentRuntimeConfig }
+    | { ok: false; error: string };
+
 /**
  * Mutate block.meta["agent:runtime"] with a partial runtime config.
- * Returns the merged config on success, null on RPC failure — callers
- * check and skip the success message if the mutation didn't land.
+ * Returns the merged config on success or the underlying error
+ * message on RPC failure. Callers fold the error into a SlashResult
+ * so the user sees the real reason instead of a generic "failed".
  */
 async function updateRuntime(
     ctx: SlashCommandContext,
     patch: Partial<AgentRuntimeConfig>,
-): Promise<AgentRuntimeConfig | null> {
+): Promise<RuntimeUpdateResult> {
     const current = getRuntimeConfig(ctx.block()?.meta);
     const updated: AgentRuntimeConfig = { ...current, ...patch };
     try {
@@ -71,10 +76,14 @@ async function updateRuntime(
             oref: WOS.makeORef("block", ctx.blockId),
             meta: { "agent:runtime": updated },
         });
-        return updated;
+        return { ok: true, updated };
     } catch (err: any) {
-        return null;
+        return { ok: false, error: err?.message ?? String(err) };
     }
+}
+
+function runtimeError(error: string): SlashResult {
+    return { kind: "error", message: `failed to update runtime config: ${error}` };
 }
 
 export const modelCommand: SlashCommand = {
@@ -92,11 +101,9 @@ export const modelCommand: SlashCommand = {
             };
         }
         const model = MODEL_ALIASES[key];
-        const updated = await updateRuntime(ctx, { model });
-        if (!updated) {
-            return { kind: "error", message: "failed to update runtime config" };
-        }
-        const label = updated.model ?? "default";
+        const result = await updateRuntime(ctx, { model });
+        if (result.ok === false) return runtimeError(result.error);
+        const label = result.updated.model ?? "default";
         return { kind: "ok", message: `model set to ${label} (applies to next turn)` };
     },
 };
@@ -116,11 +123,9 @@ export const effortCommand: SlashCommand = {
             };
         }
         const effort = EFFORT_ALIASES[key];
-        const updated = await updateRuntime(ctx, { effort });
-        if (!updated) {
-            return { kind: "error", message: "failed to update runtime config" };
-        }
-        const label = updated.effort ?? "default";
+        const result = await updateRuntime(ctx, { effort });
+        if (result.ok === false) return runtimeError(result.error);
+        const label = result.updated.effort ?? "default";
         return { kind: "ok", message: `effort set to ${label} (applies to next turn)` };
     },
 };
@@ -141,13 +146,11 @@ export const permissionModeCommand: SlashCommand = {
             };
         }
         const mode = PERMISSION_ALIASES[key];
-        const updated = await updateRuntime(ctx, { permissionMode: mode });
-        if (!updated) {
-            return { kind: "error", message: "failed to update runtime config" };
-        }
+        const result = await updateRuntime(ctx, { permissionMode: mode });
+        if (result.ok === false) return runtimeError(result.error);
         return {
             kind: "ok",
-            message: `permission mode set to ${updated.permissionMode} (applies to next turn)`,
+            message: `permission mode set to ${result.updated.permissionMode} (applies to next turn)`,
         };
     },
 };
@@ -173,13 +176,11 @@ export const bypassCommand: SlashCommand = {
                 message: `/bypass: unknown arg '${arg}'. Use '/bypass' to enable or '/bypass off' to disable.`,
             };
         }
-        const updated = await updateRuntime(ctx, patch);
-        if (!updated) {
-            return { kind: "error", message: "failed to update runtime config" };
-        }
+        const result = await updateRuntime(ctx, patch);
+        if (result.ok === false) return runtimeError(result.error);
         return {
             kind: "ok",
-            message: `permission mode set to ${updated.permissionMode} (applies to next turn)`,
+            message: `permission mode set to ${result.updated.permissionMode} (applies to next turn)`,
         };
     },
 };
@@ -191,10 +192,8 @@ export const planCommand: SlashCommand = {
     arg: { kind: "none" },
     availability: "any-agent",
     handler: async (ctx): Promise<SlashResult> => {
-        const updated = await updateRuntime(ctx, { permissionMode: "plan" });
-        if (!updated) {
-            return { kind: "error", message: "failed to update runtime config" };
-        }
+        const result = await updateRuntime(ctx, { permissionMode: "plan" });
+        if (result.ok === false) return runtimeError(result.error);
         return { kind: "ok", message: "permission mode set to plan (applies to next turn)" };
     },
 };

--- a/frontend/app/view/agent/commands/parse.ts
+++ b/frontend/app/view/agent/commands/parse.ts
@@ -1,0 +1,36 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Parse `/command arg1 arg2 ...` composer input into `[name, argString]`.
+ *
+ * Part of the slash command architecture —
+ * specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md.
+ *
+ * The dispatcher hands the full argument string to the command handler;
+ * commands that want to tokenize further do so themselves. This keeps
+ * the parser trivial and avoids the "quoted arg" rabbit hole that shell
+ * parsers grow over time — slash commands don't need shell-grade
+ * quoting because their args are either enums or short freeform text.
+ */
+
+/**
+ * Parse `/command arg` → `["command", "arg"]`. Leading slash stripped,
+ * command name lowercased, arg trimmed. For bare `/command`, returns
+ * `["command", ""]`. For input that doesn't start with `/`, returns
+ * `["", ""]`.
+ */
+export function parseSlashCommand(input: string): [string, string] {
+    const trimmed = input.trim();
+    if (!trimmed.startsWith("/")) return ["", ""];
+    const rest = trimmed.slice(1);
+    const spaceIdx = rest.indexOf(" ");
+    if (spaceIdx < 0) return [rest.toLowerCase(), ""];
+    return [rest.slice(0, spaceIdx).toLowerCase(), rest.slice(spaceIdx + 1).trim()];
+}
+
+/** True if the string is a recognizable slash-command prefix. */
+export function isSlashCommandInput(input: string): boolean {
+    const t = input.trim();
+    return t.startsWith("/") && t.length > 1;
+}

--- a/frontend/app/view/agent/commands/providers/claude.ts
+++ b/frontend/app/view/agent/commands/providers/claude.ts
@@ -1,0 +1,13 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Claude-specific slash commands. Empty in step 1 — step 5 of
+ * specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md populates this
+ * with /cost, /status, /doctor, /memory, /hooks, /mcp, /config,
+ * /compact, /bug, /release-notes.
+ */
+
+import type { SlashCommand } from "../types";
+
+export const CLAUDE_COMMANDS: SlashCommand[] = [];

--- a/frontend/app/view/agent/commands/providers/index.ts
+++ b/frontend/app/view/agent/commands/providers/index.ts
@@ -1,0 +1,15 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Provider-scoped slash command tables, keyed by ProviderDefinition.id.
+ * The registry factory (commands/registry.ts) overlays these on top of
+ * the global commands when a provider is active.
+ */
+
+import type { SlashCommand } from "../types";
+import { CLAUDE_COMMANDS } from "./claude";
+
+export const SLASH_COMMANDS_BY_PROVIDER: Record<string, SlashCommand[]> = {
+    claude: CLAUDE_COMMANDS,
+};

--- a/frontend/app/view/agent/commands/registry.ts
+++ b/frontend/app/view/agent/commands/registry.ts
@@ -1,0 +1,116 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SlashCommandRegistry — map of name → command, plus a factory that builds
+ * one for a given provider.
+ *
+ * Step 1 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md.
+ *
+ * The dispatcher, picker, autocomplete, and /help panel all read from the
+ * same registry, so adding a new command is a single file registration —
+ * see commands/global/*.ts and commands/providers/*.ts.
+ */
+
+import type { ProviderDefinition } from "../providers";
+import type { SlashCommand, SlashCommandContext, SlashAvailability } from "./types";
+import { registerGlobalCommands } from "./global";
+import { SLASH_COMMANDS_BY_PROVIDER } from "./providers";
+
+export class SlashCommandRegistry {
+    private commands = new Map<string, SlashCommand>();
+
+    /**
+     * Register a command. Collisions log a warning and keep the first
+     * registration — this way a provider can't accidentally shadow a
+     * global command (e.g. /clear). If the second registration is
+     * intentional, unregister the first explicitly.
+     */
+    register(cmd: SlashCommand): void {
+        if (this.commands.has(cmd.name)) {
+            // eslint-disable-next-line no-console
+            console.warn(`[slash] duplicate registration for /${cmd.name} — keeping first`);
+            return;
+        }
+        this.commands.set(cmd.name, cmd);
+        for (const alias of cmd.aliases ?? []) {
+            if (!this.commands.has(alias)) {
+                this.commands.set(alias, cmd);
+            }
+        }
+    }
+
+    /** Case-insensitive lookup by name or alias. */
+    lookup(name: string): SlashCommand | undefined {
+        return this.commands.get(name.toLowerCase());
+    }
+
+    /** Iterate over unique commands (de-duped across aliases). */
+    all(): SlashCommand[] {
+        const seen = new Set<SlashCommand>();
+        for (const cmd of this.commands.values()) seen.add(cmd);
+        return Array.from(seen);
+    }
+
+    /**
+     * Commands available in the given context. Filters by
+     * `availability` against whether the pane has an active agent.
+     */
+    list(ctx: SlashCommandContext): SlashCommand[] {
+        const hasAgent = Boolean(ctx.block()?.meta?.["agentId"]);
+        const providerId = ctx.provider()?.id;
+        return this.all().filter((cmd) => isAvailable(cmd.availability, hasAgent, providerId));
+    }
+
+    /**
+     * Autocomplete — commands whose name or primary alias starts with
+     * the given prefix (lowercase-insensitive). Returns unique commands
+     * sorted by category then name.
+     */
+    completions(prefix: string, ctx: SlashCommandContext): SlashCommand[] {
+        const p = prefix.toLowerCase();
+        return this.list(ctx)
+            .filter((cmd) => cmd.name.startsWith(p) || (cmd.aliases ?? []).some((a) => a.startsWith(p)))
+            .sort((a, b) => {
+                if (a.category !== b.category) return a.category.localeCompare(b.category);
+                return a.name.localeCompare(b.name);
+            });
+    }
+}
+
+/**
+ * Build a registry for a given provider. Called from useAgentCommands
+ * and memoized — re-runs only when the provider changes.
+ *
+ * Order:
+ *   1. Global commands (always available)
+ *   2. Provider-scoped commands (if a provider is active)
+ */
+export function buildRegistry(provider: ProviderDefinition | undefined): SlashCommandRegistry {
+    const registry = new SlashCommandRegistry();
+
+    registerGlobalCommands(registry);
+
+    if (provider) {
+        const providerCommands = SLASH_COMMANDS_BY_PROVIDER[provider.id] ?? [];
+        for (const cmd of providerCommands) {
+            registry.register(cmd);
+        }
+    }
+
+    return registry;
+}
+
+function isAvailable(
+    availability: SlashAvailability | undefined,
+    hasAgent: boolean,
+    providerId: string | undefined,
+): boolean {
+    if (availability === undefined || availability === "global") return true;
+    if (availability === "any-agent") return hasAgent;
+    if (availability === "picker-only") return !hasAgent;
+    if (typeof availability === "object" && "provider" in availability) {
+        return availability.provider === providerId;
+    }
+    return false;
+}

--- a/frontend/app/view/agent/commands/types.ts
+++ b/frontend/app/view/agent/commands/types.ts
@@ -1,0 +1,119 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Slash-command architecture — type definitions.
+ *
+ * Step 1 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md.
+ *
+ * Commands are data. This file defines the shape. The dispatcher, picker,
+ * autocomplete, and help panel all consume the same registry, so adding a
+ * new command is one file create — no touches to any presentation or
+ * dispatch code.
+ *
+ * See the spec §4 for the design rationale.
+ */
+
+import type { ProviderDefinition } from "../providers";
+import type { SignalPair } from "../state";
+import type { DocumentNode } from "../types";
+import type { LogFn } from "../hooks/useAgentControllerStatus";
+
+/** Grouping used by /help and (eventually) the settings browser. */
+export type SlashCommandCategory = "runtime" | "session" | "auth" | "query" | "system" | "help";
+
+/** A picker choice surface. Used by enum + dynamic arg kinds. */
+export interface SlashChoice {
+    value: string;
+    label: string;
+    description?: string;
+    /** Render this option as the currently-active selection. */
+    current?: boolean;
+}
+
+/**
+ * Argument contract for a slash command. The dispatcher uses this to
+ * decide whether to open a picker, error, or dispatch immediately.
+ */
+export type SlashArg =
+    | { kind: "none" }
+    | { kind: "enum"; choices: SlashChoice[]; required: boolean; defaultLabel?: string }
+    | { kind: "freeform"; placeholder: string; required: boolean }
+    | {
+          kind: "dynamic";
+          placeholder: string;
+          completions: (ctx: SlashCommandContext) => Promise<SlashChoice[]>;
+      };
+
+/**
+ * Where a command is allowed to run. Undefined = always available.
+ *
+ *   "global"        — always available (e.g. /help, /clear, /login)
+ *   "any-agent"     — only when block.meta.agentId is set (pane has launched)
+ *   "picker-only"   — only on the pre-launch agent picker screen
+ *   { provider: X } — only when the active provider.id matches
+ */
+export type SlashAvailability =
+    | "global"
+    | "any-agent"
+    | "picker-only"
+    | { provider: string };
+
+/** Outcome of dispatching a command. */
+export type SlashResult =
+    | { kind: "ok"; message?: string }
+    | { kind: "error"; message: string }
+    /**
+     * The dispatcher should fall through to AgentInputCommand — i.e. treat
+     * the input as a regular user message. Used when the command matches
+     * but the handler decides the user didn't actually mean to invoke it
+     * (rare; mostly a future escape hatch).
+     */
+    | { kind: "passthrough" };
+
+/**
+ * Context passed to every command handler. A grab bag of the things a
+ * handler might need — the dispatcher builds it once per invocation.
+ *
+ * Intentionally small: if a command needs something not here, add it in
+ * the spec and this type together, not hidden behind a closure in the
+ * handler file.
+ */
+export interface SlashCommandContext {
+    /** Block id this command runs against. */
+    blockId: string;
+    /** Current provider definition, if the pane is in presentation mode. */
+    provider: () => ProviderDefinition | undefined;
+    /** Reactive accessor for the current block meta. */
+    block: () => { meta?: Record<string, any> } | undefined;
+    /** Document atom pair for commands that mutate the conversation (/clear). */
+    documentAtom: SignalPair<DocumentNode[]>;
+    /** Launch-log sink for system messages. */
+    log: LogFn;
+    /** Set the OAuth URL for /login. */
+    setAuthUrl: (url: string | null) => void;
+}
+
+/**
+ * Shape of a single slash command. Handlers are pure async functions
+ * that return a SlashResult — no direct logging, no direct UI calls.
+ * The dispatcher centralizes result formatting.
+ */
+export interface SlashCommand {
+    /** Primary name. Always lowercase, no leading slash. */
+    name: string;
+    /** Alternate names. Lookup is case-insensitive. */
+    aliases?: string[];
+    /** Grouping for /help and autocomplete. */
+    category: SlashCommandCategory;
+    /** One-line description. Shown in /help and autocomplete. */
+    description: string;
+    /** Optional longer help text (also Markdown-safe). */
+    longDescription?: string;
+    /** Argument contract. */
+    arg: SlashArg;
+    /** Where the command is allowed to run. */
+    availability?: SlashAvailability;
+    /** The actual handler. Called AFTER arg validation / picker resolution. */
+    handler: (ctx: SlashCommandContext, arg: string) => Promise<SlashResult>;
+}

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -23,15 +23,17 @@
  * flags (permission mode, model, effort) take effect on this turn.
  */
 
-import type { Accessor } from "solid-js";
+import { type Accessor, createMemo } from "solid-js";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
 import * as WOS from "@/app/store/wos";
-import { getApi } from "@/app/store/global";
 import { buildRuntimeArgs, getRuntimeConfig } from "../buildRuntimeArgs";
+import { dispatchSlashCommand } from "../commands/dispatch";
+import { buildRegistry } from "../commands/registry";
+import type { SlashCommandContext } from "../commands/types";
 import type { ProviderDefinition } from "../providers";
 import type { SignalPair } from "../state";
-import type { AgentRuntimeConfig, DocumentNode, EffortLevel, ModelChoice, PermissionMode } from "../types";
+import type { DocumentNode } from "../types";
 import type { LogFn } from "./useAgentControllerStatus";
 
 export interface UseAgentCommandsOptions {
@@ -75,235 +77,21 @@ export interface UseAgentCommands {
     stopAgent: () => void;
 }
 
-// ── Runtime-config slash-command helpers ───────────────────────────────────
-//
-// The Claude Code CLI runs in non-interactive stream-json mode, so the user's
-// slash commands (e.g. `/model sonnet`) reach the model as raw text instead
-// of being handled by the CLI's own dispatcher. We intercept the well-known
-// runtime-config commands here and map them to `block.meta["agent:runtime"]`
-// mutations — the exact same path the AgentControlBar dropdowns use. Takes
-// effect on the NEXT turn (runtime args are rebuilt in sendMessage below
-// before each RPC invocation).
-//
-// Non-runtime commands are listed below as "recognized but not supported in
-// stream-json mode" so the user gets a helpful error instead of silently
-// sending `/memory` as a user message to the model.
-
-const MODEL_ALIASES: Record<string, ModelChoice> = {
-    "opus": "opus",
-    "sonnet": "sonnet",
-    "haiku": "haiku",
-    "claude-opus": "opus",
-    "claude-sonnet": "sonnet",
-    "claude-haiku": "haiku",
-    "default": null,
-    "": null,
-};
-
-const EFFORT_ALIASES: Record<string, EffortLevel> = {
-    "low": "low",
-    "medium": "medium",
-    "med": "medium",
-    "high": "high",
-    "max": "max",
-    "default": null,
-    "": null,
-};
-
-const PERMISSION_ALIASES: Record<string, PermissionMode> = {
-    "bypass": "bypass",
-    "dangerous": "bypass",
-    "skip": "bypass",
-    "dangerously-skip-permissions": "bypass",
-    "auto": "auto",
-    "accept": "acceptEdits",
-    "acceptedits": "acceptEdits",
-    "accept-edits": "acceptEdits",
-    "plan": "plan",
-    "default": "default",
-    "": "default",
-};
-
-/** Parse `/command arg` → `["command", "arg"]`. Leading slash stripped. */
-function parseSlashCommand(input: string): [string, string] {
-    const trimmed = input.trim();
-    if (!trimmed.startsWith("/")) return ["", ""];
-    const rest = trimmed.slice(1);
-    const spaceIdx = rest.indexOf(" ");
-    if (spaceIdx < 0) return [rest.toLowerCase(), ""];
-    return [rest.slice(0, spaceIdx).toLowerCase(), rest.slice(spaceIdx + 1).trim()];
-}
-
-/** True if `input` is a known slash command we handle client-side. */
-function isRuntimeSlashCommand(name: string): boolean {
-    return (
-        name === "model" ||
-        name === "effort" ||
-        name === "permission-mode" ||
-        name === "permission" ||
-        name === "perm" ||
-        name === "bypass" ||
-        name === "plan" ||
-        name === "runtime"
-    );
-}
+// Runtime-config + auth slash commands (/model /effort /permission-mode
+// /bypass /plan /runtime /login /clear) are now data-driven via
+// `frontend/app/view/agent/commands/`. See
+// specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md for the design.
+// sendMessage below dispatches through the registry; adding a new
+// command is one file create in `commands/global/` or
+// `commands/providers/`, not an edit here.
 
 export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommands {
     const [, setDocument] = opts.documentAtom;
 
-    // Mutate block.meta["agent:runtime"] with a partial runtime config, the
-    // same way AgentControlBar.updateRuntime does. Returns the merged config
-    // on success, null on RPC failure — callers check the return value and
-    // skip the user-visible confirmation if the mutation didn't actually
-    // land (otherwise we log "model set to X" right alongside the error
-    // from SetMetaCommand, which reagent flagged as a false-success path).
-    const updateRuntime = async (patch: Partial<AgentRuntimeConfig>): Promise<AgentRuntimeConfig | null> => {
-        const current = getRuntimeConfig(opts.block()?.meta);
-        const updated: AgentRuntimeConfig = { ...current, ...patch };
-        try {
-            await RpcApi.SetMetaCommand(TabRpcClient, {
-                oref: WOS.makeORef("block", opts.blockId),
-                meta: { "agent:runtime": updated },
-            });
-            return updated;
-        } catch (err: any) {
-            opts.log("error", `failed to update runtime config: ${err?.message ?? String(err)}`, "error");
-            return null;
-        }
-    };
-
-    const handleModelCommand = async (arg: string): Promise<void> => {
-        const key = arg.toLowerCase();
-        if (!(key in MODEL_ALIASES)) {
-            opts.log(
-                "system",
-                `/model: unknown model '${arg}'. Try: opus | sonnet | haiku | default`,
-                "warn",
-            );
-            return;
-        }
-        const model = MODEL_ALIASES[key];
-        const updated = await updateRuntime({ model });
-        if (!updated) return;
-        const label = updated.model ?? "default";
-        opts.log("system", `model set to ${label} (applies to next turn)`);
-    };
-
-    const handleEffortCommand = async (arg: string): Promise<void> => {
-        const key = arg.toLowerCase();
-        if (!(key in EFFORT_ALIASES)) {
-            opts.log(
-                "system",
-                `/effort: unknown level '${arg}'. Try: low | medium | high | max | default`,
-                "warn",
-            );
-            return;
-        }
-        const effort = EFFORT_ALIASES[key];
-        const updated = await updateRuntime({ effort });
-        if (!updated) return;
-        const label = updated.effort ?? "default";
-        opts.log("system", `effort set to ${label} (applies to next turn)`);
-    };
-
-    const handlePermissionModeCommand = async (arg: string): Promise<void> => {
-        const key = arg.toLowerCase();
-        if (!(key in PERMISSION_ALIASES)) {
-            opts.log(
-                "system",
-                `/permission-mode: unknown mode '${arg}'. Try: bypass | auto | accept | plan | default`,
-                "warn",
-            );
-            return;
-        }
-        const mode = PERMISSION_ALIASES[key];
-        const updated = await updateRuntime({ permissionMode: mode });
-        if (!updated) return;
-        opts.log("system", `permission mode set to ${updated.permissionMode} (applies to next turn)`);
-    };
-
-    const handleRuntimeCommand = async (): Promise<void> => {
-        const r = getRuntimeConfig(opts.block()?.meta);
-        const parts = [
-            `permission: ${r.permissionMode}`,
-            `model: ${r.model ?? "default"}`,
-            `effort: ${r.effort ?? "default"}`,
-        ];
-        opts.log("system", `runtime config — ${parts.join(" · ")}`);
-    };
-
-    const dispatchRuntimeSlashCommand = async (name: string, arg: string): Promise<void> => {
-        switch (name) {
-            case "model":
-                await handleModelCommand(arg);
-                return;
-            case "effort":
-                await handleEffortCommand(arg);
-                return;
-            case "permission-mode":
-            case "permission":
-            case "perm":
-                await handlePermissionModeCommand(arg);
-                return;
-            case "bypass": {
-                // Shortcut: `/bypass` with no arg enables permission bypass;
-                // `/bypass off` or `/bypass default` reverts to default. Any
-                // other arg is a typo — warn instead of silently enabling
-                // dangerous mode, since bypass disables permission prompts
-                // and a typo like `/bypass of` shouldn't be load-bearing.
-                const bypassArg = arg.toLowerCase();
-                if (bypassArg === "") {
-                    await handlePermissionModeCommand("bypass");
-                } else if (bypassArg === "off" || bypassArg === "default") {
-                    await handlePermissionModeCommand("default");
-                } else {
-                    opts.log(
-                        "system",
-                        `/bypass: unknown arg '${arg}'. Use '/bypass' to enable or '/bypass off' to disable.`,
-                        "warn",
-                    );
-                }
-                return;
-            }
-            case "plan":
-                // Shortcut: `/plan` = permission-mode plan
-                await handlePermissionModeCommand("plan");
-                return;
-            case "runtime":
-                await handleRuntimeCommand();
-                return;
-        }
-    };
-
-    const runLoginCommand = async (): Promise<void> => {
-        const prov = opts.provider();
-        const cliPath = opts.block()?.meta?.["cmd"] ?? "";
-        if (!prov || !cliPath) {
-            opts.log("error", "/login: provider or CLI path not available", "error");
-            return;
-        }
-        opts.log("auth", "running /login via GUI flow...");
-        try {
-            const authEnv: Record<string, string> = {};
-            const envMeta = opts.block()?.meta?.["cmd:env"];
-            if (envMeta && typeof envMeta === "object") {
-                for (const [k, v] of Object.entries(envMeta)) {
-                    if (typeof v === "string") authEnv[k] = v;
-                }
-            }
-            const url = await getApi().runCliLogin(cliPath, prov.authLoginCommand, authEnv);
-            if (url) {
-                opts.setAuthUrl(url);
-                opts.log("auth", "OAuth URL captured — browser should open automatically");
-                opts.log("auth", "if it didn't, copy the URL from the box above");
-            } else {
-                opts.log("auth", "a browser window should have opened — complete login there");
-            }
-            opts.log("auth", "run /cost to verify authentication once logged in");
-        } catch (err: any) {
-            opts.log("error", `/login failed: ${err?.message ?? String(err)}`, "error");
-        }
-    };
+    // Registry is rebuilt whenever the provider changes so
+    // provider-scoped commands swap in/out. Global commands are
+    // registered first and can't be shadowed (see registry.register).
+    const registry = createMemo(() => buildRegistry(opts.provider()));
 
     const sendMessage = async (message: string): Promise<void> => {
         setDocument((prev) => [
@@ -327,30 +115,22 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             requestAnimationFrame(() => opts.onSent?.());
         }
 
+        // Intercept slash commands via the registry. Claude runs in
+        // stream-json mode so the CLI doesn't see these as control
+        // commands — we handle them client-side. Unknown `/foo` falls
+        // through to AgentInputCommand via the "passthrough" outcome.
         const trimmed = message.trim();
-        if (trimmed === "/login") {
-            await runLoginCommand();
-            return;
-        }
-        if (trimmed === "/clear") {
-            setDocument([]);
-            opts.log("system", "chat cleared");
-            return;
-        }
-
-        // Intercept runtime-config slash commands (/model, /effort,
-        // /permission-mode, /bypass, /plan, /runtime). AgentMux drives
-        // Claude in stream-json mode, so the CLI never sees these as
-        // control commands — it treats them as user text and Claude
-        // replies "not a command". We handle them client-side and mutate
-        // block.meta["agent:runtime"] so they take effect on the NEXT
-        // turn via the runtime-args rebuild below.
         if (trimmed.startsWith("/")) {
-            const [name, arg] = parseSlashCommand(trimmed);
-            if (isRuntimeSlashCommand(name)) {
-                await dispatchRuntimeSlashCommand(name, arg);
-                return;
-            }
+            const ctx: SlashCommandContext = {
+                blockId: opts.blockId,
+                provider: opts.provider,
+                block: opts.block,
+                documentAtom: opts.documentAtom,
+                log: opts.log,
+                setAuthUrl: opts.setAuthUrl,
+            };
+            const outcome = await dispatchSlashCommand(trimmed, registry(), ctx);
+            if (outcome.kind === "handled") return;
         }
 
         // Apply runtime args (permission mode, model, effort) before this turn.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.148",
+  "version": "0.33.149",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.149",
+  "version": "0.33.150",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md
+++ b/specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md
@@ -1,0 +1,477 @@
+# SPEC — Slash Command Architecture
+
+**Date:** 2026-04-14
+**Status:** Draft
+**Owner:** AgentA
+**Scope:** `frontend/app/view/agent/` — the composer's slash command surface
+**Related:** PR #378 (minimal `/model` /`/effort` /`/permission-mode` dispatcher — the mechanism proof this spec grows into a real architecture)
+
+---
+
+## 1. Why a spec, not just more case statements
+
+PR #378 shipped a ~80-line switch in `useAgentCommands.sendMessage` that intercepts `/model`, `/effort`, `/permission-mode`, `/bypass`, `/plan`, `/runtime` and maps them to the existing runtime-config path. It works, but four observations make the switch a dead end:
+
+1. **Five commands today, ten more tomorrow.** Claude Code has ~20 slash commands (`/model`, `/memory`, `/hooks`, `/mcp`, `/compact`, `/cost`, `/status`, `/doctor`, `/config`, `/bug`, `/release-notes`, `/help`, `/clear`, `/login`, ...). Codex has its own vocabulary. Gemini CLI ships a third. Some commands map to the same action (`/clear` = reset conversation), some don't exist in one CLI and do in another.
+2. **Args want structure.** `/model <name>` needs a picker when invoked bare. `/memory` wants autocomplete over recent memory files. `/cost` needs no arg at all. A string dispatcher doesn't know any of that.
+3. **Users want discovery.** `/help` should list *all* commands available in the current pane, not a hardcoded subset. Pressing `/` should show completions as the user types.
+4. **The CLI isn't the only command source.** Built-in AgentMux commands (`/clear`, `/runtime`, `/login`) are orthogonal to the CLI's own vocabulary. Forge-defined agents might want their own commands. A command registry lets all three sources coexist.
+
+The right abstraction is: **commands are data, not code**. The dispatcher, picker, autocomplete, and help panel all consume the same registry.
+
+## 2. What doesn't exist yet
+
+To ground the design, here's what AgentMux currently has and lacks:
+
+| Feature | Today (0.33.148) | After this spec |
+|---|---|---|
+| Client-side intercepting dispatcher | ✓ PR #378 switch | Registry lookup |
+| Runtime-config commands (`/model`, `/effort`, `/permission-mode`) | ✓ PR #378 | Same commands, registered via registry |
+| Arg picker when `/model` is typed bare | ✗ logs a warning | Inline picker overlay |
+| Autocomplete while typing `/mo...` | ✗ | Dropdown above composer |
+| `/help` command listing all available commands | ✗ falls through to CLI | Help panel renders from registry |
+| Provider-scoped commands (e.g. Claude vs Codex) | ✗ everything is Claude | Each `ProviderDefinition` contributes commands |
+| Agent-specific commands (forge-defined) | ✗ | Registry accepts per-agent additions (deferred to a later spec) |
+| Error for commands that exist in interactive CLI but not stream-json | ✗ silently becomes a user message | Registry entry with "not-in-stream-json" handler |
+
+Nothing below creates a new RPC, a new data store, or a new backend concept. Everything is a frontend refactor of the dispatch path plus three new presentation surfaces.
+
+## 3. Non-goals
+
+- **Backend slash command handling.** The sidecar never sees a slash command; all dispatch is in the frontend.
+- **Custom commands in block meta.** A block storing its own command list is an interesting future feature but out of scope. Current providers + static global commands cover everything we need.
+- **Rewriting `/login` or `/clear`.** Those work today. They just get registered into the new registry and keep their current behavior.
+- **Command aliasing at the user-settings level.** Could come later via a settings panel; not part of this architecture spec.
+- **Slash command history / up-arrow replay.** Separate feature.
+- **Support for slash commands inside tool arguments.** Only applies to composer input.
+
+## 4. Design
+
+### 4.1 The `SlashCommand` shape
+
+```ts
+// frontend/app/view/agent/commands/types.ts — new file
+export type SlashCommandCategory = "runtime" | "session" | "auth" | "query" | "system" | "help";
+
+export interface SlashCommandContext {
+    /** Block id this command runs against. */
+    blockId: string;
+    /** Current provider definition, if the pane is in presentation mode. */
+    provider: () => ProviderDefinition | undefined;
+    /** Block meta accessor. */
+    block: () => Block | undefined;
+    /** Document atom pair for commands that mutate the conversation. */
+    documentAtom: SignalPair<DocumentNode[]>;
+    /** Log a system message to the launch-log sink. */
+    log: LogFn;
+    /** Set the OAuth URL for /login. */
+    setAuthUrl: (url: string | null) => void;
+    /** Open the inline arg picker. Returns a promise that resolves with the selected value or rejects if dismissed. */
+    openPicker: (spec: SlashPickerSpec) => Promise<string>;
+    /** Access the registry so commands like /help can iterate. */
+    registry: SlashCommandRegistry;
+}
+
+export type SlashArg =
+    | { kind: "none" }
+    | { kind: "enum"; choices: SlashChoice[]; required: boolean; defaultLabel?: string }
+    | { kind: "freeform"; placeholder: string; required: boolean }
+    | { kind: "dynamic"; placeholder: string; completions: (ctx: SlashCommandContext) => Promise<SlashChoice[]> };
+
+export interface SlashChoice {
+    value: string;
+    label: string;
+    description?: string;
+    current?: boolean; // if true, render as the currently-active option
+}
+
+export interface SlashCommand {
+    name: string;
+    aliases?: string[];
+    category: SlashCommandCategory;
+    description: string;
+    /** Longer help text shown in /help panel or on hover. */
+    longDescription?: string;
+    arg: SlashArg;
+    /**
+     * Called after arg validation. If `arg.required` and no arg provided,
+     * the dispatcher opens a picker first and invokes handler with the
+     * selected value.
+     */
+    handler: (ctx: SlashCommandContext, arg: string) => Promise<SlashResult>;
+    /**
+     * Optional: where the command is available. Undefined = global. A
+     * provider match scopes to that CLI; `"any-agent"` scopes to
+     * "pane has an agentId set"; `"picker-only"` scopes to the agent
+     * picker screen.
+     */
+    availability?: "global" | "any-agent" | "picker-only" | { provider: string };
+}
+
+export type SlashResult =
+    | { kind: "ok"; message?: string }
+    | { kind: "error"; message: string }
+    | { kind: "passthrough" }; // fall through to AgentInputCommand
+```
+
+### 4.2 The registry
+
+```ts
+// frontend/app/view/agent/commands/registry.ts — new file
+export class SlashCommandRegistry {
+    private commands = new Map<string, SlashCommand>();
+
+    register(cmd: SlashCommand): void {
+        this.commands.set(cmd.name, cmd);
+        for (const alias of cmd.aliases ?? []) {
+            this.commands.set(alias, cmd);
+        }
+    }
+
+    lookup(name: string): SlashCommand | undefined {
+        return this.commands.get(name.toLowerCase());
+    }
+
+    /** List commands available in the given context (applies availability filter). */
+    list(ctx: SlashCommandContext): SlashCommand[] { ... }
+
+    /** Autocomplete — returns commands whose name or aliases start with the prefix. */
+    completions(prefix: string, ctx: SlashCommandContext): SlashCommand[] { ... }
+}
+
+/**
+ * Build the registry with all commands for the current pane. Called from
+ * useAgentCommands, memoized. Re-run only when the provider changes.
+ */
+export function buildRegistry(provider: ProviderDefinition | undefined): SlashCommandRegistry {
+    const registry = new SlashCommandRegistry();
+
+    // Global commands (always available)
+    registerGlobalCommands(registry);
+
+    // Provider-scoped commands
+    if (provider) {
+        const providerCommands = SLASH_COMMANDS_BY_PROVIDER[provider.id] ?? [];
+        for (const cmd of providerCommands) {
+            registry.register(cmd);
+        }
+    }
+
+    return registry;
+}
+```
+
+### 4.3 Command files layout
+
+```
+frontend/app/view/agent/commands/
+├── types.ts                # SlashCommand, SlashArg, SlashContext, SlashResult
+├── registry.ts             # SlashCommandRegistry + buildRegistry
+├── global/
+│   ├── clear.ts            # /clear
+│   ├── help.ts             # /help
+│   ├── runtime.ts          # /runtime, /model, /effort, /permission-mode, /bypass, /plan
+│   ├── login.ts            # /login
+│   └── index.ts            # registerGlobalCommands
+├── providers/
+│   ├── claude.ts           # /cost, /status, /doctor, /memory, /hooks, /mcp, /compact, /config
+│   ├── codex.ts            # (placeholder for when we wire Codex commands)
+│   ├── gemini.ts           # (placeholder)
+│   └── index.ts            # SLASH_COMMANDS_BY_PROVIDER
+├── pickers.ts              # SlashPickerSpec, picker resolver (called by dispatcher)
+└── dispatch.ts             # dispatchSlashCommand — the main entry point
+```
+
+### 4.4 The dispatcher
+
+```ts
+// frontend/app/view/agent/commands/dispatch.ts — new file
+export async function dispatchSlashCommand(
+    input: string,
+    ctx: SlashCommandContext,
+): Promise<SlashResult> {
+    const [name, arg] = parseSlashCommand(input);
+    const cmd = ctx.registry.lookup(name);
+    if (!cmd) {
+        // Unknown slash command — fall through to AgentInputCommand (current behavior).
+        return { kind: "passthrough" };
+    }
+
+    // Validate arg
+    if (cmd.arg.kind === "enum") {
+        if (arg === "" && cmd.arg.required) {
+            // Bare command → open picker
+            try {
+                const picked = await ctx.openPicker({
+                    title: `Select ${cmd.name}`,
+                    choices: cmd.arg.choices,
+                });
+                return await cmd.handler(ctx, picked);
+            } catch {
+                return { kind: "ok", message: "cancelled" };
+            }
+        }
+        const match = cmd.arg.choices.find(
+            (c) => c.value.toLowerCase() === arg.toLowerCase()
+        );
+        if (!match && cmd.arg.required) {
+            return {
+                kind: "error",
+                message: `/${cmd.name}: unknown value '${arg}'. Try: ${cmd.arg.choices.map((c) => c.value).join(" | ")}`,
+            };
+        }
+        return await cmd.handler(ctx, match?.value ?? arg);
+    }
+
+    if (cmd.arg.kind === "dynamic") {
+        if (arg === "" && cmd.arg.required) {
+            const choices = await cmd.arg.completions(ctx);
+            try {
+                const picked = await ctx.openPicker({
+                    title: `Select ${cmd.name}`,
+                    choices,
+                });
+                return await cmd.handler(ctx, picked);
+            } catch {
+                return { kind: "ok", message: "cancelled" };
+            }
+        }
+        return await cmd.handler(ctx, arg);
+    }
+
+    if (cmd.arg.kind === "freeform") {
+        if (arg === "" && cmd.arg.required) {
+            return {
+                kind: "error",
+                message: `/${cmd.name} requires an argument: ${cmd.arg.placeholder}`,
+            };
+        }
+        return await cmd.handler(ctx, arg);
+    }
+
+    // kind === "none"
+    return await cmd.handler(ctx, "");
+}
+```
+
+### 4.5 The inline picker UI
+
+`frontend/app/view/agent/components/SlashCommandPicker.tsx` — a new component mounted above `AgentFooter` in `AgentPresentationView`. Visible only when the picker signal is non-null.
+
+Visual:
+
+```
+┌─ Select model ────────────────────────────────┐
+│  ◉  Opus          Claude Opus 4.6           │  ← current model highlighted
+│     Sonnet        Claude Sonnet              │
+│     Haiku         Claude Haiku               │
+│     Default       Provider default           │
+│  ─────────────                                │
+│  Esc to cancel · ↵ to select                  │
+└───────────────────────────────────────────────┘
+```
+
+- Mouse click or keyboard (↑/↓ + Enter) picks an option.
+- Esc dismisses → dispatcher's `openPicker` Promise rejects → command handler returns `cancelled`.
+- Single-keystroke filter: typing a letter jumps to the first matching option (same pattern as the existing AgentSearchBar).
+- Uses the existing picker state signal pattern from `useScrollToNode` — a signal owned by the hook, set via `openPicker`, consumed by the component via Accessor prop.
+
+### 4.6 Autocomplete dropdown
+
+When the user types `/` in `AgentFooter`, a dropdown appears showing commands whose name or alias starts with the typed prefix. Filters as the user types.
+
+Implementation:
+- New signal in the composer hook (`useSlashAutocomplete`) tracks the current composer value.
+- If value starts with `/` and has no space, look up completions in the registry.
+- Render as a floating list above the textarea using the same positioning pattern as the ToolBlock portal (PR #367).
+- Tab / Enter accepts the top completion; keeps typing to narrow.
+- Esc dismisses.
+
+The autocomplete consumes the **same** registry as the dispatcher, so adding a command automatically shows up in autocomplete.
+
+### 4.7 The `/help` panel
+
+Registered as a global command in `global/help.ts`. When invoked:
+1. Calls `ctx.registry.list(ctx)` to get all currently-available commands
+2. Groups by `category` (runtime, session, auth, query, system, help)
+3. Renders a new `SlashHelpPanel` component as an overlay
+4. Each command entry shows: name, aliases, description, arg hint
+5. Clicking a row either runs the command (for arg-less ones) or pre-fills the composer with `/<name> `
+
+Keyboard: `?` or `/help` opens; Esc closes.
+
+## 5. Migration path
+
+Bridging PR #378 (current) to this architecture without a flag-day rewrite:
+
+### Step 1 — Wire the registry, keep the switch
+
+- Create `commands/` directory with `types.ts`, `registry.ts`, empty stubs for `global/` and `providers/`.
+- Register exactly the six commands PR #378 handles into `global/runtime.ts`.
+- Replace the switch in `useAgentCommands.sendMessage` with `dispatchSlashCommand(input, ctx)`.
+- Behavior: identical to PR #378. The switch is just hidden behind a registry lookup.
+
+### Step 2 — Inline picker
+
+- Add `SlashCommandPicker.tsx` component.
+- Wire the picker signal through `UseAgentCommands` options (same pattern as `onSent`).
+- Change `/model`, `/effort`, `/permission-mode` commands to `arg: { kind: "enum", required: true, ... }`.
+- Bare `/model` now opens the picker instead of logging a warning.
+
+### Step 3 — Autocomplete
+
+- Add `useSlashAutocomplete` hook.
+- Wire into `AgentFooter` via a new `onAutocomplete` prop.
+- Render the dropdown component above the composer.
+- Tab / Enter accepts the top match.
+
+### Step 4 — `/help` panel
+
+- Add `global/help.ts` registering `/help`.
+- Add `SlashHelpPanel` component.
+- Wire the overlay into `AgentPresentationView` controlled by a signal from `useAgentCommands`.
+
+### Step 5 — Claude provider commands
+
+- Populate `providers/claude.ts` with:
+  - `/cost` — shells out to `claude -p --output-format json /cost` via a new host-level RPC, parses the result, logs it
+  - `/status` — same pattern
+  - `/doctor` — same pattern
+  - `/memory` — opens `~/.claude/CLAUDE.md` in the system editor via the existing CEF host API
+  - `/hooks`, `/mcp`, `/config` — same (open the relevant files)
+  - `/compact` — **not supported in stream-json mode**; registered with a handler that explains why and suggests alternatives
+  - `/bug`, `/release-notes`, `/help` (CLI-level) — open external URLs
+- Each is a separate commit so they land incrementally.
+
+### Step 6 — Codex / Gemini
+
+- When someone wires Codex or Gemini as a first-class provider, they populate `providers/codex.ts` / `providers/gemini.ts`.
+- The dispatcher, picker, autocomplete, and help all work automatically.
+- No changes to the core.
+
+## 6. Example: `/model` command registration
+
+```ts
+// frontend/app/view/agent/commands/global/runtime.ts
+import { SlashCommand } from "../types";
+import { getRuntimeConfig } from "../../buildRuntimeArgs";
+
+const MODEL_CHOICES = [
+    { value: "opus", label: "Opus", description: "Claude Opus — highest quality" },
+    { value: "sonnet", label: "Sonnet", description: "Claude Sonnet — balanced" },
+    { value: "haiku", label: "Haiku", description: "Claude Haiku — fastest" },
+    { value: "default", label: "Default", description: "Provider default" },
+];
+
+export const modelCommand: SlashCommand = {
+    name: "model",
+    category: "runtime",
+    description: "Change the active model",
+    longDescription:
+        "Sets the model for the next turn. Does not restart the session or affect " +
+        "history. Maps to --model <choice> in the next CLI invocation.",
+    arg: {
+        kind: "enum",
+        required: true,
+        choices: MODEL_CHOICES,
+    },
+    availability: "any-agent",
+    handler: async (ctx, arg) => {
+        const current = getRuntimeConfig(ctx.block()?.meta);
+        const model = arg === "default" ? null : arg as ModelChoice;
+        const updated = { ...current, model };
+        try {
+            await RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: WOS.makeORef("block", ctx.blockId),
+                meta: { "agent:runtime": updated },
+            });
+            return { kind: "ok", message: `model set to ${arg} (applies to next turn)` };
+        } catch (err: any) {
+            return { kind: "error", message: `failed to update runtime: ${err?.message ?? err}` };
+        }
+    },
+};
+```
+
+Notice:
+- The **picker choices are part of the command definition**, so the picker UI has everything it needs without touching the dispatcher.
+- The **handler is pure async** and returns a `SlashResult`. The dispatcher logs the message.
+- Error handling is centralized — the handler never logs directly, just returns `{ kind: "error", message }`.
+- **Availability** scopes it to panes with an agent loaded, so the agent picker screen doesn't offer `/model`.
+
+## 7. Estimated cost per step
+
+| Step | Time | Risk |
+|---|---:|---|
+| 1. Registry + migrate PR #378 | 1h | Low — behavior identical, just refactored |
+| 2. Inline picker + enum arg support | 1.5h | Low — new component, localized |
+| 3. Autocomplete dropdown | 2h | Medium — composer focus/keyboard conflicts |
+| 4. `/help` panel | 1h | Low |
+| 5. Claude provider commands (6 commands, one PR each) | 4–6h | Medium — some need new RPCs for CLI shelling |
+| 6. Codex / Gemini registration | 30 min each when those providers land | Low |
+
+**Total to steps 1–4:** ~5.5 hours. Gets the whole frontend architecture in place with no behavior regressions. Step 5 can be spread over days as useful.
+
+## 8. Open questions
+
+1. **Where does the shell-out to `claude -p /cost` run?** Options: (a) new CEF host RPC that spawns the CLI and returns the JSON result; (b) frontend-only via `fetch` to the sidecar which then spawns. (a) is simpler because the host already has `runCliLogin` and can grow a sibling `runCliCommand`.
+2. **Does `/compact` have *any* meaningful representation in stream-json mode?** The CLI's `/compact` is an interactive session action. Probably needs to be "not supported, use a new session via /clear + reseed" as a helpful error.
+3. **How do we handle commands that need to re-spawn the CLI?** `/model` takes effect on the next turn without restart — that's the happy case. `/config` that changes the base args would require a resync. For now, all restart-requiring commands should just log "restart the pane to apply" and not auto-restart.
+4. **Autocomplete conflict with path completion?** If the user types `/home/foo`, autocomplete shouldn't fire. Fix: only trigger if the value starts with `/` **and** doesn't contain a space AND there's no trailing slash in the first token. Keep it a fast regex check.
+5. **Command help as Markdown?** `longDescription` could be Markdown if we want to reuse `MarkdownBlock`. Open for a later call — text is fine for now.
+
+## 9. Success criteria
+
+After steps 1–4 land:
+
+- Typing `/model` alone shows a picker with Opus/Sonnet/Haiku/Default, marks the current one, Enter/Esc works.
+- Typing `/m` shows autocomplete with `/memory`, `/model`, `/mcp` (or whatever is registered).
+- Tab on autocomplete completes to the top match.
+- `/help` opens a grouped list of every currently-available command.
+- All six commands from PR #378 still behave exactly the same when given an explicit arg.
+- Unknown slash commands still fall through to `AgentInputCommand` (no behavior regression).
+- Adding a new command is one file create in `commands/global/` or `commands/providers/`, no touches to the dispatcher or picker or autocomplete.
+
+After step 5 lands (full Claude provider coverage):
+
+- Every Claude Code CLI slash command has a corresponding client-side handler or a helpful error explaining why stream-json mode doesn't support it.
+- Multi-CLI support is one directory add (`commands/providers/codex.ts`) away, not a dispatcher change.
+
+## 10. Out of scope
+
+- Backend awareness of slash commands (they never cross the wire)
+- Custom user-defined commands in settings
+- Command history / up-arrow replay
+- Inline markdown or JSX in command output (log lines stay plain text)
+- Command aliases edited at runtime
+- Slash commands in subagent panes (same dispatcher reuses transparently)
+- Supporting commands in tool arguments or inside agent-generated messages (composer-only)
+
+## 11. Appendix: Claude CLI slash command inventory
+
+For reference when filling in `providers/claude.ts`. Based on Claude Code 2.x documentation; marked ✗ for anything that's interactive-only (won't work via our shell-out approach).
+
+| Command | Category | Arg | Stream-json viable? | Notes |
+|---|---|---|---|---|
+| `/model` | runtime | enum | ✓ (via runtime config) | PR #378 mechanism |
+| `/effort` | runtime | enum | ✓ (via runtime config) | PR #378 |
+| `/permission-mode` | runtime | enum | ✓ (via runtime config) | PR #378 |
+| `/bypass` | runtime | none | ✓ (via runtime config) | PR #378 |
+| `/plan` | runtime | none | ✓ (via runtime config) | PR #378 |
+| `/clear` | session | none | ✓ | Already handled; reset frontend doc |
+| `/login` | auth | none | ✓ | Already handled |
+| `/cost` | query | none | ✓ via shell-out | Spawns `claude /cost --output-format json` |
+| `/status` | query | none | ✓ via shell-out | Same |
+| `/doctor` | query | none | ✓ via shell-out | Same |
+| `/help` | help | none | ✓ client-side | Reads registry |
+| `/memory` | system | none | ✓ open file in editor | Points at `~/.claude/CLAUDE.md` |
+| `/hooks` | system | none | ✓ open file in editor | Points at hooks file |
+| `/mcp` | system | none | ✓ open file in editor | Points at MCP config |
+| `/config` | system | none | ✓ open file in editor | Points at settings.json |
+| `/compact` | session | none | ✗ | Requires live CLI session; offer "start new pane" instead |
+| `/bug` | help | none | ✓ | Open issue URL |
+| `/release-notes` | help | none | ✓ | Open GitHub releases URL |
+| `/logout` | auth | none | ✓ via shell-out | `claude auth logout` |
+| `/compact` | session | none | ✗ | Same as above |
+
+Codex and Gemini inventories get their own appendix when those providers land.


### PR DESCRIPTION
## Summary

Step 1 of [SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md](../blob/agenta/slash-command-registry/specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md). Moves the inline slash-command switch from PR #378 into a data-driven registry so adding new commands is a one-file create, not an edit to the dispatcher.

- **Behavior identical to PR #378** — every command keeps its current arg handling, alias tables, error messages, and log levels.
- New structure under `frontend/app/view/agent/commands/`:
  - `types.ts` — `SlashCommand` / `SlashArg` / `SlashResult` / `SlashCommandContext` shapes
  - `parse.ts` / `registry.ts` / `dispatch.ts` — parse, lookup, validate, invoke, format
  - `global/runtime.ts` — `/model` `/effort` `/permission-mode` `/bypass` `/plan` `/runtime`
  - `global/login.ts` — `/login`
  - `global/clear.ts` — `/clear`
  - `providers/claude.ts` — empty, populated in Step 5
- `useAgentCommands.sendMessage` now calls `dispatchSlashCommand(trimmed, registry(), ctx)`; the registry is memoized per provider so provider-scoped commands swap in/out automatically when #5 lands.

Steps 2–6 build on top:
2. Inline picker for bare `/model` / `/effort` / `/permission-mode` (enum arg kind)
3. Autocomplete dropdown (`/m` → suggestions)
4. `/help` panel
5. Claude provider commands (`/cost`, `/status`, `/doctor`, `/memory`, …)
6. Codex / Gemini registration when those providers land

## Test plan

- [ ] `npx tsc --noEmit` — clean for commands/ and hooks/useAgentCommands.ts (3 pre-existing errors in `term.tsx` + `cef-api.ts` unrelated)
- [ ] Build: `task dev`, open agent pane with Claude provider
- [ ] `/model sonnet` — logs "model set to sonnet (applies to next turn)"
- [ ] `/model claude-opus` — alias still maps to opus
- [ ] `/model garbage` — error listing valid choices
- [ ] bare `/model` — sets to default (same as #378 behavior)
- [ ] `/effort med` — alias still maps to medium
- [ ] `/permission-mode bypass`, `/perm bypass`, `/permission bypass` — all work (aliases)
- [ ] `/bypass` — enables; `/bypass off` — reverts; `/bypass wat` — warns
- [ ] `/plan` — sets permission mode to plan
- [ ] `/runtime` — logs current config
- [ ] `/login` — runs GUI OAuth flow, logs progress at auth level
- [ ] `/clear` — empties document
- [ ] `/unknown` — falls through to `AgentInputCommand` (sent as user message)
- [ ] Non-slash message — still calls `SetMetaCommand(cmd:args)` then `AgentInputCommand`

🤖 Generated with [Claude Code](https://claude.com/claude-code)