### PR TITLE
feat(agent): inline slash command picker (Step 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.150"
+version = "0.33.151"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.150"
+version = "0.33.151"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.150"
+version = "0.33.151"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.150"
+version = "0.33.151"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.150"
+version = "0.33.151"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.150"
+version = "0.33.151"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.150"
+version = "0.33.151"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.150"
+version = "0.33.151"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -546,6 +546,81 @@
         flex-shrink: 0;
     }
 
+    .slash-picker {
+        display: flex;
+        flex-direction: column;
+        background: color-mix(in srgb, var(--accent-color, #4a9eff) 8%, var(--main-bg-color));
+        border-top: 1px solid color-mix(in srgb, var(--accent-color, #4a9eff) 40%, var(--border-color));
+        border-bottom: 1px solid var(--border-color);
+        font-size: 12px;
+        max-height: 240px;
+        overflow: hidden;
+    }
+
+    .slash-picker__title {
+        padding: 4px 10px;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--secondary-text-color);
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .slash-picker__list {
+        flex: 1;
+        overflow-y: auto;
+        padding: 2px 0;
+    }
+
+    .slash-picker__row {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+        padding: 4px 10px;
+        cursor: pointer;
+        line-height: 1.4;
+        color: var(--main-text-color);
+
+        &--selected {
+            background: color-mix(in srgb, var(--accent-color, #4a9eff) 22%, transparent);
+        }
+    }
+
+    .slash-picker__marker {
+        flex-shrink: 0;
+        width: 10px;
+        text-align: center;
+        font-size: 9px;
+        color: var(--accent-color, #4a9eff);
+    }
+
+    .slash-picker__label {
+        flex-shrink: 0;
+        font-weight: 500;
+        min-width: 80px;
+    }
+
+    .slash-picker__description {
+        flex: 1;
+        min-width: 0;
+        color: var(--secondary-text-color);
+        font-size: 11px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .slash-picker__hint {
+        display: flex;
+        gap: 12px;
+        padding: 3px 10px;
+        border-top: 1px solid var(--border-color);
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        background: color-mix(in srgb, var(--main-bg-color) 80%, transparent);
+    }
+
     .agent-interrupted-banner {
         display: flex;
         align-items: center;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -25,6 +25,7 @@ import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter } from "./components/AgentFooter";
 import { AgentPicker } from "./components/AgentPicker";
 import { AgentSearchBar } from "./components/AgentSearchBar";
+import { SlashCommandPicker } from "./components/SlashCommandPicker";
 import { BookmarksPanel } from "./components/BookmarksPanel";
 import { SessionDigestBanner } from "./components/SessionDigestBanner";
 import { ContextMenuModel } from "@/app/store/contextmenu";
@@ -283,6 +284,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             </Show>
 
             <div class="agent-composer-region">
+                <Show when={commands.pickerSpec()}>
+                    {(spec) => (
+                        <SlashCommandPicker
+                            spec={spec()}
+                            onSelect={commands.resolvePicker}
+                            onDismiss={commands.dismissPicker}
+                        />
+                    )}
+                </Show>
                 <AgentFooter
                     agentId={agentId}
                     onSendMessage={commands.sendMessage}

--- a/frontend/app/view/agent/commands/dispatch.ts
+++ b/frontend/app/view/agent/commands/dispatch.ts
@@ -30,7 +30,7 @@
  */
 
 import { parseSlashCommand } from "./parse";
-import type { SlashCommand, SlashCommandContext, SlashResult } from "./types";
+import type { SlashChoice, SlashCommand, SlashCommandContext, SlashResult } from "./types";
 import type { SlashCommandRegistry } from "./registry";
 
 export type DispatchOutcome =
@@ -63,9 +63,10 @@ export async function dispatchSlashCommand(
  * handler. Returns the handler's SlashResult (or a validation-error
  * result if the arg didn't pass).
  *
- * Picker UX (enum with missing required arg) is not yet implemented —
- * that lands in step 2 of the spec. For now, bare `/model` returns an
- * error that lists the choices, matching PR #378's behavior.
+ * For required enum args with no value, opens an inline picker via
+ * ctx.openPicker (step 2 of the spec). The picker resolves with the
+ * selected value or rejects on dismissal — dismissal is surfaced as
+ * a silent ok so we don't spam the log.
  */
 async function runValidatedHandler(
     cmd: SlashCommand,
@@ -77,26 +78,26 @@ async function runValidatedHandler(
     }
 
     if (cmd.arg.kind === "enum") {
+        const choices = typeof cmd.arg.choices === "function" ? cmd.arg.choices(ctx) : cmd.arg.choices;
         if (arg === "") {
             if (cmd.arg.required) {
-                // TODO step 2 — open picker here. For now, fall through to
-                // listing the choices as an error (same UX as PR #378).
-                return {
-                    kind: "error",
-                    message: `/${cmd.name} requires an argument. Try: ${cmd.arg.choices
-                        .map((c) => c.value)
-                        .join(" | ")}`,
-                };
+                try {
+                    const picked = await ctx.openPicker({
+                        title: `Select ${cmd.name}`,
+                        choices,
+                    });
+                    return cmd.handler(ctx, picked);
+                } catch {
+                    return { kind: "ok" };
+                }
             }
             return cmd.handler(ctx, "");
         }
-        const match = cmd.arg.choices.find(
-            (c) => c.value.toLowerCase() === arg.toLowerCase(),
-        );
+        const match = matchEnumChoice(choices, arg);
         if (!match) {
             return {
                 kind: "error",
-                message: `/${cmd.name}: unknown value '${arg}'. Try: ${cmd.arg.choices
+                message: `/${cmd.name}: unknown value '${arg}'. Try: ${choices
                     .map((c) => c.value)
                     .join(" | ")}`,
             };
@@ -114,14 +115,33 @@ async function runValidatedHandler(
         return cmd.handler(ctx, arg);
     }
 
-    // kind === "dynamic" — picker lands in step 2; for now require an explicit arg.
+    // kind === "dynamic" — resolve completions and open picker if empty.
     if (arg === "") {
-        return {
-            kind: "error",
-            message: `/${cmd.name} requires an argument: ${cmd.arg.placeholder}`,
-        };
+        try {
+            const choices = await cmd.arg.completions(ctx);
+            const picked = await ctx.openPicker({
+                title: `Select ${cmd.name}`,
+                choices,
+            });
+            return cmd.handler(ctx, picked);
+        } catch {
+            return { kind: "ok" };
+        }
     }
     return cmd.handler(ctx, arg);
+}
+
+/**
+ * Match an enum arg against its choices. Tries exact value match
+ * first, then aliases. Case-insensitive on both sides.
+ */
+function matchEnumChoice(choices: SlashChoice[], arg: string): SlashChoice | undefined {
+    const a = arg.toLowerCase();
+    return choices.find(
+        (c) =>
+            c.value.toLowerCase() === a ||
+            (c.aliases ?? []).some((alias) => alias.toLowerCase() === a),
+    );
 }
 
 /**

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -3,12 +3,17 @@
 
 /**
  * Runtime-config slash commands: /model /effort /permission-mode /bypass
- * /plan /runtime. Migrated from the inline switch in
- * useAgentCommands.sendMessage (PR #378) into the registry.
+ * /plan /runtime.
  *
- * Step 1 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md —
- * behavior is intentionally identical to #378. Enum/picker work lands
- * in step 2.
+ * Step 2 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md —
+ * /model, /effort, and /permission-mode are now `enum` arg kind so a
+ * bare `/model` opens the inline picker. Aliases (e.g.
+ * `claude-sonnet` → `sonnet`) live on each SlashChoice for backwards
+ * compatibility with PR #378's parsing.
+ *
+ * The `choices` factory reads the current runtime config so the picker
+ * marks the active option — the user opens `/model`, sees `Opus
+ * (current)`, and Enter is a no-op confirmation.
  */
 
 import { RpcApi } from "@/app/store/wshclientapi";
@@ -16,44 +21,7 @@ import { TabRpcClient } from "@/app/store/wshrpcutil";
 import * as WOS from "@/app/store/wos";
 import { getRuntimeConfig } from "../../buildRuntimeArgs";
 import type { AgentRuntimeConfig, EffortLevel, ModelChoice, PermissionMode } from "../../types";
-import type { SlashCommand, SlashCommandContext, SlashResult } from "../types";
-
-// Alias tables — preserved from PR #378 so `/model claude-sonnet` and
-// `/effort med` keep working. Step 2 replaces these with picker enums.
-const MODEL_ALIASES: Record<string, ModelChoice> = {
-    "opus": "opus",
-    "sonnet": "sonnet",
-    "haiku": "haiku",
-    "claude-opus": "opus",
-    "claude-sonnet": "sonnet",
-    "claude-haiku": "haiku",
-    "default": null,
-    "": null,
-};
-
-const EFFORT_ALIASES: Record<string, EffortLevel> = {
-    "low": "low",
-    "medium": "medium",
-    "med": "medium",
-    "high": "high",
-    "max": "max",
-    "default": null,
-    "": null,
-};
-
-const PERMISSION_ALIASES: Record<string, PermissionMode> = {
-    "bypass": "bypass",
-    "dangerous": "bypass",
-    "skip": "bypass",
-    "dangerously-skip-permissions": "bypass",
-    "auto": "auto",
-    "accept": "acceptEdits",
-    "acceptedits": "acceptEdits",
-    "accept-edits": "acceptEdits",
-    "plan": "plan",
-    "default": "default",
-    "": "default",
-};
+import type { SlashChoice, SlashCommand, SlashCommandContext, SlashResult } from "../types";
 
 type RuntimeUpdateResult =
     | { ok: true; updated: AgentRuntimeConfig }
@@ -86,21 +54,32 @@ function runtimeError(error: string): SlashResult {
     return { kind: "error", message: `failed to update runtime config: ${error}` };
 }
 
+// ── /model ────────────────────────────────────────────────────────────
+
+function modelChoices(ctx: SlashCommandContext): SlashChoice[] {
+    const current = getRuntimeConfig(ctx.block()?.meta).model;
+    const make = (value: string, label: string, description: string, model: ModelChoice): SlashChoice => ({
+        value,
+        label,
+        description,
+        current: current === model,
+    });
+    return [
+        { ...make("opus", "Opus", "Claude Opus — highest quality", "opus"), aliases: ["claude-opus"] },
+        { ...make("sonnet", "Sonnet", "Claude Sonnet — balanced", "sonnet"), aliases: ["claude-sonnet"] },
+        { ...make("haiku", "Haiku", "Claude Haiku — fastest", "haiku"), aliases: ["claude-haiku"] },
+        make("default", "Default", "Provider default", null),
+    ];
+}
+
 export const modelCommand: SlashCommand = {
     name: "model",
     category: "runtime",
     description: "Change the active model (applies to next turn)",
-    arg: { kind: "freeform", placeholder: "opus | sonnet | haiku | default", required: false },
+    arg: { kind: "enum", required: true, choices: modelChoices },
     availability: "any-agent",
     handler: async (ctx, arg): Promise<SlashResult> => {
-        const key = arg.toLowerCase();
-        if (!(key in MODEL_ALIASES)) {
-            return {
-                kind: "error",
-                message: `/model: unknown model '${arg}'. Try: opus | sonnet | haiku | default`,
-            };
-        }
-        const model = MODEL_ALIASES[key];
+        const model: ModelChoice = arg === "default" ? null : (arg as ModelChoice);
         const result = await updateRuntime(ctx, { model });
         if (result.ok === false) return runtimeError(result.error);
         const label = result.updated.model ?? "default";
@@ -108,21 +87,40 @@ export const modelCommand: SlashCommand = {
     },
 };
 
+// ── /effort ───────────────────────────────────────────────────────────
+
+function effortChoices(ctx: SlashCommandContext): SlashChoice[] {
+    const current = getRuntimeConfig(ctx.block()?.meta).effort;
+    const make = (
+        value: string,
+        label: string,
+        description: string,
+        effort: EffortLevel,
+        aliases?: string[],
+    ): SlashChoice => ({
+        value,
+        label,
+        description,
+        current: current === effort,
+        aliases,
+    });
+    return [
+        make("low", "Low", "Minimal reasoning effort", "low"),
+        make("medium", "Medium", "Balanced reasoning effort", "medium", ["med"]),
+        make("high", "High", "High reasoning effort", "high"),
+        make("max", "Max", "Maximum reasoning effort", "max"),
+        make("default", "Default", "Provider default", null),
+    ];
+}
+
 export const effortCommand: SlashCommand = {
     name: "effort",
     category: "runtime",
     description: "Change reasoning effort level (applies to next turn)",
-    arg: { kind: "freeform", placeholder: "low | medium | high | max | default", required: false },
+    arg: { kind: "enum", required: true, choices: effortChoices },
     availability: "any-agent",
     handler: async (ctx, arg): Promise<SlashResult> => {
-        const key = arg.toLowerCase();
-        if (!(key in EFFORT_ALIASES)) {
-            return {
-                kind: "error",
-                message: `/effort: unknown level '${arg}'. Try: low | medium | high | max | default`,
-            };
-        }
-        const effort = EFFORT_ALIASES[key];
+        const effort: EffortLevel = arg === "default" ? null : (arg as EffortLevel);
         const result = await updateRuntime(ctx, { effort });
         if (result.ok === false) return runtimeError(result.error);
         const label = result.updated.effort ?? "default";
@@ -130,23 +128,49 @@ export const effortCommand: SlashCommand = {
     },
 };
 
+// ── /permission-mode ──────────────────────────────────────────────────
+
+function permissionChoices(ctx: SlashCommandContext): SlashChoice[] {
+    const current = getRuntimeConfig(ctx.block()?.meta).permissionMode;
+    const make = (
+        value: string,
+        label: string,
+        description: string,
+        mode: PermissionMode,
+        aliases?: string[],
+    ): SlashChoice => ({
+        value,
+        label,
+        description,
+        current: current === mode,
+        aliases,
+    });
+    return [
+        make("default", "Default", "Standard permission prompts", "default"),
+        make("auto", "Auto", "Auto-approve safe operations", "auto"),
+        make("acceptEdits", "Accept Edits", "Auto-approve file edits", "acceptEdits", [
+            "accept",
+            "acceptedits",
+            "accept-edits",
+        ]),
+        make("plan", "Plan", "No tool execution — read-only planning", "plan"),
+        make("bypass", "Bypass", "Skip all permission prompts (dangerous)", "bypass", [
+            "dangerous",
+            "skip",
+            "dangerously-skip-permissions",
+        ]),
+    ];
+}
+
 export const permissionModeCommand: SlashCommand = {
     name: "permission-mode",
     aliases: ["permission", "perm"],
     category: "runtime",
     description: "Change permission mode (applies to next turn)",
-    arg: { kind: "freeform", placeholder: "bypass | auto | accept | plan | default", required: false },
+    arg: { kind: "enum", required: true, choices: permissionChoices },
     availability: "any-agent",
     handler: async (ctx, arg): Promise<SlashResult> => {
-        const key = arg.toLowerCase();
-        if (!(key in PERMISSION_ALIASES)) {
-            return {
-                kind: "error",
-                message: `/permission-mode: unknown mode '${arg}'. Try: bypass | auto | accept | plan | default`,
-            };
-        }
-        const mode = PERMISSION_ALIASES[key];
-        const result = await updateRuntime(ctx, { permissionMode: mode });
+        const result = await updateRuntime(ctx, { permissionMode: arg as PermissionMode });
         if (result.ok === false) return runtimeError(result.error);
         return {
             kind: "ok",
@@ -155,12 +179,15 @@ export const permissionModeCommand: SlashCommand = {
     },
 };
 
+// ── /bypass ───────────────────────────────────────────────────────────
+// Shortcut: bare `/bypass` enables; `/bypass off` (or `default`) reverts.
+// Not an enum because the no-arg case has the *opposite* meaning of
+// /model — bare `/bypass` should DO something, not open a picker.
+
 export const bypassCommand: SlashCommand = {
     name: "bypass",
     category: "runtime",
     description: "Enable permission bypass for the next turn (dangerous)",
-    // Shortcut: bare `/bypass` enables; `/bypass off` or `/bypass default`
-    // reverts. Any other arg is a typo — warn instead of silently enabling.
     arg: { kind: "freeform", placeholder: "(empty) | off | default", required: false },
     availability: "any-agent",
     handler: async (ctx, arg): Promise<SlashResult> => {
@@ -185,6 +212,8 @@ export const bypassCommand: SlashCommand = {
     },
 };
 
+// ── /plan ─────────────────────────────────────────────────────────────
+
 export const planCommand: SlashCommand = {
     name: "plan",
     category: "runtime",
@@ -197,6 +226,8 @@ export const planCommand: SlashCommand = {
         return { kind: "ok", message: "permission mode set to plan (applies to next turn)" };
     },
 };
+
+// ── /runtime ──────────────────────────────────────────────────────────
 
 export const runtimeCommand: SlashCommand = {
     name: "runtime",

--- a/frontend/app/view/agent/commands/types.ts
+++ b/frontend/app/view/agent/commands/types.ts
@@ -29,6 +29,24 @@ export interface SlashChoice {
     description?: string;
     /** Render this option as the currently-active selection. */
     current?: boolean;
+    /**
+     * Alternate text representations that resolve to this choice when
+     * typed inline. The picker only displays `value`; aliases keep
+     * PR #378 backwards-compat (e.g. `/model claude-sonnet` → `sonnet`).
+     */
+    aliases?: string[];
+}
+
+/**
+ * Spec passed to `ctx.openPicker(...)`. The dispatcher builds this
+ * from a command's enum/dynamic arg when the user submits a bare
+ * `/cmd` and the command requires an argument. The picker UI reads
+ * choices and resolves the promise with the selected value (or
+ * rejects on dismiss).
+ */
+export interface SlashPickerSpec {
+    title: string;
+    choices: SlashChoice[];
 }
 
 /**
@@ -37,7 +55,19 @@ export interface SlashChoice {
  */
 export type SlashArg =
     | { kind: "none" }
-    | { kind: "enum"; choices: SlashChoice[]; required: boolean; defaultLabel?: string }
+    | {
+          kind: "enum";
+          /**
+           * Either a static array of choices or a factory that receives ctx
+           * and returns the choices fresh on every invocation. The factory
+           * form lets commands mark the currently-active option (`current:
+           * true`) by reading reactive state at picker-open time — e.g.
+           * `/model` highlights the active model in the picker.
+           */
+          choices: SlashChoice[] | ((ctx: SlashCommandContext) => SlashChoice[]);
+          required: boolean;
+          defaultLabel?: string;
+      }
     | { kind: "freeform"; placeholder: string; required: boolean }
     | {
           kind: "dynamic";
@@ -92,6 +122,12 @@ export interface SlashCommandContext {
     log: LogFn;
     /** Set the OAuth URL for /login. */
     setAuthUrl: (url: string | null) => void;
+    /**
+     * Open the inline picker. Returns a promise that resolves with the
+     * selected value, or rejects if the user dismisses (Esc / click-outside).
+     * Set by useAgentCommands; the dispatcher only sees the function.
+     */
+    openPicker: (spec: SlashPickerSpec) => Promise<string>;
 }
 
 /**

--- a/frontend/app/view/agent/components/SlashCommandPicker.tsx
+++ b/frontend/app/view/agent/components/SlashCommandPicker.tsx
@@ -1,0 +1,129 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SlashCommandPicker — inline picker shown above the composer when the
+ * user submits a bare `/cmd` whose arg is a required enum.
+ *
+ * Step 2 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md.
+ *
+ * Lifecycle is owned by useAgentCommands: the dispatcher calls
+ * `ctx.openPicker(spec)`, which sets the hook's pickerSpec signal and
+ * returns a Promise. This component renders when the signal is non-null
+ * and resolves/rejects the Promise via the `onSelect` / `onDismiss` props.
+ */
+
+import { type JSX, createSignal, onCleanup, onMount } from "solid-js";
+import { For } from "solid-js/web";
+import type { SlashChoice, SlashPickerSpec } from "../commands/types";
+
+interface SlashCommandPickerProps {
+    spec: SlashPickerSpec;
+    onSelect: (value: string) => void;
+    onDismiss: () => void;
+}
+
+export function SlashCommandPicker(props: SlashCommandPickerProps): JSX.Element {
+    const initialIndex = (): number => {
+        const idx = props.spec.choices.findIndex((c) => c.current);
+        return idx >= 0 ? idx : 0;
+    };
+    const [selectedIndex, setSelectedIndex] = createSignal(initialIndex());
+
+    let containerRef: HTMLDivElement | undefined;
+
+    const move = (delta: number): void => {
+        const choices = props.spec.choices;
+        if (choices.length === 0) return;
+        const next = (selectedIndex() + delta + choices.length) % choices.length;
+        setSelectedIndex(next);
+    };
+
+    const commit = (): void => {
+        const choice = props.spec.choices[selectedIndex()];
+        if (choice) props.onSelect(choice.value);
+    };
+
+    const handleKeyDown = (e: KeyboardEvent): void => {
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            move(1);
+            return;
+        }
+        if (e.key === "ArrowUp") {
+            e.preventDefault();
+            move(-1);
+            return;
+        }
+        if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+            return;
+        }
+        if (e.key === "Escape") {
+            e.preventDefault();
+            props.onDismiss();
+            return;
+        }
+        // Letter-jump: first choice whose label or value starts with the key.
+        if (e.key.length === 1 && /[a-z0-9]/i.test(e.key)) {
+            const k = e.key.toLowerCase();
+            const idx = props.spec.choices.findIndex(
+                (c) => c.label.toLowerCase().startsWith(k) || c.value.toLowerCase().startsWith(k),
+            );
+            if (idx >= 0) {
+                e.preventDefault();
+                setSelectedIndex(idx);
+            }
+        }
+    };
+
+    onMount(() => {
+        document.addEventListener("keydown", handleKeyDown, true);
+        // Scroll into view in case the composer region is short.
+        requestAnimationFrame(() => containerRef?.scrollIntoView({ block: "nearest" }));
+    });
+    onCleanup(() => {
+        document.removeEventListener("keydown", handleKeyDown, true);
+    });
+
+    const handleRowClick = (idx: number) => (e: MouseEvent) => {
+        e.preventDefault();
+        setSelectedIndex(idx);
+        commit();
+    };
+
+    return (
+        <div class="slash-picker" ref={containerRef} role="listbox" aria-label={props.spec.title}>
+            <div class="slash-picker__title">{props.spec.title}</div>
+            <div class="slash-picker__list">
+                <For each={props.spec.choices}>
+                    {(choice: SlashChoice, idx) => (
+                        <div
+                            class="slash-picker__row"
+                            classList={{
+                                "slash-picker__row--selected": idx() === selectedIndex(),
+                                "slash-picker__row--current": !!choice.current,
+                            }}
+                            role="option"
+                            aria-selected={idx() === selectedIndex()}
+                            onMouseEnter={() => setSelectedIndex(idx())}
+                            onClick={handleRowClick(idx())}
+                        >
+                            <span class="slash-picker__marker">{choice.current ? "●" : ""}</span>
+                            <span class="slash-picker__label">{choice.label}</span>
+                            {choice.description && (
+                                <span class="slash-picker__description">{choice.description}</span>
+                            )}
+                        </div>
+                    )}
+                </For>
+            </div>
+            <div class="slash-picker__hint">
+                <span>↑↓ navigate</span>
+                <span>↵ select</span>
+                <span>Esc cancel</span>
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -23,14 +23,14 @@
  * flags (permission mode, model, effort) take effect on this turn.
  */
 
-import { type Accessor, createMemo } from "solid-js";
+import { type Accessor, createMemo, createSignal } from "solid-js";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
 import * as WOS from "@/app/store/wos";
 import { buildRuntimeArgs, getRuntimeConfig } from "../buildRuntimeArgs";
 import { dispatchSlashCommand } from "../commands/dispatch";
 import { buildRegistry } from "../commands/registry";
-import type { SlashCommandContext } from "../commands/types";
+import type { SlashCommandContext, SlashPickerSpec } from "../commands/types";
 import type { ProviderDefinition } from "../providers";
 import type { SignalPair } from "../state";
 import type { DocumentNode } from "../types";
@@ -63,7 +63,7 @@ export interface UseAgentCommandsOptions {
 }
 
 export interface UseAgentCommands {
-    /** Send a user message. Handles `/login` and `/clear` as special cases. */
+    /** Send a user message. Slash commands are intercepted via the registry. */
     sendMessage: (message: string) => Promise<void>;
     /** Return to the agent picker by clearing the agent-identity meta keys. */
     back: () => Promise<void>;
@@ -75,6 +75,17 @@ export interface UseAgentCommands {
      * See SPEC_AGENT_PANE_FOLLOWUPS item #9.
      */
     stopAgent: () => void;
+    /**
+     * Inline picker state. Non-null when a slash command needs to
+     * resolve a required enum/dynamic arg via the picker UI. The
+     * AgentPresentationView reads this to decide whether to render
+     * <SlashCommandPicker /> above the composer.
+     */
+    pickerSpec: Accessor<SlashPickerSpec | null>;
+    /** Resolve the picker promise with the chosen value. */
+    resolvePicker: (value: string) => void;
+    /** Reject the picker promise (Esc / dismiss). */
+    dismissPicker: () => void;
 }
 
 // Runtime-config + auth slash commands (/model /effort /permission-mode
@@ -92,6 +103,42 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
     // provider-scoped commands swap in/out. Global commands are
     // registered first and can't be shadowed (see registry.register).
     const registry = createMemo(() => buildRegistry(opts.provider()));
+
+    // ── Inline picker state ───────────────────────────────────────────
+    // The dispatcher calls `ctx.openPicker(spec)` for required enum/
+    // dynamic args; this hook hands back a Promise that resolves when
+    // the user picks (or rejects on Esc). The picker spec signal is
+    // consumed by AgentPresentationView to render the picker overlay.
+    const [pickerSpec, setPickerSpec] = createSignal<SlashPickerSpec | null>(null);
+    let pickerResolver: ((value: string) => void) | null = null;
+    let pickerRejecter: (() => void) | null = null;
+
+    const openPicker = (spec: SlashPickerSpec): Promise<string> => {
+        // If a previous picker is still open (shouldn't happen because
+        // dispatch awaits), dismiss it cleanly so the new one wins.
+        pickerRejecter?.();
+        return new Promise<string>((resolve, reject) => {
+            pickerResolver = resolve;
+            pickerRejecter = reject;
+            setPickerSpec(spec);
+        });
+    };
+
+    const resolvePicker = (value: string): void => {
+        const r = pickerResolver;
+        pickerResolver = null;
+        pickerRejecter = null;
+        setPickerSpec(null);
+        r?.(value);
+    };
+
+    const dismissPicker = (): void => {
+        const r = pickerRejecter;
+        pickerResolver = null;
+        pickerRejecter = null;
+        setPickerSpec(null);
+        r?.();
+    };
 
     const sendMessage = async (message: string): Promise<void> => {
         setDocument((prev) => [
@@ -128,6 +175,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
                 documentAtom: opts.documentAtom,
                 log: opts.log,
                 setAuthUrl: opts.setAuthUrl,
+                openPicker,
             };
             const outcome = await dispatchSlashCommand(trimmed, registry(), ctx);
             if (outcome.kind === "handled") return;
@@ -174,5 +222,5 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         });
     };
 
-    return { sendMessage, back, stopAgent };
+    return { sendMessage, back, stopAgent, pickerSpec, resolvePicker, dismissPicker };
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.150",
+  "version": "0.33.151",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 2 of [SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md](../blob/main/specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md). Bare \`/model\`, \`/effort\`, and \`/permission-mode\` now open an inline picker above the composer instead of erroring with a list of choices.

> Replaces #380 (auto-closed when its base branch \`agenta/slash-command-registry\` was deleted after #379 merged).

### What changed

- \`types.ts\`
  - new \`SlashPickerSpec\` type
  - \`SlashChoice\` gains \`aliases?: string[]\` for inline alt-form parsing
  - \`SlashArg.enum.choices\` may now be \`SlashChoice[] | ((ctx) => SlashChoice[])\` — factory form lets commands mark the active option dynamically
  - \`SlashCommandContext\` gains \`openPicker(spec): Promise<string>\`
- \`dispatch.ts\`
  - required enum/dynamic args with no value → \`ctx.openPicker()\` → resolved value forwarded to handler
  - dismissal returns silent \`{kind: \"ok\"}\` (no log spam)
  - aliases matched via new \`matchEnumChoice\` helper
- \`global/runtime.ts\`
  - \`/model\`, \`/effort\`, \`/permission-mode\` converted to enum kind
  - \`choices\` is a factory reading \`getRuntimeConfig()\` so the picker marks the currently active option with \`current: true\`
  - PR #378 alias forms (\`claude-sonnet\`, \`med\`, \`accept-edits\`, etc.) preserved on individual \`SlashChoice.aliases\`
  - \`/bypass\` stays freeform — bare \`/bypass\` should *do* something (enable), not open a picker
  - Carries forward the \`RuntimeUpdateResult\` discriminated-union fix from #379 so /model et al surface the underlying RPC error message instead of a generic \"failed\"
- \`components/SlashCommandPicker.tsx\` (new)
  - up/down navigation, Enter selects, Esc dismisses
  - letter-jump (typing a letter jumps to first match)
  - mouse hover updates selection, click commits
  - document-level keydown capture so Esc works regardless of focus
- \`useAgentCommands.ts\`
  - owns \`pickerSpec\` signal + resolver/rejecter refs
  - exposes \`pickerSpec\`, \`resolvePicker\`, \`dismissPicker\` on the returned API
- \`agent-view.tsx\` mounts \`<SlashCommandPicker />\` above \`AgentFooter\` inside \`agent-composer-region\`
- \`agent-view.scss\` adds \`.slash-picker\` styles using existing color tokens

## Test plan

- [ ] \`tsc --noEmit\` — clean
- [ ] \`task dev\` → agent pane → bare \`/model\` opens picker with current model marked
- [ ] Up/Down navigates; Enter commits; Esc dismisses (no log line)
- [ ] Click row commits
- [ ] Type \`s\` jumps to Sonnet; \`o\` jumps to Opus
- [ ] \`/model sonnet\` (with explicit arg) still works without opening picker
- [ ] \`/model claude-sonnet\` alias still resolves to Sonnet
- [ ] \`/effort med\` alias still resolves to medium
- [ ] \`/permission-mode accept-edits\` alias still works
- [ ] Bare \`/effort\`, \`/permission-mode\` open pickers
- [ ] Bare \`/bypass\` still enables bypass (no picker)
- [ ] \`/plan\`, \`/runtime\` still work (no picker)
- [ ] \`/clear\`, \`/login\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)