### PR TITLE
feat(agent): slash command autocomplete dropdown (Step 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.151"
+version = "0.33.152"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.151"
+version = "0.33.152"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.151"
+version = "0.33.152"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.151"
+version = "0.33.152"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.151"
+version = "0.33.152"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.151"
+version = "0.33.152"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.151"
+version = "0.33.152"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.151"
+version = "0.33.152"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -621,6 +621,65 @@
         background: color-mix(in srgb, var(--main-bg-color) 80%, transparent);
     }
 
+    .slash-autocomplete {
+        position: absolute;
+        bottom: calc(100% + 2px);
+        left: 0;
+        right: 0;
+        max-height: 220px;
+        overflow-y: auto;
+        background: var(--main-bg-color);
+        border: 1px solid color-mix(in srgb, var(--accent-color, #4a9eff) 50%, var(--border-color));
+        border-radius: 3px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+        z-index: 50;
+        font-size: 12px;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .slash-autocomplete__row {
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+        padding: 4px 10px;
+        cursor: pointer;
+        line-height: 1.4;
+        color: var(--main-text-color);
+
+        &--selected {
+            background: color-mix(in srgb, var(--accent-color, #4a9eff) 22%, transparent);
+        }
+    }
+
+    .slash-autocomplete__name {
+        flex-shrink: 0;
+        font-weight: 500;
+        color: var(--accent-color, #4a9eff);
+        min-width: 110px;
+        font-family: var(--monospace-font, monospace);
+    }
+
+    .slash-autocomplete__description {
+        flex: 1;
+        min-width: 0;
+        color: var(--secondary-text-color);
+        font-size: 11px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .slash-autocomplete__hint {
+        display: flex;
+        gap: 12px;
+        padding: 3px 10px;
+        border-top: 1px solid var(--border-color);
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        background: color-mix(in srgb, var(--main-bg-color) 90%, transparent);
+    }
+
     .agent-interrupted-banner {
         display: flex;
         align-items: center;
@@ -1514,6 +1573,7 @@
             display: flex;
             flex-direction: column;
             gap: 1px;
+            position: relative;
 
             .agent-input {
                 width: 100%;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -299,6 +299,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onTyping={() => scrollToBottomFn?.()}
                     onStopAgent={commands.stopAgent}
                     loading={status.isLoading()}
+                    getCompletions={commands.completions}
                 />
                 <AgentControlBar
                     blockId={model.blockId}

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -5,7 +5,9 @@
  * AgentFooter - Minimal Claude Code-style input
  */
 
-import { Show, type JSX } from "solid-js";
+import { Show, createMemo, createSignal, type JSX } from "solid-js";
+import type { SlashCommand } from "../commands/types";
+import { SlashAutocomplete } from "./SlashAutocomplete";
 
 interface AgentFooterProps {
     agentId: string;
@@ -25,6 +27,13 @@ interface AgentFooterProps {
      */
     onStopAgent?: () => void;
     loading?: boolean;
+    /**
+     * Slash command completions. When the textarea value matches
+     * `^/\w*$` (no space), AgentFooter calls this with the prefix
+     * (no leading slash) and renders the SlashAutocomplete dropdown.
+     * If absent, autocomplete is disabled.
+     */
+    getCompletions?: (prefix: string) => SlashCommand[];
 }
 
 export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
@@ -50,11 +59,51 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // specs/SPEC_TOOL_OVERLAY_AND_SCROLL_ON_TYPE_2026_04_13.md §3.4.
     let textareaRef: HTMLTextAreaElement | undefined;
 
+    // ── Slash autocomplete state ──────────────────────────────────────
+    // Tracks the current `/prefix` (without the leading slash) when the
+    // textarea matches `^/\w*$`. Null = dropdown hidden. Reading the
+    // value via signal lets the dropdown re-render reactively without
+    // controlling the textarea.
+    const [autocompletePrefix, setAutocompletePrefix] = createSignal<string | null>(null);
+    const [autocompleteIndex, setAutocompleteIndex] = createSignal(0);
+
+    const completions = createMemo<SlashCommand[]>(() => {
+        const p = autocompletePrefix();
+        if (p === null || !props.getCompletions) return [];
+        return props.getCompletions(p);
+    });
+
+    const updateAutocomplete = (): void => {
+        if (!textareaRef) return;
+        const val = textareaRef.value;
+        // Show the dropdown only when the value starts with `/` AND
+        // contains no space — once the user types past the command name
+        // they're filling in args, not picking a command.
+        if (val.startsWith("/") && !val.includes(" ") && !val.includes("\n")) {
+            const prefix = val.slice(1);
+            if (autocompletePrefix() !== prefix) {
+                setAutocompletePrefix(prefix);
+                setAutocompleteIndex(0);
+            }
+        } else if (autocompletePrefix() !== null) {
+            setAutocompletePrefix(null);
+        }
+    };
+
+    const acceptCompletion = (cmd: SlashCommand): void => {
+        if (!textareaRef) return;
+        textareaRef.value = `/${cmd.name} `;
+        setAutocompletePrefix(null);
+        textareaRef.focus();
+        props.onTyping?.();
+    };
+
     // RAF debounce for the onTyping callback. Sustained typing in a single
     // frame collapses to one callback; even rapid typing costs ~1 callback
     // per 16ms. Flag is per-component-instance (captured in closure).
     let typingScrollPending = false;
     const handleInput = () => {
+        updateAutocomplete();
         const cb = props.onTyping;
         if (!cb) return;
         if (typingScrollPending) return;
@@ -78,6 +127,33 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
+        // Autocomplete keys take precedence when the dropdown is open
+        // and has at least one match. Tab/Enter accept the selection;
+        // arrows navigate; Esc dismisses without affecting text.
+        if (autocompletePrefix() !== null && completions().length > 0) {
+            const list = completions();
+            if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setAutocompleteIndex((i) => (i + 1) % list.length);
+                return;
+            }
+            if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setAutocompleteIndex((i) => (i - 1 + list.length) % list.length);
+                return;
+            }
+            if (e.key === "Tab" || e.key === "Enter") {
+                e.preventDefault();
+                const match = list[autocompleteIndex()];
+                if (match) acceptCompletion(match);
+                return;
+            }
+            if (e.key === "Escape") {
+                e.preventDefault();
+                setAutocompletePrefix(null);
+                return;
+            }
+        }
         if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
             handleSend();
@@ -104,6 +180,14 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     return (
         <div class="agent-footer">
             <div class="agent-input-container">
+                <Show when={autocompletePrefix() !== null && completions().length > 0}>
+                    <SlashAutocomplete
+                        completions={completions()}
+                        selectedIndex={autocompleteIndex()}
+                        onHover={(idx) => setAutocompleteIndex(idx)}
+                        onSelect={acceptCompletion}
+                    />
+                </Show>
                 <textarea
                     ref={textareaRef}
                     class="agent-input"

--- a/frontend/app/view/agent/components/SlashAutocomplete.tsx
+++ b/frontend/app/view/agent/components/SlashAutocomplete.tsx
@@ -1,0 +1,58 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SlashAutocomplete — dropdown that appears above the composer textarea
+ * when the user types `/` followed by a partial command name.
+ *
+ * Step 3 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md.
+ *
+ * Pure presentation: receives the completion list + current selection
+ * index from AgentFooter, renders rows. AgentFooter owns the keyboard
+ * handling (so Tab/Enter inside the textarea reach the autocomplete
+ * before reaching send).
+ */
+
+import { type JSX } from "solid-js";
+import { For } from "solid-js/web";
+import type { SlashCommand } from "../commands/types";
+
+interface SlashAutocompleteProps {
+    completions: SlashCommand[];
+    selectedIndex: number;
+    onHover: (index: number) => void;
+    onSelect: (cmd: SlashCommand) => void;
+}
+
+export function SlashAutocomplete(props: SlashAutocompleteProps): JSX.Element {
+    return (
+        <div class="slash-autocomplete" role="listbox" aria-label="Slash command suggestions">
+            <For each={props.completions}>
+                {(cmd, idx) => (
+                    <div
+                        class="slash-autocomplete__row"
+                        classList={{
+                            "slash-autocomplete__row--selected": idx() === props.selectedIndex,
+                        }}
+                        role="option"
+                        aria-selected={idx() === props.selectedIndex}
+                        onMouseEnter={() => props.onHover(idx())}
+                        onMouseDown={(e) => {
+                            // mousedown beats blur so the textarea keeps focus
+                            e.preventDefault();
+                            props.onSelect(cmd);
+                        }}
+                    >
+                        <span class="slash-autocomplete__name">/{cmd.name}</span>
+                        <span class="slash-autocomplete__description">{cmd.description}</span>
+                    </div>
+                )}
+            </For>
+            <div class="slash-autocomplete__hint">
+                <span>↑↓</span>
+                <span>Tab/↵ accept</span>
+                <span>Esc dismiss</span>
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -30,7 +30,7 @@ import * as WOS from "@/app/store/wos";
 import { buildRuntimeArgs, getRuntimeConfig } from "../buildRuntimeArgs";
 import { dispatchSlashCommand } from "../commands/dispatch";
 import { buildRegistry } from "../commands/registry";
-import type { SlashCommandContext, SlashPickerSpec } from "../commands/types";
+import type { SlashCommand, SlashCommandContext, SlashPickerSpec } from "../commands/types";
 import type { ProviderDefinition } from "../providers";
 import type { SignalPair } from "../state";
 import type { DocumentNode } from "../types";
@@ -86,6 +86,14 @@ export interface UseAgentCommands {
     resolvePicker: (value: string) => void;
     /** Reject the picker promise (Esc / dismiss). */
     dismissPicker: () => void;
+    /**
+     * Autocomplete completions for the composer. Returns commands
+     * available in the current context whose name or alias starts
+     * with the given prefix (no leading slash). Sorted by category
+     * then name. Consumed by AgentFooter to render the inline
+     * autocomplete dropdown.
+     */
+    completions: (prefix: string) => SlashCommand[];
 }
 
 // Runtime-config + auth slash commands (/model /effort /permission-mode
@@ -140,6 +148,23 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         r?.();
     };
 
+    // Build the SlashCommandContext bundle. Used by sendMessage's
+    // dispatch and by completions(); both need the same view of the
+    // pane's reactive state.
+    const buildCommandContext = (): SlashCommandContext => ({
+        blockId: opts.blockId,
+        provider: opts.provider,
+        block: opts.block,
+        documentAtom: opts.documentAtom,
+        log: opts.log,
+        setAuthUrl: opts.setAuthUrl,
+        openPicker,
+    });
+
+    const completions = (prefix: string): SlashCommand[] => {
+        return registry().completions(prefix, buildCommandContext());
+    };
+
     const sendMessage = async (message: string): Promise<void> => {
         setDocument((prev) => [
             ...prev,
@@ -168,16 +193,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // through to AgentInputCommand via the "passthrough" outcome.
         const trimmed = message.trim();
         if (trimmed.startsWith("/")) {
-            const ctx: SlashCommandContext = {
-                blockId: opts.blockId,
-                provider: opts.provider,
-                block: opts.block,
-                documentAtom: opts.documentAtom,
-                log: opts.log,
-                setAuthUrl: opts.setAuthUrl,
-                openPicker,
-            };
-            const outcome = await dispatchSlashCommand(trimmed, registry(), ctx);
+            const outcome = await dispatchSlashCommand(trimmed, registry(), buildCommandContext());
             if (outcome.kind === "handled") return;
         }
 
@@ -222,5 +238,13 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         });
     };
 
-    return { sendMessage, back, stopAgent, pickerSpec, resolvePicker, dismissPicker };
+    return {
+        sendMessage,
+        back,
+        stopAgent,
+        pickerSpec,
+        resolvePicker,
+        dismissPicker,
+        completions,
+    };
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.151",
+  "version": "0.33.152",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 3 of [SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md](../blob/main/specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md) §4.6. Typing \`/\` in the composer pops a floating list of matching commands above the textarea. Tab/Enter accept the highlighted match, ↑↓ navigate, Esc dismisses without affecting text.

### What changed

- **\`useAgentCommands\`** exposes \`completions(prefix): SlashCommand[]\` which calls \`registry.completions\` with a fresh ctx. Same registry as the dispatcher and picker, so any new command registered under \`commands/global\` or \`commands/providers\` shows up automatically.
- **\`buildCommandContext()\` helper** factored inside the hook to dedupe the ctx bundle between \`sendMessage\` and \`completions\`.
- **\`AgentFooter\`** gains an \`autocompletePrefix\` signal updated from \`onInput\`. Only fires when the textarea matches \`^/\w*\$\` (no space, no newline) — the moment a space or newline appears, the dropdown closes because the user has moved on to args. The signal change triggers the dropdown re-render WITHOUT touching the uncontrolled textarea state, so per-keystroke cost stays under the 2ms budget set in \`SPEC_TOOL_OVERLAY_AND_SCROLL_ON_TYPE_2026_04_13.md\`.
- **\`SlashAutocomplete.tsx\`** (new) — pure presentation, receives the completions list + selectedIndex from \`AgentFooter\` and renders rows. Uses \`onMouseDown\` (not \`onClick\`) so the textarea keeps focus when the user clicks a suggestion.
- **Keyboard precedence**: when the dropdown is open and has matches, ↑↓/Tab/Enter/Esc are intercepted before the existing send/clear/stop logic. Esc only dismisses the dropdown — it doesn't clear the textarea or stop the agent.
- **agent-view.scss**: \`.slash-autocomplete\` floats above the textarea via \`position: absolute; bottom: calc(100% + 2px)\` on a newly-positioned \`.agent-input-container\`.

### Test plan

- [ ] \`tsc --noEmit\` — clean
- [ ] \`task dev\` → agent pane
- [ ] Type \`/\` → dropdown shows all global commands sorted by category
- [ ] Type \`/m\` → narrows to \`/model\`
- [ ] Type \`/perm\` → narrows to \`/permission-mode\` (alias match)
- [ ] ↑/↓ navigates
- [ ] Tab accepts → textarea becomes \`/model \` (with trailing space)
- [ ] Enter accepts the same way
- [ ] Esc dismisses dropdown without clearing textarea
- [ ] Click a suggestion → textarea focused, content set, dropdown gone
- [ ] Type space after \`/model\` → dropdown auto-dismisses (transitioning to args)
- [ ] Bare \`/model\` (no autocomplete acceptance) + Enter still opens picker (Step 2 unaffected)
- [ ] \`/foo\` (unknown) shows empty dropdown — falls through to AgentInputCommand on send

🤖 Generated with [Claude Code](https://claude.com/claude-code)