### PR TITLE
feat(agent): /help slash command panel (Step 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.153"
+version = "0.33.154"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.153"
+version = "0.33.154"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.153"
+version = "0.33.154"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.153"
+version = "0.33.154"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.152"
+version = "0.33.153"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.152"
+version = "0.33.153"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.152"
+version = "0.33.153"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.152"
+version = "0.33.153"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -2319,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.153"
+version = "0.33.154"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.152"
+version = "0.33.153"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.152"
+version = "0.33.153"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.153"
+version = "0.33.154"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.152"
+version = "0.33.153"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.153"
+version = "0.33.154"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.153"
+version = "0.33.154"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.152"
+version = "0.33.153"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -680,6 +680,131 @@
         background: color-mix(in srgb, var(--main-bg-color) 90%, transparent);
     }
 
+    .slash-help {
+        display: flex;
+        flex-direction: column;
+        background: color-mix(in srgb, var(--accent-color, #4a9eff) 6%, var(--main-bg-color));
+        border-top: 1px solid color-mix(in srgb, var(--accent-color, #4a9eff) 40%, var(--border-color));
+        border-bottom: 1px solid var(--border-color);
+        font-size: 12px;
+        max-height: 360px;
+        overflow: hidden;
+    }
+
+    .slash-help__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 4px 10px;
+        border-bottom: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--main-bg-color) 90%, transparent);
+    }
+
+    .slash-help__title {
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--secondary-text-color);
+    }
+
+    .slash-help__close {
+        background: none;
+        border: 1px solid transparent;
+        border-radius: 3px;
+        cursor: pointer;
+        color: var(--secondary-text-color);
+        font-size: 16px;
+        line-height: 1;
+        width: 22px;
+        height: 22px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background 0.1s, color 0.1s, border-color 0.1s;
+
+        &:hover {
+            background: color-mix(in srgb, var(--error-color, #f87171) 15%, transparent);
+            border-color: color-mix(in srgb, var(--error-color, #f87171) 40%, transparent);
+            color: var(--error-color, #f87171);
+        }
+    }
+
+    .slash-help__body {
+        flex: 1;
+        overflow-y: auto;
+        padding: 4px 0;
+    }
+
+    .slash-help__group + .slash-help__group {
+        margin-top: 4px;
+    }
+
+    .slash-help__group-label {
+        padding: 4px 10px 2px;
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--secondary-text-color);
+        opacity: 0.75;
+    }
+
+    .slash-help__row {
+        display: grid;
+        grid-template-columns: 130px auto auto 1fr;
+        align-items: baseline;
+        gap: 8px;
+        padding: 3px 10px;
+        cursor: pointer;
+        line-height: 1.4;
+        color: var(--main-text-color);
+
+        &:hover,
+        &:focus {
+            background: color-mix(in srgb, var(--accent-color, #4a9eff) 18%, transparent);
+            outline: none;
+        }
+    }
+
+    .slash-help__name {
+        font-weight: 500;
+        color: var(--accent-color, #4a9eff);
+        font-family: var(--monospace-font, monospace);
+    }
+
+    .slash-help__aliases {
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        font-family: var(--monospace-font, monospace);
+        opacity: 0.75;
+    }
+
+    .slash-help__arg {
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        font-family: var(--monospace-font, monospace);
+        opacity: 0.6;
+    }
+
+    .slash-help__description {
+        color: var(--secondary-text-color);
+        font-size: 11px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .slash-help__hint {
+        display: flex;
+        gap: 12px;
+        padding: 3px 10px;
+        border-top: 1px solid var(--border-color);
+        font-size: 10px;
+        color: var(--secondary-text-color);
+        background: color-mix(in srgb, var(--main-bg-color) 80%, transparent);
+    }
+
     .agent-interrupted-banner {
         display: flex;
         align-items: center;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -26,6 +26,7 @@ import { AgentFooter } from "./components/AgentFooter";
 import { AgentPicker } from "./components/AgentPicker";
 import { AgentSearchBar } from "./components/AgentSearchBar";
 import { SlashCommandPicker } from "./components/SlashCommandPicker";
+import { SlashHelpPanel } from "./components/SlashHelpPanel";
 import { BookmarksPanel } from "./components/BookmarksPanel";
 import { SessionDigestBanner } from "./components/SessionDigestBanner";
 import { ContextMenuModel } from "@/app/store/contextmenu";
@@ -284,6 +285,16 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             </Show>
 
             <div class="agent-composer-region">
+                <Show when={commands.helpVisible()}>
+                    <SlashHelpPanel
+                        commands={commands.availableCommands()}
+                        onInvoke={(cmd) => {
+                            commands.closeHelp();
+                            void commands.sendMessage(`/${cmd.name}`);
+                        }}
+                        onClose={commands.closeHelp}
+                    />
+                </Show>
                 <Show when={commands.pickerSpec()}>
                     {(spec) => (
                         <SlashCommandPicker

--- a/frontend/app/view/agent/commands/global/help.ts
+++ b/frontend/app/view/agent/commands/global/help.ts
@@ -1,0 +1,26 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * /help — open the slash command reference panel.
+ *
+ * Step 4 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md.
+ *
+ * The handler doesn't render the panel itself — it calls ctx.openHelp(),
+ * which flips a signal in useAgentCommands that AgentPresentationView
+ * reads to mount <SlashHelpPanel />.
+ */
+
+import type { SlashCommand, SlashResult } from "../types";
+
+export const helpCommand: SlashCommand = {
+    name: "help",
+    aliases: ["?"],
+    category: "help",
+    description: "Show available slash commands",
+    arg: { kind: "none" },
+    handler: async (ctx): Promise<SlashResult> => {
+        ctx.openHelp();
+        return { kind: "ok" };
+    },
+};

--- a/frontend/app/view/agent/commands/global/index.ts
+++ b/frontend/app/view/agent/commands/global/index.ts
@@ -9,6 +9,7 @@
 
 import type { SlashCommandRegistry } from "../registry";
 import { clearCommand } from "./clear";
+import { helpCommand } from "./help";
 import { loginCommand } from "./login";
 import { RUNTIME_COMMANDS } from "./runtime";
 
@@ -18,4 +19,5 @@ export function registerGlobalCommands(registry: SlashCommandRegistry): void {
     }
     registry.register(loginCommand);
     registry.register(clearCommand);
+    registry.register(helpCommand);
 }

--- a/frontend/app/view/agent/commands/types.ts
+++ b/frontend/app/view/agent/commands/types.ts
@@ -128,6 +128,11 @@ export interface SlashCommandContext {
      * Set by useAgentCommands; the dispatcher only sees the function.
      */
     openPicker: (spec: SlashPickerSpec) => Promise<string>;
+    /**
+     * Show the slash command help panel. Wired by useAgentCommands to
+     * a `helpVisible` signal that AgentPresentationView reads.
+     */
+    openHelp: () => void;
 }
 
 /**

--- a/frontend/app/view/agent/components/SlashHelpPanel.tsx
+++ b/frontend/app/view/agent/components/SlashHelpPanel.tsx
@@ -98,23 +98,30 @@ export function SlashHelpPanel(props: SlashHelpPanelProps): JSX.Element {
                         <div class="slash-help__group">
                             <div class="slash-help__group-label">{group.label}</div>
                             <For each={group.commands}>
-                                {(cmd) => (
-                                    <div
-                                        class="slash-help__row"
-                                        role="button"
-                                        tabIndex={0}
-                                        onClick={() => props.onInvoke(cmd)}
-                                    >
-                                        <span class="slash-help__name">/{cmd.name}</span>
-                                        {(cmd.aliases ?? []).length > 0 && (
-                                            <span class="slash-help__aliases">
-                                                {(cmd.aliases ?? []).map((a) => `/${a}`).join(" · ")}
-                                            </span>
-                                        )}
-                                        <span class="slash-help__arg">{argHint(cmd)}</span>
-                                        <span class="slash-help__description">{cmd.description}</span>
-                                    </div>
-                                )}
+                                {(cmd) => {
+                                    const activate = () => props.onInvoke(cmd);
+                                    const onKeyDown = (e: KeyboardEvent) => {
+                                        if (e.key === "Enter" || e.key === " ") {
+                                            e.preventDefault();
+                                            activate();
+                                        }
+                                    };
+                                    const aliasText = (cmd.aliases ?? []).map((a) => `/${a}`).join(" · ");
+                                    return (
+                                        <div
+                                            class="slash-help__row"
+                                            role="button"
+                                            tabIndex={0}
+                                            onClick={activate}
+                                            onKeyDown={onKeyDown}
+                                        >
+                                            <span class="slash-help__name">/{cmd.name}</span>
+                                            <span class="slash-help__aliases">{aliasText}</span>
+                                            <span class="slash-help__arg">{argHint(cmd)}</span>
+                                            <span class="slash-help__description">{cmd.description}</span>
+                                        </div>
+                                    );
+                                }}
                             </For>
                         </div>
                     )}

--- a/frontend/app/view/agent/components/SlashHelpPanel.tsx
+++ b/frontend/app/view/agent/components/SlashHelpPanel.tsx
@@ -1,0 +1,128 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SlashHelpPanel — overlay listing every slash command currently
+ * available in the pane, grouped by category.
+ *
+ * Step 4 of specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md.
+ *
+ * Reads the command list from props (computed by useAgentCommands via
+ * registry.list(ctx)) so the panel automatically reflects new
+ * registrations without any wiring here. Click a row to invoke that
+ * command — for arg-less ones it runs immediately; for ones with a
+ * required enum it triggers the Step 2 picker.
+ */
+
+import { type JSX, createMemo, onCleanup, onMount } from "solid-js";
+import { For } from "solid-js/web";
+import type { SlashCommand, SlashCommandCategory } from "../commands/types";
+
+interface SlashHelpPanelProps {
+    commands: SlashCommand[];
+    onInvoke: (cmd: SlashCommand) => void;
+    onClose: () => void;
+}
+
+const CATEGORY_ORDER: SlashCommandCategory[] = [
+    "runtime",
+    "session",
+    "auth",
+    "query",
+    "system",
+    "help",
+];
+
+const CATEGORY_LABEL: Record<SlashCommandCategory, string> = {
+    runtime: "Runtime",
+    session: "Session",
+    auth: "Auth",
+    query: "Query",
+    system: "System",
+    help: "Help",
+};
+
+function argHint(cmd: SlashCommand): string {
+    if (cmd.arg.kind === "none") return "";
+    if (cmd.arg.kind === "enum") {
+        const choices = typeof cmd.arg.choices === "function" ? "<choice>" : cmd.arg.choices.map((c) => c.value).join(" | ");
+        return cmd.arg.required ? `<${choices}>` : `[${choices}]`;
+    }
+    if (cmd.arg.kind === "freeform") {
+        return cmd.arg.required ? `<${cmd.arg.placeholder}>` : `[${cmd.arg.placeholder}]`;
+    }
+    return `<${cmd.arg.placeholder}>`;
+}
+
+export function SlashHelpPanel(props: SlashHelpPanelProps): JSX.Element {
+    const grouped = createMemo(() => {
+        const byCategory = new Map<SlashCommandCategory, SlashCommand[]>();
+        for (const cmd of props.commands) {
+            const list = byCategory.get(cmd.category) ?? [];
+            list.push(cmd);
+            byCategory.set(cmd.category, list);
+        }
+        return CATEGORY_ORDER.filter((cat) => byCategory.has(cat)).map((cat) => ({
+            category: cat,
+            label: CATEGORY_LABEL[cat],
+            commands: (byCategory.get(cat) ?? []).sort((a, b) => a.name.localeCompare(b.name)),
+        }));
+    });
+
+    const handleKeyDown = (e: KeyboardEvent): void => {
+        if (e.key === "Escape") {
+            e.preventDefault();
+            props.onClose();
+        }
+    };
+
+    onMount(() => document.addEventListener("keydown", handleKeyDown, true));
+    onCleanup(() => document.removeEventListener("keydown", handleKeyDown, true));
+
+    return (
+        <div class="slash-help" role="dialog" aria-label="Slash command help">
+            <div class="slash-help__header">
+                <span class="slash-help__title">Slash commands</span>
+                <button
+                    type="button"
+                    class="slash-help__close"
+                    aria-label="Close help"
+                    onClick={() => props.onClose()}
+                >
+                    ×
+                </button>
+            </div>
+            <div class="slash-help__body">
+                <For each={grouped()}>
+                    {(group) => (
+                        <div class="slash-help__group">
+                            <div class="slash-help__group-label">{group.label}</div>
+                            <For each={group.commands}>
+                                {(cmd) => (
+                                    <div
+                                        class="slash-help__row"
+                                        role="button"
+                                        tabIndex={0}
+                                        onClick={() => props.onInvoke(cmd)}
+                                    >
+                                        <span class="slash-help__name">/{cmd.name}</span>
+                                        {(cmd.aliases ?? []).length > 0 && (
+                                            <span class="slash-help__aliases">
+                                                {(cmd.aliases ?? []).map((a) => `/${a}`).join(" · ")}
+                                            </span>
+                                        )}
+                                        <span class="slash-help__arg">{argHint(cmd)}</span>
+                                        <span class="slash-help__description">{cmd.description}</span>
+                                    </div>
+                                )}
+                            </For>
+                        </div>
+                    )}
+                </For>
+            </div>
+            <div class="slash-help__hint">
+                <span>Click to run · Esc to close</span>
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -94,6 +94,18 @@ export interface UseAgentCommands {
      * autocomplete dropdown.
      */
     completions: (prefix: string) => SlashCommand[];
+    /**
+     * Help panel state. /help sets this to true via ctx.openHelp;
+     * AgentPresentationView reads it to mount <SlashHelpPanel />.
+     */
+    helpVisible: Accessor<boolean>;
+    /** Close the help panel (Esc / close button / row click). */
+    closeHelp: () => void;
+    /**
+     * Every command currently available in this pane (post-availability
+     * filter). Consumed by SlashHelpPanel to render the grouped list.
+     */
+    availableCommands: () => SlashCommand[];
 }
 
 // Runtime-config + auth slash commands (/model /effort /permission-mode
@@ -148,6 +160,17 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         r?.();
     };
 
+    // ── Help panel state ──────────────────────────────────────────────
+    // /help calls ctx.openHelp(); the view reads helpVisible() and
+    // mounts <SlashHelpPanel />. Stays open until the user dismisses.
+    const [helpVisible, setHelpVisible] = createSignal(false);
+    const openHelp = (): void => {
+        setHelpVisible(true);
+    };
+    const closeHelp = (): void => {
+        setHelpVisible(false);
+    };
+
     // Build the SlashCommandContext bundle. Used by sendMessage's
     // dispatch and by completions(); both need the same view of the
     // pane's reactive state.
@@ -159,10 +182,15 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         log: opts.log,
         setAuthUrl: opts.setAuthUrl,
         openPicker,
+        openHelp,
     });
 
     const completions = (prefix: string): SlashCommand[] => {
         return registry().completions(prefix, buildCommandContext());
+    };
+
+    const availableCommands = (): SlashCommand[] => {
+        return registry().list(buildCommandContext());
     };
 
     const sendMessage = async (message: string): Promise<void> => {
@@ -246,5 +274,8 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         resolvePicker,
         dismissPicker,
         completions,
+        helpVisible,
+        closeHelp,
+        availableCommands,
     };
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.153",
+  "version": "0.33.154",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.152",
+  "version": "0.33.153",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 4 of [SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md](../blob/main/specs/SPEC_SLASH_COMMAND_ARCHITECTURE_2026_04_14.md) §4.7. \`/help\` (also aliased to \`/?\`) opens an overlay listing every available slash command in the pane, grouped by category. Click a row to invoke; Esc or × closes.

### What changed

- **\`types.ts\`** — \`SlashCommandContext\` gains \`openHelp(): void\`
- **\`commands/global/help.ts\`** (new) — registers \`/help\` (aliases: \`?\`), arg \`none\`, handler calls \`ctx.openHelp()\` and returns ok
- **\`global/index.ts\`** — registers \`helpCommand\` alongside the others
- **\`components/SlashHelpPanel.tsx\`** (new) — pure presentation, groups commands by \`SlashCommandCategory\` in stable order (\`runtime → session → auth → query → system → help\`), renders name + aliases + arg hint + description per row, document-level Esc handler
- **\`useAgentCommands\`** — owns \`helpVisible\` signal, \`openHelp\`/\`closeHelp\` methods, exposes \`availableCommands()\` that runs \`registry.list(ctx)\`
- **\`agent-view.tsx\`** — mounts \`<SlashHelpPanel />\` above the picker inside \`agent-composer-region\`. Row click dispatches \`/<name>\` via \`sendMessage\` so commands needing args still flow through the Step 2 picker.
- **\`agent-view.scss\`** — \`.slash-help\` styles using existing color tokens, grid-based row layout for name/aliases/arg/description

### Test plan

- [ ] \`tsc --noEmit\` — clean
- [ ] \`task dev\` → agent pane → \`/help\` opens panel
- [ ] \`/?\` (alias) opens the same panel
- [ ] Panel shows all global commands grouped by category
- [ ] Click \`/clear\` row → panel closes, document clears
- [ ] Click \`/model\` row → panel closes, picker opens (Step 2 path)
- [ ] Click \`/runtime\` row → panel closes, runtime config logged
- [ ] Esc closes panel
- [ ] × button closes panel
- [ ] \`/help\` shows up in autocomplete when typing \`/h\` (Step 3 path — registry consistency)
- [ ] Picker \`current\` markers still work after closing help
- [ ] Sending a regular message after closing help unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)