### PR TITLE
fix(agent): AgentCardSettingsPanel rendering as just a blue line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.155"
+version = "0.33.156"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.155"
+version = "0.33.156"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.155"
+version = "0.33.156"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.155"
+version = "0.33.156"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.155"
+version = "0.33.156"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.155"
+version = "0.33.156"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.155"
+version = "0.33.156"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.155"
+version = "0.33.156"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -383,7 +383,13 @@
         border-radius: 6px;
         background: color-mix(in srgb, var(--main-bg-color) 95%, transparent);
         overflow: hidden;
+        // Guarantee a visible content area below the header. Without
+        // an explicit minimum the panel collapses to just its border
+        // (the "blue line" bug) because the picker-list parent is
+        // `flex: 1` and this panel had no `flex-shrink: 0` floor.
+        min-height: 320px;
         max-height: 60vh;
+        flex-shrink: 0;
         display: flex;
         flex-direction: column;
 
@@ -445,7 +451,21 @@
             flex: 1;
             overflow: auto;
             padding: 8px;
-            min-height: 200px;
+            min-height: 0;
+
+            // ForgeDetail / IdentityPanel were designed for full-pane
+            // rendering and set `height: 100%` on their root. Percent
+            // heights don't resolve inside this flex container because
+            // the panel is sized by content (capped at 60vh), so the
+            // 100% chain collapses to 0 and the body renders empty —
+            // which combined with the panel's 1px accent border shows
+            // as just a horizontal blue line under the agent card.
+            // Override: let them flow naturally + fill available space.
+            .forge-pane,
+            .identity-view {
+                height: auto;
+                min-height: 100%;
+            }
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.155",
+  "version": "0.33.156",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.155",
+      "version": "0.33.156",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.148",
+  "version": "0.33.155",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.148",
+      "version": "0.33.155",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.155",
+  "version": "0.33.156",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Clicking ⚙ (Forge) or 👤 (Identity) on an agent card was supposed to expand an inline settings panel below the card. Instead the panel rendered as just a horizontal blue line — the 1px accent-color border with zero content area.

## Root cause

Two compounding issues in \`frontend/app/view/agent/agent-view.scss\`:

1. \`.agent-card-settings-panel\` had \`max-height: 60vh\` but no \`flex-shrink: 0\` inside the \`flex: 1\` \`.agent-picker-list\` parent, so the flex container could squeeze it.
2. \`ForgeDetail\` and \`IdentityPanel\` were designed for full-pane rendering with \`height: 100%\` on their roots (\`.forge-pane\`, \`.identity-view\`). Percent heights don't resolve inside a max-height-capped container without a definite parent height, so the 100% chain collapsed to 0 and the body rendered empty.

## Fix

Purely SCSS, ~20 lines:

- Panel gains \`min-height: 320px\` + \`flex-shrink: 0\` — guarantees a visible content area below the header and stops the picker-list from squeezing it.
- Inside \`.agent-card-settings-body\`, override \`.forge-pane\` and \`.identity-view\` to \`height: auto\` + \`min-height: 100%\` so they flow naturally with content and fill available space.
- Body also gets \`min-height: 0\` (replacing \`200px\`) to allow the flex child to shrink below content size when needed — the panel's own min-height-320px is the effective floor.

No TS / model changes. No new behavior — just makes the existing panel visible.

## Related

Flagged as side issue §8 in [\`SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md\`](../blob/main/specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md). The naming restructure (slug/display name split + rename UX + agent-scoped identity) is landing next, one PR at a time.

## Test plan

- [ ] \`tsc --noEmit\` clean (no TS changes)
- [ ] \`task dev\` → agent picker → click ⚙ on AgentX → AgentCardSettingsPanel expands below the card showing the Forge detail view (not a blue line)
- [ ] Click 👤 on the same card → panel switches to the Identity tab, shows the AccountsTab
- [ ] Click the tabs inside the panel to swap Forge/Identity
- [ ] Esc closes the panel
- [ ] × button closes the panel
- [ ] Panel respects 60vh max-height — long content scrolls inside
- [ ] Panel is ≥ 320px tall even when content is short (no more sliver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)