### PR TITLE
feat(agent): identity restructure Step 1 — backend slug field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.156"
+version = "0.33.157"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.156"
+version = "0.33.157"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.156"
+version = "0.33.157"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.156"
+version = "0.33.157"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.8"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.157"
+version = "0.33.158"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.157"
+version = "0.33.158"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.157"
+version = "0.33.158"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.157"
+version = "0.33.158"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.156"
+version = "0.33.157"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.157"
+version = "0.33.158"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.156"
+version = "0.33.157"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.157"
+version = "0.33.158"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.156"
+version = "0.33.157"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.157"
+version = "0.33.158"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.157"
+version = "0.33.158"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.156"
+version = "0.33.157"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/forge_seed.rs
+++ b/agentmux-srv/src/backend/forge_seed.rs
@@ -117,9 +117,13 @@ pub fn seed_forge_agents(wstore: &Arc<WaveStore>) -> Result<SeedReport, StoreErr
             continue;
         }
 
-        // Insert agent
+        // Insert agent. For seeded agents, the manifest `id` is already
+        // a human-readable slug-form string (agentx, agent1, etc.), so
+        // reuse it as the slug. For user-created agents, forge_insert
+        // auto-derives slug from name if the field is empty.
         let agent = ForgeAgent {
             id: agent_def.id.clone(),
+            slug: agent_def.id.clone(),
             name: agent_def.name.clone(),
             icon: agent_def.icon.clone(),
             provider: agent_def.provider.clone(),
@@ -287,6 +291,7 @@ fn reseed_if_needed(
     for agent_def in &manifest.agents {
         let agent = ForgeAgent {
             id: agent_def.id.clone(),
+            slug: agent_def.id.clone(),
             name: agent_def.name.clone(),
             icon: agent_def.icon.clone(),
             provider: agent_def.provider.clone(),

--- a/agentmux-srv/src/backend/forge_seed.rs
+++ b/agentmux-srv/src/backend/forge_seed.rs
@@ -119,9 +119,9 @@ pub fn seed_forge_agents(wstore: &Arc<WaveStore>) -> Result<SeedReport, StoreErr
 
         // Insert agent. For seeded agents, the manifest `id` is already
         // a human-readable slug-form string (agentx, agent1, etc.), so
-        // reuse it as the slug. For user-created agents, forge_insert
-        // auto-derives slug from name if the field is empty.
-        let agent = ForgeAgent {
+        // reuse it as the slug. forge_insert collision-resolves if
+        // needed and mutates the slug field in place.
+        let mut agent = ForgeAgent {
             id: agent_def.id.clone(),
             slug: agent_def.id.clone(),
             name: agent_def.name.clone(),
@@ -140,7 +140,7 @@ pub fn seed_forge_agents(wstore: &Arc<WaveStore>) -> Result<SeedReport, StoreErr
             agent_bus_id: agent_def.agent_bus_id.clone(),
             is_seeded: 1,
         };
-        wstore.forge_insert(&agent)?;
+        wstore.forge_insert(&mut agent)?;
 
         // Insert content blobs
         let content_pairs = [
@@ -289,7 +289,7 @@ fn reseed_if_needed(
 
     // Upsert agents from manifest
     for agent_def in &manifest.agents {
-        let agent = ForgeAgent {
+        let mut agent = ForgeAgent {
             id: agent_def.id.clone(),
             slug: agent_def.id.clone(),
             name: agent_def.name.clone(),
@@ -313,7 +313,7 @@ fn reseed_if_needed(
             wstore.forge_update(&agent)?;
             updated += 1;
         } else {
-            wstore.forge_insert(&agent)?;
+            wstore.forge_insert(&mut agent)?;
             created += 1;
         }
     }

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -77,6 +77,7 @@ pub fn run_forge_migrations(conn: &Connection) -> Result<(), StoreError> {
     )?;
     run_forge_v2_migrations(conn)?;
     run_forge_v3_migrations(conn)?;
+    run_forge_v4_migrations(conn)?;
     Ok(())
 }
 
@@ -190,6 +191,79 @@ pub fn run_forge_v3_migrations(conn: &Connection) -> Result<(), StoreError> {
     Ok(())
 }
 
+/// Forge v4 migrations: add `slug` column — a stable, filesystem-safe
+/// identifier distinct from the renameable `name`. Backfills existing
+/// rows by deriving slug from name (with collision suffixes), then
+/// adds a unique index.
+///
+/// See specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md for design.
+pub fn run_forge_v4_migrations(conn: &Connection) -> Result<(), StoreError> {
+    use std::collections::HashSet;
+
+    // 1. Add the column (empty default so existing rows survive)
+    match conn.execute_batch(
+        "ALTER TABLE db_forge_agents ADD COLUMN slug TEXT NOT NULL DEFAULT ''",
+    ) {
+        Ok(_) => {}
+        Err(e) => {
+            let msg = e.to_string();
+            if !msg.contains("duplicate column") {
+                return Err(StoreError::Sqlite(match e {
+                    rusqlite::Error::SqliteFailure(code, _) => {
+                        rusqlite::Error::SqliteFailure(code, Some(msg))
+                    }
+                    other => other,
+                }));
+            }
+        }
+    }
+
+    // 2. Backfill: find rows with empty slug, derive from name, collision-resolve.
+    let rows_to_backfill: Vec<(String, String)> = {
+        let mut stmt = conn.prepare(
+            "SELECT id, name FROM db_forge_agents WHERE slug IS NULL OR slug = ''",
+        )?;
+        let mapped = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        mapped
+    };
+
+    let mut used_slugs: HashSet<String> = {
+        let mut stmt =
+            conn.prepare("SELECT slug FROM db_forge_agents WHERE slug != ''")?;
+        let collected = stmt
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<HashSet<_>, _>>()?;
+        collected
+    };
+
+    for (id, name) in rows_to_backfill {
+        let base = super::wstore::derive_slug(&name);
+        let mut candidate = base.clone();
+        let mut n: u32 = 2;
+        while used_slugs.contains(&candidate) {
+            candidate = format!("{}-{}", base, n);
+            n += 1;
+        }
+        used_slugs.insert(candidate.clone());
+        conn.execute(
+            "UPDATE db_forge_agents SET slug = ?1 WHERE id = ?2",
+            rusqlite::params![candidate, id],
+        )?;
+    }
+
+    // 3. Unique index on slug (after backfill so existing dupes are resolved).
+    conn.execute_batch(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_forge_agents_slug
+             ON db_forge_agents(slug)",
+    )?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,5 +301,82 @@ mod tests {
             .query_row("SELECT count(*) FROM db_wave_file", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_forge_v4_slug_backfill_and_collision() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL;").unwrap();
+
+        // Run forge migrations up to v3 (no slug yet) manually to simulate
+        // a pre-v4 database. We go through run_forge_migrations which now
+        // includes v4 — but since the ALTER+backfill is idempotent, we can
+        // inject pre-existing rows and re-run to exercise the backfill path.
+        run_forge_migrations(&conn).unwrap();
+
+        // Drop the unique index FIRST so we can stage rows with empty
+        // slugs (which would otherwise collide with each other under
+        // the UNIQUE constraint).
+        conn.execute_batch("DROP INDEX IF EXISTS idx_forge_agents_slug")
+            .unwrap();
+
+        // Wipe the slug and insert rows as if they came from v3
+        conn.execute_batch("UPDATE db_forge_agents SET slug = ''").unwrap();
+
+        conn.execute(
+            "INSERT INTO db_forge_agents (id, name, icon, provider, description,
+             created_at, is_seeded)
+             VALUES (?1, ?2, '✦', 'claude', '', 0, 0)",
+            rusqlite::params!["id-a", "AgentX"],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO db_forge_agents (id, name, icon, provider, description,
+             created_at, is_seeded)
+             VALUES (?1, ?2, '✦', 'claude', '', 0, 0)",
+            rusqlite::params!["id-b", "AgentX"], // collision!
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO db_forge_agents (id, name, icon, provider, description,
+             created_at, is_seeded)
+             VALUES (?1, ?2, '✦', 'claude', '', 0, 0)",
+            rusqlite::params!["id-c", "My Fancy Agent!"],
+        )
+        .unwrap();
+
+        // Re-run the v4 migration — should backfill all three rows
+        run_forge_v4_migrations(&conn).unwrap();
+
+        let mut stmt = conn
+            .prepare("SELECT id, slug FROM db_forge_agents ORDER BY id")
+            .unwrap();
+        let rows: Vec<(String, String)> = stmt
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        // id-a wins "agentx", id-b gets "agentx-2", id-c gets "my-fancy-agent"
+        assert_eq!(rows.len(), 3);
+        let a = rows.iter().find(|(id, _)| id == "id-a").unwrap();
+        let b = rows.iter().find(|(id, _)| id == "id-b").unwrap();
+        let c = rows.iter().find(|(id, _)| id == "id-c").unwrap();
+        assert_eq!(a.1, "agentx");
+        assert_eq!(b.1, "agentx-2");
+        assert_eq!(c.1, "my-fancy-agent");
+
+        // Unique index must exist after the migration
+        let idx_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master
+                 WHERE type='index' AND name='idx_forge_agents_slug'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(idx_count, 1);
     }
 }

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -400,6 +400,13 @@ impl<'a> StoreTx<'a> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ForgeAgent {
     pub id: String,
+    /// Stable, filesystem-safe identifier. Drives working directory,
+    /// env var keys (AGENTMUX_AGENT_ID), and cross-references.
+    /// NEVER changes after creation — distinct from `name` which is
+    /// the renameable display. See
+    /// specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md.
+    #[serde(default)]
+    pub slug: String,
     pub name: String,
     pub icon: String,
     pub provider: String,
@@ -425,6 +432,35 @@ pub struct ForgeAgent {
     pub agent_bus_id: String,
     #[serde(default)]
     pub is_seeded: i64,
+}
+
+/// Derive a filesystem-safe slug from a display name. Lowercase,
+/// ASCII alphanumeric + dash/underscore, consecutive dashes collapsed,
+/// trimmed to 64 chars. Returns `"agent"` if the input has no valid
+/// characters (defensive fallback).
+pub fn derive_slug(name: &str) -> String {
+    let filtered: String = name
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let collapsed: String = filtered
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    let trimmed: String = collapsed.chars().take(64).collect();
+    if trimmed.is_empty() {
+        "agent".to_string()
+    } else {
+        trimmed
+    }
 }
 
 fn default_agent_type() -> String {
@@ -468,7 +504,7 @@ impl WaveStore {
     pub fn forge_list(&self) -> Result<Vec<ForgeAgent>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, name, icon, provider, description, working_directory, shell,
+            "SELECT id, slug, name, icon, provider, description, working_directory, shell,
                     provider_flags, auto_start, restart_on_crash, idle_timeout_minutes, created_at,
                     agent_type, environment, agent_bus_id, is_seeded
              FROM db_forge_agents ORDER BY created_at ASC",
@@ -476,21 +512,22 @@ impl WaveStore {
         let rows = stmt.query_map([], |row| {
             Ok(ForgeAgent {
                 id: row.get(0)?,
-                name: row.get(1)?,
-                icon: row.get(2)?,
-                provider: row.get(3)?,
-                description: row.get(4)?,
-                working_directory: row.get(5)?,
-                shell: row.get(6)?,
-                provider_flags: row.get(7)?,
-                auto_start: row.get(8)?,
-                restart_on_crash: row.get(9)?,
-                idle_timeout_minutes: row.get(10)?,
-                created_at: row.get(11)?,
-                agent_type: row.get(12)?,
-                environment: row.get(13)?,
-                agent_bus_id: row.get(14)?,
-                is_seeded: row.get(15)?,
+                slug: row.get(1)?,
+                name: row.get(2)?,
+                icon: row.get(3)?,
+                provider: row.get(4)?,
+                description: row.get(5)?,
+                working_directory: row.get(6)?,
+                shell: row.get(7)?,
+                provider_flags: row.get(8)?,
+                auto_start: row.get(9)?,
+                restart_on_crash: row.get(10)?,
+                idle_timeout_minutes: row.get(11)?,
+                created_at: row.get(12)?,
+                agent_type: row.get(13)?,
+                environment: row.get(14)?,
+                agent_bus_id: row.get(15)?,
+                is_seeded: row.get(16)?,
             })
         })?;
         let mut agents = Vec::new();
@@ -518,16 +555,22 @@ impl WaveStore {
         Ok(rows)
     }
 
-    /// Insert a new forge agent.
+    /// Insert a new forge agent. Auto-derives slug from name if empty.
     pub fn forge_insert(&self, agent: &ForgeAgent) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
+        let slug = if agent.slug.is_empty() {
+            derive_slug(&agent.name)
+        } else {
+            agent.slug.clone()
+        };
         conn.execute(
-            "INSERT INTO db_forge_agents (id, name, icon, provider, description,
+            "INSERT INTO db_forge_agents (id, slug, name, icon, provider, description,
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
              idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id, is_seeded)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
             params![
                 agent.id,
+                slug,
                 agent.name,
                 agent.icon,
                 agent.provider,

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -555,14 +555,40 @@ impl WaveStore {
         Ok(rows)
     }
 
-    /// Insert a new forge agent. Auto-derives slug from name if empty.
-    pub fn forge_insert(&self, agent: &ForgeAgent) -> Result<(), StoreError> {
+    /// Insert a new forge agent. Auto-derives slug from name if empty,
+    /// resolves collisions by appending `-2`, `-3`, etc., and mutates
+    /// `agent.slug` so the caller sees the resolved value (important
+    /// for handlers that serialize the struct back to the frontend
+    /// after insert).
+    ///
+    /// The collision check + insert run under a single mutex lock,
+    /// so this is race-safe against concurrent inserts on the same
+    /// connection.
+    pub fn forge_insert(&self, agent: &mut ForgeAgent) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
-        let slug = if agent.slug.is_empty() {
+        let base = if agent.slug.is_empty() {
             derive_slug(&agent.name)
         } else {
             agent.slug.clone()
         };
+        // Collision-resolve: scan for existing slugs matching base or
+        // base-N. The migration backfill does the same dance for
+        // pre-existing rows (see run_forge_v4_migrations).
+        let mut candidate = base.clone();
+        let mut n: u32 = 2;
+        loop {
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM db_forge_agents WHERE slug = ?1",
+                params![candidate],
+                |row| row.get(0),
+            )?;
+            if count == 0 {
+                break;
+            }
+            candidate = format!("{}-{}", base, n);
+            n += 1;
+        }
+        agent.slug = candidate;
         conn.execute(
             "INSERT INTO db_forge_agents (id, slug, name, icon, provider, description,
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
@@ -570,7 +596,7 @@ impl WaveStore {
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
             params![
                 agent.id,
-                slug,
+                agent.slug,
                 agent.name,
                 agent.icon,
                 agent.provider,
@@ -1211,5 +1237,103 @@ mod tests {
         // Verify the insert was rolled back
         let ws = store.get::<Workspace>("ws-rollback").unwrap();
         assert!(ws.is_none());
+    }
+
+    #[test]
+    fn test_forge_insert_collision_resolves_at_runtime() {
+        // Two agents whose names derive to the same slug must both
+        // insert successfully, with the second getting a `-2` suffix.
+        // This exercises the runtime collision-resolution path in
+        // forge_insert (separate from the migration backfill path
+        // tested in migrations.rs).
+        let store = make_store();
+
+        let mut a1 = ForgeAgent {
+            id: "id-a".to_string(),
+            slug: String::new(),
+            name: "Agent X".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+        };
+        store.forge_insert(&mut a1).unwrap();
+        // "Agent X" → "agent-x"
+        assert_eq!(a1.slug, "agent-x");
+
+        let mut a2 = ForgeAgent {
+            id: "id-b".to_string(),
+            // Different surface form, derives to the same slug
+            name: "agent x".to_string(),
+            ..a1.clone()
+        };
+        a2.slug = String::new();
+        store.forge_insert(&mut a2).unwrap();
+        assert_eq!(a2.slug, "agent-x-2");
+
+        let mut a3 = ForgeAgent {
+            id: "id-c".to_string(),
+            name: "AGENT-X".to_string(),
+            ..a1.clone()
+        };
+        a3.slug = String::new();
+        store.forge_insert(&mut a3).unwrap();
+        assert_eq!(a3.slug, "agent-x-3");
+
+        // Verify the underlying rows actually got written
+        let listed = store.forge_list().unwrap();
+        let slugs: Vec<&str> = listed.iter().map(|a| a.slug.as_str()).collect();
+        assert!(slugs.contains(&"agent-x"));
+        assert!(slugs.contains(&"agent-x-2"));
+        assert!(slugs.contains(&"agent-x-3"));
+    }
+
+    #[test]
+    fn test_forge_insert_explicit_slug_collision_resolves() {
+        // When a caller passes an explicit (non-empty) slug that
+        // already exists, forge_insert still resolves the collision
+        // via suffixing — guards against the seed pre-loading the
+        // same slug twice or any other "I know the slug" path.
+        let store = make_store();
+
+        let mut a1 = ForgeAgent {
+            id: "id-a".to_string(),
+            slug: "explicit".to_string(),
+            name: "First".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+        };
+        store.forge_insert(&mut a1).unwrap();
+        assert_eq!(a1.slug, "explicit");
+
+        let mut a2 = ForgeAgent {
+            id: "id-b".to_string(),
+            ..a1.clone()
+        };
+        a2.slug = "explicit".to_string();
+        store.forge_insert(&mut a2).unwrap();
+        assert_eq!(a2.slug, "explicit-2");
     }
 }

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -53,8 +53,13 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .duration_since(UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_millis() as i64;
+                // slug is empty here — forge_insert auto-derives it
+                // from name. Once Step 3 of the identity restructure
+                // lands, the create-agent UI can supply an explicit
+                // slug at creation; for now we let the backend pick.
                 let agent = ForgeAgent {
                     id: uuid::Uuid::new_v4().to_string(),
+                    slug: String::new(),
                     name: cmd.name,
                     icon: cmd.icon,
                     provider: cmd.provider,
@@ -99,8 +104,12 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let existing = wstore.forge_list().map_err(|e| format!("updateforgeagent: {e}"))?;
                 let old = existing.iter().find(|a| a.id == cmd.id)
                     .ok_or_else(|| format!("updateforgeagent: agent {} not found", cmd.id))?;
+                // slug is preserved from the existing row — it's
+                // immutable after creation. The update path never
+                // accepts a new slug from the client.
                 let agent = ForgeAgent {
                     id: cmd.id,
+                    slug: old.slug.clone(),
                     name: cmd.name,
                     icon: cmd.icon,
                     provider: cmd.provider,
@@ -443,9 +452,11 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
                 }
 
-                // Create the agent
+                // Create the agent — slug is empty, forge_insert will
+                // auto-derive from agent_name.
                 let agent = ForgeAgent {
                     id: uuid::Uuid::new_v4().to_string(),
+                    slug: String::new(),
                     name: cmd.agent_name.clone(),
                     icon: "\u{2726}".to_string(),
                     provider,

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -54,10 +54,10 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .unwrap_or_default()
                     .as_millis() as i64;
                 // slug is empty here — forge_insert auto-derives it
-                // from name. Once Step 3 of the identity restructure
-                // lands, the create-agent UI can supply an explicit
-                // slug at creation; for now we let the backend pick.
-                let agent = ForgeAgent {
+                // from name AND collision-resolves AND mutates the
+                // struct so we serialize the resolved value back to
+                // the frontend (not "").
+                let mut agent = ForgeAgent {
                     id: uuid::Uuid::new_v4().to_string(),
                     slug: String::new(),
                     name: cmd.name,
@@ -76,7 +76,7 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     agent_bus_id: cmd.agent_bus_id,
                     is_seeded: 0,
                 };
-                wstore.forge_insert(&agent).map_err(|e| format!("createforgeagent: {e}"))?;
+                wstore.forge_insert(&mut agent).map_err(|e| format!("createforgeagent: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
                     event: "forgeagents:changed".to_string(),
                     scopes: vec![],
@@ -453,8 +453,9 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 }
 
                 // Create the agent — slug is empty, forge_insert will
-                // auto-derive from agent_name.
-                let agent = ForgeAgent {
+                // auto-derive from agent_name and mutate the struct
+                // so the resolved slug is returned to the frontend.
+                let mut agent = ForgeAgent {
                     id: uuid::Uuid::new_v4().to_string(),
                     slug: String::new(),
                     name: cmd.agent_name.clone(),
@@ -473,7 +474,7 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     agent_bus_id: String::new(),
                     is_seeded: 0,
                 };
-                wstore.forge_insert(&agent).map_err(|e| format!("importforgefromclaw: {e}"))?;
+                wstore.forge_insert(&mut agent).map_err(|e| format!("importforgefromclaw: {e}"))?;
 
                 // Read CLAUDE.md → agentmd content
                 let claude_md_path = workspace_path.join("CLAUDE.md");

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -198,6 +198,11 @@ declare global {
     // ForgeAgent
     type ForgeAgent = {
         id: string;
+        // Stable, filesystem-safe identifier. Drives working dir, env vars,
+        // and cross-references. NEVER changes — distinct from `name` which
+        // is the renameable display. See
+        // specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md.
+        slug: string;
         name: string;
         icon: string;
         provider: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.157",
+  "version": "0.33.158",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.157",
+      "version": "0.33.158",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.156",
+  "version": "0.33.157",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.156",
+      "version": "0.33.157",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.156",
+  "version": "0.33.157",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.157",
+  "version": "0.33.158",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md
+++ b/specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md
@@ -1,0 +1,490 @@
+# Spec: Agent identity restructure — two names, easy rename, external usernames
+
+**Status:** Draft
+**Date:** 2026-04-14
+**Scope:** `ForgeAgent` data model, agent picker UX, `IdentityViewModel`
+account storage, launch-side working-directory / env-var derivation
+**Related:** `SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md`,
+`SPEC_AGENT_PANE_FOLLOWUPS_2026_04_13.md`
+
+---
+
+## 1. Problem
+
+Agents today have **one name field** that is asked to do three incompatible jobs:
+
+1. **Display name** shown in the agent picker, the pane frame title, the
+   notification tray. Wants to be human, pretty, renameable.
+2. **Stable identity** used to derive working directories, env vars,
+   GitHub CLI config dirs, and cross-references from memories and
+   plans. Wants to never change.
+3. **External identity** (GitHub username, AWS profile, Anthropic account)
+   used when the agent actually talks to a service. Wants to be
+   multi-valued and provider-specific.
+
+The single `ForgeAgent.name` field is tied to all three at launch time
+(see `agent-model.ts:236-270`):
+
+```ts
+// Working directory slug — derived from name
+const workDir = agent.working_directory
+    || `~/.agentmux/agents/${agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-")}`;
+
+// GitHub CLI config dir — derived from name
+const agentSlug = agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
+envVars["GH_CONFIG_DIR"] = `~/.agentmux/config/gh-${agentSlug}`;
+
+// Env var that downstream MCPs + claw read as "who am I"
+envVars["AGENTMUX_AGENT_ID"] = agent.name;
+```
+
+Consequences:
+
+- **Renaming an agent is dangerous.** Changing "AgentX" → "Alex" would
+  silently orphan `~/.agentmux/agents/agentx/`, break `GH_CONFIG_DIR
+  =~/.agentmux/config/gh-agentx/`, and break every memory / plan file
+  that refers to "AgentX" by name. There's no rename UX at all right
+  now — you have to delete and re-create the agent, which is exactly
+  why the existing forge seed hardcodes five Agent1-5's: nobody dares
+  rename them.
+- **There is no place to record external usernames.** The `IdentityViewModel`
+  has `AccountContext` with `github_username`, `aws_profile`, etc., but
+  the storage is a flat `localStorage` list of accounts (`Account[]`),
+  not linked to any particular `ForgeAgent`. Clicking 👤 on an agent
+  card opens a panel that shows *all* accounts in the system, with an
+  `assigned_agents: string[]` back-reference. It works, but the
+  coupling is loose and the agent has no `githubUser` / `awsProfile`
+  direct field. So a user who wants to rename "AgentX" to "Alex" but
+  keep the underlying GitHub user `a5af-agentx` and AWS profile
+  `agentx-dev` is stuck.
+- **`AGENTMUX_AGENT_ID` serves two roles.** Downstream code treats it
+  as both the agent's human-readable display AND its stable identifier
+  — so CLAUDE.md templates say "You are **AgentX**" (display) while
+  inter-agent MCP messaging routes via `agent.name` as a primary key
+  (stable). Rename breaks one or the other.
+
+## 2. What the user asked for
+
+Restating to make sure the restructure matches intent:
+
+1. **An agent has two names:**
+   - An **AgentMux identity** (the one inside the app) — must be
+     unique within an AgentMux instance, and renameable.
+   - **External username(s)**, set in the Identity view — currently only
+     GitHub and AWS fields exist there.
+2. **Rename should be easy.** One click, inline on the card or in the
+   agent settings panel. No breakage.
+3. **Keep external identity separate.** The GitHub username, AWS
+   profile, etc. live in the Identity view and point *to* an agent,
+   not the other way around.
+
+Plus one side question about two buttons on the agent pane that "do
+nothing except show a blue line" — addressed as a separate issue in
+§8 below, not a scope item here.
+
+## 3. Target model
+
+### 3.1 ForgeAgent gains a stable slug
+
+Add a new field `slug: string` to `ForgeAgent`. This is the forever-ID
+used by:
+
+- Working directory path (`~/.agentmux/agents/<slug>/`)
+- GitHub CLI config dir (`~/.agentmux/config/gh-<slug>/`)
+- Per-agent auth dir
+- Backend references (memories, plans, message routing)
+
+`slug` is set **once at creation** (typically to
+`name.toLowerCase().replace(/[^a-z0-9-_]/g, "-")`), never changes, and
+is surfaced in the UI as a small secondary line under the display
+name — like how Slack shows `@handle` below a display name.
+
+`name` keeps its current semantics but becomes pure display: shown
+to humans, used in the agent picker, in the pane frame title, and
+substituted into `{{AGENT_DISPLAY}}` in CLAUDE.md templates. **Renamable
+at any time** without side effects.
+
+New invariants (enforced in the backend):
+
+| Field | Required | Unique? | Renameable? | Source of truth |
+|---|---|---|---|---|
+| `slug` | yes | yes (within AgentMux instance) | **NO** | set on create |
+| `name` | yes | yes (within AgentMux instance) | **YES** | editable in UI |
+
+**Why both must be unique:** slug because it's the key; name because
+picking two agents named "AgentX" in the list is worse than forbidding
+it. The uniqueness check on rename is cheap (single in-memory scan
+over `ForgeAgent[]`).
+
+### 3.2 `AGENTMUX_AGENT_ID` becomes the slug, not the name
+
+Current launch code (`agent-model.ts:271`):
+
+```ts
+envVars["AGENTMUX_AGENT_ID"] = agent.name;
+```
+
+becomes:
+
+```ts
+envVars["AGENTMUX_AGENT_ID"] = agent.slug;
+envVars["AGENTMUX_AGENT_DISPLAY"] = agent.name;
+```
+
+Downstream consumers (MCP servers, claw, memory routing) migrate to
+read `AGENTMUX_AGENT_ID` as the stable slug. The display name is
+available for prompt templates via `AGENTMUX_AGENT_DISPLAY`.
+
+The claw host template (`a5af/claw:templates/host/CLAUDE.md`) already
+uses `{{AGENT_DISPLAY}}` — this spec doesn't touch that, but once the
+AgentMux seed → claw bridge lands (see the sibling report
+`docs/analysis/agentx-git-identity-2026-04-14.md`), claw can source
+`AGENT_DISPLAY` from `AGENTMUX_AGENT_DISPLAY` and stay stable through
+renames.
+
+### 3.3 External identity lives on the agent record as references
+
+Current Identity storage (`identity-model.ts:9-45`) has:
+
+```ts
+interface Account {
+    id: string;
+    provider: "github" | "aws" | "anthropic" | "custom";
+    context: { github_username?, aws_profile?, ... };
+    assigned_agents: string[];
+    ...
+}
+```
+
+— i.e., accounts own a list of agent IDs they're assigned to. That's
+backwards for the "rename an agent, keep its external username" flow
+the user asked for, because the agent has no direct pointer to its
+accounts.
+
+**Target:** agents reference accounts by ID, not the other way
+around:
+
+```ts
+interface ForgeAgent {
+    id: string;           // existing — internal DB primary key (unchanged)
+    slug: string;         // NEW — stable, unique, filesystem-safe
+    name: string;         // existing — display, renameable
+    icon: string;
+    provider: string;
+    description: string;
+    working_directory: string;
+    agent_type: string;
+    // ...existing fields...
+
+    /**
+     * Per-provider external account IDs, keyed by provider. Each
+     * value is an Account.id from the Identity store.
+     */
+    accounts: Record<AccountProvider, string | null>;
+    // e.g. { github: "acct-abc123", aws: "acct-def456", anthropic: null, custom: null }
+}
+```
+
+`Account.assigned_agents[]` is deprecated and derived from the
+reverse index when needed (for the Identity view's "which agents
+use this account?" display).
+
+**Why this direction:** when you rename the agent, its accounts pointer
+stays valid. When you delete an account, the agent's `accounts[provider]`
+becomes null but the agent itself survives. When you swap accounts (e.g.
+"use my prod GitHub token instead of dev for AgentX"), you just repoint
+`accounts.github`. All O(1) operations, no string matching.
+
+### 3.4 Identity panel on the agent card becomes agent-scoped
+
+Currently, clicking 👤 on an agent card opens a panel showing *all*
+accounts in the system and lets you pick which to assign to this
+agent. The UX target is the opposite:
+
+- **Default view:** the panel shows "AgentX uses **github: @a5af-agentx** and **aws: agentx-dev**" and lets you swap either.
+- **Swap UI:** a dropdown per provider, listing all accounts of that
+  provider, with a "+ Create new" at the bottom that opens the
+  existing form inline.
+- **Global list** (the current default view) moves to a separate tab
+  or is deleted. We can bring it back later if needed — it's not the
+  primary way people interact with accounts.
+
+## 4. Rename UX
+
+### 4.1 Where rename lives
+
+Two entry points, both opening the same modal:
+
+1. **Inline from the agent card** — a tiny ✏ button next to the name,
+   visible on hover. Clicking replaces the name span with an
+   `<input>` + ✓/✗ buttons. Enter saves, Esc cancels. Same pattern as
+   the notebook tab rename in `tabmanager.tsx`.
+2. **From the agent settings panel** (the one that opens on ⚙): a
+   "Display name" field at the top. Changing it and hitting save
+   renames the agent.
+
+### 4.2 What rename does / doesn't change
+
+| Field | Before rename | After rename |
+|---|---|---|
+| `slug` | `agentx` | `agentx` (unchanged) |
+| `name` | `AgentX` | `Alex` |
+| Working directory | `~/.agentmux/agents/agentx/` | same (because it's derived from slug) |
+| `GH_CONFIG_DIR` | `~/.agentmux/config/gh-agentx/` | same |
+| `AGENTMUX_AGENT_ID` env | `agentx` | same |
+| `AGENTMUX_AGENT_DISPLAY` env | `AgentX` | `Alex` |
+| Pane frame title | `AgentX` | `Alex` (live; see blockAtom in `agent-model.ts:44`) |
+| Agent picker card | `AgentX` | `Alex` |
+| Memories, assignments, plans | reference `agentx` | still valid |
+| Linked GitHub / AWS accounts | `accounts.github = "acct-abc"` | still valid |
+
+Running panes update live on the next reactive cycle — `agent-model.ts`
+already reads `agentName` from block meta, so setting the new name
+in the agent's record + notifying open panes is enough.
+
+### 4.3 Validation
+
+On save, enforce:
+
+1. Name not empty, not whitespace-only, length ≤ 64.
+2. Name is unique among existing ForgeAgent names (case-insensitive).
+3. No-op if the new name equals the old name (don't bump `updated_at`).
+
+Slug is never edited in this flow.
+
+### 4.4 Edge case — creating a new agent
+
+When the user creates a new agent via the `+` card, the form should:
+
+1. Ask for a **display name** first.
+2. Autogenerate a slug from that name (lowercase, dash, punctuation
+   stripped).
+3. Show the slug in small text below the name input, with a "✏ edit
+   slug" affordance for power users who want a different filesystem
+   name. Editing the slug is allowed *only at creation*; after
+   creation it's immutable.
+4. If the autogenerated slug collides with an existing one, append
+   `-2`, `-3`, etc. until unique, and show a hint to the user.
+
+This matches how most services handle handle generation (GitHub,
+Slack, Discord all let you pick once, change later only with
+intervention).
+
+## 5. Implementation steps
+
+Each step is a separate PR. Steps 1-3 are reversible data/UI
+changes; step 4 is the external-identity coupling.
+
+### Step 1 — Backend: add `slug` column
+
+- **Touch:** `agentmux-srv/src/backend/storage/wstore.rs` (or whatever
+  owns `ForgeAgent`), `forge-seed.json`, migration logic.
+- Add `slug: String` to the `ForgeAgent` row schema.
+- Backfill migration: for every existing row, derive
+  `slug = name.to_lowercase().filter(is_filesystem_safe).take(64)`,
+  collision-resolve with `-2`, `-3`.
+- Update the seed manifest (`forge-seed.json`) to include `slug` on
+  each entry.
+- Uniqueness constraint on `slug` at the storage layer.
+- Unit tests for the slug derivation + collision resolution.
+
+### Step 2 — Launch: use slug for filesystem paths
+
+- **Touch:** `frontend/app/view/agent/agent-model.ts:236-271`,
+  backend `WriteAgentConfigCommand` handler.
+- Change `workDir` default to
+  `~/.agentmux/agents/${agent.slug}/` (no fallback to `name`).
+- Change `GH_CONFIG_DIR` derivation to `gh-${agent.slug}`.
+- Change `envVars["AGENTMUX_AGENT_ID"]` to `agent.slug`.
+- Add `envVars["AGENTMUX_AGENT_DISPLAY"] = agent.name`.
+- Template variable expansion: add `{{AGENT_SLUG}}` alongside the
+  existing `{{AGENT}}` / `{{AGENT_DISPLAY}}` / `{{AGENT_ID}}`.
+- **Behavior-preserving migration.** Step 1 already backfilled
+  `slug = name.toLowerCase()` for existing agents, so the paths
+  don't change for anyone in practice — the derivation just stops
+  going through the `.toLowerCase().replace(...)` call site and
+  reads the stored field directly.
+
+### Step 3 — UI: rename widget
+
+- **Touch:** `AgentCard.tsx`, `AgentCardSettingsPanel.tsx`, a new small
+  `InlineRenameField.tsx` (or reuse an existing rename primitive if
+  there's one — check `tabmanager.tsx`, `ForgeDetail.tsx`).
+- Add ✏ hover button to `AgentCard`.
+- Add "Display name" field to the Forge tab of the settings panel.
+- Wire save → `forge:updateAgent` RPC with `{id, name}`.
+- Validation client-side (empty, duplicate) before the RPC.
+- Show the slug in small grey text under the name in both the card
+  and the settings panel. Not editable.
+- Live-update open panes: since `agent-view.tsx` already reads
+  `agentName` from block meta, the rename handler also needs to push
+  `agentName` into block meta for any block currently running that
+  agent. Skip the update if no pane has this agent open.
+
+### Step 4 — Identity: agent-owned account refs
+
+- **Touch:** `identity-model.ts`, `forge-seed.json`, backend storage,
+  `IdentityPanel` component.
+- Add `accounts: Record<AccountProvider, string | null>` to
+  `ForgeAgent`. Seed with `{github: null, aws: null, anthropic: null, custom: null}`
+  for existing rows.
+- Deprecate `Account.assigned_agents[]`: keep the field for now but
+  derive it from the reverse index at query time. Schedule a removal
+  follow-up.
+- Rewrite the Identity panel opened from the agent card:
+  - Top: "AgentX uses the following accounts:"
+  - Per provider row: the currently-assigned account (if any) +
+    a dropdown to pick a different one + "+ New" to open the
+    existing account-create form inline.
+  - Unassign is a button that sets `accounts[provider] = null`.
+- Surface the GitHub username / AWS profile from the assigned
+  account inline on the agent card (the user asked for external
+  usernames to be visible under identity).
+
+### Step 5 — Polish + docs
+
+- Update the `CLAUDE.md` in `a5af/claw:templates/host/` to read
+  from `AGENTMUX_AGENT_DISPLAY` instead of hardcoding the agent name.
+  (Separate PR on the claw side — out of scope for AgentMux but
+  tracked in the migration notes.)
+- Add a section to `docs/analysis/agentx-git-identity-2026-04-14.md`
+  that cross-references this spec — once slug lands, claw can trust
+  that `~/.agentmux/agents/<slug>/` never moves.
+- Write a short "How to rename an agent" note in the main README.
+
+### Estimated cost
+
+| Step | Time | Risk |
+|---|---:|---|
+| 1. Backend slug + migration | 2h | Low — purely additive |
+| 2. Launch-side derivation | 1h | Low — value-preserving |
+| 3. Rename UI + validation | 2h | Low |
+| 4. Identity panel restructure | 3-4h | Medium — reshapes the Account ↔ agent link |
+| 5. Docs + claw follow-up | 30 min | Low |
+
+**Total: ~9 hours**, four PRs, shippable independently.
+
+## 6. Out of scope
+
+- Multi-agent-instance sync (Identity accounts cross AgentMux
+  installations). Each instance keeps its own localStorage for now.
+- Renaming the `slug` after creation. Deliberately forbidden — the
+  whole point of the split is that *something* is stable.
+- Importing the user's existing git global config as the default
+  GitHub username on account creation. Nice, but not required.
+- The claw host-template update to use `AGENTMUX_AGENT_DISPLAY` —
+  that's a claw-side PR tracked separately.
+
+## 7. Open questions
+
+1. **Slug character set:** allow hyphens only, or also underscores?
+   Current derivation uses `[^a-z0-9-_]`. Keep as-is unless there's
+   a reason to tighten.
+2. **Rename in the running pane:** should the pane title update live
+   (subject to the blockAtom reactive cycle) or only on next launch?
+   Leaning live — the reactive plumbing already exists.
+3. **What happens when the seed manifest bumps a name?** e.g. if a
+   future seed manifest renames `AgentX` → `AgentXReboot`. Leave it
+   to the seeder's usual "skip if slug exists" guard, which is already
+   the logic in `forge_seed.rs:seed_forge_agents`. The seeder never
+   overwrites existing rows — users who want the new name rename
+   manually.
+4. **AgentMux UUID vs slug as the filesystem key:** a UUID would be
+   100% collision-free but less debuggable (`~/.agentmux/agents/f8d2-...`).
+   Slug wins on debuggability. Collision handling via `-2`, `-3`
+   suffix is a known technique.
+
+## 8. Side question — the two "blue line" buttons on the agent card
+
+Investigating what the user saw: the two buttons on the agent *picker*
+card are ⚙ (Forge) and 👤 (Identity), defined in `AgentCard.tsx:65-84`.
+Their handlers (`onOpenForge` / `onOpenIdentity` in `AgentPicker.tsx:94-119`)
+set an `expandedId` / `expandedTab` signal that causes
+`AgentCardSettingsPanel` to render inline below the card. So they
+*should* do something — they toggle an inline settings panel with
+Forge / Identity tabs.
+
+**If the user is seeing only "a blue line"** after clicking, it means
+the panel is rendering but its *body* is empty or collapsed to
+zero height. Likely causes, ranked:
+
+1. `AgentCardSettingsPanel.tsx:120` wraps the body in `<Show when={tab() === "forge"}>` / `<Show when={tab() === "identity"}>`. If neither tab matches (e.g., `initialTab` is garbage), both `<Show>` branches return null and the panel renders just its header — which, styled with a border-bottom, looks exactly like "a blue line."
+2. `ForgeDetail` or `IdentityPanel` throws during mount, gets caught by
+   an error boundary higher up, and silently renders nothing. Check
+   the `[fe]` log in the dev server terminal for any `console.error`
+   after clicking the button.
+3. SCSS: `.agent-card-settings-body` has `max-height: 0` or
+   `overflow: hidden` and its content never expands. Scan
+   `agent-view.scss` for `agent-card-settings-body`.
+
+**This is a real bug** — the buttons do have an intent (expand the
+inline settings). They're not meant to open a new pane. Recommend a
+separate fix PR after the restructure spec lands, because the Identity
+panel shape is going to change in Step 4 anyway and fixing the render
+bug in today's shape would be thrown-away work.
+
+**Quick triage step to confirm:**
+
+```bash
+# In the dev server terminal tailing `[fe]` log:
+muxlog host '[fe]' &
+# Click the ⚙ button on AgentX. Look for:
+#   - any console.error / stack trace
+#   - any "Cannot read properties of ..." message
+```
+
+If the log is clean, the problem is SCSS / `<Show>` gating, which is
+a 5-minute CSS fix. If there's an error, it's model instantiation
+inside `AgentCardSettingsPanel` — hand it to the same PR that
+rewrites the panel in Step 4.
+
+## 9. Success criteria
+
+After all five steps land:
+
+- Creating a new agent through the `+` card lets me type a display
+  name; the slug is auto-generated and shown in small text; I can
+  override it once before save.
+- Clicking ✏ on an existing card lets me rename the display name
+  without touching any file on disk or breaking any launched pane.
+- Trying to rename AgentX to "Agent1" (duplicate) shows an error
+  inline in the input and doesn't save.
+- After a rename, the pane frame title and the picker card show the
+  new name; the working directory, env vars, and MCP routing still
+  point at the old slug.
+- Clicking 👤 on an agent card shows *that agent's* GitHub and AWS
+  accounts (if any), with dropdowns to swap and a "+ New" to add.
+- Deleting an assigned account unlinks it from the agent but leaves
+  the agent operational (the rows just show "no account assigned").
+- The `CLAUDE.md` generated at launch still says "You are **AgentX**"
+  (from the display name) but downstream inter-agent messaging keys
+  by `agentx` (from the slug) and is stable across renames.
+
+---
+
+## Appendix: exact file list
+
+**Data model:**
+- `agentmux-srv/src/backend/storage/wstore.rs` — ForgeAgent schema
+- `agentmux-srv/src/backend/storage/migrations.rs` — slug backfill
+- `agentmux-srv/forge-seed.json` — add slug to every entry
+
+**Launch path:**
+- `frontend/app/view/agent/agent-model.ts:236-271` — derivations
+- `frontend/app/view/agent/agent-model.ts:380-487` — template vars
+
+**UI components:**
+- `frontend/app/view/agent/components/AgentCard.tsx` — rename affordance
+- `frontend/app/view/agent/components/AgentCardSettingsPanel.tsx` — rename field
+- `frontend/app/view/agent/components/IdentityPanel.tsx` — agent-scoped view
+- New: `frontend/app/view/agent/components/InlineRenameField.tsx`
+
+**Identity store:**
+- `frontend/app/view/identity/identity-model.ts` — deprecate
+  `assigned_agents`, add reverse index
+- `frontend/app/view/identity/identity-view.tsx` — "which agents use
+  this account?" section (derived)
+
+**Docs:**
+- `README.md` — how to rename
+- `docs/analysis/agentx-git-identity-2026-04-14.md` — cross-reference


### PR DESCRIPTION
## Summary

Step 1 of [\`SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md\`](../blob/agenta/naming-step1-slug-field/specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md). Adds a stable, filesystem-safe \`slug\` field to \`ForgeAgent\`, distinct from the renameable \`name\`. Foundation for Steps 2-4 (launch derivation, rename UI, agent-scoped identity).

**Behavior unchanged for users.** \`slug\` defaults to the same value \`name.toLowerCase()\` would have produced, so no working directory or env var path moves. Step 2 will switch the launch path to read slug directly instead of re-deriving from name on every spawn.

## What changed

### Backend (Rust)

- **\`storage/wstore.rs\`**
  - \`ForgeAgent\` struct gains \`pub slug: String\` (\`#[serde(default)]\` for back-compat with old JSON exports)
  - New helper \`derive_slug(name)\` — lowercase, ASCII alnum + dash/underscore, consecutive dashes collapsed, trimmed to 64 chars, fallback \`\"agent\"\` for inputs with no valid chars
  - \`forge_insert\` auto-derives slug from name when the field is empty, so existing callers don't have to think about it
  - \`forge_update\` does NOT touch slug — preserves it from the existing row, since slug is immutable after creation
  - \`forge_list\` SELECT updated to fetch the new column

- **\`storage/migrations.rs\`**
  - New \`run_forge_v4_migrations\`: \`ALTER TABLE ADD COLUMN slug\` → backfill empty rows by deriving from name with collision-resolution (\`agentx\`, \`agentx-2\`, \`agentx-3\`, …) → \`CREATE UNIQUE INDEX idx_forge_agents_slug\`
  - Wired into \`run_forge_migrations\` after v3
  - **New unit test** \`test_forge_v4_slug_backfill_and_collision\` exercises the AgentX/AgentX collision case (\`id-a\` → \`agentx\`, \`id-b\` → \`agentx-2\`) and the special-character path (\`\"My Fancy Agent!\"\` → \`my-fancy-agent\`); also asserts the unique index exists post-migration

- **\`forge_seed.rs\`**
  - Both \`ForgeAgent { ... }\` constructors pass \`slug: agent_def.id.clone()\` since the manifest \`id\`s (\`agentx\`, \`agent1\`) are already slug-form

- **\`server/forge_handlers.rs\`**
  - \`createforgeagent\` passes empty slug → \`forge_insert\` auto-derives from \`name\`
  - \`updateforgeagent\` preserves \`old.slug\` — slug never changes via the update path
  - \`importforgefromclaw\` passes empty slug → auto-derive

### Frontend (TypeScript)

- **\`gotypes.d.ts\`** — \`ForgeAgent\` type gains \`slug: string\` field with a doc comment pointing at the spec

No frontend logic touched in this PR — Step 2 wires the launch side to read from \`slug\`. Today's launch code still derives the slug-equivalent inline from \`name.toLowerCase().replace(...)\`, which produces the same string the migration backfill writes to the new column.

## Verification

- \`cargo check -p agentmux-srv\` — clean
- \`cargo test -p agentmux-srv --bin agentmux-srv backend::storage::migrations\`:
  ```
  test test_filestore_migrations_idempotent ... ok
  test test_forge_v4_slug_backfill_and_collision ... ok
  test test_wstore_migrations_idempotent ... ok
  ```
- \`tsc --noEmit\` — clean (3 pre-existing errors in \`term.tsx\` / \`cef-api.ts\` unrelated and present on main)

## Migration safety

- Existing databases get the new column via \`ALTER TABLE ADD COLUMN\` (idempotent, falls through if the column already exists per the existing pattern at v2/v3)
- Backfill runs only against rows where \`slug = ''\`, so re-running the migration on an already-migrated database is a no-op
- The unique index is created only after backfill, so existing duplicate names (if any) get \`-2\`/\`-3\` suffixes before the constraint kicks in

## Out of scope (next PRs)

- Launch-side switch from \`name.toLowerCase()\` to \`agent.slug\` (Step 2)
- Rename UI on the agent card (Step 3)
- Identity panel restructure with agent-scoped account refs (Step 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)