### PR TITLE
feat(agent): identity restructure Step 2 — launch uses slug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.158"
+version = "0.33.159"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.158"
+version = "0.33.159"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.158"
+version = "0.33.159"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.158"
+version = "0.33.159"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.158"
+version = "0.33.159"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.158"
+version = "0.33.159"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.158"
+version = "0.33.159"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.158"
+version = "0.33.159"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -233,8 +233,13 @@ export class AgentViewModel implements ViewModel {
             Logger.error("agent", "Failed to load forge skills", { error: String(e) });
         }
 
-        // Determine working directory
-        const workDir = agent.working_directory || `~/.agentmux/agents/${agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-")}`;
+        // Determine working directory. Use the agent's stable slug
+        // (Step 1 of SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md) so
+        // renaming the agent doesn't move the directory on disk.
+        // Falls back to the legacy name-derived form if slug is empty
+        // (defensive — the v4 migration backfills slug for every row).
+        const slug = agent.slug || agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
+        const workDir = agent.working_directory || `~/.agentmux/agents/${slug}`;
 
         // Build CLI args: use persistent args if available, otherwise standard launch args
         const isPersistent = provider.controllerType === "persistent";
@@ -265,10 +270,25 @@ export class AgentViewModel implements ViewModel {
             }
         }
 
-        // Per-agent GitHub config isolation
-        const agentSlug = agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
-        envVars["GH_CONFIG_DIR"] = `~/.agentmux/config/gh-${agentSlug}`;
+        // Per-agent GitHub config isolation — keyed by the stable
+        // slug so renaming doesn't orphan ~/.agentmux/config/gh-<old>.
+        envVars["GH_CONFIG_DIR"] = `~/.agentmux/config/gh-${slug}`;
+
+        // AGENTMUX_AGENT_ID stays as the display name for backwards
+        // compat: shell integration scripts (bash.sh / zsh.sh / pwsh.ps1)
+        // emit OSC sequences carrying this value as the terminal pane
+        // label, and agentmux-mcp routes inter-agent messages by it.
+        // Flipping to slug here would change visible labels and break
+        // routing — that's a separate coordinated migration.
         envVars["AGENTMUX_AGENT_ID"] = agent.name;
+        // New, additive: the stable slug (Step 2 of identity
+        // restructure). Downstream code can opt into reading this
+        // when it needs the rename-stable form.
+        envVars["AGENTMUX_AGENT_SLUG"] = slug;
+        // Explicit display alias. Today identical to AGENTMUX_AGENT_ID
+        // — once Step 4's downstream coordination flips ID to the
+        // slug, DISPLAY remains the human-readable label.
+        envVars["AGENTMUX_AGENT_DISPLAY"] = agent.name;
 
         // Provider auth isolation: shared per-version auth dir (not per-agent)
         // Each AgentMux version gets its own auth space via the Tauri app data dir,
@@ -381,6 +401,7 @@ function buildConfigFiles(
     if (agent) {
         templateVars["AGENT"] = agent.name;
         templateVars["AGENT_DISPLAY"] = agent.name;
+        templateVars["AGENT_SLUG"] = agent.slug || agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
         templateVars["WORKING_DIR"] = agent.working_directory || "";
         templateVars["AGENT_ID"] = agent.id;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.158",
+  "version": "0.33.159",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.158",
+      "version": "0.33.159",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.158",
+  "version": "0.33.159",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 2 of [\`SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md\`](../blob/main/specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md). The launch path now reads \`agent.slug\` (added in #385) for filesystem and config-isolation identifiers instead of re-deriving from \`agent.name.toLowerCase()\` on every spawn.

After this PR, **renaming an agent's display name no longer moves its working directory or GitHub config dir on disk** — the rename UX in Step 3 can ship safely.

## Conservative on env vars

\`AGENTMUX_AGENT_ID\` is **unchanged** (still the display name "AgentX") because:
- Shell integration scripts (\`bash.sh\` / \`zsh.sh\` / \`pwsh.ps1\`) emit OSC sequences carrying it as the terminal pane label
- \`agentmux-mcp\` inter-agent message routing keys on it
- \`agent_config.rs:249\` writes it into \`.mcp.json\` env

Flipping it to slug here would change visible labels and break routing — a coordinated downstream migration. Two new **additive** env vars expose the slug-form for opt-in consumers:

| env var | value | added | flips later? |
|---|---|---|---|
| \`AGENTMUX_AGENT_ID\` | \`agent.name\` | unchanged | yes, in a future coordinated PR |
| \`AGENTMUX_AGENT_SLUG\` | \`agent.slug\` | **new** | no |
| \`AGENTMUX_AGENT_DISPLAY\` | \`agent.name\` | **new** | no |

Once Step 4's downstream coordination lands, \`AGENTMUX_AGENT_ID\` can flip to slug and \`AGENTMUX_AGENT_DISPLAY\` remains the human label.

## What changed

\`frontend/app/view/agent/agent-model.ts\`:

- \`workDir\` default (when \`agent.working_directory\` is empty) now resolves to \`~/.agentmux/agents/<slug>\` instead of inline \`name.toLowerCase().replace(...)\`
- \`GH_CONFIG_DIR\` keyed by \`slug\`
- New \`AGENTMUX_AGENT_SLUG\` and \`AGENTMUX_AGENT_DISPLAY\` env vars (additive)
- New \`{{AGENT_SLUG}}\` template variable in \`buildConfigFiles\` for CLAUDE.md / .mcp.json substitution
- Defensive fallback: if \`agent.slug\` is empty (shouldn't happen post-v4 migration), falls back to the legacy name-derived form so we never write to \`~/.agentmux/agents/\`

## Behavior

For existing agents on machines that ran the #385 migration: **identical**. The v4 backfill set \`slug = derive_slug(name)\`, which produces the same string as the old inline derivation, so workDir / GH_CONFIG_DIR resolve to exactly the same paths.

The divergence only matters once an agent is renamed — at which point Step 3's UX will let the user change the display name without moving any files.

## Test plan

- [ ] \`tsc --noEmit\` clean
- [ ] \`task dev\` → launch AgentX from picker → confirm working directory is still \`~/.agentmux/agents/agentx/\` (not a new path)
- [ ] Open the agent pane terminal → \`echo \$AGENTMUX_AGENT_ID\` returns \`AgentX\` (unchanged)
- [ ] \`echo \$AGENTMUX_AGENT_SLUG\` returns \`agentx\` (new)
- [ ] \`echo \$AGENTMUX_AGENT_DISPLAY\` returns \`AgentX\` (new)
- [ ] \`echo \$GH_CONFIG_DIR\` still resolves to \`~/.agentmux/config/gh-agentx\`
- [ ] CLAUDE.md template \`{{AGENT_SLUG}}\` (if any template uses it) substitutes correctly
- [ ] No regressions in the existing \`{{AGENT}}\` / \`{{AGENT_DISPLAY}}\` substitutions

## Out of scope (next PRs)

- Step 3 — rename UI on the agent card
- Step 4 — Identity panel restructure with agent-scoped account refs
- The \`AGENTMUX_AGENT_ID\` flip (separate coordinated PR with downstream consumers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)