### PR TITLE
feat(agent): identity restructure Step 3 — rename UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.159"
+version = "0.33.160"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.159"
+version = "0.33.160"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.159"
+version = "0.33.160"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.159"
+version = "0.33.160"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.159"
+version = "0.33.160"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.159"
+version = "0.33.160"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.159"
+version = "0.33.160"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.159"
+version = "0.33.160"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -366,6 +366,73 @@
             text-overflow: ellipsis;
         }
 
+        .agent-card-slug {
+            font-size: 10px;
+            color: color-mix(in srgb, var(--secondary-text-color) 65%, transparent);
+            font-family: var(--termfontfamily, monospace);
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        // Inline rename row — replaces the name span while editing
+        .agent-card-rename-row {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .agent-card-rename-input {
+            flex: 1;
+            min-width: 0;
+            font-size: 13px;
+            font-weight: 500;
+            font-family: inherit;
+            color: var(--main-text-color);
+            background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
+            border: 1px solid var(--accent-color);
+            border-radius: 3px;
+            padding: 1px 5px;
+            outline: none;
+
+            &.agent-card-rename-input--error {
+                border-color: var(--error-color, #e55);
+            }
+        }
+
+        .agent-card-rename-btn {
+            width: 22px;
+            height: 22px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0;
+            border: 1px solid var(--border-color);
+            background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
+            border-radius: 3px;
+            color: var(--main-text-color);
+            font-size: 11px;
+            cursor: pointer;
+            flex-shrink: 0;
+
+            &:hover {
+                border-color: var(--accent-color);
+                background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+            }
+
+            &--confirm:hover {
+                color: var(--success-color, #4c8);
+                border-color: var(--success-color, #4c8);
+                background: color-mix(in srgb, var(--success-color, #4c8) 15%, transparent);
+            }
+
+            &--cancel:hover {
+                color: var(--error-color, #e55);
+                border-color: var(--error-color, #e55);
+                background: color-mix(in srgb, var(--error-color, #e55) 15%, transparent);
+            }
+        }
+
         .agent-card-spinner {
             width: 14px;
             height: 14px;

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -8,6 +8,10 @@
  * adds the ⚙ Forge and 👤 Identity buttons that expand an inline
  * settings panel below the card.
  *
+ * Step 3 of SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md adds:
+ * - Slug displayed as small secondary line under the name.
+ * - ✏ hover button for inline rename; Enter saves, Esc cancels.
+ *
  * Clicking the card body still launches the agent. The buttons call
  * stopPropagation so they never accidentally trigger launch.
  *
@@ -16,7 +20,7 @@
  * buttons).
  */
 
-import { Show, type JSX } from "solid-js";
+import { createSignal, Show, type JSX } from "solid-js";
 
 interface AgentCardProps {
     agent: ForgeAgent;
@@ -25,25 +29,80 @@ interface AgentCardProps {
     onLaunch: (agent: ForgeAgent) => void;
     onOpenForge: (agent: ForgeAgent) => void;
     onOpenIdentity: (agent: ForgeAgent) => void;
+    /** Called when the user commits a rename via the inline ✏ control. */
+    onRename: (agent: ForgeAgent, newName: string) => Promise<string | null>;
 }
 
 export const AgentCard = (props: AgentCardProps): JSX.Element => {
+    const [renaming, setRenaming] = createSignal(false);
+    const [editName, setEditName] = createSignal("");
+    const [renameError, setRenameError] = createSignal<string | null>(null);
+    const [saving, setSaving] = createSignal(false);
+
     const stopAndRun = (fn: () => void) => (e: MouseEvent) => {
         e.stopPropagation();
         fn();
     };
 
     const handleCardClick = () => {
-        if (!props.disabled) props.onLaunch(props.agent);
+        if (!props.disabled && !renaming()) props.onLaunch(props.agent);
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
-        if (props.disabled) return;
+        if (props.disabled || renaming()) return;
         if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
             props.onLaunch(props.agent);
         }
     };
+
+    const startRename = (e: MouseEvent) => {
+        e.stopPropagation();
+        setEditName(props.agent.name);
+        setRenameError(null);
+        setRenaming(true);
+    };
+
+    const cancelRename = (e?: MouseEvent) => {
+        e?.stopPropagation();
+        setRenaming(false);
+        setRenameError(null);
+    };
+
+    const commitRename = async (e?: MouseEvent) => {
+        e?.stopPropagation();
+        const newName = editName().trim();
+        if (!newName) {
+            setRenameError("Name cannot be empty");
+            return;
+        }
+        if (newName === props.agent.name) {
+            setRenaming(false);
+            return;
+        }
+        setSaving(true);
+        const err = await props.onRename(props.agent, newName);
+        setSaving(false);
+        if (err) {
+            setRenameError(err);
+        } else {
+            setRenaming(false);
+            setRenameError(null);
+        }
+    };
+
+    const handleInputKeyDown = (e: KeyboardEvent) => {
+        e.stopPropagation();
+        if (e.key === "Enter") {
+            e.preventDefault();
+            void commitRename();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            cancelRename();
+        }
+    };
+
+    const slug = () => props.agent.slug || "";
 
     return (
         <div
@@ -57,31 +116,89 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
         >
             <span class="agent-card-icon">{props.agent.icon}</span>
             <span class="agent-card-info">
-                <span class="agent-card-name">{props.agent.name}</span>
-                <Show when={props.agent.description}>
-                    <span class="agent-card-desc">{props.agent.description}</span>
+                <Show
+                    when={renaming()}
+                    fallback={
+                        <>
+                            <span class="agent-card-name">{props.agent.name}</span>
+                            <Show when={slug()}>
+                                <span class="agent-card-slug">{slug()}</span>
+                            </Show>
+                            <Show when={props.agent.description}>
+                                <span class="agent-card-desc">{props.agent.description}</span>
+                            </Show>
+                        </>
+                    }
+                >
+                    <div class="agent-card-rename-row" onClick={(e) => e.stopPropagation()}>
+                        <input
+                            class={`agent-card-rename-input${renameError() ? " agent-card-rename-input--error" : ""}`}
+                            type="text"
+                            value={editName()}
+                            onInput={(e) => {
+                                setEditName(e.currentTarget.value);
+                                setRenameError(null);
+                            }}
+                            onKeyDown={handleInputKeyDown}
+                            disabled={saving()}
+                            ref={(el) => setTimeout(() => el?.focus(), 0)}
+                            aria-label="Rename agent"
+                        />
+                        <button
+                            class="agent-card-rename-btn agent-card-rename-btn--confirm"
+                            onClick={(e) => { e.stopPropagation(); void commitRename(); }}
+                            disabled={saving()}
+                            type="button"
+                            title="Save (Enter)"
+                        >
+                            {"\u2713"}
+                        </button>
+                        <button
+                            class="agent-card-rename-btn agent-card-rename-btn--cancel"
+                            onClick={cancelRename}
+                            disabled={saving()}
+                            type="button"
+                            title="Cancel (Esc)"
+                        >
+                            {"\u2715"}
+                        </button>
+                    </div>
+                    <Show when={renameError()}>
+                        <span class="agent-card-desc" style={{ color: "var(--error-color, #e55)" }}>{renameError()}</span>
+                    </Show>
                 </Show>
             </span>
-            <div class="agent-card-actions">
-                <button
-                    class="agent-card-action-btn"
-                    onClick={stopAndRun(() => props.onOpenForge(props.agent))}
-                    title="Configure this agent in the Forge"
-                    disabled={props.disabled}
-                    type="button"
-                >
-                    {"\u2699"}
-                </button>
-                <button
-                    class="agent-card-action-btn"
-                    onClick={stopAndRun(() => props.onOpenIdentity(props.agent))}
-                    title="Manage this agent's identity"
-                    disabled={props.disabled}
-                    type="button"
-                >
-                    {"\uD83D\uDC64"}
-                </button>
-            </div>
+            <Show when={!renaming()}>
+                <div class="agent-card-actions">
+                    <button
+                        class="agent-card-action-btn"
+                        onClick={startRename}
+                        title="Rename this agent"
+                        disabled={props.disabled}
+                        type="button"
+                    >
+                        {"\u270F"}
+                    </button>
+                    <button
+                        class="agent-card-action-btn"
+                        onClick={stopAndRun(() => props.onOpenForge(props.agent))}
+                        title="Configure this agent in the Forge"
+                        disabled={props.disabled}
+                        type="button"
+                    >
+                        {"\u2699"}
+                    </button>
+                    <button
+                        class="agent-card-action-btn"
+                        onClick={stopAndRun(() => props.onOpenIdentity(props.agent))}
+                        title="Manage this agent's identity"
+                        disabled={props.disabled}
+                        type="button"
+                    >
+                        {"\uD83D\uDC64"}
+                    </button>
+                </div>
+            </Show>
             <Show when={props.launching}>
                 <span class="agent-card-spinner" />
             </Show>

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -13,6 +13,7 @@
 import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
+import { atoms, WOS } from "@/app/store/global";
 import { waveEventSubscribe } from "@/app/store/wps";
 import type { AgentViewModel } from "../agent-model";
 import { AgentCard } from "./AgentCard";
@@ -129,6 +130,71 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         setCreateMode(false);
     };
 
+    /**
+     * Validate + execute an inline rename from AgentCard.
+     * Returns null on success, or an error string to display inline.
+     */
+    const handleRename = async (agent: ForgeAgent, newName: string): Promise<string | null> => {
+        const trimmed = newName.trim();
+        if (!trimmed) return "Name cannot be empty";
+        if (trimmed.length > 64) return "Name must be 64 characters or fewer";
+
+        // Uniqueness check (case-insensitive, exclude self)
+        const lc = trimmed.toLowerCase();
+        const collision = agents().find(
+            (a) => a.id !== agent.id && a.name.toLowerCase() === lc
+        );
+        if (collision) return `Name "${trimmed}" is already taken`;
+
+        try {
+            await RpcApi.UpdateForgeAgentCommand(TabRpcClient, {
+                id: agent.id,
+                name: trimmed,
+                icon: agent.icon,
+                provider: agent.provider,
+                description: agent.description,
+                working_directory: agent.working_directory,
+                shell: agent.shell,
+                provider_flags: agent.provider_flags,
+                auto_start: agent.auto_start,
+                restart_on_crash: agent.restart_on_crash,
+                idle_timeout_minutes: agent.idle_timeout_minutes,
+                agent_type: agent.agent_type,
+                environment: agent.environment,
+                agent_bus_id: agent.agent_bus_id,
+            });
+            // Sync the display name in the block meta of any pane running this agent
+            void syncAgentNameInOpenPanes(agent.id, trimmed);
+            return null;
+        } catch (e: any) {
+            return String(e?.message ?? e);
+        }
+    };
+
+    /**
+     * After a rename, find any open agent panes running this agent and update
+     * their block meta agentName so the pane-frame title refreshes immediately.
+     */
+    const syncAgentNameInOpenPanes = async (agentId: string, newName: string): Promise<void> => {
+        try {
+            const tabId = atoms.staticTabId();
+            if (!tabId) return;
+            const tab = WOS.getWaveObjectAtom<Tab>(`tab:${tabId}`)();
+            if (!tab?.blockids) return;
+            for (const blockId of tab.blockids) {
+                const block = WOS.getWaveObjectAtom<Block>(`block:${blockId}`)();
+                if (block?.meta?.["agentId"] === agentId) {
+                    await RpcApi.SetMetaCommand(TabRpcClient, {
+                        oref: WOS.makeORef("block", blockId),
+                        meta: { agentName: newName },
+                    });
+                }
+            }
+        } catch {
+            // best-effort — pane title will update on next interaction
+        }
+    };
+
     const busy = () => launching() !== null;
 
     return (
@@ -169,6 +235,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                                         onLaunch={handleSelect}
                                         onOpenForge={openForgeFor}
                                         onOpenIdentity={openIdentityFor}
+                                        onRename={handleRename}
                                     />
                                     <Show when={expandedId() === agent.id && !createMode()}>
                                         <AgentCardSettingsPanel

--- a/frontend/app/view/forge/components/ForgeDetail.tsx
+++ b/frontend/app/view/forge/components/ForgeDetail.tsx
@@ -67,6 +67,9 @@ export function ForgeDetail(props: { model: ForgeViewModel }): JSX.Element {
                                         <span class={`forge-agent-type-badge forge-agent-type-${agentVal().agent_type}`}>{detailTypeBadge()}</span>
                                     </Show>
                                 </div>
+                                <Show when={agentVal().slug}>
+                                    <span class="forge-detail-slug">{agentVal().slug}</span>
+                                </Show>
                                 <span class="forge-detail-sub">
                                     {providerLabel()}
                                     {agentVal().description ? ` \u2022 ${agentVal().description}` : ""}

--- a/frontend/app/view/forge/forge-view.scss
+++ b/frontend/app/view/forge/forge-view.scss
@@ -388,6 +388,15 @@
     text-overflow: ellipsis;
 }
 
+.forge-detail-slug {
+    font-size: 10px;
+    color: color-mix(in srgb, var(--secondary-text-color) 65%, transparent);
+    font-family: var(--termfontfamily, monospace);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 // ── Content tabs ────────────────────────────────────────────────────────────
 
 .forge-content-tabs {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.159",
+  "version": "0.33.160",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 3 of `specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md`.

- **AgentCard slug line** — the stable `slug` is shown as a small dimmed monospace line directly below the display name in the picker card. Never editable — purely informational so users know what won't change when they rename.
- **Inline rename** — a ✏ button appears on hover alongside ⚙ and 👤. Clicking it replaces the name span with an `<input>` plus ✓/✗ buttons. Enter saves, Esc cancels.
- **Client-side validation** — non-empty, ≤ 64 chars, unique (case-insensitive) among existing agents.
- **Live pane-title sync** — after a successful rename, any open pane whose `meta.agentId` matches gets its `agentName` block meta updated via `SetMetaCommand` so the pane-frame title refreshes without restart.
- **ForgeDetail slug** — the forge detail header now shows the slug as a dimmed monospace line under the display name (same visual language as the card).

## Test plan

- [ ] Hover over an agent card — ✏, ⚙, 👤 buttons appear
- [ ] Click ✏ — input appears pre-filled with current name, Enter saves, Esc cancels
- [ ] Rename succeeds — card name updates reactively (forgeagents:changed fires)
- [ ] Rename to duplicate name — inline error "Name X is already taken"
- [ ] Rename to empty string — inline error "Name cannot be empty"
- [ ] Slug line appears under name (dimmed, monospace)
- [ ] Open an agent pane, go back to picker, rename the agent — pane-frame title updates live
- [ ] Open Forge detail for an agent — slug shown under name in the detail header
- [ ] tsc --noEmit clean (only pre-existing errors in term.tsx / cef-api.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)