### PR TITLE
feat(agent): syntax highlighting in tool overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.160"
+version = "0.33.161"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.160"
+version = "0.33.161"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.160"
+version = "0.33.161"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.160"
+version = "0.33.161"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.161"
+version = "0.33.162"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.161"
+version = "0.33.162"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.161"
+version = "0.33.162"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.161"
+version = "0.33.162"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.160"
+version = "0.33.161"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.161"
+version = "0.33.162"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.161"
+version = "0.33.162"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.160"
+version = "0.33.161"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.160"
+version = "0.33.161"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.161"
+version = "0.33.162"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.160"
+version = "0.33.161"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.161"
+version = "0.33.162"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1213,6 +1213,34 @@
     }
 
     // === Diff Viewer ===
+    // === Shared Shiki highlighted-code base ===
+    // Shiki emits <pre><code> with <span class="line"> per line.
+    // We wrap in our own <pre class="agent-highlighted-code"> and inject innerHTML.
+    .agent-highlighted-code {
+        font-family: var(--termfontfamily, "JetBrains Mono", monospace);
+        font-size: 12px;
+        line-height: 1.5;
+        margin: 0;
+        overflow-x: auto;
+        background: transparent; // Shiki adds its own bg on the <code> element
+        color: var(--main-text-color);
+        white-space: pre;
+
+        // Shiki wraps each line in <span class="line"> — give lines display:block
+        // so backgrounds and padding work correctly.
+        :global(.line) {
+            display: block;
+            padding: 0 6px;
+            min-height: 1.5em;
+        }
+
+        // Shiki adds background-color on the <pre> via inline style — remove it
+        // so our themed background (from the parent container) wins.
+        &[style*="background"] {
+            background: transparent !important;
+        }
+    }
+
     .agent-diff {
         background: var(--main-bg-color);
         border: none;
@@ -1228,6 +1256,7 @@
             border-bottom: 1px solid var(--border-color);
         }
 
+        // Plain-render diff classes (used before Shiki resolves and as fallback)
         .agent-diff-add {
             background: color-mix(in srgb, green 15%, transparent);
             color: #a0ffa0;
@@ -1245,6 +1274,36 @@
 
         .agent-diff-ctx {
             color: var(--secondary-text-color);
+        }
+
+        // Highlighted variant: Shiki emits <span class="line agent-diff-add">
+        // so the same colour rules above apply automatically. We additionally
+        // strip the Shiki-generated span colour on add/del lines so our
+        // contrasting palette (not Shiki's) wins for the diff chrome.
+        &.agent-diff--highlighted {
+            :global(.line.agent-diff-add) {
+                background: color-mix(in srgb, green 15%, transparent);
+                // Shiki token colours are preserved; only the line bg is forced.
+            }
+            :global(.line.agent-diff-del) {
+                background: color-mix(in srgb, red 15%, transparent);
+            }
+            :global(.line.agent-diff-hunk) {
+                background: color-mix(in srgb, blue 10%, transparent);
+                color: var(--accent-color);
+            }
+            :global(.line.agent-diff-ctx) {
+                // default Shiki token colours — no override needed
+            }
+            :global(.agent-diff-marker) {
+                opacity: 0.6;
+                user-select: none;
+                margin-right: 2px;
+            }
+            :global(.agent-diff-hunk-text) {
+                color: var(--accent-color);
+                opacity: 0.8;
+            }
         }
     }
 
@@ -1267,10 +1326,29 @@
             background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
             padding: 3px 6px;
             border-bottom: 1px solid var(--border-color);
+            display: flex;
+            align-items: baseline;
+            gap: 6px;
 
             .agent-bash-dollar {
                 color: var(--accent-color);
-                margin-right: 8px;
+                flex-shrink: 0;
+            }
+
+            // HighlightedCode inside the cmd row: inline, no extra padding/bg
+            .agent-bash-cmd-code {
+                flex: 1;
+                margin: 0;
+                padding: 0;
+                background: transparent;
+                border: none;
+                overflow: visible;
+                white-space: pre-wrap;
+
+                :global(.line) {
+                    display: inline;
+                    padding: 0;
+                }
             }
         }
 
@@ -1503,11 +1581,14 @@
         .agent-tool-read-content {
             background: var(--main-bg-color);
             border: 1px solid var(--border-color);
-            padding: 4px 6px;
             border-radius: 3px;
             max-height: 400px;
             overflow-y: auto;
             margin: 0;
+            // Shiki <pre> override: ensure our bg wins
+            &[style*="background"] {
+                background: var(--main-bg-color) !important;
+            }
         }
     }
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1276,6 +1276,16 @@
             color: var(--secondary-text-color);
         }
 
+        // Highlighted variant wrapper: header stays as a div, Shiki content
+        // goes into a separate <pre> so innerHTML doesn't destroy the header.
+        .agent-diff-highlighted-body {
+            margin: 0;
+            padding: 0;
+            background: transparent;
+            border: none;
+            overflow-x: auto;
+        }
+
         // Highlighted variant: Shiki emits <span class="line agent-diff-add">
         // so the same colour rules above apply automatically. We additionally
         // strip the Shiki-generated span colour on add/del lines so our

--- a/frontend/app/view/agent/components/BashOutputViewer.tsx
+++ b/frontend/app/view/agent/components/BashOutputViewer.tsx
@@ -8,6 +8,7 @@
 import clsx from "clsx";
 import { Show, type JSX } from "solid-js";
 import type { BashParams, BashResult } from "../types";
+import { HighlightedCode } from "./HighlightedCode";
 
 interface BashOutputViewerProps {
     params: BashParams;
@@ -21,7 +22,12 @@ export const BashOutputViewer = ({ params, result }: BashOutputViewerProps): JSX
     return (
         <div class="agent-bash">
             <div class="agent-bash-cmd">
-                <span class="agent-bash-dollar">$</span> {params.command}
+                <span class="agent-bash-dollar">$</span>
+                <HighlightedCode
+                    code={params.command}
+                    lang="bash"
+                    class="agent-bash-cmd-code"
+                />
             </div>
             <Show when={hasOutput}>
                 <pre class={clsx("agent-bash-output", { "has-error": hasError })}>

--- a/frontend/app/view/agent/components/DiffViewer.tsx
+++ b/frontend/app/view/agent/components/DiffViewer.tsx
@@ -77,7 +77,7 @@ export const DiffViewer = (props: DiffViewerProps): JSX.Element => {
         const lines = parseDiffLines(d);
         if (lines.length > CAP_LINES) return; // fall back to plain render
 
-        const key = `${fp}::${d.length}::${d.slice(0, 64)}`;
+        const key = `${fp}::${d}`;
         if (diffCache.has(key)) {
             setHighlightedHtml(diffCache.get(key)!);
             return;
@@ -196,9 +196,12 @@ export const DiffViewer = (props: DiffViewerProps): JSX.Element => {
             when={highlightedHtml() !== null}
             fallback={<PlainDiff />}
         >
-            <pre ref={preEl} class="agent-diff agent-diff--highlighted">
+            {/* Header lives outside the <pre> so that innerHTML = shikiHtml
+                does not overwrite it. The <pre> receives only Shiki content. */}
+            <div class="agent-diff agent-diff--highlighted">
                 <div class="agent-diff-header">{filePath()}</div>
-            </pre>
+                <pre ref={preEl} class="agent-diff-highlighted-body" />
+            </div>
         </Show>
     );
 };

--- a/frontend/app/view/agent/components/DiffViewer.tsx
+++ b/frontend/app/view/agent/components/DiffViewer.tsx
@@ -2,48 +2,204 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * DiffViewer - Displays unified diff format with syntax highlighting
+ * DiffViewer — unified-diff display with token-level syntax highlighting.
+ *
+ * Step 3 of SPEC_TOOL_OVERLAY_CODE_HIGHLIGHTING_2026_04_14.md.
+ *
+ * Rendering strategy:
+ *  1. Parse unified diff lines, classify each as add/del/hunk/ctx.
+ *  2. Reconstruct the "clean" source (stripped of +/-/space prefix) and pass
+ *     it through Shiki with a custom line transformer that re-injects the
+ *     diff CSS class on the Shiki-generated <span class="line"> element.
+ *  3. Inject the resulting HTML via innerHTML on the <pre> wrapper.
+ *  4. Falls back to the plain line-by-line render if Shiki fails or the
+ *     diff is too large.
+ *
+ * The `.agent-diff-add` / `-del` / `-hunk` / `-ctx` SCSS rules remain
+ * unchanged — they now target `.line.agent-diff-add` etc. in the Shiki
+ * output.
  */
 
-import { For, Show, type JSX } from "solid-js";
+import { createEffect, createSignal, onCleanup, Show, type JSX } from "solid-js";
+import { For } from "solid-js";
 import type { EditParams, EditResult } from "../types";
+import { detectLanguage } from "./detectLanguage";
+
+const ShikiTheme = "github-dark-high-contrast";
+
+let shikiModule: typeof import("shiki/bundle/web") | null = null;
+const getShiki = async () => {
+    if (!shikiModule) shikiModule = await import("shiki/bundle/web");
+    return shikiModule;
+};
+
+const CAP_LINES = 1500;
+
+// Cache keyed on (filePath, diffText) since diffs are immutable once rendered.
+const diffCache = new Map<string, string>();
+
+type LineType = "add" | "del" | "hunk" | "ctx";
+
+interface DiffLine {
+    type: LineType;
+    raw: string;   // original line including +/-/space prefix
+    body: string;  // line without the leading marker
+}
+
+function parseDiffLines(diff: string): DiffLine[] {
+    return diff.split("\n").map((raw) => {
+        if (raw.startsWith("+")) return { type: "add" as LineType, raw, body: raw.slice(1) };
+        if (raw.startsWith("-")) return { type: "del" as LineType, raw, body: raw.slice(1) };
+        if (raw.startsWith("@")) return { type: "hunk" as LineType, raw, body: raw };
+        return { type: "ctx" as LineType, raw, body: raw.startsWith(" ") ? raw.slice(1) : raw };
+    });
+}
 
 interface DiffViewerProps {
     params: EditParams;
     result?: EditResult;
 }
 
-export const DiffViewer = ({ params, result }: DiffViewerProps): JSX.Element => {
-    const diff = result?.diff;
+export const DiffViewer = (props: DiffViewerProps): JSX.Element => {
+    const diff = () => props.result?.diff;
+    const filePath = () => props.params.file_path ?? "";
 
-    if (!diff) {
+    // --- Highlighted path ---
+    const [highlightedHtml, setHighlightedHtml] = createSignal<string | null>(null);
+    let seq = 0;
+
+    createEffect(() => {
+        const d = diff();
+        const fp = filePath();
+        setHighlightedHtml(null);
+        if (!d) return;
+
+        const lines = parseDiffLines(d);
+        if (lines.length > CAP_LINES) return; // fall back to plain render
+
+        const key = `${fp}::${d.length}::${d.slice(0, 64)}`;
+        if (diffCache.has(key)) {
+            setHighlightedHtml(diffCache.get(key)!);
+            return;
+        }
+
+        const mySeq = ++seq;
+        let cancelled = false;
+        onCleanup(() => { cancelled = true; });
+
+        void (async () => {
+            try {
+                const { codeToHtml } = await getShiki();
+                if (cancelled || mySeq !== seq) return;
+
+                const lang = detectLanguage(fp);
+
+                // Build clean source (strip diff markers so Shiki sees valid code)
+                const cleanSource = lines.map((l) => l.body).join("\n");
+
+                // Shiki transformer: after each line is wrapped in <span class="line">,
+                // inject the diff CSS class based on the original line type.
+                const lineTypes = lines.map((l) => l.type);
+                let lineIdx = 0;
+                const transformer = {
+                    line(node: any) {
+                        const type = lineTypes[lineIdx++] ?? "ctx";
+                        const existing = (node.properties?.class ?? "") as string;
+                        node.properties = node.properties ?? {};
+                        node.properties.class = `${existing} agent-diff-${type}`.trim();
+                        // Re-insert the marker character as a non-highlighted prefix span
+                        if (type === "add" || type === "del") {
+                            const marker = type === "add" ? "+" : "-";
+                            node.children = [
+                                { type: "element", tagName: "span",
+                                  properties: { class: "agent-diff-marker" },
+                                  children: [{ type: "text", value: marker }] },
+                                ...node.children,
+                            ];
+                        } else if (type === "hunk") {
+                            // Hunk headers: re-render as plain text (grammar doesn't know @@ syntax)
+                            node.children = [
+                                { type: "element", tagName: "span",
+                                  properties: { class: "agent-diff-hunk-text" },
+                                  children: [{ type: "text", value: lines[lineIdx - 1]?.raw ?? "" }] },
+                            ];
+                        } else {
+                            // ctx: space prefix
+                            node.children = [
+                                { type: "element", tagName: "span",
+                                  properties: { class: "agent-diff-marker" },
+                                  children: [{ type: "text", value: " " }] },
+                                ...node.children,
+                            ];
+                        }
+                    },
+                };
+
+                const full = await codeToHtml(cleanSource, {
+                    lang: lang === "text" ? "plaintext" : lang,
+                    theme: ShikiTheme,
+                    transformers: [transformer],
+                });
+                if (cancelled || mySeq !== seq) return;
+
+                // Extract inner content of the <pre>
+                const preStart = full.indexOf("<pre");
+                const preOpen = full.indexOf(">", preStart);
+                const preEnd = full.lastIndexOf("</pre>");
+                const inner = preStart !== -1 && preOpen !== -1 && preEnd !== -1
+                    ? full.slice(preOpen + 1, preEnd)
+                    : full;
+
+                diffCache.set(key, inner);
+                setHighlightedHtml(inner);
+            } catch (e) {
+                // Fall through to plain render
+                console.warn("[DiffViewer] Shiki highlight failed", e);
+            }
+        })();
+    });
+
+    let preEl: HTMLPreElement | undefined;
+    createEffect(() => {
+        const h = highlightedHtml();
+        if (preEl && h !== null) preEl.innerHTML = h;
+    });
+
+    // --- No diff path ---
+    if (!diff()) {
         return (
             <pre class="agent-diff-empty">
                 No diff available
                 {"\n"}
-                File: {params.file_path}
+                File: {filePath()}
             </pre>
         );
     }
 
-    const lines = diff.split("\n");
+    // --- Plain fallback (shown until Shiki resolves, or permanently if Shiki fails) ---
+    const PlainDiff = () => {
+        const lines = parseDiffLines(diff()!);
+        return (
+            <pre class="agent-diff">
+                <div class="agent-diff-header">{filePath()}</div>
+                <For each={lines}>
+                    {(line) => (
+                        <div class={`agent-diff-${line.type}`}>{line.raw}</div>
+                    )}
+                </For>
+            </pre>
+        );
+    };
 
     return (
-        <pre class="agent-diff">
-            <div class="agent-diff-header">{params.file_path}</div>
-            <For each={lines}>
-                {(line) => {
-                    const cls = line.startsWith("+")
-                        ? "agent-diff-add"
-                        : line.startsWith("-")
-                          ? "agent-diff-del"
-                          : line.startsWith("@")
-                            ? "agent-diff-hunk"
-                            : "agent-diff-ctx";
-                    return <div class={cls}>{line}</div>;
-                }}
-            </For>
-        </pre>
+        <Show
+            when={highlightedHtml() !== null}
+            fallback={<PlainDiff />}
+        >
+            <pre ref={preEl} class="agent-diff agent-diff--highlighted">
+                <div class="agent-diff-header">{filePath()}</div>
+            </pre>
+        </Show>
     );
 };
 

--- a/frontend/app/view/agent/components/HighlightedCode.tsx
+++ b/frontend/app/view/agent/components/HighlightedCode.tsx
@@ -39,12 +39,12 @@ const CAP_BYTES = 200 * 1024; // 200 KB
 const CAP_LINES = 2000;
 
 // Module-level cache: ToolNode objects are immutable, so the same
-// (code, lang) pair always produces the same HTML. Key on the code
-// string itself since ToolNode isn't always available at call sites.
+// (code, lang) pair always produces the same HTML. Key on the full code +
+// lang string — no collision risk, and the code is already in memory.
 const highlightCache = new Map<string, string>();
 
 function cacheKey(code: string, lang: string): string {
-    return `${lang}:${code.length}:${code.slice(0, 64)}`;
+    return `${lang}:${code}`;
 }
 
 interface HighlightedCodeProps {

--- a/frontend/app/view/agent/components/HighlightedCode.tsx
+++ b/frontend/app/view/agent/components/HighlightedCode.tsx
@@ -1,0 +1,139 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * HighlightedCode — async Shiki syntax highlighting for tool overlay content.
+ *
+ * Renders a plain <pre> immediately (no layout shift) then swaps in the
+ * Shiki-generated HTML once the highlight resolves. Uses the same lazy-load
+ * pattern and theme as streamdown.tsx so the Shiki chunk is only fetched once
+ * across the whole app.
+ *
+ * Features:
+ *  - WeakMap-based per-node cache: re-hovering the same tool block is instant.
+ *  - Size cap: files > CAP_BYTES or > CAP_LINES skip highlighting (avoids
+ *    stalling the main thread on huge files).
+ *  - Sequence guard: stale async results are discarded if props changed.
+ *  - Error fallback: Shiki failures silently degrade to plaintext.
+ *
+ * Spec: specs/SPEC_TOOL_OVERLAY_CODE_HIGHLIGHTING_2026_04_14.md §4.1
+ */
+
+import { createEffect, createSignal, onCleanup, type JSX } from "solid-js";
+
+const ShikiTheme = "github-dark-high-contrast";
+
+// Lazy-load shiki — same singleton as streamdown.tsx so the chunk is
+// only fetched once per app session.
+let shikiModule: typeof import("shiki/bundle/web") | null = null;
+const getShiki = async () => {
+    if (!shikiModule) {
+        shikiModule = await import("shiki/bundle/web");
+    }
+    return shikiModule;
+};
+
+// Size caps — skip highlighting for very large content to avoid blocking
+// the main thread.
+const CAP_BYTES = 200 * 1024; // 200 KB
+const CAP_LINES = 2000;
+
+// Module-level cache: ToolNode objects are immutable, so the same
+// (code, lang) pair always produces the same HTML. Key on the code
+// string itself since ToolNode isn't always available at call sites.
+const highlightCache = new Map<string, string>();
+
+function cacheKey(code: string, lang: string): string {
+    return `${lang}:${code.length}:${code.slice(0, 64)}`;
+}
+
+interface HighlightedCodeProps {
+    code: string;
+    /** Shiki language id — "text" for plain. Falls back to plaintext on failure. */
+    lang: string;
+    /** Extra CSS class applied to the outer <pre>. */
+    class?: string;
+}
+
+export const HighlightedCode = (props: HighlightedCodeProps): JSX.Element => {
+    const [html, setHtml] = createSignal<string | null>(null);
+    let seq = 0;
+    let preEl: HTMLPreElement | undefined;
+
+    createEffect(() => {
+        const code = props.code;
+        const lang = props.lang;
+
+        // Reset to plaintext while the new highlight computes
+        setHtml(null);
+
+        // Trivial: plain text or empty
+        if (!code || lang === "text") return;
+
+        // Size cap
+        if (code.length > CAP_BYTES || code.split("\n").length > CAP_LINES) {
+            console.debug(`[HighlightedCode] skipping highlight: file too large (${code.length} bytes)`);
+            return;
+        }
+
+        // Cache hit — apply synchronously
+        const key = cacheKey(code, lang);
+        if (highlightCache.has(key)) {
+            setHtml(highlightCache.get(key)!);
+            return;
+        }
+
+        // Async highlight
+        const mySeq = ++seq;
+        let cancelled = false;
+        onCleanup(() => { cancelled = true; });
+
+        void (async () => {
+            try {
+                const { codeToHtml } = await getShiki();
+                if (cancelled || mySeq !== seq) return;
+                const full = await codeToHtml(code, { lang, theme: ShikiTheme });
+                if (cancelled || mySeq !== seq) return;
+                // Shiki wraps output in <pre><code>...</code></pre>; we only
+                // want the inner HTML of the <pre> so our own <pre> wrapper
+                // gets the Shiki token spans without the outer element.
+                const preStart = full.indexOf("<pre");
+                const preOpen = full.indexOf(">", preStart);
+                const preEnd = full.lastIndexOf("</pre>");
+                const inner = preStart !== -1 && preOpen !== -1 && preEnd !== -1
+                    ? full.slice(preOpen + 1, preEnd)
+                    : full;
+                highlightCache.set(key, inner);
+                setHtml(inner);
+            } catch (e) {
+                if (!cancelled && mySeq === seq) {
+                    // Stay on plaintext fallback; don't retry
+                    console.warn(`[HighlightedCode] Shiki failed for lang=${lang}`, e);
+                }
+            }
+        })();
+    });
+
+    // When html() is set, inject it via innerHTML. Shiki output is sanitised
+    // (only <span> elements with class/style attributes), so this is safe.
+    createEffect(() => {
+        const h = html();
+        if (preEl && h !== null) {
+            preEl.innerHTML = h;
+        } else if (preEl && h === null) {
+            // Reset to text content (plaintext fallback while loading)
+            preEl.textContent = props.code;
+        }
+    });
+
+    return (
+        <pre
+            ref={preEl}
+            class={`agent-highlighted-code${props.class ? ` ${props.class}` : ""}`}
+        >
+            {props.code}
+        </pre>
+    );
+};
+
+HighlightedCode.displayName = "HighlightedCode";

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -44,6 +44,8 @@ import type { ToolNode } from "../types";
 import { BashOutputViewer } from "./BashOutputViewer";
 import { CompactResult } from "./CompactResult";
 import { DiffViewer } from "./DiffViewer";
+import { HighlightedCode } from "./HighlightedCode";
+import { detectLanguage } from "./detectLanguage";
 
 interface ToolBlockProps {
     node: ToolNode;
@@ -206,19 +208,29 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
             case "Bash":
                 return <BashOutputViewer params={node.params as any} result={node.result as any} />;
 
-            case "Read":
+            case "Read": {
+                const filePath = (node.params as any).file_path ?? "";
+                const content: string | undefined = (node.result as any)?.content;
                 return (
                     <div class="agent-tool-read">
-                        <div class="agent-tool-file-path">{(node.params as any).file_path}</div>
-                        <Show when={node.result}>
-                            {(node.result as any).content ? (
-                                <pre class="agent-tool-read-content">{(node.result as any).content}</pre>
-                            ) : (
-                                <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
-                            )}
+                        <div class="agent-tool-file-path">{filePath}</div>
+                        <Show
+                            when={content}
+                            fallback={
+                                <Show when={node.result}>
+                                    <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
+                                </Show>
+                            }
+                        >
+                            <HighlightedCode
+                                code={content!}
+                                lang={detectLanguage(filePath, content!.split("\n")[0])}
+                                class="agent-tool-read-content"
+                            />
                         </Show>
                     </div>
                 );
+            }
 
             case "Write":
                 return (

--- a/frontend/app/view/agent/components/detectLanguage.test.ts
+++ b/frontend/app/view/agent/components/detectLanguage.test.ts
@@ -1,0 +1,63 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { detectLanguage } from "./detectLanguage";
+
+describe("detectLanguage", () => {
+    // Extension map
+    it("maps .ts to typescript", () => expect(detectLanguage("foo.ts")).toBe("typescript"));
+    it("maps .tsx to tsx", () => expect(detectLanguage("foo.tsx")).toBe("tsx"));
+    it("maps .js to javascript", () => expect(detectLanguage("foo.js")).toBe("javascript"));
+    it("maps .jsx to jsx", () => expect(detectLanguage("foo.jsx")).toBe("jsx"));
+    it("maps .py to python", () => expect(detectLanguage("foo.py")).toBe("python"));
+    it("maps .rs to rust", () => expect(detectLanguage("foo.rs")).toBe("rust"));
+    it("maps .go to go", () => expect(detectLanguage("foo.go")).toBe("go"));
+    it("maps .sh to bash", () => expect(detectLanguage("foo.sh")).toBe("bash"));
+    it("maps .ps1 to powershell", () => expect(detectLanguage("foo.ps1")).toBe("powershell"));
+    it("maps .json to json", () => expect(detectLanguage("foo.json")).toBe("json"));
+    it("maps .yaml to yaml", () => expect(detectLanguage("foo.yaml")).toBe("yaml"));
+    it("maps .yml to yaml", () => expect(detectLanguage("foo.yml")).toBe("yaml"));
+    it("maps .toml to toml", () => expect(detectLanguage("foo.toml")).toBe("toml"));
+    it("maps .scss to scss", () => expect(detectLanguage("foo.scss")).toBe("scss"));
+    it("maps .css to css", () => expect(detectLanguage("foo.css")).toBe("css"));
+    it("maps .sql to sql", () => expect(detectLanguage("foo.sql")).toBe("sql"));
+    it("maps .md to markdown", () => expect(detectLanguage("foo.md")).toBe("markdown"));
+    it("maps .tf to terraform", () => expect(detectLanguage("foo.tf")).toBe("terraform"));
+    it("maps .graphql to graphql", () => expect(detectLanguage("foo.graphql")).toBe("graphql"));
+
+    // Absolute paths — extension still wins
+    it("handles absolute paths", () =>
+        expect(detectLanguage("/home/user/project/src/main.rs")).toBe("rust"));
+    it("handles Windows paths", () =>
+        expect(detectLanguage("C:\\Users\\dev\\app\\index.ts")).toBe("typescript"));
+
+    // Basename matches
+    it("maps Dockerfile to dockerfile", () => expect(detectLanguage("Dockerfile")).toBe("dockerfile"));
+    it("maps dockerfile (lowercase) to dockerfile", () =>
+        expect(detectLanguage("/app/dockerfile")).toBe("dockerfile"));
+    it("maps Makefile to makefile", () => expect(detectLanguage("Makefile")).toBe("makefile"));
+    it("maps .gitignore to ignore", () => expect(detectLanguage(".gitignore")).toBe("ignore"));
+    it("maps .env to bash", () => expect(detectLanguage(".env")).toBe("bash"));
+    it("maps .env.local to bash", () => expect(detectLanguage(".env.local")).toBe("bash"));
+
+    // Shebang detection
+    it("detects python3 shebang", () =>
+        expect(detectLanguage("script", "#!/usr/bin/env python3")).toBe("python"));
+    it("detects bash shebang", () =>
+        expect(detectLanguage("myscript", "#!/bin/bash")).toBe("bash"));
+    it("detects /bin/sh shebang", () =>
+        expect(detectLanguage("myscript", "#!/bin/sh")).toBe("bash"));
+    it("detects node shebang", () =>
+        expect(detectLanguage("script", "#!/usr/bin/env node")).toBe("javascript"));
+    it("detects ruby shebang", () =>
+        expect(detectLanguage("script", "#!/usr/bin/ruby")).toBe("ruby"));
+
+    // Fallback
+    it("returns text for unknown extension", () =>
+        expect(detectLanguage("foo.unknown")).toBe("text"));
+    it("returns text for no extension", () =>
+        expect(detectLanguage("somefile")).toBe("text"));
+    it("returns text for empty string", () =>
+        expect(detectLanguage("")).toBe("text"));
+});

--- a/frontend/app/view/agent/components/detectLanguage.ts
+++ b/frontend/app/view/agent/components/detectLanguage.ts
@@ -1,0 +1,181 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Map a file path (absolute or relative) or a raw first-line shebang to a
+ * Shiki language id. Returns "text" for unknown inputs so callers can always
+ * route through HighlightedCode without branching.
+ *
+ * Detection order (first hit wins):
+ *   1. Extension map  — covers the common programmer file types
+ *   2. Basename match — Dockerfile, Makefile, .gitignore, .env*
+ *   3. Shebang scan   — #!/usr/bin/env python3, #!/bin/bash, etc.
+ *   4. Fallback       — "text"
+ *
+ * Spec: specs/SPEC_TOOL_OVERLAY_CODE_HIGHLIGHTING_2026_04_14.md §4.2
+ */
+
+const EXT_MAP: Record<string, string> = {
+    // TypeScript / JavaScript
+    ts: "typescript",
+    tsx: "tsx",
+    js: "javascript",
+    jsx: "jsx",
+    mjs: "javascript",
+    cjs: "javascript",
+    // Python
+    py: "python",
+    pyw: "python",
+    // Rust
+    rs: "rust",
+    // Go
+    go: "go",
+    // Shell
+    sh: "bash",
+    bash: "bash",
+    zsh: "bash",
+    fish: "fish",
+    ps1: "powershell",
+    psm1: "powershell",
+    // Markup / config
+    md: "markdown",
+    mdx: "markdown",
+    json: "json",
+    jsonc: "jsonc",
+    yaml: "yaml",
+    yml: "yaml",
+    toml: "toml",
+    xml: "xml",
+    html: "html",
+    htm: "html",
+    // CSS
+    css: "css",
+    scss: "scss",
+    sass: "scss",
+    less: "less",
+    // SQL
+    sql: "sql",
+    // Ruby
+    rb: "ruby",
+    // Java / JVM
+    java: "java",
+    kt: "kotlin",
+    kts: "kotlin",
+    // Swift
+    swift: "swift",
+    // C / C++
+    c: "c",
+    h: "c",
+    cpp: "cpp",
+    cxx: "cpp",
+    cc: "cpp",
+    hpp: "cpp",
+    hxx: "cpp",
+    // C#
+    cs: "csharp",
+    // PHP
+    php: "php",
+    // Lua
+    lua: "lua",
+    // Web frameworks
+    vue: "vue",
+    svelte: "svelte",
+    // Infrastructure
+    tf: "terraform",
+    hcl: "hcl",
+    graphql: "graphql",
+    gql: "graphql",
+    // Other
+    r: "r",
+    dart: "dart",
+    ex: "elixir",
+    exs: "elixir",
+    elm: "elm",
+    hs: "haskell",
+    clj: "clojure",
+    cljs: "clojure",
+    scala: "scala",
+    groovy: "groovy",
+    pl: "perl",
+    dockerfile: "dockerfile",
+    lock: "text",
+    log: "text",
+};
+
+/** Exact basename matches (case-insensitive). */
+const BASENAME_MAP: Record<string, string> = {
+    dockerfile: "dockerfile",
+    makefile: "makefile",
+    gnumakefile: "makefile",
+    rakefile: "ruby",
+    gemfile: "ruby",
+    podfile: "ruby",
+    vagrantfile: "ruby",
+    ".gitignore": "ignore",
+    ".npmignore": "ignore",
+    ".dockerignore": "ignore",
+    ".gitattributes": "ini",
+    ".editorconfig": "ini",
+    ".babelrc": "json",
+    ".eslintrc": "json",
+    ".prettierrc": "json",
+};
+
+/** Map shebang interpreter names to Shiki lang ids. */
+const SHEBANG_MAP: Record<string, string> = {
+    python: "python",
+    python3: "python",
+    python2: "python",
+    node: "javascript",
+    nodejs: "javascript",
+    bash: "bash",
+    sh: "bash",
+    zsh: "bash",
+    fish: "fish",
+    ruby: "ruby",
+    perl: "perl",
+    php: "php",
+    lua: "lua",
+    "deno": "typescript",
+};
+
+/**
+ * Detect language from a file path. Pass the full content to enable
+ * shebang detection for extension-less files.
+ */
+export function detectLanguage(filePath: string, firstLine?: string): string {
+    const base = filePath.split(/[\\/]/).pop() ?? filePath;
+
+    // 1. Extension map
+    const dotIdx = base.lastIndexOf(".");
+    if (dotIdx > 0) {
+        const ext = base.slice(dotIdx + 1).toLowerCase();
+        if (EXT_MAP[ext]) return EXT_MAP[ext];
+    }
+
+    // 2. Basename match (case-insensitive)
+    const baseLower = base.toLowerCase();
+    if (BASENAME_MAP[baseLower]) return BASENAME_MAP[baseLower];
+
+    // Handle .env, .env.local, .env.production etc.
+    if (baseLower === ".env" || baseLower.startsWith(".env.")) return "bash";
+
+    // 3. Shebang scan
+    if (firstLine?.startsWith("#!")) {
+        // #!/usr/bin/env python3  or  #!/bin/bash
+        const parts = firstLine.replace(/^#!\s*/, "").split(/\s+/);
+        // Last segment of the path is the interpreter name (e.g. "python3" from "/usr/bin/env python3")
+        const interp = (parts[0].includes("/") ? parts[0].split("/").pop() : parts[0]) ?? "";
+        const interpLower = interp.toLowerCase().replace(/\d+$/, ""); // strip trailing version
+        if (SHEBANG_MAP[interp.toLowerCase()]) return SHEBANG_MAP[interp.toLowerCase()];
+        if (SHEBANG_MAP[interpLower]) return SHEBANG_MAP[interpLower];
+        // env-style: #!/usr/bin/env python3
+        if (parts.length > 1) {
+            const envInterp = parts[1].toLowerCase().replace(/\d+$/, "");
+            if (SHEBANG_MAP[parts[1].toLowerCase()]) return SHEBANG_MAP[parts[1].toLowerCase()];
+            if (SHEBANG_MAP[envInterp]) return SHEBANG_MAP[envInterp];
+        }
+    }
+
+    return "text";
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.160",
+  "version": "0.33.161",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.161",
+  "version": "0.33.162",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Implements all 5 steps of `specs/SPEC_TOOL_OVERLAY_CODE_HIGHLIGHTING_2026_04_14.md`.
Zero new dependencies — uses the Shiki instance already lazy-loaded by `streamdown.tsx`.

- **`detectLanguage.ts`** — maps file paths to Shiki language IDs via extension map (40+ types), basename matches (Dockerfile, Makefile, .env\*), and shebang detection. 35-case unit test, all green.
- **`HighlightedCode.tsx`** — async Shiki component. Renders plaintext immediately, swaps to highlighted HTML once Shiki resolves. Module-level Map cache: re-hovering the same tool block is instant. Size caps (200 KB / 2000 lines) degrade to plaintext. Sequence guard drops stale async results.
- **`ToolBlock` Read case** — `HighlightedCode` replaces the plain `<pre>`. Language detected from file extension + optional shebang on first line.
- **`DiffViewer`** — custom Shiki line transformer strips `+`/`-`/` ` prefix before highlighting, injects `agent-diff-add/del/hunk/ctx` class on the `<span class="line">` element, re-inserts marker as a non-highlighted prefix span. Plain-diff render stays as the immediate fallback until Shiki resolves.
- **`BashOutputViewer`** — `params.command` → `HighlightedCode lang="bash"`. Output stays plaintext.
- **SCSS** — `.agent-highlighted-code` base (font-family, `.line { display: block }`), diff highlighted variant (bg override behind token colours), bash cmd flex row, read-content bg guard.

## Test plan

- [ ] Hover a `Read` tool block on a `.ts` file — keywords, strings, comments are coloured
- [ ] Hover an `Edit` diff — add lines green bg + token colours, del lines red bg + token colours, hunk headers blue
- [ ] Hover a `Bash` tool — command is bash-highlighted, output is plaintext
- [ ] Re-hover the same block — instant (no Shiki re-run)
- [ ] Unknown extension (`.xyz`) — renders as plaintext, no crash
- [ ] `tsc --noEmit` clean; 171/171 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)