### PR TITLE
feat(identity): Step 4 — agent-owned account refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.163"
+version = "0.33.164"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.163"
+version = "0.33.164"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.163"
+version = "0.33.164"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.163"
+version = "0.33.164"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -2782,9 +2782,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,8 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.163 | 2026-04-14 | 155.9 MiB | 323.7 MiB | |
+| 0.33.155 | 2026-04-14 | 155.0 MiB | 318.8 MiB | |
 | 0.33.145 | 2026-04-14 | 155.0 MiB | 318.8 MiB | |
 | 0.33.142 | 2026-04-14 | 155.0 MiB | 318.8 MiB | |
 | 0.33.122 | 2026-04-13 | 155.5 MiB | 319.9 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.163"
+version = "0.33.164"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.163"
+version = "0.33.164"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.163"
+version = "0.33.164"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.163"
+version = "0.33.164"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/forge_seed.rs
+++ b/agentmux-srv/src/backend/forge_seed.rs
@@ -139,6 +139,7 @@ pub fn seed_forge_agents(wstore: &Arc<WaveStore>) -> Result<SeedReport, StoreErr
             environment: agent_def.environment.clone(),
             agent_bus_id: agent_def.agent_bus_id.clone(),
             is_seeded: 1,
+            accounts: String::new(),
         };
         wstore.forge_insert(&mut agent)?;
 
@@ -307,6 +308,7 @@ fn reseed_if_needed(
             environment: agent_def.environment.clone(),
             agent_bus_id: agent_def.agent_bus_id.clone(),
             is_seeded: 1,
+            accounts: String::new(),
         };
 
         if existing_map.contains_key(agent_def.id.as_str()) {

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -1076,6 +1076,9 @@ pub struct CommandUpdateForgeAgentData {
     pub environment: String,
     #[serde(default)]
     pub agent_bus_id: String,
+    /// JSON-encoded per-provider account refs (see ForgeAgent.accounts).
+    #[serde(default)]
+    pub accounts: String,
 }
 
 /// Input for deleteforgeagent

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -78,6 +78,7 @@ pub fn run_forge_migrations(conn: &Connection) -> Result<(), StoreError> {
     run_forge_v2_migrations(conn)?;
     run_forge_v3_migrations(conn)?;
     run_forge_v4_migrations(conn)?;
+    run_forge_v5_migrations(conn)?;
     Ok(())
 }
 
@@ -261,6 +262,32 @@ pub fn run_forge_v4_migrations(conn: &Connection) -> Result<(), StoreError> {
              ON db_forge_agents(slug)",
     )?;
 
+    Ok(())
+}
+
+/// Forge v5 migrations: add `accounts` column — JSON-encoded per-provider
+/// account references owned by each agent.
+/// Shape: `{"github":"acct-id"|null,"aws":"acct-id"|null,...}`
+/// Empty string = no accounts assigned. Existing rows default to ''.
+///
+/// See SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md §3.3.
+pub fn run_forge_v5_migrations(conn: &Connection) -> Result<(), StoreError> {
+    match conn.execute_batch(
+        "ALTER TABLE db_forge_agents ADD COLUMN accounts TEXT NOT NULL DEFAULT ''",
+    ) {
+        Ok(_) => {}
+        Err(e) => {
+            let msg = e.to_string();
+            if !msg.contains("duplicate column") {
+                return Err(StoreError::Sqlite(match e {
+                    rusqlite::Error::SqliteFailure(code, _) => {
+                        rusqlite::Error::SqliteFailure(code, Some(msg))
+                    }
+                    other => other,
+                }));
+            }
+        }
+    }
     Ok(())
 }
 

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -432,6 +432,12 @@ pub struct ForgeAgent {
     pub agent_bus_id: String,
     #[serde(default)]
     pub is_seeded: i64,
+    /// JSON-encoded per-provider account references.
+    /// Shape: `{"github":"acct-id"|null,"aws":"acct-id"|null,...}`
+    /// Null or missing provider key = no account assigned for that provider.
+    /// See SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md §3.3.
+    #[serde(default)]
+    pub accounts: String,
 }
 
 /// Derive a filesystem-safe slug from a display name. Lowercase,
@@ -506,7 +512,7 @@ impl WaveStore {
         let mut stmt = conn.prepare(
             "SELECT id, slug, name, icon, provider, description, working_directory, shell,
                     provider_flags, auto_start, restart_on_crash, idle_timeout_minutes, created_at,
-                    agent_type, environment, agent_bus_id, is_seeded
+                    agent_type, environment, agent_bus_id, is_seeded, accounts
              FROM db_forge_agents ORDER BY created_at ASC",
         )?;
         let rows = stmt.query_map([], |row| {
@@ -528,6 +534,7 @@ impl WaveStore {
                 environment: row.get(14)?,
                 agent_bus_id: row.get(15)?,
                 is_seeded: row.get(16)?,
+                accounts: row.get(17)?,
             })
         })?;
         let mut agents = Vec::new();
@@ -592,8 +599,9 @@ impl WaveStore {
         conn.execute(
             "INSERT INTO db_forge_agents (id, slug, name, icon, provider, description,
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
-             idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id, is_seeded)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
+             idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
+             is_seeded, accounts)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
             params![
                 agent.id,
                 agent.slug,
@@ -611,7 +619,8 @@ impl WaveStore {
                 agent.agent_type,
                 agent.environment,
                 agent.agent_bus_id,
-                agent.is_seeded
+                agent.is_seeded,
+                agent.accounts
             ],
         )?;
         Ok(())
@@ -624,8 +633,8 @@ impl WaveStore {
             "UPDATE db_forge_agents SET name=?1, icon=?2, provider=?3, description=?4,
              working_directory=?5, shell=?6, provider_flags=?7, auto_start=?8,
              restart_on_crash=?9, idle_timeout_minutes=?10,
-             agent_type=?11, environment=?12, agent_bus_id=?13
-             WHERE id=?14",
+             agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14
+             WHERE id=?15",
             params![
                 agent.name,
                 agent.icon,
@@ -640,6 +649,7 @@ impl WaveStore {
                 agent.agent_type,
                 agent.environment,
                 agent.agent_bus_id,
+                agent.accounts,
                 agent.id
             ],
         )?;

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -126,7 +126,12 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     environment: cmd.environment,
                     agent_bus_id: cmd.agent_bus_id,
                     is_seeded: old.is_seeded,
-                    accounts: cmd.accounts,
+                    // Preserve existing accounts when the caller omits the field
+                    // (cmd.accounts defaults to "" via #[serde(default)]). Callers
+                    // that only update name/icon/etc. (ForgeForm, AgentPicker rename)
+                    // don't carry accounts, so falling back to old.accounts prevents
+                    // silently wiping saved assignments.
+                    accounts: if cmd.accounts.is_empty() { old.accounts.clone() } else { cmd.accounts },
                 };
                 let found = wstore.forge_update(&agent).map_err(|e| format!("updateforgeagent: {e}"))?;
                 if !found {

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -75,6 +75,7 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     environment: cmd.environment,
                     agent_bus_id: cmd.agent_bus_id,
                     is_seeded: 0,
+                    accounts: String::new(),
                 };
                 wstore.forge_insert(&mut agent).map_err(|e| format!("createforgeagent: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
@@ -125,6 +126,7 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     environment: cmd.environment,
                     agent_bus_id: cmd.agent_bus_id,
                     is_seeded: old.is_seeded,
+                    accounts: cmd.accounts,
                 };
                 let found = wstore.forge_update(&agent).map_err(|e| format!("updateforgeagent: {e}"))?;
                 if !found {
@@ -473,6 +475,7 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     environment: String::new(),
                     agent_bus_id: String::new(),
                     is_seeded: 0,
+                    accounts: String::new(),
                 };
                 wstore.forge_insert(&mut agent).map_err(|e| format!("importforgefromclaw: {e}"))?;
 

--- a/docs/analysis/agentx-git-identity-2026-04-14.md
+++ b/docs/analysis/agentx-git-identity-2026-04-14.md
@@ -1,0 +1,317 @@
+# Report: AgentX in AgentMux reports "no git identity" — root cause and claw bridge fix
+
+**Date:** 2026-04-14
+**Severity:** Startup warning — every AgentX pane launch shows it; blocks
+commits from inside the agent
+**Affected:** `agentmux-srv/forge-seed.json`, AgentX environment on this
+machine, the bridge between AgentMux's forge agent store and claw
+
+---
+
+## 1. Symptom
+
+Launching the AgentX forge agent from the AgentMux agent picker:
+
+1. AgentMux spawns Claude Code in a new pane with
+   `working_directory = ~/.agentmux/agents/agentx`.
+2. Claude Code's startup output includes:
+   ```
+   ⚠ No git identity configured. Set user.name and user.email
+     with `git config --global ...` to enable commits.
+   ```
+3. Any tool call that touches git (`Bash git commit …`) fails because
+   the host has no `user.name` / `user.email`.
+
+This is **not** AgentMux's message — a `grep -r "no git identity"`
+across `frontend/` and `agentmux-srv/src/` returns zero hits. The
+warning is produced by Claude Code itself on startup when the working
+directory is inside a git repo (or has a git parent) and no
+`user.name`/`user.email` can be resolved.
+
+---
+
+## 2. Root cause — two stacked problems
+
+### 2a. This host has no global git identity
+
+```bash
+$ git config --global --get user.name
+(empty)
+$ git config --global --get user.email
+(empty)
+```
+
+Every terminal / agent / task started by the current user inherits
+that empty state. On a fresh Windows dev machine this is normal —
+the user hasn't run `git config --global user.name "..."` yet. Claude
+Code flags it because every edit-then-commit workflow would silently
+fail.
+
+### 2b. AgentMux runs AgentX in the wrong directory
+
+`agentmux-srv/forge-seed.json:12` sets:
+
+```json
+"working_directory": "~/.agentmux/agents/agentx"
+```
+
+On this machine that directory exists but contains only:
+
+```
+~/.agentmux/agents/agentx/
+├── .mcp.json
+├── ~/
+└── specs/
+```
+
+**No `.git`, no CLAUDE.md, no repo state.** Meanwhile, the claw
+deployment has already built the real AgentX workspace elsewhere:
+
+```
+~/.claw/agentx-workspace/
+└── CLAUDE.md       ← the 'managed by claw' agent-identity doc
+```
+
+— and that's where claw expects AgentX to run (see
+`a5af/claw:templates/host/CLAUDE.md` which reads
+`You are **{{AGENT_DISPLAY}}**, running from ~/.claw/{{WORKSPACE}}`).
+
+So AgentMux launches AgentX in an empty parking-lot directory that
+has nothing to do with claw. Even if the user fixes the global git
+identity, AgentX would still be operating from the wrong workspace —
+no CLAUDE.md, no skills, no claw deployment state, no ability to run
+`claw deploy`.
+
+### 2c. Why the warning is structural, not incidental
+
+Even with git identity fixed, the `~/.agentmux/agents/agentx/` path is
+technically a subdirectory of `$HOME` — a non-git directory. Claude's
+startup check walks up looking for a `.git` and finds none until it
+hits a much higher ancestor (or the filesystem root, or whatever `$HOME`
+happens to be part of). Depending on the walk, it may still warn about
+missing identity because the closest useful git scope is absent.
+
+The correct workspace — `~/.claw/agentx-workspace/` — is *also* not a
+git repo (verified: `git config --get user.name` returns empty there
+too). Claw's host template doesn't git-init the workspace. So moving
+the working dir alone doesn't silence the warning; the global git
+config still has to be right.
+
+---
+
+## 3. What claw *does* set up (and for whom)
+
+Searching `a5af/claw` for `user.name` / `user.email`:
+
+| Script | Target | Sets |
+|---|---|---|
+| `docker/lib/github-auth.sh:63` | **container** agents (agent1-5) via GitHub Apps | `user.name = ${agent}-workflow[bot]`, `user.email = <app-id>+${agent}-workflow[bot]@users.noreply.github.com` |
+| `docker/lib/github-auth.sh:67` | **container** agents via PAT fallback | `user.name = ${Agent^}-asaf` (e.g. `Agent1-asaf`), `user.email = ${agent}@asaf.cc` |
+
+**Host agents (AgentX, AgentY) have no claw-side git identity setup.**
+The host templates under `templates/host/` include `CLAUDE.md`,
+`STARTUP_PROMPT.md`, and `.mcp.json.template`, but nothing that runs
+`git config`. Host agents inherit the user's global git identity —
+which, on this machine, doesn't exist yet.
+
+This is a gap on the claw side too, but fixing AgentMux to bridge
+properly is the more urgent move because AgentMux already has a seed
+manifest with a `working_directory` field that simply points at the
+wrong place.
+
+---
+
+## 4. Fix — three layers
+
+### Layer 1 (immediate, ~30 sec) — set the global git identity
+
+On this host, run once:
+
+```powershell
+git config --global user.name "AgentX-asaf"
+git config --global user.email "agentx@asaf.cc"
+```
+
+Mirrors claw's container-PAT naming (`Agent1-asaf`, `agent1@asaf.cc`).
+Claude Code's startup warning goes away immediately. Every pane
+launched afterwards — AgentMux's forge agents, hand-started Claude,
+gh CLI — now has a valid commit identity.
+
+**Caveat:** host AgentX and host AgentY will both commit under
+`AgentX-asaf` unless AgentY's working directory carries a local
+`.git/config` override. For a solo dev that's fine. For the multi-host
+setup claw envisions, each host agent should have its own local git
+config inside its workspace (see Layer 3).
+
+### Layer 2 (short — point AgentMux at the right workspace, ~1h)
+
+Update `agentmux-srv/forge-seed.json` to use claw's workspace paths
+for host agents:
+
+```json
+{
+  "id": "agentx",
+  "name": "AgentX",
+  ...
+  "working_directory": "~/.claw/agentx-workspace",
+  ...
+},
+{
+  "id": "agenty",
+  "name": "AgentY",
+  ...
+  "working_directory": "~/.claw/agenty-workspace",
+  ...
+}
+```
+
+Then:
+
+- AgentX boots inside `~/.claw/agentx-workspace/` and immediately
+  sees claw's managed `CLAUDE.md` with the correct agent identity
+  prompt.
+- Any `claw deploy` / `claw status` invocation from inside the pane
+  runs from the directory claw expects.
+- Skills, secrets, and context files that claw lays down land in a
+  directory the agent is actually in.
+
+**Compatibility note:** this only works for machines where the user
+has already run claw's `bootstrap.ps1` and deployed the agentx
+workspace. On a machine without claw, `~/.claw/agentx-workspace/`
+doesn't exist and Claude Code starts in `$HOME` as fallback. The
+fix for that is in Layer 3 — AgentMux should detect claw and offer
+to bootstrap it.
+
+### Layer 3 (medium — AgentMux ↔ claw bridge, ~4-6h)
+
+Wire a formal bridge so AgentMux stops embedding duplicate agent
+definitions and defers to claw as the system of record for host
+agents. Possible shape:
+
+1. **New module:** `agentmux-srv/src/backend/claw_bridge.rs`
+   - Detects whether claw is installed: check for `~/.claw/claw.ps1`
+     or `~/.claw/manifest.json`.
+   - Reads claw's `~/.claw/manifest.json` to enumerate configured
+     host agents (AgentX, AgentY, …) and their workspace paths.
+   - On first run, if claw is present but the forge store has stale
+     `agentx`/`agenty` entries pointing at `~/.agentmux/agents/...`,
+     migrate them to point at the claw paths.
+
+2. **Forge seed change:** mark host agents as "provided by claw"
+   instead of hardcoding their working_directory. When claw is
+   present, the agent picker shows "(claw)" next to the name. When
+   not, they're hidden OR shown as "install claw to enable."
+
+3. **Git identity probe:** when launching a host agent, run a
+   pre-flight `git config --global user.name` + `user.email` check.
+   If missing, pop a dialog offering to set them to the claw default
+   pattern (`AgentX-asaf` / `agentx@asaf.cc`). User confirms once;
+   AgentMux runs the `git config --global` calls.
+
+4. **Per-workspace override:** for AgentY, also write
+   `~/.claw/agenty-workspace/.git/config` (if the workspace is a git
+   repo) with `user.name = AgentY-asaf` / `user.email = agenty@asaf.cc`
+   so commits from that pane attribute correctly even though the
+   global is AgentX-asaf.
+
+None of step 3 or 4 is needed for Layer 1 to work — they're a polish
+pass once the basic bridge is in place.
+
+---
+
+## 5. Proposed commit — smallest viable fix (Layer 1 + 2)
+
+Two changes, one PR:
+
+**`agentmux-srv/forge-seed.json`** — swap the two host agent
+working_directory fields:
+
+```diff
+-      "working_directory": "~/.agentmux/agents/agentx",
++      "working_directory": "~/.claw/agentx-workspace",
+```
+
+```diff
+-      "working_directory": "~/.agentmux/agents/agenty",
++      "working_directory": "~/.claw/agenty-workspace",
+```
+
+**Release note / README update** — add to `CLAUDE.md` or `BUILD.md`:
+
+```markdown
+## Host agent prerequisites
+
+AgentX and AgentY are host-side forge agents that expect their
+workspaces to exist under `~/.claw/`. Before launching them from
+the AgentMux agent picker:
+
+1. Install claw (one-liner from
+   https://github.com/a5af/claw/blob/main/bootstrap.ps1):
+   ```powershell
+   irm https://raw.githubusercontent.com/a5af/claw/main/bootstrap.ps1 | iex
+   ```
+2. Deploy the host workspaces:
+   ```powershell
+   claw deploy agentx-workspace
+   claw deploy agenty-workspace
+   ```
+3. Set git identity once (claw naming convention):
+   ```powershell
+   git config --global user.name "AgentX-asaf"
+   git config --global user.email "agentx@asaf.cc"
+   ```
+
+On machines without claw installed, host forge agents will still
+launch but will operate from `$HOME` and commits will fail until
+git identity is configured.
+```
+
+**No migration needed.** The existing `~/.agentmux/agents/agentx/`
+directory is essentially empty on real machines and can be left
+alone as a safe fallback path. If a migration is desired, it's a
+single `mv` on the backend during seeding.
+
+**Risk:** low. Users without claw see the same "no workspace" state
+they do today, just under a different path. Users with claw
+immediately get the right workspace.
+
+---
+
+## 6. Open questions
+
+1. **Should AgentMux ship a `claw install` wizard?** When a host
+   agent is launched on a machine without claw, should the forge
+   picker offer to run `bootstrap.ps1` instead of falling through to
+   `$HOME`? — Leaning yes but as a follow-up. The Layer 1+2 change
+   doesn't need it.
+2. **Should the git identity probe on launch be blocking or
+   advisory?** If AgentMux detects missing identity and pops a
+   dialog, does it block launch until resolved or just warn and
+   continue? — Advisory. Blocking would make the agent unusable for
+   users who don't care about commits from that pane.
+3. **Does claw want its host agents git-init'd during deploy?**
+   i.e. should `claw deploy agentx-workspace` run `git init` in
+   `~/.claw/agentx-workspace` and set a local `user.name`/`user.email`?
+   That would make the "no git identity" warning go away without
+   touching the user's global config. — Worth raising on the claw
+   side as a separate issue. Out of scope here.
+4. **Where does AgentZ (Gemini host) fit?** The forge-seed has
+   `agentz` but there's no `~/.claw/agentz-workspace/` currently.
+   Either add it to claw or drop AgentZ from the seed until claw
+   catches up.
+
+---
+
+## 7. Verification after fix
+
+1. Apply Layer 1 (`git config --global` commands).
+2. Apply Layer 2 (forge-seed.json changes), rebuild, restart AgentMux.
+3. Open the agent picker → launch AgentX.
+4. Observe: Claude Code starts in `~/.claw/agentx-workspace/`, no
+   "no git identity" warning, the managed claw `CLAUDE.md` is
+   visible on first read.
+5. Run `/runtime` in the composer to sanity-check slash commands
+   still work post-restart.
+6. Have AgentX attempt a trivial commit (e.g. `git init` + touch
+   + commit a scratch file). Should succeed as `AgentX-asaf
+   <agentx@asaf.cc>`.

--- a/docs/analysis/edit-tool-no-diff-available-2026-04-14.md
+++ b/docs/analysis/edit-tool-no-diff-available-2026-04-14.md
@@ -1,0 +1,281 @@
+# Report: Why "No diff available" always shows on Edit tool expansion
+
+**Date:** 2026-04-14
+**Severity:** Visible bug — every Edit tool expansion shows an error stub instead of the actual edit
+**Affected:** `frontend/app/view/agent/components/DiffViewer.tsx`,
+`frontend/app/view/agent/stream-parser.ts`, Claude provider translator
+
+---
+
+## Symptom
+
+Every `Edit` tool block in the agent pane, when hovered/pinned open,
+shows:
+
+```
+No diff available
+File: /path/to/file
+```
+
+It's never anything else. Success, failed, running — always this stub.
+
+## Root cause
+
+It's a **dead shape bug**: the `EditResult` type exists in
+`types.ts:120` but nothing in the codebase ever constructs one.
+
+### Trace through the code
+
+1. **`frontend/app/view/agent/types.ts:120`** declares:
+   ```ts
+   export interface EditResult {
+       linesChanged: number;
+       diff?: string;
+   }
+   ```
+
+2. **`frontend/app/view/agent/components/DiffViewer.tsx:17`** reads:
+   ```tsx
+   const diff = result?.diff;
+   if (!diff) {
+       return (
+           <pre class="agent-diff-empty">
+               No diff available
+               {"\n"}
+               File: {params.file_path}
+           </pre>
+       );
+   }
+   ```
+
+3. **`frontend/app/view/agent/stream-parser.ts:207-234`** populates the
+   tool node:
+   ```ts
+   return {
+       type: "tool",
+       id: event.id,
+       tool: this.normalizeToolName(toolName),
+       params,
+       status: event.status,
+       duration: event.duration,
+       result: event.result,   // ← straight from the translator
+       ...
+   };
+   ```
+
+4. **`frontend/app/view/agent/providers/claude-translator.ts:179-188`**
+   takes Claude's `tool_result` block and passes its content through
+   as-is. Claude's Edit tool API response is a plain-text string:
+
+   ```
+   The file /path/to/file.ts has been updated. Here's the result of
+   running `cat -n` on a snippet of the edited file:
+      1  import { foo } from "bar";
+      2  ...
+   ```
+
+   — which gets stored as a string. The translator does not construct
+   a JS object with `{diff: "..."}`, and nothing downstream of it
+   does either.
+
+5. Therefore, when `DiffViewer` does `result?.diff`, it hits one of
+   two cases depending on what `result` actually is at runtime:
+
+   - **Case A:** `result` is a string (Claude's Edit response text).
+     `"some string".diff` is `undefined`. Fall into the empty state.
+   - **Case B:** `result` is an object (e.g. from some error path or
+     the compact result shape). No `.diff` key exists. Same result.
+
+Either way: "No diff available" shows, every single time. The
+`EditResult` interface is a fossil — someone wrote the type expecting
+the backend to populate it, then either the backend work never
+happened or the translator never hooked it up.
+
+### Why this wasn't caught earlier
+
+- The string branch of `result` happens to work for `Read` (which
+  reads `result.content`) and `Bash` (reads `result.output`) because
+  the Claude translator for those builds the expected shape. For
+  `Edit`, nobody built the shape.
+- There's no `grep -r '\.diff\s*=' frontend/app/view/agent/` hit.
+- There's no translator test asserting that an Edit tool_result
+  produces an object with a `diff` field.
+- The one-line collapsed-by-default tool UI (PR #367 /
+  `SPEC_TOOL_OVERLAY_AND_SCROLL_ON_TYPE_2026_04_13.md`) means most
+  users hover only occasionally and it reads as "huh, weird" rather
+  than "this is broken."
+
+---
+
+## Important observation: we don't need Claude to send a diff
+
+The `EditParams` we already have on every Edit tool call contains:
+
+```ts
+export interface EditParams {
+    file_path: string;
+    old_string: string;
+    new_string: string;
+    replace_all?: boolean;
+}
+```
+
+That is literally enough to render a meaningful diff in the UI,
+**without any backend work and without any library**. Claude's Edit
+tool is `old_string → new_string`; the viewer just has to show both.
+
+## Fix options, ranked
+
+### Option A — Render from params (recommended, ~1h)
+
+Change `DiffViewer` to ignore `result.diff` entirely and render from
+`params.old_string` / `params.new_string`:
+
+```tsx
+export const DiffViewer = ({ params, result }: DiffViewerProps): JSX.Element => {
+    const oldLines = params.old_string.split("\n");
+    const newLines = params.new_string.split("\n");
+
+    return (
+        <pre class="agent-diff">
+            <div class="agent-diff-header">{params.file_path}</div>
+            <For each={oldLines}>
+                {(line) => <div class="agent-diff-del">-{line}</div>}
+            </For>
+            <For each={newLines}>
+                {(line) => <div class="agent-diff-add">+{line}</div>}
+            </For>
+            <Show when={result && (result as any).error}>
+                <div class="agent-diff-error">
+                    {(result as any).error}
+                </div>
+            </Show>
+        </pre>
+    );
+};
+```
+
+**Pros:**
+- Zero new dependencies.
+- Works for every Edit, always.
+- The "diff" matches exactly what the model asked for (it IS the
+  old/new string pair).
+- Status is surfaced by the surrounding `agent-tool-block` status
+  class, so failures still show a red ✗ on the collapsed row.
+
+**Cons:**
+- Not a unified diff — `old_string` and `new_string` are shown
+  independently, so if a 50-line replacement has 45 unchanged lines
+  you see 45 deletions + 45 additions. Rare in practice since Claude
+  picks minimal old_strings, but noted.
+
+### Option B — Compute a real unified diff client-side (~2h)
+
+Add the `diff` npm package (20 KB) and call `diffLines(old, new)` to
+produce a proper unified diff with context lines. Render the result
+through the existing diff line classes.
+
+**Pros:**
+- Looks exactly like `git diff`.
+- Collapses unchanged lines correctly.
+
+**Cons:**
+- New dependency.
+- More code for a case that's rarely hit by long replacements.
+- Still doesn't show surrounding file context — we don't have the
+  full file on hand.
+
+### Option C — Populate `EditResult.diff` from the backend (not recommended)
+
+Plumb a real unified diff through the Claude translator. Requires
+writing a git-diff-compatible diff in the backend, passing it
+through the WebSocket, and updating the translator to split the
+Claude string response from our structured result.
+
+**Pros:**
+- Matches the original type design.
+
+**Cons:**
+- Lot of wiring for no visible improvement over Option A.
+- Adds a code path that only works when the backend is AgentMux's
+  own — any provider that doesn't speak our protocol still sees
+  "No diff available."
+- Claude's API never returns a structured diff, so the backend
+  would have to compute it locally anyway, duplicating Option B's
+  work.
+
+### Recommendation
+
+**Go with Option A.** It's the smallest change, uses data we already
+have, and closes the visible bug. Option B is a nice follow-up if
+someone complains about large replacements looking weird, and the
+`diff` package is trivial to drop in later.
+
+After Option A lands, **delete the `diff?: string` field from
+`EditResult`** since nothing writes it. Also delete the
+`if (!diff) { return <No diff available> }` branch entirely.
+
+---
+
+## Interaction with the code-highlighting spec
+
+`SPEC_TOOL_OVERLAY_CODE_HIGHLIGHTING_2026_04_14.md` step 3 is
+"DiffViewer with highlighted diff lines." That spec assumes
+DiffViewer actually renders lines — it currently doesn't.
+
+**Order of operations:**
+1. Fix DiffViewer to render from params (this report, Option A).
+2. *Then* land the highlighting spec step 3 on top — it's a small
+   transformer over the same `For each={lines}` loop.
+
+Landing highlighting first on a viewer that never renders anything
+would be a no-op user-visibly.
+
+---
+
+## Related dead shapes to audit
+
+Since `EditResult.diff` was never populated, worth a quick check
+for siblings:
+
+- **`ReadResult.lines`** (types.ts:117) — is this ever set? Used?
+- **`WriteResult.bytesWritten`** (types.ts:125) — see
+  `ToolBlock.tsx:228` which reads `(result as any).bytesWritten`. If
+  the translator passes Claude's plain-text response, this is `undefined`
+  and the UI shows `Wrote undefined bytes` or falls through. **Probably
+  the same bug in miniature.**
+- **`BashResult.output`** — verify the translator actually sets this.
+  `BashOutputViewer` depends on it being populated.
+
+These should each get a 5-line grep to confirm. If any are also dead,
+bundle the fixes with the DiffViewer one so the whole "tool result
+shapes" layer gets a consistency pass.
+
+---
+
+## Suggested PR scope
+
+Single PR titled **"fix(agent): render Edit tool diff from params"**
+with:
+
+1. `DiffViewer.tsx` → render from `params.old_string` / `params.new_string`
+2. `types.ts` → remove `diff?: string` from `EditResult`; keep
+   `linesChanged` for now (it's also dead, but not visible)
+3. `ToolBlock.tsx` → unchanged (already passes params + result)
+4. Smoke test: open an agent pane, run an Edit, hover the tool block,
+   verify the old/new strings appear instead of the stub.
+
+No backend changes. No new deps. Probably ~40 lines of delta.
+
+---
+
+## Appendix: reproduction
+
+1. Launch AgentMux, open an agent pane running Claude.
+2. Ask Claude to edit any file: `edit foo.ts to add a comment on line 1`.
+3. Wait for the Edit tool block to appear in the document.
+4. Hover it (or click to pin).
+5. Observe: `No diff available\nFile: foo.ts` — the stub, every time.
+
+Expected (post-fix): `-<old_string>\n+<new_string>` with the existing
+red/green diff chrome.

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -3009,3 +3009,165 @@
         box-shadow: 0 -6px 20px rgba(0, 0, 0, 0.35);
     }
 }
+
+// ── AgentIdentityPanel (Step 4 of SPEC_AGENT_IDENTITY_RESTRUCTURE) ────────────
+
+.agent-identity-panel {
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--main-text-color);
+}
+
+.agent-identity-header {
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.agent-identity-title {
+    font-size: 11px;
+    color: color-mix(in srgb, var(--secondary-text-color) 80%, transparent);
+}
+
+.agent-identity-agent-name {
+    font-weight: 600;
+    color: var(--main-text-color);
+}
+
+.agent-identity-providers {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.agent-identity-provider-row {
+    display: grid;
+    grid-template-columns: 16px 72px 1fr auto;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: 3px;
+
+    &:hover {
+        background: color-mix(in srgb, var(--highlight-bg-color, #ffffff10) 50%, transparent);
+    }
+}
+
+.agent-identity-provider-icon {
+    font-size: 13px;
+    text-align: center;
+    opacity: 0.6;
+}
+
+.agent-identity-provider-label {
+    font-size: 11px;
+    color: color-mix(in srgb, var(--secondary-text-color) 80%, transparent);
+    white-space: nowrap;
+}
+
+.agent-identity-provider-assignment {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.agent-identity-account-name {
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.agent-identity-username {
+    font-size: 11px;
+    color: color-mix(in srgb, var(--secondary-text-color) 70%, transparent);
+    font-family: var(--fixed-font, monospace);
+}
+
+.agent-identity-none {
+    font-size: 11px;
+    color: color-mix(in srgb, var(--secondary-text-color) 50%, transparent);
+    font-style: italic;
+}
+
+.agent-identity-provider-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.agent-identity-select {
+    font-size: 11px;
+    background: var(--panel-bg-color, var(--main-bg-color));
+    color: var(--main-text-color);
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    padding: 2px 4px;
+    max-width: 140px;
+    cursor: pointer;
+
+    &:focus {
+        outline: 1px solid var(--accent-color, #4a90e2);
+        outline-offset: 1px;
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: default;
+    }
+}
+
+.agent-identity-new-btn,
+.agent-identity-unassign-btn {
+    font-size: 11px;
+    background: none;
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    color: color-mix(in srgb, var(--secondary-text-color) 80%, transparent);
+    padding: 2px 5px;
+    cursor: pointer;
+    white-space: nowrap;
+
+    &:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--highlight-bg-color, #ffffff15) 60%, transparent);
+        color: var(--main-text-color);
+    }
+
+    &:disabled {
+        opacity: 0.4;
+        cursor: default;
+    }
+}
+
+.agent-identity-unassign-btn {
+    padding: 2px 6px;
+    border-color: color-mix(in srgb, var(--error-color, #e06c75) 50%, transparent);
+    color: color-mix(in srgb, var(--error-color, #e06c75) 70%, transparent);
+
+    &:hover:not(:disabled) {
+        background: color-mix(in srgb, var(--error-color, #e06c75) 15%, transparent);
+        color: var(--error-color, #e06c75);
+    }
+}
+
+.agent-identity-error {
+    font-size: 11px;
+    color: var(--error-color, #e06c75);
+    padding: 4px 6px;
+    background: color-mix(in srgb, var(--error-color, #e06c75) 10%, transparent);
+    border-radius: 3px;
+}
+
+.agent-identity-unsaved {
+    padding: 12px;
+    font-size: 12px;
+    color: color-mix(in srgb, var(--secondary-text-color) 70%, transparent);
+    text-align: center;
+    font-style: italic;
+}

--- a/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
+++ b/frontend/app/view/agent/components/AgentCardSettingsPanel.tsx
@@ -7,24 +7,23 @@
  * agent.
  *
  * PR 2 of specs/SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md.
- *
- * Instantiates a dedicated ForgeViewModel and IdentityViewModel
- * on mount (lifetime = panel lifetime) and delegates to the existing
- * ForgeDetail / ForgeForm / IdentityPanel components. No rewrite of
- * Forge or Identity internals — just reuse.
- *
- * The Identity tab currently shows the global account list (same
- * data as the old identity widget). Per-agent scoping is deferred
- * to SPEC_FORGE_AGENT_IDENTITY_2026_04_13.md.
+ * Identity tab upgraded to agent-scoped view in Step 4 of
+ * SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md.
  */
 
 import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
 import type { BlockNodeModel } from "@/app/block/blocktypes";
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
 import { ForgeViewModel } from "@/app/view/forge/forge-model";
 import { ForgeDetail } from "@/app/view/forge/components/ForgeDetail";
 import { ForgeForm } from "@/app/view/forge/components/ForgeForm";
-import { IdentityViewModel } from "@/app/view/identity/identity-model";
-import { IdentityPanel } from "@/app/view/identity/identity-view";
+import {
+    type AgentAccounts,
+    IdentityViewModel,
+    serializeAgentAccounts,
+} from "@/app/view/identity/identity-model";
+import { AgentIdentityPanel } from "./AgentIdentityPanel";
 
 export type SettingsTab = "forge" | "identity";
 
@@ -91,6 +90,30 @@ export const AgentCardSettingsPanel = (props: AgentCardSettingsPanelProps): JSX.
         }
     });
 
+    // Persist updated account assignments to the backend. Sends a full
+    // UpdateForgeAgentCommand with the existing agent fields + new accounts.
+    const handleAccountsUpdate = async (newAccounts: AgentAccounts): Promise<void> => {
+        const agent = props.agent;
+        if (!agent) return;
+        await RpcApi.UpdateForgeAgentCommand(TabRpcClient, {
+            id: agent.id,
+            name: agent.name,
+            icon: agent.icon,
+            provider: agent.provider,
+            description: agent.description,
+            working_directory: agent.working_directory,
+            shell: agent.shell,
+            provider_flags: agent.provider_flags,
+            auto_start: agent.auto_start,
+            restart_on_crash: agent.restart_on_crash,
+            idle_timeout_minutes: agent.idle_timeout_minutes,
+            agent_type: agent.agent_type,
+            environment: agent.environment,
+            agent_bus_id: agent.agent_bus_id,
+            accounts: serializeAgentAccounts(newAccounts),
+        });
+    };
+
     return (
         <div class="agent-card-settings-panel">
             <div class="agent-card-settings-header">
@@ -127,7 +150,20 @@ export const AgentCardSettingsPanel = (props: AgentCardSettingsPanelProps): JSX.
                     </Show>
                 </Show>
                 <Show when={tab() === "identity"}>
-                    <IdentityPanel model={identityModel} />
+                    <Show
+                        when={props.agent}
+                        fallback={
+                            <div class="agent-identity-unsaved">
+                                Save the agent first to assign accounts.
+                            </div>
+                        }
+                    >
+                        <AgentIdentityPanel
+                            agent={props.agent!}
+                            model={identityModel}
+                            onUpdate={handleAccountsUpdate}
+                        />
+                    </Show>
                 </Show>
             </div>
         </div>

--- a/frontend/app/view/agent/components/AgentIdentityPanel.tsx
+++ b/frontend/app/view/agent/components/AgentIdentityPanel.tsx
@@ -1,0 +1,189 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentIdentityPanel — agent-scoped identity view.
+ *
+ * Shows which account each provider (GitHub, AWS, Anthropic, Custom) is
+ * assigned to for this specific agent, with dropdowns to swap and an
+ * unassign button. Replaces the global IdentityPanel in the agent card
+ * settings panel as part of Step 4 of
+ * SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md.
+ *
+ * The panel does NOT own account CRUD — creating a new account still goes
+ * through the existing AccountForm via identityModel.openAddForm().
+ */
+
+import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
+import { AccountForm } from "@/app/view/identity/identity-view";
+import {
+    type AccountProvider,
+    type AgentAccounts,
+    type IdentityViewModel,
+    parseAgentAccounts,
+    PROVIDER_LABELS,
+    serializeAgentAccounts,
+} from "@/app/view/identity/identity-model";
+
+const ALL_PROVIDERS: AccountProvider[] = ["github", "aws", "anthropic", "custom"];
+
+const PROVIDER_ICONS: Record<AccountProvider, string> = {
+    github: "⑆",
+    aws: "☁",
+    anthropic: "◈",
+    custom: "⊞",
+};
+
+interface AgentIdentityPanelProps {
+    agent: ForgeAgent;
+    model: IdentityViewModel;
+    /** Called whenever the user assigns or unassigns an account. The caller
+     *  is responsible for persisting the new accounts value via RPC. */
+    onUpdate: (newAccounts: AgentAccounts) => Promise<void>;
+}
+
+export const AgentIdentityPanel = (props: AgentIdentityPanelProps): JSX.Element => {
+    const [saving, setSaving] = createSignal(false);
+    const [saveError, setSaveError] = createSignal<string | null>(null);
+
+    // Current assignments parsed from the agent record.
+    const accounts = createMemo(() => parseAgentAccounts(props.agent));
+
+    // For each provider, the Account object currently assigned (or null).
+    const assignedAccount = (provider: AccountProvider) => {
+        const id = accounts()[provider];
+        if (!id) return null;
+        return props.model.accountsAtom().find((a) => a.id === id) ?? null;
+    };
+
+    // Accounts available for each provider (for the dropdown).
+    const accountsForProvider = (provider: AccountProvider) =>
+        props.model.accountsAtom().filter((a) => a.provider === provider);
+
+    const handleAssign = async (provider: AccountProvider, accountId: string | null) => {
+        setSaveError(null);
+        setSaving(true);
+        try {
+            const next: AgentAccounts = { ...accounts(), [provider]: accountId };
+            await props.onUpdate(next);
+        } catch (e) {
+            setSaveError(String(e));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div class="agent-identity-panel">
+            <div class="agent-identity-header">
+                <span class="agent-identity-title">
+                    <span class="agent-identity-agent-name">{props.agent.name}</span>
+                    {" "}uses the following accounts:
+                </span>
+            </div>
+
+            <div class="agent-identity-providers">
+                <For each={ALL_PROVIDERS}>
+                    {(provider) => {
+                        const assigned = () => assignedAccount(provider);
+                        const options = () => accountsForProvider(provider);
+
+                        return (
+                            <div class="agent-identity-provider-row">
+                                <span class="agent-identity-provider-icon">
+                                    {PROVIDER_ICONS[provider]}
+                                </span>
+                                <span class="agent-identity-provider-label">
+                                    {PROVIDER_LABELS[provider]}
+                                </span>
+
+                                <div class="agent-identity-provider-assignment">
+                                    <Show
+                                        when={assigned()}
+                                        fallback={
+                                            <span class="agent-identity-none">— none —</span>
+                                        }
+                                    >
+                                        <span class="agent-identity-account-name">
+                                            {assigned()!.display_name || assigned()!.name}
+                                        </span>
+                                        <Show when={assigned()!.context?.github_username}>
+                                            <span class="agent-identity-username">
+                                                @{assigned()!.context.github_username}
+                                            </span>
+                                        </Show>
+                                        <Show when={assigned()!.context?.aws_profile}>
+                                            <span class="agent-identity-username">
+                                                {assigned()!.context.aws_profile}
+                                            </span>
+                                        </Show>
+                                    </Show>
+                                </div>
+
+                                <div class="agent-identity-provider-actions">
+                                    <Show when={options().length > 0}>
+                                        <select
+                                            class="agent-identity-select"
+                                            disabled={saving()}
+                                            value={accounts()[provider] ?? ""}
+                                            onChange={(e) => {
+                                                const v = e.currentTarget.value;
+                                                void handleAssign(provider, v || null);
+                                            }}
+                                        >
+                                            <option value="">— unassign —</option>
+                                            <For each={options()}>
+                                                {(acct) => (
+                                                    <option value={acct.id}>
+                                                        {acct.display_name || acct.name}
+                                                    </option>
+                                                )}
+                                            </For>
+                                        </select>
+                                    </Show>
+                                    <button
+                                        class="agent-identity-new-btn"
+                                        disabled={saving()}
+                                        title={`Add new ${PROVIDER_LABELS[provider]} account`}
+                                        onClick={() => {
+                                            // Pre-populate provider in the form via a
+                                            // temporary signal the AccountForm reads.
+                                            // For now just open the generic add form.
+                                            props.model.openAddForm();
+                                        }}
+                                    >
+                                        + New
+                                    </button>
+                                    <Show when={assigned()}>
+                                        <button
+                                            class="agent-identity-unassign-btn"
+                                            disabled={saving()}
+                                            title="Unassign this account"
+                                            onClick={() => void handleAssign(provider, null)}
+                                        >
+                                            ×
+                                        </button>
+                                    </Show>
+                                </div>
+                            </div>
+                        );
+                    }}
+                </For>
+            </div>
+
+            <Show when={saveError()}>
+                <div class="agent-identity-error">{saveError()}</div>
+            </Show>
+
+            {/* Inline account creation form — opened via "+ New" button */}
+            <Show when={props.model.formOpenAtom()}>
+                <AccountForm model={props.model} />
+            </Show>
+        </div>
+    );
+};
+
+AgentIdentityPanel.displayName = "AgentIdentityPanel";
+
+/** Serialize AgentAccounts to the JSON string stored on ForgeAgent. */
+export { serializeAgentAccounts };

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -38,10 +38,52 @@ export interface Account {
     display_name?: string;
     secret_ref: SecretRef;
     context: AccountContext;
+    /**
+     * @deprecated Derive from the agent-side reverse index instead.
+     * Kept for backwards compatibility. Do not write new code that
+     * reads this field — use parseAgentAccounts(agent) on ForgeAgent.
+     * Scheduled for removal after SPEC_AGENT_IDENTITY_RESTRUCTURE Step 4
+     * is fully rolled out.
+     */
     assigned_agents: string[];
     status: AccountStatus;
     created_at: string;
     updated_at: string;
+}
+
+/**
+ * Per-provider account references stored on a ForgeAgent.
+ * A null value means no account is assigned for that provider.
+ */
+export type AgentAccounts = Partial<Record<AccountProvider, string | null>>;
+
+/** Parse the JSON-encoded accounts blob from a ForgeAgent. */
+export function parseAgentAccounts(agent: ForgeAgent): AgentAccounts {
+    if (!agent.accounts) return {};
+    try {
+        return JSON.parse(agent.accounts) as AgentAccounts;
+    } catch {
+        return {};
+    }
+}
+
+/** Serialize AgentAccounts back to the JSON blob stored on ForgeAgent. */
+export function serializeAgentAccounts(accounts: AgentAccounts): string {
+    return JSON.stringify(accounts);
+}
+
+/**
+ * Return the IDs of agents that reference this account (reverse index).
+ * Used by the global Identity panel to show "assigned agents" without
+ * reading the deprecated Account.assigned_agents field.
+ */
+export function agentsAssignedToAccount(accountId: string, agents: ForgeAgent[]): string[] {
+    return agents
+        .filter((a) => {
+            const accs = parseAgentAccounts(a);
+            return Object.values(accs).includes(accountId);
+        })
+        .map((a) => a.name);
 }
 
 export const PROVIDER_LABELS: Record<AccountProvider, string> = {

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -347,7 +347,7 @@ function AssignmentsTab({ model }: { model: IdentityViewModel }): JSX.Element {
 
 // ── Add/Edit form ─────────────────────────────────────────────────────────────
 
-function AccountForm({ model }: { model: IdentityViewModel }): JSX.Element {
+export function AccountForm({ model }: { model: IdentityViewModel }): JSX.Element {
     const editing = () => model.editingAccountAtom();
     const isEdit = () => editing() !== null;
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -218,6 +218,13 @@ declare global {
         environment: string;
         agent_bus_id: string;
         is_seeded: number;
+        /**
+         * JSON-encoded per-provider account refs.
+         * Shape: `{"github":"acct-id"|null,"aws":"acct-id"|null,...}`
+         * Empty string = no accounts assigned. See identity-model.ts for
+         * parseAgentAccounts() / serializeAgentAccounts() helpers.
+         */
+        accounts?: string;
     };
 
     // ForgeContent
@@ -261,6 +268,8 @@ declare global {
         agent_type?: string;
         environment?: string;
         agent_bus_id?: string;
+        /** JSON-encoded per-provider account refs. See ForgeAgent.accounts. */
+        accounts?: string;
     };
 
     // CommandDeleteForgeAgentData

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.159",
+  "version": "0.33.163",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.159",
+      "version": "0.33.163",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.163",
+  "version": "0.33.164",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_AGENT_HOST_CONTEXT_2026_04_14.md
+++ b/specs/SPEC_AGENT_HOST_CONTEXT_2026_04_14.md
@@ -1,0 +1,435 @@
+# Spec: Agent host context — machine binding, agentbus addressing, status bar integration, service attribution
+
+**Status:** Draft
+**Date:** 2026-04-14
+**Scope:** `ForgeAgent` host identity, agentbus cross-host routing, `LanInstance` agent
+advertisement, `HostPopover` agent listing, agent pane host badge,
+tool/service interaction attribution
+**Related:** `SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md`,
+`SPEC_CONSOLIDATE_FORGE_IDENTITY_INTO_AGENT_2026_04_13.md`
+
+---
+
+## 1. Problem
+
+AgentMux already has the infrastructure for cross-host agent communication:
+
+- `agent_bus_id` is a global bus address used by `agentbus-client` to route messages
+  across machines. `AGENTMUX_AGENT_BUS_ID` is injected into every MCP server env
+  at launch time; `AGENTMUX_LOCAL_URL` lets the agentbus-client prefer direct PTY
+  delivery when source and target are on the same machine, falling back to the cloud
+  agentbus for cross-host delivery.
+- `LanInstance` already has an `agents: Vec<String>` field reserved for advertising
+  which agents are active on each LAN peer — but it is never populated (always
+  `Vec::new()` in `handle_event`).
+- The `HostPopover` in the bottom-right status bar shows the machine hostname, OS,
+  IP, and LAN peers — but has no concept of *which ForgeAgent represents this machine*
+  or *which agents are reachable on each peer via the bus*.
+
+Because these systems are disconnected:
+
+- You can see LAN peers but not which agents are active on them.
+- When an agent makes a tool call or service call, there is no indication of which
+  host it ran on — critical when agents on multiple machines share a pane view.
+- The `HostPopover` is purely machine-level; it says nothing about the agent network
+  topology that's actually in use.
+
+---
+
+## 2. What the user asked for
+
+> "Agents also need to maintain concept of their host. It is managed also in the
+> bottom right of agentmux. Whenever the agent interacts with a service, it should
+> also say the host it is on."
+
+> "agentbus is a good point, since we want to support messages between agentmux
+> instances running on different hosts"
+
+Three concrete asks:
+
+1. **Agents know their host** — the host ForgeAgent is the identity anchor for the
+   machine it runs on; container agents carry that context.
+2. **Bottom-right integration** — the `HostPopover` surfaces which agent is the
+   host for the local machine, and shows which agents are active on each LAN peer
+   (pulling from the already-existing `LanInstance.agents` field once populated).
+3. **Service interaction attribution** — whenever an agent makes a tool call or
+   service interaction, the host context (agent + machine) appears alongside it.
+
+---
+
+## 3. The agentbus and cross-host routing
+
+Understanding this is prerequisite to the data model.
+
+### 3.1 Three-tier delivery — no cloud required on a LAN
+
+```
+Agent A (machine 1)                        Agent B (machine 2)
+  │                                             │
+  │ agentbus-client                             │ agentbus-client
+  │   AGENTMUX_AGENT_BUS_ID=agenta              │   AGENTMUX_AGENT_BUS_ID=agentb
+  │   AGENTMUX_LOCAL_URL=http://127.x:port      │   AGENTMUX_LOCAL_URL=http://127.x:port
+  │                                             │
+  ├─ 1. Same machine?                           │
+  │      → POST AGENTMUX_LOCAL_URL (loopback)   │
+  │                                             │
+  ├─ 2. LAN peer? (agentb in LanInstance.agents)│
+  │      → POST http://<peer.address>:<peer.port>│  ◄── direct, no cloud
+  │                                             │
+  └─ 3. Not on LAN?                             │
+         → POST cloud agentbus ─────────────────►
+                                                └── POST AGENTMUX_LOCAL_URL
+```
+
+**Tier 1 (loopback):** already implemented via `AGENTMUX_LOCAL_URL`.
+
+**Tier 2 (LAN direct):** the agentbus-client needs a local routing table mapping
+`agent_bus_id → http://<peer.address>:<peer.port>`. This table is built from
+`LanInstance.agents` once it is populated (§5). No cloud hop, no latency, no
+dependency on external connectivity. This is the primary delivery path for
+multi-machine developer setups.
+
+**Tier 3 (cloud):** fallback for agents not on the local network — off-site machines,
+cloud VMs, mobile. Not required for local-only deployments.
+
+### 3.2 `agent_bus_id` — a global address, not a local key
+
+`agent_bus_id` is the **network address** of an agent in the bus. Other agents on
+any machine use it to route messages. It is:
+- Set once at creation (typically = `agent.slug`)
+- Unique across all AgentMux instances that may communicate
+- Injected as `AGENTMUX_AGENT_BUS_ID` into every MCP server env at launch
+- Used by the agentbus-client to look up Tier 1/2/3 delivery (in that order)
+
+`AGENTMUX_LOCAL_URL` is the **inbound delivery endpoint** for the local instance —
+all three tiers ultimately POST to the target machine's `AGENTMUX_LOCAL_URL`.
+
+### 3.3 `LanInstance.agents` is the LAN routing table
+
+`LanInstance.agents: Vec<String>` already exists in the struct but is always
+`Vec::new()`. Once populated with `agent_bus_id`s, it becomes the data the
+agentbus-client reads to answer: "is target bus ID reachable on a LAN peer, and
+if so what is `peer.address:peer.port`?"
+
+This makes §5 (LAN advertisement) load-bearing for routing, not just display.
+
+### 3.4 Host agents anchor the bus on a machine
+
+A **host agent** (`agent_type: "host"`) is both:
+- The **identity** of a person+machine combination (AgentX = the agent that runs
+  on this dev workstation)
+- The **LAN entry point** for that machine: when other agents look up a bus ID in
+  the LAN routing table, they find it under the peer that advertised it — the host
+  machine.
+
+Container agents (`agent_type: "container"`) have their own `agent_bus_id` and are
+also advertised in `LanInstance.agents`. Their *display context* (which machine they
+ran on) is tracked by `host_agent_slug` (§4.1), but their routing is independent.
+
+### 3.5 What changes this spec proposes
+
+The spec does **not** change the agentbus wire protocol. It adds:
+
+1. A new `host_agent_slug` field on ForgeAgent — the display/identity link between
+   a container agent and its host agent (separate from the routing key).
+2. Populating `LanInstance.agents` with the `agent_bus_id`s of running agents so
+   LAN peers can see which agents are reachable on each machine.
+3. UI surfaces that expose this topology (HostPopover, agent pane badges, tool attribution).
+
+---
+
+## 4. Data model changes
+
+### 4.1 New field: `host_agent_slug`
+
+Add `host_agent_slug: string` to `ForgeAgent` (v5 SQLite migration, additive
+`ALTER TABLE ADD COLUMN`).
+
+| Agent type | `host_agent_slug` value |
+|---|---|
+| `host` | `self.slug` — the agent is its own host |
+| `container` | slug of the host agent whose machine it runs on (e.g. `"agentx"`) |
+| `standalone` | `""` — treated as local, no explicit host |
+
+**Why separate from `agent_bus_id`?**
+`agent_bus_id` is the global bus routing key — a network address. It must be stable
+and unique across all connected AgentMux instances. `host_agent_slug` is the
+*machine-identity display* — which human-readable agent represents the machine.
+Renaming an agent (slug → name change) must not break bus routing. And in the
+future, one machine could have multiple host agents with different `agent_bus_id`s
+(one per provider) but the same `host_agent_slug` pointing to the primary host.
+
+### 4.2 Seeded agents — `host_agent_slug` defaults
+
+In `forge-seed.json`, container agents should declare `host_agent_slug` explicitly.
+For existing seeded agents, the migration backfills:
+- `agent_type == "host"` → `host_agent_slug = slug`
+- `agent_type == "container"` → `host_agent_slug = ""` (users/seed update to fill in)
+
+### 4.3 `HostInfo` extension
+
+Extend `HostInfo` (returned by `get_host_info` CEF command) with:
+
+```rust
+pub struct HostInfo {
+    // ...existing fields...
+    pub agent_slug: String,   // local host agent slug, "" if unresolved
+    pub agent_name: String,   // display name
+    pub agent_icon: String,   // emoji
+    pub agent_bus_ids: Vec<String>, // all bus_ids of agents currently running locally
+}
+```
+
+`agent_bus_ids` is used to populate `LanInstance.agents` on advertisement (§5).
+
+---
+
+## 5. LAN discovery — populate `agents` (the LAN routing table)
+
+`LanInstance.agents: Vec<String>` exists but is always `Vec::new()`. Populating
+it is what enables Tier 2 (LAN direct) delivery in §3.1 — without it, the
+agentbus-client cannot know which LAN peer hosts a given `agent_bus_id`.
+
+### 5.1 What to advertise
+
+On startup (and whenever the agent list changes), the backend builds the list of
+`agent_bus_id`s for **all** agents configured in Forge (host and container) and
+injects them into the mDNS advertisement as an additional property:
+
+```
+agents = "agentx,agenty,agent1,agent2"   // comma-separated bus IDs
+```
+
+The mDNS properties dict supports arbitrary string k/v pairs. mDNS has a ~1300
+byte TXT record limit; with typical 6-10 char bus IDs and a handful of agents this
+is not a concern in practice. If it ever is, truncate to host agents only.
+
+When a peer is resolved in `handle_event`, parse `agents` and populate
+`LanInstance.agents`.
+
+### 5.2 Dynamic updates
+
+When the user creates or deletes an agent, the mDNS service is re-registered with
+the updated `agents` property. The backend event bus already fires `forgeagents:changed`
+on Forge mutations — hook into this in `LanDiscovery` to trigger re-advertisement.
+
+### 5.3 Why both host and container agents
+
+Container agents have their own globally unique `agent_bus_id`. If Agent1 (container)
+is running on machine 1 and Agent B (on machine 2) wants to message it directly,
+Agent B needs to find `agent1` in a LAN peer's `agents` list to learn the delivery
+address. If only host agents are advertised, Tier 2 delivery is unavailable for
+container-to-container cross-machine messaging.
+
+Display consequence: the HostPopover peer list will show all agents on a peer,
+grouped by type (hosts prominent, containers indented).
+
+### 5.4 agentbus-client LAN routing table
+
+The frontend exposes `LanInstance[]` via `lanInstancesAtom`. The agentbus-client
+(running as an MCP server process) currently reads only `AGENTMUX_LOCAL_URL` and
+`AGENTMUX_AGENT_BUS_ID`. To enable Tier 2 delivery, add a new env var:
+
+```
+AGENTMUX_LAN_PEERS=agentx=http://192.168.1.42:8765,agenty=http://192.168.1.42:8765,agent1=http://192.168.1.55:8765
+```
+
+Format: `bus_id=delivery_url` pairs, comma-separated. Built from `lanInstancesAtom`
+at launch time and re-injected when `lanInstances` changes (requires controller
+restart or live env update — implementation detail TBD).
+
+The agentbus-client lookup order becomes:
+1. `bus_id == AGENTMUX_AGENT_BUS_ID` (self) → local in-process
+2. `bus_id` in `AGENTMUX_LAN_PEERS` → POST to peer's URL directly
+3. Otherwise → POST to cloud agentbus
+
+---
+
+## 6. Local host agent resolution
+
+On startup, the backend resolves the **local host agent** — the ForgeAgent that
+"owns" this AgentMux instance:
+
+1. Read all ForgeAgents where `agent_type == "host"`.
+2. If exactly one: use it.
+3. If multiple: prefer the one where `environment` matches current platform
+   (`windows` / `linux` / `macos`). Tie-break: lowest `created_at`.
+4. If none: slug = `""`.
+
+Exposed via new backend command `GetLocalHostAgent` →
+`{ slug, name, icon, agent_bus_id }`.
+
+Frontend: `localHostAgentAtom` (reactive, populated once on mount in `app.tsx`).
+
+---
+
+## 7. Status bar — HostPopover enhancements
+
+### 7.1 Host agent badge in trigger
+
+When the local host agent is resolved, the trigger gains an icon prefix:
+
+```
+[🔴] dev-workstation
+```
+
+Tooltip: `AgentX on dev-workstation · Click for details`.
+
+### 7.2 Popover — host agent section (top)
+
+```
+┌─ THIS HOST ───────────────────────────┐
+│  🔴  AgentX                           │
+│      agentx · Claude Code · bus: agentx │
+└───────────────────────────────────────┘
+  OS       Windows 10
+  IP       192.168.1.42
+  ...
+```
+
+Fields shown:
+- Icon + display name
+- Slug (monospace, dimmed) · Provider label · bus ID (monospace, dimmed)
+
+If no host agent resolved:
+```
+  No host agent configured
+  Set one in Forge ▶
+```
+(link opens the forge widget)
+
+### 7.3 Popover — LAN peers with agent column
+
+Each LAN peer row gains a right-side agent column showing the `agents` bus IDs,
+resolved to display names where local ForgeAgent records match:
+
+```
+◆  peer-hostname.local    🟡 AgentY          v0.33.160
+◆  server01.local         🔵 Agent3          v0.33.155
+◆  laptop.local           ?  (2 agents)      v0.33.140
+```
+
+- Icon + name if a ForgeAgent with that `agent_bus_id` exists locally.
+- `(N agents)` if the peer advertises multiple agents not in local Forge.
+- `?` placeholder if `agents` is empty (older peer version or not yet resolved).
+
+Clicking a peer row expands it inline to show all advertised bus IDs.
+
+---
+
+## 8. Agent pane — host context
+
+### 8.1 Block meta at launch
+
+`agent-model.ts` stores in block meta at launch:
+
+```ts
+agentHostSlug:   string   // host_agent_slug, or agent.slug if agent_type=="host"
+agentHostName:   string   // display name of host agent
+agentHostIcon:   string   // emoji
+agentHostBusId:  string   // agent_bus_id of the host agent
+agentHostMachine: string  // OS hostname of the host (from getApi().getHostName())
+```
+
+Derivation priority:
+1. `agent.host_agent_slug` (explicit)
+2. If `agent.agent_type === "host"`: `agent.slug`
+3. Fallback: `localHostAgentAtom()?.slug`
+
+### 8.2 Header host badge (container agents only)
+
+```
+╔═ Agent1 ═══════════════════════════ [🔴 AgentX] ═╗
+```
+
+Small pill in the pane-frame header, right-aligned. Only shown when
+`agentMode === "container"` — host agents don't need to say they're on themselves.
+
+Clicking the badge opens the HostPopover.
+
+### 8.3 Footer host line
+
+In the agent footer status strip (already has `ConnectionStatus`), add:
+
+```
+🔴 agentx · dev-workstation
+```
+
+Same visibility condition: container agents only.
+
+---
+
+## 9. Tool / service interaction attribution
+
+### 9.1 Host footer on tool blocks
+
+`ToolBlock.tsx` renders a host attribution line below the tool result:
+
+```
+┌─ bash ──────────────────────────────────────────┐
+│  $ docker ps                                     │
+│  CONTAINER ID   IMAGE   ...                      │
+├──────────────────────────────────────────────────┤
+│  🔴 AgentX · dev-workstation                     │  ← host footer
+└──────────────────────────────────────────────────┘
+```
+
+**Visibility rules:**
+- Container agents: **always shown** (their Docker runtime is on the host machine,
+  so "which machine ran this" matters).
+- Host agents: **shown on hover** only (avoids noise when everything is local).
+
+The footer reads `agentHostIcon`, `agentHostName`, `agentHostMachine` from
+`nodeModel.blockAtom()?.meta`.
+
+### 9.2 Cross-host attribution (future)
+
+When AgentMux gains the ability to send tool calls to a remote agent (via the
+agentbus), the `agentHostMachine` in the footer will naturally show the remote
+machine's hostname — no additional changes to `ToolBlock` needed. The block meta
+carries the origin at launch time; a remote-execution flow would write a different
+`agentHostMachine` into the meta.
+
+---
+
+## 10. Implementation steps
+
+Recommended shipping order — each step is independently mergeable after A–C land.
+
+| Step | What | Files | Est. |
+|---|---|---|---|
+| **A** | `host_agent_slug` column (v5 migration), `ForgeAgent` struct, `gotypes.d.ts`, backfill host agents | `migrations.rs`, `wstore.rs`, `gotypes.d.ts` | ~1h |
+| **B** | `GetLocalHostAgent` backend command; extend `HostInfo` with `agent_slug/name/icon/agent_bus_ids` | `forge_handlers.rs`, `server.rs` | ~1h |
+| **C** | `localHostAgentAtom` in `global.ts`; block meta gains `agentHost*` fields at launch in `agent-model.ts` | `global.ts`, `agent-model.ts` | ~1h |
+| **D** | LAN: populate `LanInstance.agents` on advertisement; re-advertise on `forgeagents:changed`; inject `AGENTMUX_LAN_PEERS` env at agent launch | `lan_discovery.rs`, `agent-model.ts` | ~1.5h |
+| **E** | `HostPopover`: host agent section + LAN peer agent column (hosts + containers grouped) | `HostPopover.tsx`, `StatusBar.scss` | ~1h |
+| **F** | Agent pane header badge + footer host line (container agents) | `AgentHeader.tsx` or `agent-view.tsx`, `agent-view.scss` | ~45m |
+| **G** | `ToolBlock` host attribution footer (always/hover rules) | `ToolBlock.tsx`, `agent-view.scss` | ~1h |
+
+**Recommended PR grouping:**
+- PR 1: A + B + C (foundation — backend + frontend atom + launch meta)
+- PR 2: D + E (LAN agent advertisement + HostPopover)
+- PR 3: F + G (agent pane + tool attribution)
+
+---
+
+## 11. Non-scope
+
+- **Remote tool execution** (sending a tool call to an agent on another machine via
+  the agentbus) — the attribution in §9.2 is a placeholder. Actual remote execution
+  is a separate, larger feature.
+- **Host agent auto-assignment UI** — when a user creates a container agent,
+  there's no picker yet for "which host does this run on?" Default: blank; seed
+  manifest sets it explicitly. Deferred to a future Forge form update.
+- **Cloud agentbus protocol changes** — the cloud path (Tier 3) is unchanged.
+  `agent_bus_id` semantics are unchanged. Cloud is now explicitly the fallback for
+  non-LAN peers, not the primary path.
+- **agentbus-client implementation** — `AGENTMUX_LAN_PEERS` is specified here as the
+  interface contract; the agentbus-client internals (how it reads the env, how it
+  selects Tier 2 vs Tier 3) are implementation details outside this spec's scope.
+- **Live `AGENTMUX_LAN_PEERS` refresh** — when LAN peers join/leave mid-session,
+  updating already-running agent processes requires either a controller restart or
+  a side-channel. Mechanism TBD; static injection at launch is the v1 behaviour.
+- **Multi-instance same-machine bus deduplication** — two AgentMux instances on the
+  same machine advertising the same `agent_bus_id` is an existing concern, not
+  addressed here.

--- a/specs/SPEC_TOOL_OVERLAY_CODE_HIGHLIGHTING_2026_04_14.md
+++ b/specs/SPEC_TOOL_OVERLAY_CODE_HIGHLIGHTING_2026_04_14.md
@@ -1,0 +1,415 @@
+# Spec: Syntax highlighting inside the tool hover overlay
+
+**Status:** Draft
+**Date:** 2026-04-14
+**Scope:** `frontend/app/view/agent/components/ToolBlock.tsx` + children
+
+---
+
+## 1. Why this matters
+
+Tool blocks in the agent pane are one-line collapsed by default (per
+`docs/specs/tool-collapse.md` + SPEC_AGENT_PANE_FOLLOWUPS items #4/#5).
+Hover expands them in a portal overlay that shows the full tool content
+— file reads, diffs, bash output, etc.
+
+Right now that overlay renders code as plaintext:
+
+- `Read` → raw `<pre>` of the file contents
+- `Edit` → `DiffViewer` splits by `+` / `-` / `@` but each line is still
+  plain characters; no keyword / identifier / string coloring
+- `Write` → currently only shows bytes-written, so no code is visible
+- `Bash` → command string and output are plaintext
+- `Grep` results → via `CompactResult`, plaintext
+
+Scrolling back through a long session to find "the place where I edited
+the dispatcher" is visually jarring because every tool expansion looks
+like a wall of monospace. The user can't scan diffs the way they can in
+the rest of the app (the markdown panel uses highlight.js and Streamdown
+uses Shiki — both produce colored output).
+
+A ~30 minute addition using the already-bundled Shiki pipeline closes
+that gap: `Read` file contents, `Edit` diff bodies, and `Bash` commands
+all show up in the same GitHub-dark-high-contrast theme already in use
+elsewhere in the app, with zero new dependencies.
+
+---
+
+## 2. Current state
+
+- `ToolBlock.tsx` branches on `node.tool` and delegates to:
+  - `DiffViewer` (for Edit)
+  - `BashOutputViewer` (for Bash)
+  - Inline `<pre>` with `{(node.result as any).content}` (for Read)
+  - `CompactResult` (Grep/Glob/Agent/Task/default)
+- **No syntax highlighting anywhere.** Each component renders its text
+  directly into a `<pre>` or `<div>`.
+
+**Shiki is already in the repo** (`shiki@^3.21.0` in package.json) and
+lazy-loaded in `frontend/app/element/streamdown.tsx`:
+
+```ts
+let shikiModule: typeof import("shiki/bundle/web") | null = null;
+const getShiki = async () => {
+    if (!shikiModule) {
+        shikiModule = await import("shiki/bundle/web");
+    }
+    return shikiModule;
+};
+```
+
+The theme constant in that file is `"github-dark-high-contrast"`. The
+same theme should be reused here for visual consistency.
+
+**highlight.js is also bundled** (used by `markdown.tsx` with
+`github-dark-dimmed.scss`), but Shiki is the right pick here because
+(a) Streamdown already pulled it into the chunk we pay for, so lazy
+loading is essentially free on the second open, and (b) Shiki uses
+real TextMate grammars so diff + code look right.
+
+---
+
+## 3. Target
+
+When the user hovers (or pins) a tool block, the overlay body renders
+code with the same visual quality as Streamdown: keyword coloring,
+string literals, comments, numbers. Specifically:
+
+- **`Read`**: file contents are highlighted in the language implied
+  by the file extension. File path header stays plain.
+- **`Edit`**: diff body is highlighted in the file's language, with
+  the existing `agent-diff-add` / `-del` / `-hunk` / `-ctx` line
+  backgrounds layered *behind* the token coloring (so you still see
+  green/red for added/removed lines, but the code inside those lines
+  is colored normally). File path header stays plain.
+- **`Write`**: currently a bytes-written stub — out of scope here, but
+  the spec leaves room to show the written content when
+  `(result as any).content` is present.
+- **`Bash`**: the command (`params.command`) is highlighted as `bash`;
+  the output is plaintext (it's rarely source code, and guessing is
+  worse than plain).
+- **`Grep` / `Glob` / `Agent` / `Task` / default**: unchanged for
+  v1 — these go through `CompactResult` which isn't meaningfully
+  code. Spec leaves this for a follow-up if we add a `Read` fallback
+  for Grep match context.
+
+---
+
+## 4. Design
+
+### 4.1 Component shape
+
+New file: `frontend/app/view/agent/components/HighlightedCode.tsx`
+
+```ts
+interface HighlightedCodeProps {
+    code: string;
+    /**
+     * Shiki language id (e.g. "typescript", "python", "bash"). Falls
+     * back to "text" when unknown or when detection returns null.
+     */
+    lang: string;
+    /**
+     * Optional extra class for the rendered <pre>. Used by callers
+     * like DiffViewer to add .agent-diff or similar.
+     */
+    class?: string;
+}
+```
+
+Internally:
+
+1. Mounts with a plain `<pre>` showing unhighlighted text as the
+   placeholder — same perf posture as streamdown.tsx, so the first
+   paint is never blocked on the Shiki chunk.
+2. `createEffect` kicks off `getShiki()` and calls
+   `highlighter.codeToHtml(code, { lang, theme: "github-dark-high-contrast" })`.
+3. On completion, swaps the placeholder for the Shiki-generated HTML
+   via `innerHTML`. This is safe — Shiki output is sanitized HTML
+   wrapping `<span>` elements.
+4. **Seq guard** like streamdown.tsx: if props change before the
+   highlight completes, drop the stale result. Same `seqRef++` pattern.
+5. **Size cap**: if `code.length > CAP_BYTES` (default 200 KB) or
+   `line_count > CAP_LINES` (default 2000), skip highlighting entirely
+   and render plaintext. Huge files would stall the main thread
+   otherwise.
+6. **Error path**: if `getShiki()` throws (rare — usually a network
+   hiccup on first load) render plaintext and don't retry. Log via
+   `console.warn` for observability.
+
+### 4.2 Language detection
+
+New helper: `frontend/app/view/agent/components/detectLanguage.ts`
+
+```ts
+/**
+ * Map a file path (absolute or relative) to a Shiki language id.
+ * Returns "text" for unknown extensions so the caller can still
+ * route through HighlightedCode without branching.
+ */
+export function detectLanguage(filePath: string): string;
+```
+
+Detection strategy (first hit wins):
+
+1. **Extension map** — a static Record<string, string> covering at
+   least: `ts tsx js jsx mjs cjs` → typescript/tsx, `py` → python,
+   `rs` → rust, `go` → go, `sh bash zsh` → bash, `ps1` → powershell,
+   `md mdx` → markdown, `json` → json, `yaml yml` → yaml,
+   `toml` → toml, `css scss sass` → scss, `html htm` → html,
+   `sql` → sql, `xml` → xml, `rb` → ruby, `java` → java,
+   `kt` → kotlin, `swift` → swift, `c h` → c, `cpp hpp cxx hxx` →
+   cpp, `cs` → csharp, `php` → php, `lua` → lua, `vue` → vue,
+   `svelte` → svelte, `dockerfile` → dockerfile, `tf` → terraform,
+   `graphql gql` → graphql.
+2. **Filename match** for things without extensions: `Dockerfile`,
+   `Makefile`, `.gitignore` → ignore, `.env*` → bash.
+3. **Shebang scan** of the first line for files without a recognized
+   extension: `#!/usr/bin/env python3` → python, `#!/bin/bash` → bash,
+   etc. Only scans if the first line starts with `#!`.
+4. **Fallback** → `"text"` (Shiki's plain-text path, no grammar load).
+
+Detection is pure + synchronous. The handful of cases it gets wrong
+are acceptable v1 failure modes — this isn't the LSP.
+
+### 4.3 `Read` integration
+
+In `ToolBlock.tsx`, replace:
+
+```tsx
+case "Read":
+    return (
+        <div class="agent-tool-read">
+            <div class="agent-tool-file-path">{(node.params as any).file_path}</div>
+            <Show when={node.result}>
+                {(node.result as any).content ? (
+                    <pre class="agent-tool-read-content">{(node.result as any).content}</pre>
+                ) : (
+                    <CompactResult .../>
+                )}
+            </Show>
+        </div>
+    );
+```
+
+with:
+
+```tsx
+case "Read": {
+    const filePath = (node.params as any).file_path;
+    const content = (node.result as any)?.content;
+    return (
+        <div class="agent-tool-read">
+            <div class="agent-tool-file-path">{filePath}</div>
+            <Show when={content} fallback={<CompactResult .../>}>
+                <HighlightedCode
+                    code={content}
+                    lang={detectLanguage(filePath)}
+                    class="agent-tool-read-content"
+                />
+            </Show>
+        </div>
+    );
+}
+```
+
+### 4.4 `Edit` / `DiffViewer` integration
+
+Two viable approaches:
+
+**A. Per-line highlight with diff chrome overlay.** Iterate the diff
+lines; strip the leading `+`/`-`/` ` marker; pass each *body* through
+the highlighter with the file's language; wrap the result in the
+existing `.agent-diff-add` / `-del` / `-ctx` class. Hunk headers
+(`@@ -1,5 +1,5 @@`) stay plain.
+
+Pro: tokens inside added/removed lines are colored correctly; the
+green/red line background is just a CSS class on the wrapping div.
+Con: calling `codeToHtml` 200 times for a 200-line diff is wasteful.
+
+**B. Highlight the whole diff body once as the file's language.**
+Pass the entire diff (with `+`/`-` markers) to
+`codeToHtml(..., { lang: "diff" })` — Shiki has a built-in `diff`
+grammar that colors add/remove/hunk markers. This gets you line-level
+coloring but loses token-level coloring inside added/removed code.
+
+**Recommended: hybrid.** Call
+`codeToHtml(diffBody, { lang: detectLanguage(filePath), transformers: [diffTransformer] })`
+where `diffTransformer` is a tiny Shiki transformer (supported first-
+class in Shiki 3.x) that:
+
+1. Detects lines starting with `+`/`-`/` ` in the source.
+2. Strips the marker before highlighting (so the grammar sees valid
+   code, not `+const foo = 1;`).
+3. Adds the `diff-add` / `diff-del` / `diff-ctx` class to the
+   generated `<span class="line">` wrapper.
+4. Re-inserts the marker as a leading non-highlighted `<span>`.
+
+Shiki's `transformerNotationDiff` package does almost exactly this but
+expects `// [!code ++]` annotations, not raw `+`/`-` prefixes — so
+we'll write a ~30-line custom transformer inline in DiffViewer. The
+existing `.agent-diff-add` / `-del` / `-hunk` / `-ctx` SCSS rules stay
+in place but apply to the `.line` elements Shiki emits.
+
+DiffViewer's current empty-state path (`No diff available`) stays
+plaintext — out of scope.
+
+### 4.5 `Bash` integration
+
+`BashOutputViewer` currently renders `params.command` and
+`result.output` separately. Update it to:
+
+- **Command**: `HighlightedCode` with `lang="bash"`.
+- **Output**: stays as plaintext `<pre>`. Guessing at output format
+  (JSON? Python? log?) is worse than plain. If the command was
+  something like `cat foo.json`, the user can still see structure via
+  indentation.
+
+### 4.6 Theme
+
+Reuse the existing `"github-dark-high-contrast"` constant already
+picked in `streamdown.tsx`. Export it from a new
+`frontend/app/view/agent/commands/theme.ts` … actually just hardcode
+it in `HighlightedCode.tsx` with a `// TODO: read from settings` comment.
+Theme switching isn't in the spec and AgentMux is dark-theme-only right
+now anyway.
+
+### 4.7 Caching
+
+Highlighting is pure: `(code, lang, theme) → html`. The same tool call
+keeps its code forever (ToolNode is immutable), so:
+
+- Use a per-node cache keyed by `node.id` — a `WeakMap<ToolNode, string>`
+  at module scope in `HighlightedCode.tsx`.
+- On first render, check the cache; if present, render directly without
+  round-tripping through Shiki.
+- On first render without cache, kick off the async highlight; on
+  completion, store the HTML in the cache before swapping it in.
+
+This matters because hovering the same tool block multiple times is
+the expected UX — the user hovers, reads, scrolls, hovers again. Each
+re-hover should be instant.
+
+### 4.8 Performance guardrails
+
+- **Size cap** as noted: `> 200 KB` OR `> 2000 lines` → skip highlight,
+  render plaintext. Log once via `console.debug` so we can spot cases
+  where the cap trips in practice.
+- **Lazy grammar load**: Shiki's `bundle/web` ships every grammar we
+  need in one chunk. Already paid for by Streamdown. Second use is
+  free.
+- **Main-thread highlighting is fine for the sizes we care about.**
+  Shiki doesn't offload to a worker in the web bundle and running a
+  TextMate grammar over 2000 lines is sub-100ms on the dev machine.
+  If that changes, Shiki exposes a `createHighlighterCore` API that
+  could be moved to a worker — marked as a follow-up.
+
+---
+
+## 5. Out of scope
+
+- Light theme support (AgentMux is dark-only for now)
+- Language auto-detection from content (no extension + no shebang ⇒ plaintext)
+- Grep match highlighting — `CompactResult` doesn't render full file
+  context, so there's nothing code-like to color
+- Re-highlighting markdown panel or Streamdown — they already highlight
+- Theme picker or per-pane theme override
+- Worker-offloaded highlighting
+
+---
+
+## 6. Implementation steps
+
+Each step is self-contained and testable.
+
+### Step 1 — `detectLanguage.ts` + unit test
+
+- Create the helper with the extension/filename/shebang logic.
+- Add a small test file at
+  `frontend/app/view/agent/components/detectLanguage.test.ts` that
+  asserts: `foo.ts → typescript`, `Dockerfile → dockerfile`,
+  `foo.unknown → text`, `#!/usr/bin/env python3 → python`.
+- No behavior change to the app — can ship as its own PR.
+
+### Step 2 — `HighlightedCode.tsx`
+
+- Component with the structure above: placeholder → async Shiki
+  swap → WeakMap cache.
+- Handles size cap + error fallback.
+- Drop-in replacement for `<pre class="agent-tool-read-content">`.
+- **Wire into `Read` case only** in this step. Leave `Edit` and
+  `Bash` alone. Ship, validate, then move on.
+
+### Step 3 — `DiffViewer` with highlighted diff lines
+
+- Custom Shiki transformer that strips `+`/`-` prefix, highlights
+  the underlying code, re-applies the diff class on the `.line`
+  wrapper.
+- Fallback to the existing plain-diff rendering when
+  `getShiki()` rejects.
+- Keep the `No diff available` path unchanged (see separate report on
+  when/why that path trips — it may become real work).
+
+### Step 4 — `BashOutputViewer` command highlighting
+
+- `HighlightedCode` for `params.command` with `lang="bash"`.
+- Output stays plaintext.
+- ~10 lines of change.
+
+### Step 5 — SCSS polish
+
+- Shiki emits its own `<span class="line">` wrappers. Ensure our
+  `.agent-tool-read-content`, `.agent-diff`, and `.agent-diff-*`
+  classes compose cleanly with those. Mostly removing redundant
+  `color:` rules so Shiki's tokens win.
+- Check font-family: Shiki's generated `<pre>` has no default; we
+  want `var(--monospace-font)`.
+
+---
+
+## 7. Success criteria
+
+After Steps 1-5 land:
+
+- `Read` overlay of a TypeScript file shows keyword / string / comment
+  coloring matching the rest of the app.
+- `Edit` overlay of the same file shows diff chrome (green/red line
+  backgrounds) with token-level coloring inside each line.
+- `Bash` overlay shows the command in bash highlighting; output plain.
+- No observable latency on hover: first hover may flash plaintext for
+  ~50ms (the Shiki chunk load); subsequent hovers for the same node
+  are instant thanks to the WeakMap cache.
+- Unknown extensions render as plaintext without crashing.
+- Files > 200 KB render as plaintext without stalling.
+- No new dependencies in `package.json`.
+
+---
+
+## 8. Estimated cost
+
+| Step | Time | Risk |
+|---|---:|---|
+| 1. detectLanguage + test | 45 min | Low |
+| 2. HighlightedCode + Read integration | 1h | Low — same pattern as streamdown.tsx |
+| 3. DiffViewer transformer | 1.5h | Medium — custom Shiki transformer |
+| 4. Bash command highlight | 20 min | Low |
+| 5. SCSS polish | 30 min | Low |
+
+**Total: ~4 hours.** Each step is independent, so they can ship as
+separate PRs.
+
+---
+
+## 9. Open questions
+
+1. Should the size cap be a setting? Leaning no — 200 KB / 2000 lines
+   is a reasonable default and nobody will tweak it. If someone does
+   want to, they can open a follow-up.
+2. Should we lift `HighlightedCode` to a shared component in
+   `frontend/app/element/` so markdown / streamdown / tool overlay all
+   converge on one implementation? Leaning yes *after* this lands —
+   ship it scoped first, then refactor upward in a separate PR once
+   we're sure the API is right.
+3. Shiki's `diff` grammar vs. custom transformer: I prefer the custom
+   transformer for token-level coloring. Confirm by eyeballing before
+   committing to the approach.


### PR DESCRIPTION
## Summary

- **ForgeAgent** gains an `accounts` field (JSON blob storing per-provider account refs) so each agent directly owns its GitHub/AWS/Anthropic/Custom account assignments
- **v5 DB migration** adds the `accounts` column to `db_forge_agents` via idempotent `ALTER TABLE ADD COLUMN`
- **`AgentIdentityPanel`** (new component) replaces the global `IdentityPanel` in the agent card settings — shows per-agent rows with assignment dropdown, "+ New", and unassign button
- **`Account.assigned_agents`** marked `@deprecated`; new `agentsAssignedToAccount()` reverse-index helper derives the same info without the back-reference

Implements Step 4 of `specs/SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md`.

## Files changed

**Backend**
- `agentmux-srv/src/backend/storage/wstore.rs` — ForgeAgent struct + SELECT/INSERT/UPDATE
- `agentmux-srv/src/backend/storage/migrations.rs` — `run_forge_v5_migrations()`
- `agentmux-srv/src/backend/rpc_types.rs` — `CommandUpdateForgeAgentData.accounts`
- `agentmux-srv/src/server/forge_handlers.rs` — update + create + import handlers
- `agentmux-srv/src/backend/forge_seed.rs` — seed constructors

**Frontend**
- `frontend/types/gotypes.d.ts` — `ForgeAgent.accounts`, `CommandUpdateForgeAgentData.accounts`
- `frontend/app/view/identity/identity-model.ts` — `AgentAccounts` type + helpers
- `frontend/app/view/identity/identity-view.tsx` — export `AccountForm`
- `frontend/app/view/agent/components/AgentIdentityPanel.tsx` — new component
- `frontend/app/view/agent/components/AgentCardSettingsPanel.tsx` — wire up
- `frontend/app/view/agent/agent-view.scss` — panel styles

## Test plan

- [ ] Open the 👤 Identity tab on any agent card — confirm per-provider rows render (GitHub, AWS, Anthropic, Custom), all showing "— none —" initially
- [ ] Create a GitHub account in Identity → assign it to an agent via the dropdown → reload → confirm it persists (stored in backend DB)
- [ ] Unassign via × button → confirm row reverts to "— none —"
- [ ] "+ New" button opens the inline `AccountForm`
- [ ] Create mode (new agent, no ID yet) → Identity tab shows "Save the agent first" placeholder
- [ ] `cargo test -p agentmux-srv` — v5 migration is idempotent (run twice, no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)