### PR TITLE
feat: composer UX polish — controls above input, status line, session stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.164"
+version = "0.33.165"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.164"
+version = "0.33.165"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.164"
+version = "0.33.165"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.164"
+version = "0.33.165"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.164"
+version = "0.33.165"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.164"
+version = "0.33.165"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.164"
+version = "0.33.165"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.164"
+version = "0.33.165"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1906,6 +1906,42 @@
                 }
             }
 
+            .agent-status-line {
+                min-height: 14px;
+                font-size: 10px;
+                color: var(--secondary-text-color);
+                opacity: 0.6;
+                padding: 1px 4px;
+                display: flex;
+                align-items: center;
+                gap: 5px;
+                font-family: var(--fixed-font, monospace);
+
+                &.agent-status-line--loading {
+                    color: #8cc8ff;
+                    opacity: 1;
+                }
+
+                &.agent-status-line--stats {
+                    opacity: 0.5;
+                    gap: 0;
+                }
+            }
+
+            .agent-spinner-dot {
+                width: 7px;
+                height: 7px;
+                border-radius: 50%;
+                background: #8cc8ff;
+                flex-shrink: 0;
+                animation: agent-pulse 1.2s ease-in-out infinite;
+            }
+
+            @keyframes agent-pulse {
+                0%, 100% { opacity: 0.4; transform: scale(0.85); }
+                50% { opacity: 1; transform: scale(1.3); }
+            }
+
             .agent-input-hint {
                 font-size: 9px;
                 color: var(--secondary-text-color);
@@ -1913,33 +1949,7 @@
                 padding: 0 2px;
                 line-height: 1.2;
                 display: flex;
-                justify-content: space-between;
                 align-items: center;
-            }
-
-            .agent-loading-spinner {
-                display: inline-flex;
-                align-items: center;
-                gap: 5px;
-                opacity: 1;
-                color: #8cc8ff;
-                font-size: 10px;
-            }
-
-            .agent-spinner-dot {
-                width: 8px;
-                height: 8px;
-                border-radius: 50%;
-                background: #8cc8ff;
-                animation: agent-pulse 1.2s ease-in-out infinite;
-
-                &:nth-child(2) { animation-delay: 0.2s; }
-                &:nth-child(3) { animation-delay: 0.4s; }
-            }
-
-            @keyframes agent-pulse {
-                0%, 100% { opacity: 0.4; transform: scale(0.85); }
-                50% { opacity: 1; transform: scale(1.3); }
             }
         }
     }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -111,6 +111,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         outputFormat: outputFormat(),
         documentAtom: agentAtoms().documentAtom,
         streamingStateAtom: agentAtoms().streamingStateAtom,
+        sessionStatsAtom: agentAtoms().sessionStatsAtom,
+        currentToolAtom: agentAtoms().currentToolAtom,
         enabled: true,
         documentVersion: history.documentVersion,
     });
@@ -139,7 +141,13 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // included in scrollHeight. See SPEC_AGENT_PANE_FOLLOWUPS item #1.
         onSent: () => scrollToBottomFn?.(),
     });
-    const handleSendMessage = commands.sendMessage;
+
+    // Clear session stats when the user sends a new message.
+    const [, setSessionStats] = agentAtoms().sessionStatsAtom;
+    const handleSendMessage = (message: string): Promise<void> => {
+        setSessionStats(null);
+        return commands.sendMessage(message);
+    };
 
     // ── Jump-to-node + Bookmarks ────────────────────────────────────────────────
 
@@ -304,18 +312,20 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                         />
                     )}
                 </Show>
-                <AgentFooter
-                    agentId={agentId}
-                    onSendMessage={commands.sendMessage}
-                    onTyping={() => scrollToBottomFn?.()}
-                    onStopAgent={commands.stopAgent}
-                    loading={status.isLoading()}
-                    getCompletions={commands.completions}
-                />
                 <AgentControlBar
                     blockId={model.blockId}
                     blockAtom={block}
                     providerId={provider()?.id ?? ""}
+                />
+                <AgentFooter
+                    agentId={agentId}
+                    onSendMessage={handleSendMessage}
+                    onTyping={() => scrollToBottomFn?.()}
+                    onStopAgent={commands.stopAgent}
+                    loading={status.isLoading()}
+                    getCompletions={commands.completions}
+                    currentTool={agentAtoms().currentToolAtom[0]()}
+                    sessionStats={agentAtoms().sessionStatsAtom[0]()}
                 />
             </div>
         </div>

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -7,11 +7,12 @@
 
 import { Show, createMemo, createSignal, type JSX } from "solid-js";
 import type { SlashCommand } from "../commands/types";
+import type { SessionStats } from "../types";
 import { SlashAutocomplete } from "./SlashAutocomplete";
 
 interface AgentFooterProps {
     agentId: string;
-    onSendMessage?: (message: string) => void;
+    onSendMessage?: (message: string) => void | Promise<void>;
     /**
      * Called when the user types in the composer. Used to tell the document
      * view to scroll to the latest content so the composer input is visually
@@ -34,6 +35,10 @@ interface AgentFooterProps {
      * If absent, autocomplete is disabled.
      */
     getCompletions?: (prefix: string) => SlashCommand[];
+    /** Name of the currently-running tool (from the last tool_call event). */
+    currentTool?: string | null;
+    /** Stats from the last completed session. Displayed until the next send. */
+    sessionStats?: SessionStats | null;
 }
 
 export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
@@ -177,6 +182,40 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         }
     };
 
+    const statusLine = (): JSX.Element => {
+        if (props.loading) {
+            return (
+                <span class="agent-status-line agent-status-line--loading">
+                    <span class="agent-spinner-dot" />
+                    {props.currentTool ? props.currentTool : "Thinking\u2026"}
+                </span>
+            );
+        }
+        const stats = props.sessionStats;
+        if (!stats) return <span class="agent-status-line" />;
+
+        const parts: string[] = [];
+        if (stats.cost_usd) parts.push(`$${stats.cost_usd.toFixed(3)}`);
+        if (stats.duration_ms != null) {
+            const s = Math.round(stats.duration_ms / 1000);
+            if (s < 60) {
+                parts.push(`${Math.max(1, s)}s`);
+            } else {
+                parts.push(`${Math.floor(s / 60)}m ${s % 60}s`);
+            }
+        }
+        if (stats.num_turns) {
+            parts.push(`${stats.num_turns} ${stats.num_turns === 1 ? "turn" : "turns"}`);
+        }
+        if (parts.length === 0) return <span class="agent-status-line" />;
+
+        return (
+            <span class="agent-status-line agent-status-line--stats">
+                {parts.join("  \u00b7  ")}
+            </span>
+        );
+    };
+
     return (
         <div class="agent-footer">
             <div class="agent-input-container">
@@ -196,14 +235,9 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                     onInput={handleInput}
                     rows={1}
                 />
+                {statusLine()}
                 <div class="agent-input-hint">
                     <span>Enter to send • Shift+Enter for newline • Esc to clear / stop</span>
-                    <Show when={props.loading}>
-                        <span class="agent-loading-spinner">
-                            <span class="agent-spinner-dot" />
-                            loading
-                        </span>
-                    </Show>
                 </div>
             </div>
         </div>

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -195,7 +195,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         if (!stats) return <span class="agent-status-line" />;
 
         const parts: string[] = [];
-        if (stats.cost_usd) parts.push(`$${stats.cost_usd.toFixed(3)}`);
+        if (stats.cost_usd != null) parts.push(`$${stats.cost_usd.toFixed(3)}`);
         if (stats.duration_ms != null) {
             const s = Math.round(stats.duration_ms / 1000);
             if (s < 60) {

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -1,7 +1,7 @@
 // Copyright 2025, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { StreamEvent } from "../types";
+import type { SessionStats, StreamEvent } from "../types";
 import type { OutputTranslator } from "./translator";
 
 /**
@@ -52,6 +52,15 @@ export class ClaudeTranslator implements OutputTranslator {
             return this.handleUserMessage(rawEvent.message);
         }
 
+        // Case 5a: Top-level "result" event — session complete with stats
+        if (rawEvent.type === "result") {
+            const stats: SessionStats = {};
+            if (typeof rawEvent.cost_usd === "number") stats.cost_usd = rawEvent.cost_usd;
+            if (typeof rawEvent.duration_ms === "number") stats.duration_ms = rawEvent.duration_ms;
+            if (typeof rawEvent.num_turns === "number") stats.num_turns = rawEvent.num_turns;
+            return [{ type: "session_end", stats }];
+        }
+
         // Case 5: Raw Anthropic API event (content_block_delta, etc.)
         if (this.isAnthropicEvent(rawEvent)) {
             return this.translateInnerEvent(rawEvent);
@@ -76,6 +85,7 @@ export class ClaudeTranslator implements OutputTranslator {
             "tool_result",
             "agent_message",
             "user_message",
+            "session_end",
         ];
         return streamTypes.includes(event.type);
     }

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -15,6 +15,7 @@ import {
     DocumentNode,
     DocumentState,
     MessageRouterState,
+    SessionStats,
     StreamingState,
     UserInfo,
 } from "./types";
@@ -38,6 +39,8 @@ export interface AgentAtoms {
     providerConfigAtom: SignalPair<ProviderConfig | null>;
     sessionIdAtom: SignalPair<string>;
     rawOutputAtom: SignalPair<string>;
+    sessionStatsAtom: SignalPair<SessionStats | null>;
+    currentToolAtom: SignalPair<string | null>;
 }
 
 /**
@@ -84,5 +87,7 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         providerConfigAtom: createSignal<ProviderConfig | null>(null),
         sessionIdAtom: createSignal<string>(""),
         rawOutputAtom: createSignal<string>(""),
+        sessionStatsAtom: createSignal<SessionStats | null>(null),
+        currentToolAtom: createSignal<string | null>(null),
     };
 }

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -201,6 +201,15 @@ export interface SubagentLinkNode {
 }
 
 /**
+ * Stats from a completed agent session (from the Claude CLI `result` event).
+ */
+export interface SessionStats {
+    cost_usd?: number;    // from result.cost_usd
+    duration_ms?: number; // from result.duration_ms
+    num_turns?: number;   // from result.num_turns
+}
+
+/**
  * Stream events from Claude Code NDJSON output
  */
 export type StreamEvent =
@@ -209,7 +218,8 @@ export type StreamEvent =
     | ToolCallEvent
     | ToolResultEvent
     | AgentMessageEvent
-    | UserMessageEvent;
+    | UserMessageEvent
+    | SessionEndEvent;
 
 export interface TextEvent {
     type: "text";
@@ -251,6 +261,11 @@ export interface UserMessageEvent {
     type: "user_message";
     message: string;
     timestamp?: number;
+}
+
+export interface SessionEndEvent {
+    type: "session_end";
+    stats: SessionStats;
 }
 
 /**

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -13,7 +13,7 @@ import { createEffect, onCleanup, onMount, untrack } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import { ClaudeCodeStreamParser } from "./stream-parser";
 import type { SignalPair } from "./state";
-import type { DocumentNode, StreamingState } from "./types";
+import type { DocumentNode, SessionStats, StreamingState } from "./types";
 
 const OutputFileName = "output";
 
@@ -22,6 +22,8 @@ interface UseAgentStreamOpts {
     outputFormat: string;
     documentAtom: SignalPair<DocumentNode[]>;
     streamingStateAtom: SignalPair<StreamingState>;
+    sessionStatsAtom: SignalPair<SessionStats | null>;
+    currentToolAtom: SignalPair<string | null>;
     enabled: boolean;
     /**
      * Version signal bumped by external document mutations (e.g. history
@@ -40,11 +42,15 @@ export function useAgentStream({
     outputFormat,
     documentAtom,
     streamingStateAtom,
+    sessionStatsAtom,
+    currentToolAtom,
     enabled,
     documentVersion,
 }: UseAgentStreamOpts): void {
     const [, setDocument] = documentAtom;
     const [, setStreaming] = streamingStateAtom;
+    const [, setSessionStats] = sessionStatsAtom;
+    const [, setCurrentTool] = currentToolAtom;
 
     // Mutable state that doesn't trigger re-renders
     let lineBuffer = "";
@@ -176,6 +182,8 @@ export function useAgentStream({
                 pendingUpdates = [];
                 nodeIndexMap = new Map();
                 setDocument([]);
+                setSessionStats(null);
+                setCurrentTool(null);
                 lineBuffer = "";
                 translator.reset();
                 parser.reset();
@@ -244,6 +252,18 @@ export function useAgentStream({
 
                 // Convert StreamEvents → DocumentNodes
                 for (const event of streamEvents) {
+                    // Handle session_end: store stats, clear loading state
+                    if (event.type === "session_end") {
+                        setSessionStats(event.stats ?? null);
+                        setCurrentTool(null);
+                        continue;
+                    }
+                    // Track the currently-running tool for the status line
+                    if (event.type === "tool_call") {
+                        setCurrentTool(event.tool ?? null);
+                    } else if (event.type === "tool_result") {
+                        setCurrentTool(null);
+                    }
                     const node = parser.parseLine(JSON.stringify(event));
                     if (!node) continue;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.164",
+  "version": "0.33.165",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.164",
+      "version": "0.33.165",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.163",
+  "version": "0.33.164",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.163",
+      "version": "0.33.164",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.164",
+  "version": "0.33.165",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- **Controls above input**: `AgentControlBar` (mode/model/effort) is now rendered above `AgentFooter` in `.agent-composer-region` — no logic changes to the control bar itself
- **Status line below textarea**: New `.agent-status-line` row between the textarea and hint line. Shows `⏳ Thinking…` (or active tool name) while loading, and `$0.023  ·  34s  ·  4 turns` after a session ends. Disappears on next send. Uses `min-height: 14px` so there's no layout shift.
- **Session stats from Claude CLI**: `result` event from the CLI is now parsed in `claude-translator.ts` and emitted as a `session_end` StreamEvent carrying `cost_usd`, `duration_ms`, `num_turns`. Codex/Gemini don't emit this event so their stats line stays hidden.
- **Hint line cleanup**: `.agent-input-hint` is now text-only — the old spinner and `justify-content: space-between` flex hack are removed.

## Files changed

| File | Change |
|------|--------|
| `types.ts` | Add `SessionStats`, `SessionEndEvent`, extend `StreamEvent` union |
| `state.ts` | Add `sessionStatsAtom` + `currentToolAtom` to `AgentAtoms` |
| `claude-translator.ts` | Handle `result` event → emit `session_end` |
| `useAgentStream.ts` | Accept + set `sessionStatsAtom`/`currentToolAtom`; track tool name |
| `agent-view.tsx` | Swap order, wire new props, clear stats on send |
| `AgentFooter.tsx` | New `currentTool`/`sessionStats` props, `statusLine()` renderer |
| `agent-view.scss` | `.agent-status-line` + `--loading`/`--stats` variants; remove old spinner |

## Test plan

- [ ] Launch Claude agent, send a message — control bar appears above the input
- [ ] While agent is responding: status line shows `⏳ Thinking…`
- [ ] When a tool runs (e.g. Bash): status line shows `⏳ Bash`
- [ ] After session ends: status line shows e.g. `$0.023  ·  34s  ·  4 turns`
- [ ] Send another message: stats line disappears
- [ ] Hint line shows only the keyboard shortcut text (no spinner)
- [ ] Codex/Gemini agent: status line hidden after session (no fake stats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)