### PR TITLE
fix: auto-scroll on send, single-enter slash select, login UX (v0.33.168)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.167"
+version = "0.33.168"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.167"
+version = "0.33.168"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.167"
+version = "0.33.168"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.167"
+version = "0.33.168"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.167"
+version = "0.33.168"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.167"
+version = "0.33.168"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.167"
+version = "0.33.168"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.167"
+version = "0.33.168"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -177,6 +177,48 @@
         }
     }
 
+    .agent-auth-paste-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-top: 8px;
+
+        .agent-auth-paste-input {
+            flex: 1;
+            padding: 6px 10px;
+            background: rgba(0, 0, 0, 0.35);
+            border: 1px solid rgba(74, 158, 255, 0.3);
+            border-radius: 4px;
+            color: var(--main-text-color);
+            font-size: 11px;
+            font-family: var(--fixed-font, monospace);
+            outline: none;
+
+            &:focus {
+                border-color: #4a9eff;
+            }
+
+            &::placeholder {
+                color: rgba(140, 200, 255, 0.4);
+            }
+        }
+
+        .agent-auth-url-copy {
+            position: static;
+            transform: none;
+            opacity: 1;
+            &:hover { background: #6bb0ff; }
+            &:disabled { opacity: 0.4; cursor: default; }
+        }
+    }
+
+    .agent-auth-paste-result {
+        margin-top: 5px;
+        font-size: 10px;
+        color: #8cc8ff;
+        opacity: 0.8;
+    }
+
     // === Retry Login Bar ===
     .agent-retry-bar {
         flex-shrink: 0;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -82,7 +82,23 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     // Auth + launch flow state and the onCleanup that kills the CLI
     // if the pane closes mid-login.
-    const status = useAgentControllerStatus({ blockId: model.blockId, provider, log });
+    const [, setDocument] = agentAtoms().documentAtom;
+    const status = useAgentControllerStatus({
+        blockId: model.blockId,
+        provider,
+        log,
+        onLoginSuccess: (email) => {
+            const display = email ? `Logged in as **${email}**` : "Login successful";
+            setDocument((prev) => [
+                ...prev,
+                {
+                    type: "markdown",
+                    id: `login_success_${Date.now()}`,
+                    content: `\u2713 ${display}`,
+                } as import("./types").MarkdownNode,
+            ]);
+        },
+    });
 
     onMount(() => {
         const name = block()?.meta?.["agentName"] ?? agentId;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -283,6 +283,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 documentStateAtom={agentAtoms().documentStateAtom}
                 logLines={logLines}
                 authUrl={status.authUrl}
+                authProviderId={provider()?.id ?? providerKey()}
                 onSubagentClick={handleSubagentClick}
                 onLoadOlder={history.loadOlder}
                 loadingOlder={history.loadingOlder}

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -22,6 +22,8 @@ interface AgentDocumentViewProps {
     documentStateAtom: SignalPair<DocumentState>;
     logLines: Accessor<LogLine[]>;
     authUrl?: Accessor<string | null>;
+    /** Provider ID for the active auth flow — used when submitting a pasted auth code. */
+    authProviderId?: string;
     onSubagentClick?: (node: SubagentLinkNode) => void;
     /** Called when the user scrolls near the top — load the previous page of history. */
     onLoadOlder?: () => Promise<void>;
@@ -48,7 +50,7 @@ interface AgentDocumentViewProps {
     highlightNodeId?: Accessor<string | null>;
 }
 
-export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, onSubagentClick, onLoadOlder, loadingOlder, bookmarkedNodeIds, onBookmark, scrollCommand, scrollToBottomRef, highlightNodeId }: AgentDocumentViewProps): JSX.Element => {
+export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, authUrl, authProviderId, onSubagentClick, onLoadOlder, loadingOlder, bookmarkedNodeIds, onBookmark, scrollCommand, scrollToBottomRef, highlightNodeId }: AgentDocumentViewProps): JSX.Element => {
     const [document] = documentAtom;
     const [documentState, setDocumentState] = documentStateAtom;
     let scrollRef!: HTMLDivElement;
@@ -246,7 +248,7 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                 setPasteResult(null);
                                 try {
                                     const { getApi } = await import("@/app/store/global");
-                                    await getApi().setProviderAuth("claude", code);
+                                    await getApi().setProviderAuth(authProviderId ?? "claude", code);
                                     setPasteResult("Code accepted — waiting for confirmation...");
                                     setPasteCode("");
                                 } catch (err: any) {

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -7,7 +7,7 @@
  * When no document nodes exist yet, shows accumulated log lines (terminal-style).
  */
 
-import { createEffect, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
+import { createEffect, createSignal, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, LogLine, SubagentLinkNode } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
@@ -234,21 +234,64 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                         )}
                     </For>
                     <Show when={authUrl?.()}>
-                        {(url) => (
-                            <div class="agent-auth-url-box">
-                                <div class="agent-auth-url-label">Login URL (if browser didn't open):</div>
-                                <div class="agent-auth-url-row">
-                                    <span class="agent-auth-url-text">{url()}</span>
-                                    <button
-                                        class="agent-auth-url-copy"
-                                        onClick={() => { import("@/util/clipboard").then(c => c.writeText(url())); }}
-                                        title="Copy URL"
-                                    >
-                                        Copy
-                                    </button>
+                        {(url) => {
+                            const [pasteCode, setPasteCode] = createSignal("");
+                            const [pasting, setPasting] = createSignal(false);
+                            const [pasteResult, setPasteResult] = createSignal<string | null>(null);
+
+                            const handleSubmitCode = async () => {
+                                const code = pasteCode().trim();
+                                if (!code) return;
+                                setPasting(true);
+                                setPasteResult(null);
+                                try {
+                                    const { getApi } = await import("@/app/store/global");
+                                    await getApi().setProviderAuth("claude", code);
+                                    setPasteResult("Code accepted — waiting for confirmation...");
+                                    setPasteCode("");
+                                } catch (err: any) {
+                                    setPasteResult(`Error: ${err?.message ?? String(err)}`);
+                                } finally {
+                                    setPasting(false);
+                                }
+                            };
+
+                            return (
+                                <div class="agent-auth-url-box">
+                                    <div class="agent-auth-url-label">Open this URL to log in:</div>
+                                    <div class="agent-auth-url-row">
+                                        <span class="agent-auth-url-text">{url()}</span>
+                                        <button
+                                            class="agent-auth-url-copy"
+                                            onClick={() => { import("@/util/clipboard").then(c => c.writeText(url())); }}
+                                            title="Copy URL"
+                                        >
+                                            Copy
+                                        </button>
+                                    </div>
+                                    <div class="agent-auth-paste-row">
+                                        <input
+                                            class="agent-auth-paste-input"
+                                            type="text"
+                                            placeholder="Paste auth code from Anthropic..."
+                                            value={pasteCode()}
+                                            onInput={(e) => setPasteCode((e.target as HTMLInputElement).value)}
+                                            onKeyDown={(e) => { if (e.key === "Enter") void handleSubmitCode(); }}
+                                        />
+                                        <button
+                                            class="agent-auth-url-copy"
+                                            onClick={handleSubmitCode}
+                                            disabled={!pasteCode().trim() || pasting()}
+                                        >
+                                            {pasting() ? "..." : "Submit"}
+                                        </button>
+                                    </div>
+                                    <Show when={pasteResult()}>
+                                        <div class="agent-auth-paste-result">{pasteResult()}</div>
+                                    </Show>
                                 </div>
-                            </div>
-                        )}
+                            );
+                        }}
                     </Show>
                 </div>
             </Show>

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -126,8 +126,11 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         if (props.onSendMessage) {
             props.onSendMessage(message);
             textareaRef.value = "";
-            // No style reset — browser's field-sizing handles it
-            // automatically when the content empties.
+            setAutocompletePrefix(null);
+            // Scroll the new user message into view. SolidJS flushes the
+            // document signal synchronously before this point, so jumpToBottom
+            // will include the just-added node in scrollHeight.
+            props.onTyping?.();
         }
     };
 
@@ -147,10 +150,21 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                 setAutocompleteIndex((i) => (i - 1 + list.length) % list.length);
                 return;
             }
-            if (e.key === "Tab" || e.key === "Enter") {
+            if (e.key === "Tab") {
+                // Tab: fill in the command name for further editing (e.g. adding args)
                 e.preventDefault();
                 const match = list[autocompleteIndex()];
                 if (match) acceptCompletion(match);
+                return;
+            }
+            if (e.key === "Enter") {
+                // Enter: select and send immediately — no second Enter needed
+                e.preventDefault();
+                const match = list[autocompleteIndex()];
+                if (match) {
+                    acceptCompletion(match);
+                    handleSend();
+                }
                 return;
             }
             if (e.key === "Escape") {

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -48,6 +48,8 @@ export interface LaunchFlowOptions {
     isCancelled: () => boolean;
     setLoginWaiting: (v: boolean) => void;
     authEnv?: Record<string, string>;
+    /** Called once when login is confirmed — append a success message to the chat. */
+    onLoginSuccess?: (email: string | null) => void;
 }
 
 export type LaunchFlowResult = "success" | "auth_failed" | "fatal";
@@ -199,6 +201,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                     if (recheckResult.authenticated) {
                         const emailPart = recheckResult.email ? ` as ${recheckResult.email}` : "";
                         log("auth", `authenticated${emailPart}`);
+                        opts.onLoginSuccess?.(recheckResult.email ?? null);
                         authenticated = true;
                         break;
                     }

--- a/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
+++ b/frontend/app/view/agent/hooks/useAgentControllerStatus.ts
@@ -44,6 +44,7 @@ export interface UseAgentControllerStatusOptions {
     blockId: string;
     provider: Accessor<ProviderDefinition | undefined>;
     log: LogFn;
+    onLoginSuccess?: (email: string | null) => void;
 }
 
 export interface UseAgentControllerStatus {
@@ -110,6 +111,7 @@ export function useAgentControllerStatus(
                 isCancelled: () => loginCancelled,
                 setLoginWaiting,
                 authEnv,
+                onLoginSuccess: opts.onLoginSuccess,
             });
             if (result === "success") {
                 setAgentReady(true);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.167",
+  "version": "0.33.168",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- **Auto-scroll on send**: `handleSend` now calls `props.onTyping()` after clearing the textarea — this triggers `jumpToBottom()` synchronously, after SolidJS has already flushed the new `user_message` node to the DOM. Previously the scroll relied solely on the RAF in `useAgentCommands` which could race.
- **Single Enter on slash command**: pressing Enter on an autocomplete item now accepts AND sends in one keystroke. Tab still only fills (for `/tools install jq` style usage). No more two-Enter dance.
- **Auth paste input**: the auth URL box now has a "Paste auth code from Anthropic..." input — submits via `setProviderAuth` as an escape hatch when the browser redirect doesn't complete automatically.
- **Login successful message**: when the auth polling loop detects `authenticated: true`, a `✓ Logged in as <email>` markdown node is appended to the agent chat document.

## Test plan

- [ ] Send a message when scrolled up in history — view jumps to new message
- [ ] Type `/tools` → press Enter once → command sends immediately (no second Enter)
- [ ] Type `/tools ` (with space) → press Tab → fills in name, no send
- [ ] `/login` flow → auth box shows URL + paste input
- [ ] Complete login → "✓ Logged in as email" appears in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)