### PR TITLE
fix: auth check false positive — drop credentials file fast path (v0.33.169)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.168"
+version = "0.33.169"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.168"
+version = "0.33.169"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.168"
+version = "0.33.169"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.168"
+version = "0.33.169"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.168 | 2026-04-14 | 158.3 MiB | 330.0 MiB | |
 | 0.33.166 | 2026-04-14 | 155.9 MiB | 323.7 MiB | |
 | 0.33.164 | 2026-04-14 | 155.9 MiB | 323.7 MiB | |
 | 0.33.163 | 2026-04-14 | 155.9 MiB | 323.7 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.168"
+version = "0.33.169"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.168"
+version = "0.33.169"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.168"
+version = "0.33.169"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.168"
+version = "0.33.169"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -218,82 +218,13 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .map_err(|e| format!("checkcliauth: {e}"))?;
                 tracing::info!(cli = %cmd.cli_path, "CheckCliAuth");
 
-                // Fast path: read credentials file directly (Claude)
-                if cmd.cli_path.contains("claude") {
-                    // Check isolated auth dir first (CLAUDE_CONFIG_DIR), then fall back
-                    // to global ~/.claude/. Users may be authenticated globally but not
-                    // yet in the per-version isolated dir.
-                    let home = std::env::var("HOME")
-                        .or_else(|_| std::env::var("USERPROFILE"))
-                        .unwrap_or_default();
-                    let global_creds = format!("{}/.claude/.credentials.json", home);
-
-                    let mut creds_candidates: Vec<String> = Vec::new();
-                    if let Some(config_dir) = cmd.auth_env.get("CLAUDE_CONFIG_DIR") {
-                        creds_candidates.push(format!("{}/.credentials.json", config_dir));
-                    }
-                    creds_candidates.push(global_creds);
-
-                    // Try each candidate path — first one with valid credentials wins
-                    let creds_path = creds_candidates.iter()
-                        .find(|p| std::path::Path::new(p.as_str()).exists())
-                        .cloned()
-                        .unwrap_or_else(|| creds_candidates.last().unwrap().clone());
-
-                    if let Ok(content) = std::fs::read_to_string(&creds_path) {
-                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
-                            // Check claudeAiOauth credentials
-                            let oauth = json.get("claudeAiOauth");
-                            let has_token = oauth
-                                .and_then(|o| o.get("accessToken"))
-                                .and_then(|v| v.as_str())
-                                .map(|s| !s.is_empty())
-                                .unwrap_or(false);
-
-                            let has_refresh = oauth
-                                .and_then(|o| o.get("refreshToken"))
-                                .and_then(|v| v.as_str())
-                                .map(|s| !s.is_empty())
-                                .unwrap_or(false);
-
-                            // Authenticated if we have an access token OR a refresh token
-                            // (CLI auto-refreshes expired tokens transparently)
-                            let authenticated = has_token || has_refresh;
-
-                            let subscription = oauth
-                                .and_then(|o| o.get("subscriptionType"))
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
-
-                            let auth_method = Some("claude.ai oauth".to_string());
-
-                            tracing::info!(
-                                authenticated = authenticated,
-                                subscription = ?subscription,
-                                has_refresh = has_refresh,
-                                "claude auth check (credentials file)"
-                            );
-
-                            let result = CheckCliAuthResult {
-                                authenticated,
-                                email: subscription.clone(), // no email in creds, show subscription
-                                auth_method,
-                                raw_output: format!("subscription: {}", subscription.unwrap_or_default()),
-                            };
-                            return Ok(Some(serde_json::to_value(&result).unwrap()));
-                        }
-                    }
-                    // Credentials file not found or unparseable — not authenticated
-                    let result = CheckCliAuthResult {
-                        authenticated: false,
-                        email: None,
-                        auth_method: None,
-                        raw_output: "no credentials file found".to_string(),
-                    };
-                    return Ok(Some(serde_json::to_value(&result).unwrap()));
-                }
-
-                // Slow path: run CLI auth check command (other providers)
+                // Run CLI auth check command — all providers including Claude.
+                //
+                // A previous "fast path" read ~/.claude/.credentials.json directly and
+                // declared authenticated=true if any token string was present. This caused
+                // false positives: stale, expired, and revoked tokens all passed the check,
+                // and the `email` field was set to the subscription tier ("max", "pro") instead
+                // of the user's email address. See SPEC_AUTH_CHECK_FALSE_POSITIVE_2026_04_15.md.
                 let output = tokio::time::timeout(
                     std::time::Duration::from_secs(25),
                     {
@@ -315,7 +246,9 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let mut auth_method = None;
 
                 let authenticated = if let Ok(json) = serde_json::from_str::<serde_json::Value>(&stdout) {
-                    email = json.get("email")
+                    // Claude outputs `emailAddress`; other CLIs use `email`. Check both.
+                    email = json.get("emailAddress")
+                        .or_else(|| json.get("email"))
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string());
                     auth_method = json.get("authMethod")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.167",
+  "version": "0.33.168",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.167",
+      "version": "0.33.168",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.168",
+  "version": "0.33.169",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.168",
+      "version": "0.33.169",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.168",
+  "version": "0.33.169",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_AUTH_CHECK_FALSE_POSITIVE_2026_04_15.md
+++ b/specs/SPEC_AUTH_CHECK_FALSE_POSITIVE_2026_04_15.md
@@ -1,0 +1,133 @@
+# SPEC: Auth Check False Positive — "authenticated as max" on Load
+
+**Date:** 2026-04-15  
+**Status:** Ready for implementation  
+**Priority:** High — user must manually /login every session despite being told they're authenticated
+
+---
+
+## 1. Problem
+
+When AgentMux loads an agent pane, the launch flow logs:
+
+```
+[auth] authenticated as max (claude.ai oauth)
+```
+
+…and skips the login flow entirely. But the agent is not actually authenticated — any real API call fails, and the user must run `/login` manually to recover.
+
+---
+
+## 2. Root Cause (two separate bugs)
+
+### Bug A — Fast-path reads the credentials file but never validates the token
+
+`cli_handlers.rs` `CheckCliAuth` has a fast path for Claude (`cmd.cli_path.contains("claude")`). It reads `~/.claude/.credentials.json` directly and checks:
+
+```rust
+let authenticated = has_token || has_refresh;
+```
+
+A non-empty `accessToken` or `refreshToken` string → `authenticated = true`. The tokens are **never validated against the Anthropic API**. Common failure modes:
+
+| Scenario | File state | Fast-path result | Reality |
+|----------|-----------|-----------------|---------|
+| Session expired | old accessToken + refreshToken exist | ✓ authenticated | ✗ tokens rejected |
+| Credentials revoked (logout on another device) | tokens still on disk | ✓ authenticated | ✗ revoked |
+| Different account logged in globally | stale tokens from prior user | ✓ authenticated | ✗ wrong account |
+| Isolated auth dir not yet populated | falls back to global `~/.claude/` | ✓ authenticated | ✗ wrong dir used |
+
+### Bug B — `email` field is set to `subscriptionType`, not the user's email
+
+```rust
+email: subscription.clone(), // no email in creds, show subscription
+```
+
+`subscriptionType` in `.credentials.json` is a plan tier string (`"max"`, `"pro"`, `"free"`). This is emitted in the log as:
+
+```
+authenticated as max (claude.ai oauth)
+```
+
+…making the user think "max" is their username. The actual user email is NOT in `.credentials.json` — it's only available from `claude auth status --json`. Using the subscription type as a display name for the email field is misleading and the root cause of the confusing log message.
+
+---
+
+## 3. Correct Behavior
+
+1. The launch flow should only skip `/login` if authentication is **actually working** — meaning the CLI confirms it can make API calls.
+2. The log message should show the user's real email or a neutral "authenticated (max plan)" — never a plan tier in place of a name.
+3. If token validation fails, the flow should proceed to the login phase, not silently proceed as if authenticated.
+
+---
+
+## 4. Proposed Fix
+
+### 4.1 Drop the fast-path file read; use the CLI for Claude too
+
+Remove the special-case `if cmd.cli_path.contains("claude")` block in `cli_handlers.rs`. Run `claude auth status --json` the same way other providers run their check command. This:
+
+- Validates the token is actually accepted by Anthropic
+- Returns the real `email` field from the JSON output
+- Handles token refresh transparently (the CLI does it)
+- Eliminates the file-path fallback ambiguity
+
+Cost: ~1–2 s on first load instead of ~0 ms. Acceptable — the user is already waiting on the controller registration.
+
+### 4.2 Parse email correctly from `claude auth status --json`
+
+The `claude auth status --json` output includes:
+
+```json
+{
+  "loggedIn": true,
+  "emailAddress": "user@example.com",
+  "subscriptionType": "max",
+  "authMethod": "OAuth",
+  ...
+}
+```
+
+The slow-path parser already reads `json.get("email")` — but Claude's output uses `emailAddress`. Add a fallback:
+
+```rust
+email = json.get("emailAddress")
+    .or_else(|| json.get("email"))
+    .and_then(|v| v.as_str())
+    .map(|s| s.to_string());
+```
+
+### 4.3 Display subscription type separately (optional UI polish)
+
+In `launch-flow.ts`, the `auth_method` field already carries `"claude.ai oauth"`. Subscription can be forwarded in `raw_output` or a new `subscription` field on `CheckCliAuthResult` and logged as a secondary detail:
+
+```
+[auth] authenticated as user@example.com  (max plan · claude.ai oauth)
+```
+
+---
+
+## 5. Files to Change
+
+| File | Change |
+|------|--------|
+| `agentmux-srv/src/server/cli_handlers.rs` | Remove fast-path file-read block for Claude; let it fall through to the slow-path CLI runner |
+| `agentmux-srv/src/backend/rpc_types.rs` | Optionally add `subscription: Option<String>` to `CheckCliAuthResult` |
+| `agentmux-srv/src/server/cli_handlers.rs` | Add `emailAddress` → `email` fallback in slow-path JSON parser |
+| `frontend/app/view/agent/flows/launch-flow.ts` | Update log message to include subscription if present |
+
+---
+
+## 6. Migration / Rollout
+
+- No config changes required.
+- The fast-path removal adds ~1–2 s to agent pane cold-start for Claude users. This is the correct trade-off — a 2 s delay is better than silently proceeding with invalid auth.
+- If the slow-path times out (CLI unreachable), the existing `catch` block already sets `needsLogin = true`, which is the safe default.
+
+---
+
+## 7. Out of Scope
+
+- Token refresh retry logic (the CLI handles this internally).
+- Persistent session caching beyond what the CLI already does.
+- Other providers (Codex, Gemini) — they already use the slow path.


### PR DESCRIPTION
## Problem

On agent pane load the logs showed `authenticated as max (claude.ai oauth)` and skipped the login flow — but the agent wasn't actually authenticated. The user had to manually run `/login` every session.

## Root cause (two bugs)

**Bug A** — `CheckCliAuth` had a fast path for Claude that read `~/.claude/.credentials.json` directly. Any non-empty `accessToken` or `refreshToken` → `authenticated = true`. Stale, expired, and revoked tokens all passed. The actual Anthropic API was never called.

**Bug B** — The `email` field was set to `subscriptionType` (e.g. `"max"`, `"pro"`) because the credentials file doesn't contain the user's email. So the log said "authenticated as max" where "max" is the plan tier, not a name.

## Fix

- **Remove the fast path entirely.** Claude now goes through the same slow path as all other providers: runs `claude auth status --json`, which actually validates the token against the Anthropic API.
- **Fix email parsing.** Claude's JSON output uses `emailAddress` not `email`. Added `emailAddress` → `email` fallback in the slow-path JSON parser.

**Before:** `authenticated as max (claude.ai oauth)`  
**After:** `authenticated as user@example.com (OAuth)`

Cost: ~1–2 s added to agent cold-start. Correct trade-off — a brief delay beats silently proceeding with broken auth.

## Spec

`specs/SPEC_AUTH_CHECK_FALSE_POSITIVE_2026_04_15.md`

## Test plan

- [ ] `task build:backend` — compiles cleanly
- [ ] Load agent pane with valid auth → logs show real email, agent works
- [ ] Load agent pane with expired/stale credentials → redirects to login flow
- [ ] `/login` → complete OAuth → "✓ Logged in as user@example.com" in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)