### PR TITLE
fix: null stdin on auth check to prevent Claude CLI interactive hang (v0.33.170)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.169"
+version = "0.33.170"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.169"
+version = "0.33.170"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.169"
+version = "0.33.170"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.169"
+version = "0.33.170"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.169 | 2026-04-14 | 158.3 MiB | 330.0 MiB | |
 | 0.33.168 | 2026-04-14 | 158.3 MiB | 330.0 MiB | |
 | 0.33.166 | 2026-04-14 | 155.9 MiB | 323.7 MiB | |
 | 0.33.164 | 2026-04-14 | 155.9 MiB | 323.7 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.169"
+version = "0.33.170"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.169"
+version = "0.33.170"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.169"
+version = "0.33.170"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.169"
+version = "0.33.170"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -218,25 +218,80 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .map_err(|e| format!("checkcliauth: {e}"))?;
                 tracing::info!(cli = %cmd.cli_path, "CheckCliAuth");
 
-                // Run CLI auth check command — all providers including Claude.
+                // Two-phase auth check for Claude; single-phase for other providers.
                 //
-                // A previous "fast path" read ~/.claude/.credentials.json directly and
-                // declared authenticated=true if any token string was present. This caused
-                // false positives: stale, expired, and revoked tokens all passed the check,
-                // and the `email` field was set to the subscription tier ("max", "pro") instead
-                // of the user's email address. See SPEC_AUTH_CHECK_FALSE_POSITIVE_2026_04_15.md.
+                // Phase 1 (fast, <1 ms): read the credentials file to determine whether
+                // tokens exist at all. If no file / no tokens → return unauthenticated
+                // immediately without spawning the CLI. This avoids a 10+ second cold-start
+                // stall when the user is definitely not logged in.
+                //
+                // Phase 2 (CLI, 10 s timeout): only when tokens ARE present, run
+                // `claude auth status --json` to validate them and obtain the real email.
+                // This catches expired/revoked tokens — the false-positive that the old
+                // file-only fast path missed.
+                //
+                // Other providers skip Phase 1 and go straight to the CLI (they don't have
+                // a predictable credentials file layout).
+                //
+                // See SPEC_AUTH_CHECK_FALSE_POSITIVE_2026_04_15.md.
+                if cmd.cli_path.to_lowercase().contains("claude") {
+                    let home = std::env::var("HOME")
+                        .or_else(|_| std::env::var("USERPROFILE"))
+                        .unwrap_or_default();
+
+                    // Build candidate paths: isolated dir first, then global ~/.claude/
+                    let mut creds_candidates: Vec<String> = Vec::new();
+                    if let Some(config_dir) = cmd.auth_env.get("CLAUDE_CONFIG_DIR") {
+                        creds_candidates.push(format!("{}/.credentials.json", config_dir));
+                    }
+                    creds_candidates.push(format!("{}/.claude/.credentials.json", home));
+
+                    let tokens_exist = creds_candidates.iter().any(|p| {
+                        if let Ok(content) = std::fs::read_to_string(p) {
+                            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {
+                                let oauth = json.get("claudeAiOauth");
+                                let has_token = oauth.and_then(|o| o.get("accessToken"))
+                                    .and_then(|v| v.as_str()).map(|s| !s.is_empty()).unwrap_or(false);
+                                let has_refresh = oauth.and_then(|o| o.get("refreshToken"))
+                                    .and_then(|v| v.as_str()).map(|s| !s.is_empty()).unwrap_or(false);
+                                return has_token || has_refresh;
+                            }
+                        }
+                        false
+                    });
+
+                    if !tokens_exist {
+                        // No credentials file or empty tokens — definitely not authenticated.
+                        tracing::info!("claude auth check: no credentials file, skipping CLI");
+                        let result = CheckCliAuthResult {
+                            authenticated: false,
+                            email: None,
+                            auth_method: None,
+                            raw_output: "no credentials found".to_string(),
+                        };
+                        return Ok(Some(serde_json::to_value(&result).unwrap()));
+                    }
+
+                    // Tokens exist on disk — validate with the CLI (10 s timeout).
+                    tracing::info!("claude auth check: credentials found, validating via CLI");
+                }
+
                 let output = tokio::time::timeout(
-                    std::time::Duration::from_secs(25),
+                    std::time::Duration::from_secs(10),
                     {
                         let mut check_cmd = make_cli_cmd(&cmd.cli_path);
                         check_cmd.args(&cmd.auth_check_args);
                         for (k, v) in &cmd.auth_env {
                             check_cmd.env(k, v);
                         }
+                        // Null stdin: prevents the CLI from blocking on interactive
+                        // first-run prompts (onboarding, theme selection, etc.) that
+                        // only appear when stdin is a TTY or non-null pipe.
+                        check_cmd.stdin(std::process::Stdio::null());
                         check_cmd.output()
                     },
                 ).await
-                    .map_err(|_| "auth check timed out (25s)".to_string())?
+                    .map_err(|_| "auth check timed out (10s)".to_string())?
                     .map_err(|e| format!("failed to run auth check: {e}"))?;
 
                 let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -314,7 +369,11 @@ pub(crate) fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
 async fn get_cli_version(cli_path: &str) -> String {
     let result = tokio::time::timeout(
         std::time::Duration::from_secs(5),
-        make_cli_cmd(cli_path).arg("--version").output(),
+        {
+            let mut c = make_cli_cmd(cli_path);
+            c.arg("--version").stdin(std::process::Stdio::null());
+            c.output()
+        },
     ).await;
     match result {
         Ok(Ok(output)) if output.status.success() => {

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -241,6 +241,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                         onSelect={acceptCompletion}
                     />
                 </Show>
+                {statusLine()}
                 <textarea
                     ref={textareaRef}
                     class="agent-input"
@@ -249,7 +250,6 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                     onInput={handleInput}
                     rows={1}
                 />
-                {statusLine()}
                 <div class="agent-input-hint">
                     <span>Enter to send • Shift+Enter for newline • Esc to clear / stop</span>
                 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.169",
+  "version": "0.33.170",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.169",
+      "version": "0.33.170",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.169",
+  "version": "0.33.170",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- **Root cause of auth check hang**: `make_cli_cmd` on Windows runs `node <script>` directly (to bypass `.cmd` wrapper issues), but does not set stdin. When the Claude CLI runs for the first time in an isolated auth dir, it blocks on interactive first-run prompts (onboarding, theme selection) waiting for terminal input — causing auth check to hang until the 25s timeout.
- **Fix**: Add `.stdin(Stdio::null())` to both the auth check command and `get_cli_version` so neither can block on interactive prompts.
- **Hybrid two-phase check restored**: Credential file presence gate (fast, <1ms) returns `unauthenticated` immediately when no tokens exist on disk, preventing the CLI from being spawned at all. When tokens do exist, falls through to CLI validation (10s timeout) to catch expired/revoked tokens.
- **Status line above textarea**: `Thinking…` / session stats now renders above the input, not below it.

## Test plan

- [ ] Fresh isolated auth dir (never run claude before in that dir): auth check should return unauthenticated in <5ms, no CLI spawn, no hang
- [ ] Credentials present but expired: CLI runs, returns `loggedIn: false`, auth check returns unauthenticated
- [ ] Fully authenticated: CLI runs `claude auth status --json`, returns `loggedIn: true` with real email
- [ ] Auth check completes in <3s total (no more 25s timeout)
- [ ] Status line ("Thinking…" / cost stats) appears above textarea, not below it

🤖 Generated with [Claude Code](https://claude.com/claude-code)