### PR TITLE
feat: cycle through 200+ thinking phrases in agent status line (v0.33.170)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.169"
+version = "0.33.170"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.169"
+version = "0.33.170"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.169"
+version = "0.33.170"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.169"
+version = "0.33.170"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.169"
+version = "0.33.170"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.169"
+version = "0.33.170"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.169"
+version = "0.33.170"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.169"
+version = "0.33.170"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -65,7 +65,7 @@ const THINKING_PHRASES: string[] = [
     // AgentMux additions
     "Agentifying", "Autonomizing", "Calibrating", "Channelling",
     "Conspiring", "Daydreaming", "Defragging", "Dispatching",
-    "Extrapolating", "Hallucinating", "Hyperlooping", "Interpolating",
+    "Extrapolating", "Hyperlooping", "Interpolating",
     "Muxing", "Optimizing", "Parallelizing", "Pathfinding",
     "Quantizing", "Recalibrating", "Sequencing", "Strategizing",
     "Swarmifying", "Tokenizing", "Transcribing", "Vectorizing",

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -5,10 +5,79 @@
  * AgentFooter - Minimal Claude Code-style input
  */
 
-import { Show, createMemo, createSignal, type JSX } from "solid-js";
+import { Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
 import type { SlashCommand } from "../commands/types";
 import type { SessionStats } from "../types";
 import { SlashAutocomplete } from "./SlashAutocomplete";
+
+// Thinking phrases sourced from Claude Code's cli.js, with AgentMux additions.
+// Displayed in the status line while the agent is processing (no tool active).
+const THINKING_PHRASES: string[] = [
+    "Accomplishing", "Actioning", "Actualizing", "Architecting",
+    "Baking", "Beaming", "Beboppin'", "Befuddling", "Billowing",
+    "Blanching", "Bloviating", "Boogieing", "Boondoggling", "Booping",
+    "Bootstrapping", "Brewing", "Bunning", "Burrowing",
+    "Calculating", "Canoodling", "Caramelizing", "Cascading", "Catapulting",
+    "Cerebrating", "Channeling", "Choreographing", "Churning", "Clauding",
+    "Coalescing", "Cogitating", "Combobulating", "Composing", "Computing",
+    "Concocting", "Considering", "Contemplating", "Cooking", "Crafting",
+    "Creating", "Crunching", "Crystallizing", "Cultivating",
+    "Deciphering", "Deliberating", "Determining", "Dilly-dallying",
+    "Discombobulating", "Doing", "Doodling", "Drizzling",
+    "Ebbing", "Effecting", "Elucidating", "Embellishing", "Enchanting",
+    "Envisioning", "Evaporating",
+    "Fermenting", "Fiddle-faddling", "Finagling", "Flambéing",
+    "Flibbertigibbeting", "Flowing", "Flummoxing", "Fluttering", "Forging",
+    "Forming", "Frolicking", "Frosting",
+    "Gallivanting", "Galloping", "Garnishing", "Generating", "Gesticulating",
+    "Germinating", "Gitifying", "Grooving", "Gusting",
+    "Harmonizing", "Hashing", "Hatching", "Herding", "Honking",
+    "Hullaballooing", "Hyperspacing",
+    "Ideating", "Imagining", "Improvising", "Incubating", "Inferring",
+    "Infusing", "Ionizing",
+    "Jitterbugging", "Julienning",
+    "Kneading",
+    "Leavening", "Levitating", "Lollygagging",
+    "Manifesting", "Marinating", "Meandering", "Metamorphosing", "Misting",
+    "Moonwalking", "Moseying", "Mulling", "Mustering", "Musing",
+    "Nebulizing", "Nesting", "Newspapering", "Noodling", "Nucleating",
+    "Orbiting", "Orchestrating", "Osmosing",
+    "Perambulating", "Percolating", "Perusing", "Philosophising",
+    "Photosynthesizing", "Pollinating", "Pondering", "Pontificating",
+    "Pouncing", "Precipitating", "Prestidigitating", "Processing",
+    "Proofing", "Propagating", "Puttering", "Puzzling",
+    "Quantumizing",
+    "Razzle-dazzling", "Razzmatazzing", "Recombobulating", "Reticulating",
+    "Roosting", "Ruminating",
+    "Sautéing", "Scampering", "Schlepping", "Scurrying", "Seasoning",
+    "Shenaniganing", "Shimmying", "Simmering", "Skedaddling", "Sketching",
+    "Slithering", "Smooshing", "Sock-hopping", "Spelunking", "Spinning",
+    "Sprouting", "Stewing", "Sublimating", "Swirling", "Swooping",
+    "Symbioting", "Synthesizing",
+    "Tempering", "Thinking", "Thundering", "Tinkering", "Tomfoolering",
+    "Topsy-turvying", "Transfiguring", "Transmuting", "Twisting",
+    "Undulating", "Unfurling", "Unravelling",
+    "Vibing",
+    "Waddling", "Wandering", "Warping", "Whatchamacalliting",
+    "Whirlpooling", "Whirring", "Whisking", "Wibbling", "Working",
+    "Wrangling",
+    "Zesting", "Zigzagging",
+    // AgentMux additions
+    "Agentifying", "Autonomizing", "Calibrating", "Channelling",
+    "Conspiring", "Daydreaming", "Defragging", "Dispatching",
+    "Extrapolating", "Hallucinating", "Hyperlooping", "Interpolating",
+    "Muxing", "Optimizing", "Parallelizing", "Pathfinding",
+    "Quantizing", "Recalibrating", "Sequencing", "Strategizing",
+    "Swarmifying", "Tokenizing", "Transcribing", "Vectorizing",
+];
+
+function pickThinkingPhrase(exclude?: string): string {
+    let candidate: string;
+    do {
+        candidate = THINKING_PHRASES[Math.floor(Math.random() * THINKING_PHRASES.length)];
+    } while (candidate === exclude && THINKING_PHRASES.length > 1);
+    return candidate;
+}
 
 interface AgentFooterProps {
     agentId: string;
@@ -63,6 +132,20 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // per-keystroke cost: <2ms. See
     // specs/SPEC_TOOL_OVERLAY_AND_SCROLL_ON_TYPE_2026_04_13.md §3.4.
     let textareaRef: HTMLTextAreaElement | undefined;
+
+    // ── Thinking phrase cycling ───────────────────────────────────────
+    // Picks a new random phrase every 2.5 s while the agent is loading
+    // and no specific tool name is being reported.
+    const [thinkingPhrase, setThinkingPhrase] = createSignal(pickThinkingPhrase());
+    createEffect(() => {
+        if (!props.loading || props.currentTool) return;
+        // Reset phrase on each new loading session
+        setThinkingPhrase(pickThinkingPhrase());
+        const id = setInterval(() => {
+            setThinkingPhrase((prev) => pickThinkingPhrase(prev));
+        }, 2500);
+        onCleanup(() => clearInterval(id));
+    });
 
     // ── Slash autocomplete state ──────────────────────────────────────
     // Tracks the current `/prefix` (without the leading slash) when the
@@ -201,7 +284,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             return (
                 <span class="agent-status-line agent-status-line--loading">
                     <span class="agent-spinner-dot" />
-                    {props.currentTool ? props.currentTool : "Thinking\u2026"}
+                    {props.currentTool ? props.currentTool : `${thinkingPhrase()}\u2026`}
                 </span>
             );
         }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.169",
+  "version": "0.33.170",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Replaces the static "Thinking…" with a rotating phrase that changes every 2.5 s while the agent is processing (when no specific tool name is active)
- 187 phrases sourced from Claude Code's `cli.js` — the same list Claude Code uses (`Hyperspacing…`, `Warping…`, `Cogitating…`, `Flibbertigibbeting…`, etc.)
- 24 AgentMux-specific additions: `Agentifying…`, `Autonomizing…`, `Muxing…`, `Swarmifying…`, `Vectorizing…`, `Hyperlooping…`, and more
- Avoids repeating the same phrase twice in a row
- Phrase cycling stops immediately when a tool name is reported (tool name takes over the status line)

## Test plan

- [ ] Open agent pane, start a message — verify status line cycles through different phrases every ~2.5 s instead of staying on "Thinking…"
- [ ] Trigger a tool call — verify the tool name replaces the cycling phrase immediately
- [ ] Tool call completes, back to thinking — verify cycling resumes with a new phrase
- [ ] Agent finishes — verify cycling stops and session stats (cost/time/turns) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)