### PR TITLE
feat: status line above controls, -ed completion, 30s cycling, fix subprocess auth env (v0.33.172)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.171"
+version = "0.33.172"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.171"
+version = "0.33.172"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.171"
+version = "0.33.172"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.171"
+version = "0.33.172"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.171"
+version = "0.33.172"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.171"
+version = "0.33.172"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.171"
+version = "0.33.172"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.171"
+version = "0.33.172"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1962,6 +1962,23 @@
                 &.agent-status-line--loading {
                     color: #8cc8ff;
                     opacity: 1;
+                    // Stretch to fill the line so left phrase and right
+                    // (tokens + elapsed) sit at opposite ends.
+                    width: 100%;
+
+                    .agent-status-left {
+                        flex: 1;
+                        min-width: 0;
+                        overflow: hidden;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                    }
+
+                    .agent-status-right {
+                        flex-shrink: 0;
+                        opacity: 0.7;
+                        margin-left: 8px;
+                    }
                 }
 
                 &.agent-status-line--stats {

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -129,6 +129,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         streamingStateAtom: agentAtoms().streamingStateAtom,
         sessionStatsAtom: agentAtoms().sessionStatsAtom,
         currentToolAtom: agentAtoms().currentToolAtom,
+        turnTokensAtom: agentAtoms().turnTokensAtom,
         enabled: true,
         documentVersion: history.documentVersion,
     });
@@ -333,6 +334,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     loading={status.isLoading()}
                     currentTool={agentAtoms().currentToolAtom[0]()}
                     sessionStats={agentAtoms().sessionStatsAtom[0]()}
+                    turnTokens={agentAtoms().turnTokensAtom[0]()}
                 />
                 <AgentControlBar
                     blockId={model.blockId}

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -22,7 +22,7 @@ import { useControllerStatusEvents } from "./hooks/useControllerStatusEvents";
 import { useAgentCommands } from "./hooks/useAgentCommands";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { AgentDocumentView } from "./components/AgentDocumentView";
-import { AgentFooter } from "./components/AgentFooter";
+import { AgentFooter, AgentStatusLine } from "./components/AgentFooter";
 import { AgentPicker } from "./components/AgentPicker";
 import { AgentSearchBar } from "./components/AgentSearchBar";
 import { SlashCommandPicker } from "./components/SlashCommandPicker";
@@ -329,6 +329,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                         />
                     )}
                 </Show>
+                <AgentStatusLine
+                    loading={status.isLoading()}
+                    currentTool={agentAtoms().currentToolAtom[0]()}
+                    sessionStats={agentAtoms().sessionStatsAtom[0]()}
+                />
                 <AgentControlBar
                     blockId={model.blockId}
                     blockAtom={block}
@@ -339,10 +344,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onSendMessage={handleSendMessage}
                     onTyping={() => scrollToBottomFn?.()}
                     onStopAgent={commands.stopAgent}
-                    loading={status.isLoading()}
                     getCompletions={commands.completions}
-                    currentTool={agentAtoms().currentToolAtom[0]()}
-                    sessionStats={agentAtoms().sessionStatsAtom[0]()}
                 />
             </div>
         </div>

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -7,87 +7,13 @@
 
 import { Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
 import type { SlashCommand } from "../commands/types";
-import type { SessionStats } from "../types";
+import type { SessionStats, TurnTokens } from "../types";
 import { SlashAutocomplete } from "./SlashAutocomplete";
 
 // ── AgentStatusLine ───────────────────────────────────────────────────────────
 // Displayed above the control bar. Shows a cycling thinking phrase while the
 // agent is processing, then the last phrase converted to past tense + session
 // stats when the turn completes.
-
-/** Convert "Synthesizing" → "Synthesized", "Beboppin'" → "Bebopped". */
-function ingToEd(phrase: string): string {
-    if (phrase.endsWith("ing")) return phrase.slice(0, -3) + "ed";
-    if (phrase.endsWith("in'")) return phrase.slice(0, -3) + "ped";
-    return phrase;
-}
-
-interface AgentStatusLineProps {
-    loading?: boolean;
-    currentTool?: string | null;
-    sessionStats?: SessionStats | null;
-}
-
-export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
-    const [phrase, setPhrase] = createSignal(pickThinkingPhrase());
-    // Capture the last active phrase so we can convert it to past tense when done.
-    const [lastPhrase, setLastPhrase] = createSignal(pickThinkingPhrase());
-
-    createEffect(() => {
-        if (!props.loading || props.currentTool) return;
-        setPhrase(pickThinkingPhrase());
-        const id = setInterval(() => {
-            setPhrase((prev) => {
-                const next = pickThinkingPhrase(prev);
-                setLastPhrase(next);
-                return next;
-            });
-        }, 30000);
-        onCleanup(() => clearInterval(id));
-    });
-
-    // When loading starts, seed lastPhrase from current phrase.
-    createEffect(() => {
-        if (props.loading && !props.currentTool) {
-            setLastPhrase(phrase());
-        }
-    });
-
-    const render = (): JSX.Element => {
-        if (props.loading) {
-            return (
-                <span class="agent-status-line agent-status-line--loading">
-                    <span class="agent-spinner-dot" />
-                    {props.currentTool ? props.currentTool : `${phrase()}\u2026`}
-                </span>
-            );
-        }
-
-        const stats = props.sessionStats;
-        if (!stats) return <span class="agent-status-line" />;
-
-        const parts: string[] = [];
-        parts.push(ingToEd(lastPhrase()));
-        if (stats.cost_usd != null) parts.push(`$${stats.cost_usd.toFixed(3)}`);
-        if (stats.duration_ms != null) {
-            const s = Math.round(stats.duration_ms / 1000);
-            parts.push(s < 60 ? `${Math.max(1, s)}s` : `${Math.floor(s / 60)}m ${s % 60}s`);
-        }
-        if (stats.num_turns) {
-            parts.push(`${stats.num_turns} ${stats.num_turns === 1 ? "turn" : "turns"}`);
-        }
-
-        return (
-            <span class="agent-status-line agent-status-line--stats">
-                {parts.join("  \u00b7  ")}
-            </span>
-        );
-    };
-
-    return render();
-};
-
-AgentStatusLine.displayName = "AgentStatusLine";
 
 // Thinking phrases sourced from Claude Code's cli.js, with AgentMux additions.
 // Displayed in the status line while the agent is processing (no tool active).
@@ -157,6 +83,121 @@ function pickThinkingPhrase(exclude?: string): string {
     } while (candidate === exclude && THINKING_PHRASES.length > 1);
     return candidate;
 }
+
+// Exception map for irregular -ing → past-tense conversions.
+const ING_TO_ED_EXCEPTIONS: Record<string, string> = {
+    Thinking: "Thought",
+    Doing: "Done",
+    Spinning: "Spun",
+    Flowing: "Flowed",   // regular, but guarded for clarity
+    Forging: "Forged",
+};
+
+/** Convert "Synthesizing" → "Synthesized", "Thinking" → "Thought". */
+function ingToEd(phrase: string): string {
+    if (ING_TO_ED_EXCEPTIONS[phrase]) return ING_TO_ED_EXCEPTIONS[phrase];
+    if (phrase.endsWith("ing")) return phrase.slice(0, -3) + "ed";
+    if (phrase.endsWith("in'")) return phrase.slice(0, -3) + "ped";
+    return phrase;
+}
+
+function fmtElapsed(ms: number): string {
+    const s = Math.floor(ms / 1000);
+    return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+function fmtTokens(t: TurnTokens): string {
+    const fmt = (n: number) => n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+    return `\u2191${fmt(t.input)} \u2193${fmt(t.output)}`;
+}
+
+interface AgentStatusLineProps {
+    loading?: boolean;
+    currentTool?: string | null;
+    sessionStats?: SessionStats | null;
+    turnTokens?: TurnTokens | null;
+}
+
+export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
+    const [phrase, setPhrase] = createSignal(pickThinkingPhrase());
+    const [lastPhrase, setLastPhrase] = createSignal(pickThinkingPhrase());
+    const [elapsedMs, setElapsedMs] = createSignal(0);
+
+    // Phrase cycling: 30s interval while loading without a tool name.
+    createEffect(() => {
+        if (!props.loading || props.currentTool) return;
+        setPhrase(pickThinkingPhrase());
+        const id = setInterval(() => {
+            setPhrase((prev) => {
+                const next = pickThinkingPhrase(prev);
+                setLastPhrase(next);
+                return next;
+            });
+        }, 30000);
+        onCleanup(() => clearInterval(id));
+    });
+
+    // Elapsed timer: reset to 0 and tick every second while loading.
+    createEffect(() => {
+        if (!props.loading) return;
+        const start = Date.now();
+        setElapsedMs(0);
+        const id = setInterval(() => setElapsedMs(Date.now() - start), 1000);
+        onCleanup(() => clearInterval(id));
+    });
+
+    // Seed lastPhrase when loading begins.
+    createEffect(() => {
+        if (props.loading && !props.currentTool) setLastPhrase(phrase());
+    });
+
+    // Reactive derived values used in both branches.
+    const statsText = createMemo((): string | null => {
+        const stats = props.sessionStats;
+        if (!stats) return null;
+        const parts: string[] = [];
+        parts.push(ingToEd(lastPhrase()));
+        if (stats.cost_usd != null) parts.push(`$${stats.cost_usd.toFixed(3)}`);
+        if (stats.duration_ms != null) {
+            const s = Math.round(stats.duration_ms / 1000);
+            parts.push(s < 60 ? `${Math.max(1, s)}s` : `${Math.floor(s / 60)}m ${s % 60}s`);
+        }
+        if (stats.num_turns) {
+            parts.push(`${stats.num_turns} ${stats.num_turns === 1 ? "turn" : "turns"}`);
+        }
+        return parts.join("  \u00b7  ");
+    });
+
+    const rightText = createMemo((): string => {
+        const right: string[] = [];
+        if (props.turnTokens) right.push(fmtTokens(props.turnTokens));
+        right.push(fmtElapsed(elapsedMs()));
+        return right.join("  \u00b7  ");
+    });
+
+    return (
+        <Show
+            when={props.loading}
+            fallback={
+                <Show when={statsText()} fallback={<span class="agent-status-line" />}>
+                    <span class="agent-status-line agent-status-line--stats">
+                        {statsText()}
+                    </span>
+                </Show>
+            }
+        >
+            <span class="agent-status-line agent-status-line--loading">
+                <span class="agent-spinner-dot" />
+                <span class="agent-status-left">
+                    {props.currentTool ? props.currentTool : `${phrase()}\u2026`}
+                </span>
+                <span class="agent-status-right">{rightText()}</span>
+            </span>
+        </Show>
+    );
+};
+
+AgentStatusLine.displayName = "AgentStatusLine";
 
 interface AgentFooterProps {
     agentId: string;

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -97,7 +97,7 @@ const ING_TO_ED_EXCEPTIONS: Record<string, string> = {
 function ingToEd(phrase: string): string {
     if (ING_TO_ED_EXCEPTIONS[phrase]) return ING_TO_ED_EXCEPTIONS[phrase];
     if (phrase.endsWith("ing")) return phrase.slice(0, -3) + "ed";
-    if (phrase.endsWith("in'")) return phrase.slice(0, -3) + "ped";
+    if (phrase.endsWith("in'")) return phrase.slice(0, -3) + "ed";
     return phrase;
 }
 

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -10,6 +10,85 @@ import type { SlashCommand } from "../commands/types";
 import type { SessionStats } from "../types";
 import { SlashAutocomplete } from "./SlashAutocomplete";
 
+// ── AgentStatusLine ───────────────────────────────────────────────────────────
+// Displayed above the control bar. Shows a cycling thinking phrase while the
+// agent is processing, then the last phrase converted to past tense + session
+// stats when the turn completes.
+
+/** Convert "Synthesizing" → "Synthesized", "Beboppin'" → "Bebopped". */
+function ingToEd(phrase: string): string {
+    if (phrase.endsWith("ing")) return phrase.slice(0, -3) + "ed";
+    if (phrase.endsWith("in'")) return phrase.slice(0, -3) + "ped";
+    return phrase;
+}
+
+interface AgentStatusLineProps {
+    loading?: boolean;
+    currentTool?: string | null;
+    sessionStats?: SessionStats | null;
+}
+
+export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
+    const [phrase, setPhrase] = createSignal(pickThinkingPhrase());
+    // Capture the last active phrase so we can convert it to past tense when done.
+    const [lastPhrase, setLastPhrase] = createSignal(pickThinkingPhrase());
+
+    createEffect(() => {
+        if (!props.loading || props.currentTool) return;
+        setPhrase(pickThinkingPhrase());
+        const id = setInterval(() => {
+            setPhrase((prev) => {
+                const next = pickThinkingPhrase(prev);
+                setLastPhrase(next);
+                return next;
+            });
+        }, 30000);
+        onCleanup(() => clearInterval(id));
+    });
+
+    // When loading starts, seed lastPhrase from current phrase.
+    createEffect(() => {
+        if (props.loading && !props.currentTool) {
+            setLastPhrase(phrase());
+        }
+    });
+
+    const render = (): JSX.Element => {
+        if (props.loading) {
+            return (
+                <span class="agent-status-line agent-status-line--loading">
+                    <span class="agent-spinner-dot" />
+                    {props.currentTool ? props.currentTool : `${phrase()}\u2026`}
+                </span>
+            );
+        }
+
+        const stats = props.sessionStats;
+        if (!stats) return <span class="agent-status-line" />;
+
+        const parts: string[] = [];
+        parts.push(ingToEd(lastPhrase()));
+        if (stats.cost_usd != null) parts.push(`$${stats.cost_usd.toFixed(3)}`);
+        if (stats.duration_ms != null) {
+            const s = Math.round(stats.duration_ms / 1000);
+            parts.push(s < 60 ? `${Math.max(1, s)}s` : `${Math.floor(s / 60)}m ${s % 60}s`);
+        }
+        if (stats.num_turns) {
+            parts.push(`${stats.num_turns} ${stats.num_turns === 1 ? "turn" : "turns"}`);
+        }
+
+        return (
+            <span class="agent-status-line agent-status-line--stats">
+                {parts.join("  \u00b7  ")}
+            </span>
+        );
+    };
+
+    return render();
+};
+
+AgentStatusLine.displayName = "AgentStatusLine";
+
 // Thinking phrases sourced from Claude Code's cli.js, with AgentMux additions.
 // Displayed in the status line while the agent is processing (no tool active).
 const THINKING_PHRASES: string[] = [
@@ -96,7 +175,6 @@ interface AgentFooterProps {
      * See SPEC_AGENT_PANE_FOLLOWUPS item #9.
      */
     onStopAgent?: () => void;
-    loading?: boolean;
     /**
      * Slash command completions. When the textarea value matches
      * `^/\w*$` (no space), AgentFooter calls this with the prefix
@@ -104,10 +182,6 @@ interface AgentFooterProps {
      * If absent, autocomplete is disabled.
      */
     getCompletions?: (prefix: string) => SlashCommand[];
-    /** Name of the currently-running tool (from the last tool_call event). */
-    currentTool?: string | null;
-    /** Stats from the last completed session. Displayed until the next send. */
-    sessionStats?: SessionStats | null;
 }
 
 export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
@@ -132,20 +206,6 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // per-keystroke cost: <2ms. See
     // specs/SPEC_TOOL_OVERLAY_AND_SCROLL_ON_TYPE_2026_04_13.md §3.4.
     let textareaRef: HTMLTextAreaElement | undefined;
-
-    // ── Thinking phrase cycling ───────────────────────────────────────
-    // Picks a new random phrase every 2.5 s while the agent is loading
-    // and no specific tool name is being reported.
-    const [thinkingPhrase, setThinkingPhrase] = createSignal(pickThinkingPhrase());
-    createEffect(() => {
-        if (!props.loading || props.currentTool) return;
-        // Reset phrase on each new loading session
-        setThinkingPhrase(pickThinkingPhrase());
-        const id = setInterval(() => {
-            setThinkingPhrase((prev) => pickThinkingPhrase(prev));
-        }, 2500);
-        onCleanup(() => clearInterval(id));
-    });
 
     // ── Slash autocomplete state ──────────────────────────────────────
     // Tracks the current `/prefix` (without the leading slash) when the
@@ -279,40 +339,6 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         }
     };
 
-    const statusLine = (): JSX.Element => {
-        if (props.loading) {
-            return (
-                <span class="agent-status-line agent-status-line--loading">
-                    <span class="agent-spinner-dot" />
-                    {props.currentTool ? props.currentTool : `${thinkingPhrase()}\u2026`}
-                </span>
-            );
-        }
-        const stats = props.sessionStats;
-        if (!stats) return <span class="agent-status-line" />;
-
-        const parts: string[] = [];
-        if (stats.cost_usd != null) parts.push(`$${stats.cost_usd.toFixed(3)}`);
-        if (stats.duration_ms != null) {
-            const s = Math.round(stats.duration_ms / 1000);
-            if (s < 60) {
-                parts.push(`${Math.max(1, s)}s`);
-            } else {
-                parts.push(`${Math.floor(s / 60)}m ${s % 60}s`);
-            }
-        }
-        if (stats.num_turns) {
-            parts.push(`${stats.num_turns} ${stats.num_turns === 1 ? "turn" : "turns"}`);
-        }
-        if (parts.length === 0) return <span class="agent-status-line" />;
-
-        return (
-            <span class="agent-status-line agent-status-line--stats">
-                {parts.join("  \u00b7  ")}
-            </span>
-        );
-    };
-
     return (
         <div class="agent-footer">
             <div class="agent-input-container">
@@ -324,7 +350,6 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                         onSelect={acceptCompletion}
                     />
                 </Show>
-                {statusLine()}
                 <textarea
                     ref={textareaRef}
                     class="agent-input"

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -131,10 +131,18 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
         log("cli", `found: ${cliResult.cli_path} (${cliResult.version})`);
     }
 
-    // Update block meta with resolved absolute path
+    // Update block meta with resolved CLI path and auth env vars.
+    // cmd:env is read by AgentInputCommand when spawning the subprocess —
+    // it must include CLAUDE_CONFIG_DIR (or equivalent) so the subprocess
+    // uses the same isolated auth dir that was validated in Phase 2.
+    // Without this, the subprocess runs without the env var and falls back
+    // to the global ~/.claude/ dir, failing auth silently after login.
     await RpcApi.SetMetaCommand(TabRpcClient, {
         oref,
-        meta: { cmd: cliResult.cli_path },
+        meta: {
+            cmd: cliResult.cli_path,
+            ...(authEnv && Object.keys(authEnv).length > 0 ? { "cmd:env": authEnv } : {}),
+        },
     });
 
     // Phase 2: Auth Check → auto-login if not authenticated

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -17,6 +17,7 @@ import {
     MessageRouterState,
     SessionStats,
     StreamingState,
+    TurnTokens,
     UserInfo,
 } from "./types";
 
@@ -41,6 +42,7 @@ export interface AgentAtoms {
     rawOutputAtom: SignalPair<string>;
     sessionStatsAtom: SignalPair<SessionStats | null>;
     currentToolAtom: SignalPair<string | null>;
+    turnTokensAtom: SignalPair<TurnTokens | null>;
 }
 
 /**
@@ -89,5 +91,6 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         rawOutputAtom: createSignal<string>(""),
         sessionStatsAtom: createSignal<SessionStats | null>(null),
         currentToolAtom: createSignal<string | null>(null),
+        turnTokensAtom: createSignal<TurnTokens | null>(null),
     };
 }

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -210,6 +210,16 @@ export interface SessionStats {
 }
 
 /**
+ * Live token counts accumulated during the current turn.
+ * input is set from message_start.message.usage.input_tokens.
+ * output accumulates from message_delta.usage.output_tokens.
+ */
+export interface TurnTokens {
+    input: number;
+    output: number;
+}
+
+/**
  * Stream events from Claude Code NDJSON output
  */
 export type StreamEvent =

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -13,7 +13,7 @@ import { createEffect, onCleanup, onMount, untrack } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import { ClaudeCodeStreamParser } from "./stream-parser";
 import type { SignalPair } from "./state";
-import type { DocumentNode, SessionStats, StreamingState } from "./types";
+import type { DocumentNode, SessionStats, StreamingState, TurnTokens } from "./types";
 
 const OutputFileName = "output";
 
@@ -24,6 +24,7 @@ interface UseAgentStreamOpts {
     streamingStateAtom: SignalPair<StreamingState>;
     sessionStatsAtom: SignalPair<SessionStats | null>;
     currentToolAtom: SignalPair<string | null>;
+    turnTokensAtom: SignalPair<TurnTokens | null>;
     enabled: boolean;
     /**
      * Version signal bumped by external document mutations (e.g. history
@@ -44,6 +45,7 @@ export function useAgentStream({
     streamingStateAtom,
     sessionStatsAtom,
     currentToolAtom,
+    turnTokensAtom,
     enabled,
     documentVersion,
 }: UseAgentStreamOpts): void {
@@ -51,6 +53,7 @@ export function useAgentStream({
     const [, setStreaming] = streamingStateAtom;
     const [, setSessionStats] = sessionStatsAtom;
     const [, setCurrentTool] = currentToolAtom;
+    const [, setTurnTokens] = turnTokensAtom;
 
     // Mutable state that doesn't trigger re-renders
     let lineBuffer = "";
@@ -184,6 +187,7 @@ export function useAgentStream({
                 setDocument([]);
                 setSessionStats(null);
                 setCurrentTool(null);
+                setTurnTokens(null);
                 lineBuffer = "";
                 translator.reset();
                 parser.reset();
@@ -247,6 +251,24 @@ export function useAgentStream({
                     continue;
                 }
 
+                // Extract live token counts from Anthropic stream events before
+                // the translator discards them. message_start carries input_tokens
+                // for this turn; message_delta carries the running output_tokens.
+                {
+                    const inner = rawEvent.type === "stream_event" ? rawEvent.event : rawEvent;
+                    if (inner?.type === "message_start") {
+                        const inputTok = inner.message?.usage?.input_tokens as number | undefined;
+                        if (inputTok != null) {
+                            setTurnTokens((prev) => ({ input: inputTok, output: prev?.output ?? 0 }));
+                        }
+                    } else if (inner?.type === "message_delta") {
+                        const outputTok = inner.usage?.output_tokens as number | undefined;
+                        if (outputTok != null) {
+                            setTurnTokens((prev) => ({ input: prev?.input ?? 0, output: outputTok }));
+                        }
+                    }
+                }
+
                 // Translate provider-specific format → StreamEvent[]
                 const streamEvents = translator.translate(rawEvent);
 
@@ -256,6 +278,7 @@ export function useAgentStream({
                     if (event.type === "session_end") {
                         setSessionStats(event.stats ?? null);
                         setCurrentTool(null);
+                        setTurnTokens(null);
                         continue;
                     }
                     // Track the currently-running tool for the status line

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.170",
+  "version": "0.33.171",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.170",
+      "version": "0.33.171",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.171",
+  "version": "0.33.172",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.171",
+      "version": "0.33.172",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.171",
+  "version": "0.33.172",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- **Status line position**: extracted `AgentStatusLine` component, rendered above `AgentControlBar` (above the bypass/model/effort dropdowns)
- **Cycle interval**: 2500ms → 30s
- **`-ed` completion**: when the agent responds, the last active phrase converts to past tense + stats inline: `Synthesized  ·  $0.042  ·  15s  ·  3 turns`
- **Fix agent unresponsive after login**: `authEnv` (e.g. `CLAUDE_CONFIG_DIR`) is now saved to `cmd:env` block meta. Without this, `AgentInputCommand` spawned the subprocess without the auth env var, so it used the global `~/.claude/` dir instead of the isolated auth dir — credentials weren't found, agent silently failed to run

## Root cause of unresponsive agent

`launch-flow.ts` passed `authEnv` to `CheckCliAuthCommand` and `RunCliLoginCommand` but never wrote it to block meta. `AgentInputCommand` on the backend reads `cmd:env` from the block — it was always empty, so the subprocess ran without `CLAUDE_CONFIG_DIR`.

## Test plan

- [ ] Status line appears above the mode/model/effort controls, not below them
- [ ] Phrase changes every ~30s while agent is thinking
- [ ] When agent responds: status shows `<PastTenseVerb>  ·  $X.XXX  ·  Xs  ·  N turns`
- [ ] After login flow completes, sending a message starts the agent successfully (no longer unresponsive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)