### PR TITLE
feat: Working/Worked phrases, fix browser login open, add auth paste button (v0.33.174)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.173"
+version = "0.33.174"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.173"
+version = "0.33.174"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.173"
+version = "0.33.174"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.173"
+version = "0.33.174"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,8 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.173 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
+| 0.33.171 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.169 | 2026-04-14 | 158.3 MiB | 330.0 MiB | |
 | 0.33.168 | 2026-04-14 | 158.3 MiB | 330.0 MiB | |
 | 0.33.166 | 2026-04-14 | 155.9 MiB | 323.7 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.173"
+version = "0.33.174"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.173"
+version = "0.33.174"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.173"
+version = "0.33.174"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.173"
+version = "0.33.174"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -673,6 +673,58 @@
         display: flex;
         flex-direction: column;
         flex-shrink: 0;
+
+        // Status line rendered above the control bar.
+        .agent-status-line {
+            min-height: 14px;
+            font-size: 10px;
+            color: var(--secondary-text-color);
+            opacity: 0.6;
+            padding: 2px 8px;
+            display: flex;
+            align-items: center;
+            gap: 5px;
+            font-family: var(--fixed-font, monospace);
+
+            &.agent-status-line--loading {
+                color: #8cc8ff;
+                opacity: 1;
+                width: 100%;
+
+                .agent-status-left {
+                    flex: 1;
+                    min-width: 0;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+
+                .agent-status-right {
+                    flex-shrink: 0;
+                    opacity: 0.7;
+                    margin-left: 8px;
+                }
+            }
+
+            &.agent-status-line--stats {
+                opacity: 0.5;
+                gap: 0;
+            }
+        }
+
+        .agent-spinner-dot {
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            background: #8cc8ff;
+            flex-shrink: 0;
+            animation: agent-pulse 1.2s ease-in-out infinite;
+        }
+
+        @keyframes agent-pulse {
+            0%, 100% { opacity: 0.4; transform: scale(0.85); }
+            50% { opacity: 1; transform: scale(1.3); }
+        }
     }
 
     .slash-picker {
@@ -1948,58 +2000,6 @@
                 }
             }
 
-            .agent-status-line {
-                min-height: 14px;
-                font-size: 10px;
-                color: var(--secondary-text-color);
-                opacity: 0.6;
-                padding: 1px 4px;
-                display: flex;
-                align-items: center;
-                gap: 5px;
-                font-family: var(--fixed-font, monospace);
-
-                &.agent-status-line--loading {
-                    color: #8cc8ff;
-                    opacity: 1;
-                    // Stretch to fill the line so left phrase and right
-                    // (tokens + elapsed) sit at opposite ends.
-                    width: 100%;
-
-                    .agent-status-left {
-                        flex: 1;
-                        min-width: 0;
-                        overflow: hidden;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-                    }
-
-                    .agent-status-right {
-                        flex-shrink: 0;
-                        opacity: 0.7;
-                        margin-left: 8px;
-                    }
-                }
-
-                &.agent-status-line--stats {
-                    opacity: 0.5;
-                    gap: 0;
-                }
-            }
-
-            .agent-spinner-dot {
-                width: 7px;
-                height: 7px;
-                border-radius: 50%;
-                background: #8cc8ff;
-                flex-shrink: 0;
-                animation: agent-pulse 1.2s ease-in-out infinite;
-            }
-
-            @keyframes agent-pulse {
-                0%, 100% { opacity: 0.4; transform: scale(0.85); }
-                50% { opacity: 1; transform: scale(1.3); }
-            }
 
             .agent-input-hint {
                 font-size: 9px;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -295,13 +295,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 highlightNodeId={search.highlightId}
             />
 
-            <Show when={status.loginWaiting()}>
-                <div class="agent-retry-bar">
-                    <button class="agent-retry-btn agent-retry-btn--cancel" onClick={status.cancelLogin}>
-                        Cancel Login
-                    </button>
-                </div>
-            </Show>
             <Show when={status.canRetry()}>
                 <div class="agent-retry-bar">
                     <button class="agent-retry-btn" onClick={status.startLaunchFlow}>

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -282,6 +282,17 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                         />
                                         <button
                                             class="agent-auth-url-copy"
+                                            title="Paste from clipboard"
+                                            onClick={() => {
+                                                import("@/util/clipboard").then(c => c.readText()).then(text => {
+                                                    if (text) setPasteCode(text.trim());
+                                                });
+                                            }}
+                                        >
+                                            Paste
+                                        </button>
+                                        <button
+                                            class="agent-auth-url-copy"
                                             onClick={handleSubmitCode}
                                             disabled={!pasteCode().trim() || pasting()}
                                         >

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -286,6 +286,8 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                             onClick={() => {
                                                 import("@/util/clipboard").then(c => c.readText()).then(text => {
                                                     if (text) setPasteCode(text.trim());
+                                                }).catch(() => {
+                                                    setPasteResult("Could not read clipboard — paste manually");
                                                 });
                                             }}
                                         >

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -15,90 +15,12 @@ import { SlashAutocomplete } from "./SlashAutocomplete";
 // agent is processing, then the last phrase converted to past tense + session
 // stats when the turn completes.
 
-// Thinking phrases sourced from Claude Code's cli.js, with AgentMux additions.
-// Displayed in the status line while the agent is processing (no tool active).
-const THINKING_PHRASES: string[] = [
-    "Accomplishing", "Actioning", "Actualizing", "Architecting",
-    "Baking", "Beaming", "Beboppin'", "Befuddling", "Billowing",
-    "Blanching", "Bloviating", "Boogieing", "Boondoggling", "Booping",
-    "Bootstrapping", "Brewing", "Bunning", "Burrowing",
-    "Calculating", "Canoodling", "Caramelizing", "Cascading", "Catapulting",
-    "Cerebrating", "Channeling", "Choreographing", "Churning", "Clauding",
-    "Coalescing", "Cogitating", "Combobulating", "Composing", "Computing",
-    "Concocting", "Considering", "Contemplating", "Cooking", "Crafting",
-    "Creating", "Crunching", "Crystallizing", "Cultivating",
-    "Deciphering", "Deliberating", "Determining", "Dilly-dallying",
-    "Discombobulating", "Doing", "Doodling", "Drizzling",
-    "Ebbing", "Effecting", "Elucidating", "Embellishing", "Enchanting",
-    "Envisioning", "Evaporating",
-    "Fermenting", "Fiddle-faddling", "Finagling", "Flambéing",
-    "Flibbertigibbeting", "Flowing", "Flummoxing", "Fluttering", "Forging",
-    "Forming", "Frolicking", "Frosting",
-    "Gallivanting", "Galloping", "Garnishing", "Generating", "Gesticulating",
-    "Germinating", "Gitifying", "Grooving", "Gusting",
-    "Harmonizing", "Hashing", "Hatching", "Herding", "Honking",
-    "Hullaballooing", "Hyperspacing",
-    "Ideating", "Imagining", "Improvising", "Incubating", "Inferring",
-    "Infusing", "Ionizing",
-    "Jitterbugging", "Julienning",
-    "Kneading",
-    "Leavening", "Levitating", "Lollygagging",
-    "Manifesting", "Marinating", "Meandering", "Metamorphosing", "Misting",
-    "Moonwalking", "Moseying", "Mulling", "Mustering", "Musing",
-    "Nebulizing", "Nesting", "Newspapering", "Noodling", "Nucleating",
-    "Orbiting", "Orchestrating", "Osmosing",
-    "Perambulating", "Percolating", "Perusing", "Philosophising",
-    "Photosynthesizing", "Pollinating", "Pondering", "Pontificating",
-    "Pouncing", "Precipitating", "Prestidigitating", "Processing",
-    "Proofing", "Propagating", "Puttering", "Puzzling",
-    "Quantumizing",
-    "Razzle-dazzling", "Razzmatazzing", "Recombobulating", "Reticulating",
-    "Roosting", "Ruminating",
-    "Sautéing", "Scampering", "Schlepping", "Scurrying", "Seasoning",
-    "Shenaniganing", "Shimmying", "Simmering", "Skedaddling", "Sketching",
-    "Slithering", "Smooshing", "Sock-hopping", "Spelunking", "Spinning",
-    "Sprouting", "Stewing", "Sublimating", "Swirling", "Swooping",
-    "Symbioting", "Synthesizing",
-    "Tempering", "Thinking", "Thundering", "Tinkering", "Tomfoolering",
-    "Topsy-turvying", "Transfiguring", "Transmuting", "Twisting",
-    "Undulating", "Unfurling", "Unravelling",
-    "Vibing",
-    "Waddling", "Wandering", "Warping", "Whatchamacalliting",
-    "Whirlpooling", "Whirring", "Whisking", "Wibbling", "Working",
-    "Wrangling",
-    "Zesting", "Zigzagging",
-    // AgentMux additions
-    "Agentifying", "Autonomizing", "Calibrating", "Channelling",
-    "Conspiring", "Daydreaming", "Defragging", "Dispatching",
-    "Extrapolating", "Hyperlooping", "Interpolating",
-    "Muxing", "Optimizing", "Parallelizing", "Pathfinding",
-    "Quantizing", "Recalibrating", "Sequencing", "Strategizing",
-    "Swarmifying", "Tokenizing", "Transcribing", "Vectorizing",
-];
-
-function pickThinkingPhrase(exclude?: string): string {
-    let candidate: string;
-    do {
-        candidate = THINKING_PHRASES[Math.floor(Math.random() * THINKING_PHRASES.length)];
-    } while (candidate === exclude && THINKING_PHRASES.length > 1);
-    return candidate;
+function pickThinkingPhrase(_exclude?: string): string {
+    return "Working";
 }
 
-// Exception map for irregular -ing → past-tense conversions.
-const ING_TO_ED_EXCEPTIONS: Record<string, string> = {
-    Thinking: "Thought",
-    Doing: "Done",
-    Spinning: "Spun",
-    Flowing: "Flowed",   // regular, but guarded for clarity
-    Forging: "Forged",
-};
-
-/** Convert "Synthesizing" → "Synthesized", "Thinking" → "Thought". */
-function ingToEd(phrase: string): string {
-    if (ING_TO_ED_EXCEPTIONS[phrase]) return ING_TO_ED_EXCEPTIONS[phrase];
-    if (phrase.endsWith("ing")) return phrase.slice(0, -3) + "ed";
-    if (phrase.endsWith("in'")) return phrase.slice(0, -3) + "ed";
-    return phrase;
+function ingToEd(_phrase: string): string {
+    return "Worked";
 }
 
 function fmtElapsed(ms: number): string {

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -186,8 +186,11 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             );
             if (loginUrl) {
                 setAuthUrl(loginUrl);
-                log("auth", "OAuth URL captured — browser should open automatically");
-                log("auth", "if it didn't, copy the URL from the box above");
+                // Open the URL in the system browser. If it doesn't open,
+                // the user can copy from the URL box above the composer.
+                try { getApi().openExternal(loginUrl); } catch { /* non-fatal */ }
+                log("auth", "browser opened — complete login there");
+                log("auth", "if it didn't open, copy the URL from the box above");
             } else {
                 log("auth", "a browser window should have opened — complete login there");
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.172",
+  "version": "0.33.173",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.172",
+      "version": "0.33.173",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.173",
+  "version": "0.33.174",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.173",
+      "version": "0.33.174",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.173",
+  "version": "0.33.174",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_ALWAYS_RESPOND_TO_USER_ACTIONS_2026_04_15.md
+++ b/specs/SPEC_ALWAYS_RESPOND_TO_USER_ACTIONS_2026_04_15.md
@@ -1,0 +1,134 @@
+# SPEC: Always Respond to User Actions
+
+**Date:** 2026-04-15  
+**Status:** Draft  
+**Author:** AgentA
+
+---
+
+## Problem
+
+Users frequently perform an action in the agent pane (send a message, click a button, paste a code, press Enter) and receive no visible feedback. The action silently fails or is dropped. This erodes trust and leads to repeated attempts, duplicate messages, and confusion.
+
+Examples observed:
+
+- Typing a message and pressing Enter — no visible echo, no acknowledgement
+- Submitting an auth code — no response, user doesn't know if it worked
+- Clicking "Submit" on an empty input — button does nothing, no tooltip
+- Slash command selected with Enter — silently consumed, no confirmation
+- Agent finishes a turn — status line goes blank with no summary
+- Login completes — no in-pane confirmation, user doesn't know it's ready
+
+---
+
+## Principle
+
+**Every user action that can succeed or fail must produce a visible response within 200ms.**
+
+This is non-negotiable. Silence is never acceptable feedback.
+
+---
+
+## Rules
+
+### R1 — Input submission always echoes
+
+When the user sends a message (Enter or Send button):
+
+- The message MUST appear in the document immediately, before the agent responds
+- The composer MUST clear
+- The status line MUST switch to "Working…" within one animation frame
+
+### R2 — Buttons must acknowledge clicks
+
+Every clickable button in the agent pane must:
+
+1. Visually respond on click (active/pressed state via CSS `:active` or a `loading` class)
+2. Change label or disable while the action is in-flight (e.g. "Submit" → "...")
+3. Show a result when complete — either success text or an error message
+
+Never: button that does nothing when clicked with no feedback.
+
+### R3 — Auth code submit
+
+The auth code paste/submit flow must:
+
+1. Disable the Submit button while processing (already: `disabled={pasting()}`)
+2. Show "Code accepted — waiting for confirmation…" on success
+3. Show a red error message if the call throws — never silently swallow errors
+4. Clear error state when the user edits the input field again
+
+Current gap: `setProviderAuth` writes to the AgentMux config, not the Claude CLI's stdin. This is a known bug tracked separately. Once fixed, the response text must accurately reflect whether the code was actually delivered.
+
+### R4 — Async operations show progress
+
+Any operation that takes >200ms must show a loading indicator immediately (not after the delay). Examples:
+
+- CLI installation: log lines streaming in real-time (already implemented)
+- Auth check: "checking authentication…" log line (already implemented)
+- Controller registration: "registering…" log line (already implemented)
+- Auth code submit: button label changes to "..." (already implemented)
+
+New gap: login polling — if the 2s poll cycle fails transiently, the user sees no change. A heartbeat log line ("still waiting…" every 30s) would reassure the user.
+
+### R5 — Login completion shows in-pane message
+
+When login polling succeeds:
+
+- A markdown node MUST be appended to the document: `✓ Logged in as **email**`
+- The log panel MUST show `auth: authenticated as email`
+- The auth URL box MUST disappear
+
+This is already implemented via `onLoginSuccess` callback. Do not remove it.
+
+### R6 — Status line is never empty while working
+
+While `loading=true`:
+
+- The status line MUST show "Working…" (or the active tool name)
+- The blue pulse dot MUST be visible
+
+When a turn completes:
+
+- The status line MUST show "Worked · $cost · Xs · N turns" (or subset if data unavailable)
+- This state persists until the NEXT user message is sent
+
+When idle (no stats):
+
+- The status line renders an empty placeholder (`<span class="agent-status-line" />`) — this is intentional and acceptable. It reserves vertical space so the layout doesn't jump.
+
+### R7 — Error states are always surfaced
+
+No error path in the agent pane may silently drop the error. Every catch block must either:
+
+1. Append a visible error node to the document, OR
+2. Append a log line with `level: "error"`, OR
+3. Set a visible error state in the UI
+
+Swallowing errors in a catch with only `console.warn` is not acceptable in any user-facing code path.
+
+---
+
+## Implementation Checklist
+
+- [x] Message echo: `UserMessageNode` appended in `useAgentCommands.sendMessage`
+- [x] Status line cycling phrase while loading
+- [x] Status line summary on turn complete (stats + "Worked")
+- [x] Auth URL box with Copy button
+- [x] Auth code Submit button with loading state
+- [x] Login success message appended to document
+- [ ] Auth code actually delivered to CLI stdin (requires CEF host fix — separate PR)
+- [ ] Auth code submit error surfaced as visible message (currently shows only result text, no error display)
+- [ ] Login poll heartbeat log line every 30s ("still waiting for browser login…")
+- [ ] Submit button error state: red text below input
+
+---
+
+## Testing
+
+For each of the gaps above, manual test:
+
+1. Trigger the action
+2. Verify visible feedback appears within 200ms
+3. Verify the feedback accurately describes what happened (not a lie)
+4. Verify error cases show a clear message (trigger by e.g. passing a bad auth code)


### PR DESCRIPTION
## Summary

- **Status phrases simplified**: replaced 210+ cycling phrases with "Working" while processing and "Worked" on completion — clean and unambiguous
- **Browser opens on login**: `launch-flow.ts` now calls `getApi().openExternal(loginUrl)` after capturing the OAuth URL — the browser was never being opened before
- **Auth Paste button**: added a clipboard Paste button next to the auth code input so users can paste the code with one click instead of Ctrl+V
- **Cancel Login button removed**: was added unintentionally, removed from `agent-view.tsx`
- **Status line CSS fixed**: rules were scoped under `.agent-input-container` but `AgentStatusLine` moved to `.agent-composer-region` — blue animation and color were broken
- **Spec written**: `specs/SPEC_ALWAYS_RESPOND_TO_USER_ACTIONS_2026_04_15.md` — rules for ensuring every user action gets visible feedback

## Test plan

- [ ] Start login flow — browser should open automatically
- [ ] If browser blocked, copy URL manually — paste button on auth input works
- [ ] While agent is processing: status line shows "Working…" with blue pulse dot
- [ ] After turn completes: status line shows "Worked · $cost · Xs · N turns"
- [ ] No "Cancel Login" button visible
- [ ] Blue pulse animation visible while loading

## Known gap (separate PR)

The auth code Submit still calls `setProviderAuth` which writes to the AgentMux config — not the Claude CLI's stdin. This requires a CEF host (Rust) fix to pipe stdin to the spawned login process. The Paste button is ready for when that fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)