### PR TITLE
fix: Working status line during turns, auto-scroll 200px, overlay min-width (v0.33.176)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.175"
+version = "0.33.176"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.175"
+version = "0.33.176"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.175"
+version = "0.33.176"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.175"
+version = "0.33.176"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.175 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.173 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.171 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.169 | 2026-04-14 | 158.3 MiB | 330.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.175"
+version = "0.33.176"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.175"
+version = "0.33.176"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.175"
+version = "0.33.176"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.175"
+version = "0.33.176"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -130,6 +130,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         sessionStatsAtom: agentAtoms().sessionStatsAtom,
         currentToolAtom: agentAtoms().currentToolAtom,
         turnTokensAtom: agentAtoms().turnTokensAtom,
+        turnActiveAtom: agentAtoms().turnActiveAtom,
         enabled: true,
         documentVersion: history.documentVersion,
     });
@@ -159,10 +160,12 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         onSent: () => scrollToBottomFn?.(),
     });
 
-    // Clear session stats when the user sends a new message.
+    // Clear session stats and mark turn as active when the user sends a message.
     const [, setSessionStats] = agentAtoms().sessionStatsAtom;
+    const [, setTurnActive] = agentAtoms().turnActiveAtom;
     const handleSendMessage = (message: string): Promise<void> => {
         setSessionStats(null);
+        setTurnActive(true);
         return commands.sendMessage(message);
     };
 
@@ -324,7 +327,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     )}
                 </Show>
                 <AgentStatusLine
-                    loading={status.isLoading()}
+                    loading={status.isLoading() || agentAtoms().turnActiveAtom[0]()}
                     currentTool={agentAtoms().currentToolAtom[0]()}
                     sessionStats={agentAtoms().sessionStatsAtom[0]()}
                     turnTokens={agentAtoms().turnTokensAtom[0]()}

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -179,7 +179,7 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
     const handleScroll = () => {
         if (!scrollRef) return;
         const { scrollTop, scrollHeight, clientHeight } = scrollRef;
-        autoScroll = scrollHeight - scrollTop - clientHeight < 50;
+        autoScroll = scrollHeight - scrollTop - clientHeight < 200;
 
         // Trigger older-history load when near the top
         if (

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -280,18 +280,24 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     const overlayStyle = (): Record<string, string> => {
         const r = overlayRect();
         if (!r) return { display: "none" };
+        // Use min-width (not width) so the overlay can grow rightward for wide
+        // content without creating a horizontal scrollbar on the document.
+        // Clamp right edge to viewport so the overlay never bleeds off-screen.
+        const maxRight = window.innerWidth - r.left - 16;
         if (overlayUp()) {
             return {
                 position: "fixed",
                 left: `${r.left}px`,
-                width: `${r.width}px`,
+                minWidth: `${r.width}px`,
+                maxWidth: `${maxRight}px`,
                 bottom: `${r.bottom}px`,
             };
         }
         return {
             position: "fixed",
             left: `${r.left}px`,
-            width: `${r.width}px`,
+            minWidth: `${r.width}px`,
+            maxWidth: `${maxRight}px`,
             top: `${r.top}px`,
         };
     };

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -43,6 +43,8 @@ export interface AgentAtoms {
     sessionStatsAtom: SignalPair<SessionStats | null>;
     currentToolAtom: SignalPair<string | null>;
     turnTokensAtom: SignalPair<TurnTokens | null>;
+    /** True from the moment the user sends a message until session_end arrives. */
+    turnActiveAtom: SignalPair<boolean>;
 }
 
 /**
@@ -92,5 +94,6 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         sessionStatsAtom: createSignal<SessionStats | null>(null),
         currentToolAtom: createSignal<string | null>(null),
         turnTokensAtom: createSignal<TurnTokens | null>(null),
+        turnActiveAtom: createSignal<boolean>(false),
     };
 }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -314,6 +314,9 @@ export function useAgentStream({
             if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
             subscription.unsubscribe();
             setStreaming((prev) => ({ ...prev, active: false }));
+            // Clear turn-active on teardown so a crash/exit without session_end
+            // doesn't leave the status line showing "Working…" permanently.
+            setTurnActive(false);
         });
     });
 }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -25,6 +25,7 @@ interface UseAgentStreamOpts {
     sessionStatsAtom: SignalPair<SessionStats | null>;
     currentToolAtom: SignalPair<string | null>;
     turnTokensAtom: SignalPair<TurnTokens | null>;
+    turnActiveAtom: SignalPair<boolean>;
     enabled: boolean;
     /**
      * Version signal bumped by external document mutations (e.g. history
@@ -46,12 +47,14 @@ export function useAgentStream({
     sessionStatsAtom,
     currentToolAtom,
     turnTokensAtom,
+    turnActiveAtom,
     enabled,
     documentVersion,
 }: UseAgentStreamOpts): void {
     const [, setDocument] = documentAtom;
     const [, setStreaming] = streamingStateAtom;
     const [, setSessionStats] = sessionStatsAtom;
+    const [, setTurnActive] = turnActiveAtom;
     const [, setCurrentTool] = currentToolAtom;
     const [, setTurnTokens] = turnTokensAtom;
 
@@ -188,6 +191,7 @@ export function useAgentStream({
                 setSessionStats(null);
                 setCurrentTool(null);
                 setTurnTokens(null);
+                setTurnActive(false);
                 lineBuffer = "";
                 translator.reset();
                 parser.reset();
@@ -279,6 +283,7 @@ export function useAgentStream({
                         setSessionStats(event.stats ?? null);
                         setCurrentTool(null);
                         setTurnTokens(null);
+                        setTurnActive(false);
                         continue;
                     }
                     // Track the currently-running tool for the status line

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.175",
+  "version": "0.33.176",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.175",
+      "version": "0.33.176",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.175",
+  "version": "0.33.176",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_AGENT_UX_STREAMING_SCROLL_OVERLAY_2026_04_15.md
+++ b/specs/SPEC_AGENT_UX_STREAMING_SCROLL_OVERLAY_2026_04_15.md
@@ -1,0 +1,179 @@
+# SPEC: Agent Pane — Status Line, Auto-Scroll, and Tool Overlay
+
+**Date:** 2026-04-15  
+**Status:** Draft  
+**Author:** AgentA
+
+---
+
+## Three Bugs
+
+### Bug 1 — Status line invisible while agent is working
+
+**Observed:** After the launch flow completes, `isLoading` is permanently `false`
+(`flowRunning=false`, `agentReady=true`). Sending a message doesn't flip any
+loading signal, so `AgentStatusLine` renders with `loading={false}` — the blue
+pulse dot and "Working…" phrase never appear while the agent is processing.
+
+**Root cause:**  
+`isLoading = flowRunning() || !agentReady()` tracks the LAUNCH flow, not the
+AGENT TURN. There is no signal for "agent is currently streaming a response."
+
+**Desired:**  
+From the moment the user presses Enter until `session_end` arrives (or the turn
+errors), the status line must show `Working…` with the blue pulse dot.
+
+**Fix — `turnActiveAtom`:**
+
+1. Add `turnActiveAtom: SignalPair<boolean>` to `AgentAtoms` in `state.ts`, initial value `false`.
+2. In `agent-view.tsx`, update `handleSendMessage` to set `turnActive = true` before sending.
+3. In `useAgentStream.ts`, on `session_end` event, set `turnActive = false` (after setting session stats).
+4. Also set `turnActive = false` on the `truncate` fileop (clear/reset path).
+5. In `agent-view.tsx`, wire to `AgentStatusLine`:
+   ```tsx
+   <AgentStatusLine
+       loading={status.isLoading() || agentAtoms().turnActiveAtom[0]()}
+       ...
+   />
+   ```
+6. In `handleSendMessage`, clear session stats AND set `turnActive = true`:
+   ```typescript
+   const handleSendMessage = (message: string): Promise<void> => {
+       setSessionStats(null);
+       agentAtoms().turnActiveAtom[1](true);
+       return commands.sendMessage(message);
+   };
+   ```
+
+---
+
+### Bug 2 — New streamed content doesn't auto-scroll when at the bottom
+
+**Observed:** The agent is streaming responses. The user is at the bottom of the
+pane. New content appears but the view stays still — the user must manually scroll
+down to see it. Only when the user has scrolled significantly upward should
+auto-scroll be suppressed.
+
+**Root cause:**  
+The 50px threshold in `handleScroll` may be too tight, and there are edge cases
+where `autoScroll` gets set to `false` before it should:
+
+1. When new streaming content expands the `scrollHeight`, a browser `scroll` event
+   may fire before the RAF-batched `setDocument` has fully settled, temporarily
+   computing `scrollHeight - scrollTop - clientHeight > 50` and setting
+   `autoScroll = false`.
+2. The `content-visibility: auto` estimations on off-screen nodes may underestimate
+   `scrollHeight`, causing the same false-negative.
+
+**Desired:**  
+- While `autoScroll = true`, every document update scrolls to the new bottom.
+- `autoScroll` is only disabled when the user has explicitly scrolled **more than
+  200px from the bottom** — a small accidental over-scroll or momentum scroll
+  should not break it.
+- Sending a message ALWAYS re-enables `autoScroll` and scrolls to the bottom.
+
+**Fix:**
+
+In `AgentDocumentView.tsx`, change:
+```typescript
+// Before
+autoScroll = scrollHeight - scrollTop - clientHeight < 50;
+// After
+autoScroll = scrollHeight - scrollTop - clientHeight < 200;
+```
+
+Additionally, the auto-scroll `createEffect` currently watches `document().length`.
+Because SolidJS re-runs the effect whenever `setDocument(...)` is called (signal
+reference changes), this fires correctly for both appends and content updates.
+However, batch flushes may coalesce multiple RAF cycles and miss intermediate
+frames. Ensure the effect uses a simple accessor read:
+
+```typescript
+createEffect(() => {
+    document(); // tracks any setDocument call
+    logLines();
+    scheduleAutoScroll();
+});
+```
+
+where `scheduleAutoScroll()` replaces the inline RAF logic.
+
+---
+
+### Bug 3 — Tool hover expansion shifts layout / offsets visible content
+
+**Observed:** Hovering over a one-line collapsed tool block (e.g. a Bash command)
+causes surrounding content to shift ("offset everything") rather than showing
+the expanded content as a pure overlay on top.
+
+**Root cause (likely):**  
+The `ToolBlock` component renders expanded content via a SolidJS `<Portal>` to
+`document.body` with `position: fixed`. This is architecturally correct, but one
+of the following may be failing:
+
+1. **CSS zoom interaction:** `.agent-view--presentation` applies `style={{ zoom: zoomFactor() }}`.
+   Chromium's `getBoundingClientRect()` returns zoomed-space coordinates, which
+   SHOULD match `position: fixed` coordinates. But if CEF's implementation
+   diverges, the portal appears at the wrong location and looks like layout shift.
+
+2. **`content-visibility: auto` containment:** Each `.agent-document-node-wrapper`
+   has `content-visibility: auto`. If a node wrapper is at the edge of the
+   visible area, partial containment may interfere with the Portal's mount point
+   and cause the overlay to render inline.
+
+3. **Width calculation:** The overlay uses `width: ${r.width}px`. If the block
+   has fractional pixel dimensions or the zoom multiplier creates a mismatch,
+   the overlay may appear wider than the block and push the horizontal scroll.
+
+**Desired:**  
+Hovering a collapsed tool block must:
+- Show the expanded content as a floating overlay (`position: fixed`) directly
+  below (or above) the summary row.
+- Never cause any sibling node to shift position.
+- Never cause the scroll container to change `scrollHeight`.
+- Dismiss instantly on mouse-leave (current 0ms timeout is correct).
+
+**Fix:**
+
+1. **Verify the portal is actually rendering to body:** in `ToolBlock.tsx`, add a
+   `console.debug` when `hovered = true` to confirm `overlayRect` is set correctly
+   and the portal element is attached to `document.body`, not to the block.
+
+2. **Compensate for CSS zoom in position calculation:**  
+   If `zoom !== 1`, the `getBoundingClientRect()` coords returned by CEF are in
+   the unzoomed space. Multiply by zoom before applying `position: fixed`:
+   ```typescript
+   const zoom = parseFloat(
+       getComputedStyle(document.documentElement).zoom || "1"
+   );
+   // OR walk up to find the zoomed ancestor and read its zoom
+   ```
+   
+   Actually, Chrome/CEF `getBoundingClientRect()` already returns VIEWPORT pixels
+   (accounting for zoom), so no correction should be needed. If it IS needed, wrap
+   in `agentViewZoom()` accessor passed down from `AgentPresentationView`.
+
+3. **Ensure the overlay width matches the block:**  
+   Instead of `width: ${r.width}px`, use `min-width: ${r.width}px` so content
+   wider than the block can grow rightward without causing horizontal scroll in
+   the document.
+
+---
+
+## Summary Table
+
+| Issue | Signal | Fix location | Risk |
+|-------|--------|--------------|------|
+| Status line invisible | Missing `turnActiveAtom` | state.ts, agent-view.tsx, useAgentStream.ts | Low |
+| No auto-scroll at bottom | Threshold 50px too small | AgentDocumentView.tsx line ~182 | Low |
+| Overlay shifts content | Portal position / CSS zoom | ToolBlock.tsx + agent-view.scss | Medium |
+
+---
+
+## Implementation Order
+
+1. **Bug 1** — `turnActiveAtom` (state.ts + agent-view.tsx + useAgentStream.ts)
+2. **Bug 2** — Increase threshold to 200px (one-liner in AgentDocumentView.tsx)
+3. **Bug 3** — Investigate portal overlay, apply zoom fix or min-width
+
+All three can ship in one PR.


### PR DESCRIPTION
## Summary

### Bug 1 — Status line not visible while agent is working
`isLoading` was only `true` during the launch flow (`flowRunning || !agentReady`). Once launch completed, `isLoading` was permanently `false`, so "Working…" never appeared while the agent was processing a message.

**Fix:** new `turnActiveAtom` signal — set `true` when the user sends a message, cleared by `session_end` or `truncate`. `AgentStatusLine` now receives `loading={status.isLoading() || turnActive}`.

### Bug 2 — Auto-scroll disabled by small accidental scrolls
The 50px threshold was too tight — any minor momentum scroll or mousewheel overshoot disabled auto-scroll for the rest of the streaming turn.

**Fix:** threshold raised to 200px. User must scroll 200px+ from the bottom before auto-scroll disables.

### Bug 3 — Tool overlay width caused horizontal overflow
The portal overlay used a fixed `width: r.width` matching the collapsed summary row. When the expanded content (e.g. a long file path in a Read result) was wider, it overflowed the viewport and created a horizontal scrollbar on the document.

**Fix:** `minWidth: r.width` + `maxWidth: viewport_right - 16px` so the overlay grows rightward without pushing horizontal scroll.

## Test plan

- [ ] Send a message → status line immediately shows "Working…" with blue pulse
- [ ] Turn completes → status line shows "Worked · $cost · Xs"
- [ ] Scroll near the bottom while streaming — content auto-scrolls; only 200px+ up disables it
- [ ] Hover a tool block — overlay appears without shifting sibling nodes or creating horizontal scroll

## Spec

`specs/SPEC_AGENT_UX_STREAMING_SCROLL_OVERLAY_2026_04_15.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)