### PR TITLE
fix: deliver OAuth code to CLI stdin, log hover no twitching (v0.33.178)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.177"
+version = "0.33.178"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.177"
+version = "0.33.178"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.177"
+version = "0.33.178"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.177"
+version = "0.33.178"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.177 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.175 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.173 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.171 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.177"
+version = "0.33.178"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -295,7 +295,7 @@ pub async fn run_cli_login(
     let mut cmd = make_cli_cmd(&cli_path);
     cmd.args(&login_args)
         .envs(&auth_env)
-        .stdin(std::process::Stdio::null())
+        .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
@@ -309,6 +309,12 @@ pub async fn run_cli_login(
         .map_err(|e| format!("failed to spawn {cli_path}: {e}"))?;
 
     tracing::info!(cli = %cli_path, "run_cli_login: spawned, browser should open");
+
+    // Store the stdin handle so set_provider_auth can deliver the OAuth code.
+    {
+        let mut stored_stdin = state.cli_login_stdin.lock();
+        *stored_stdin = child.stdin.take();
+    }
 
     // Capture the OAuth URL from stdout/stderr. The CLI prints it within the
     // first few hundred ms after spawn. We read until we find "https://..."
@@ -357,6 +363,7 @@ pub async fn run_cli_login(
         *stored = Some(cancel_tx);
     }
 
+    let state_for_cleanup = state.clone();
     tokio::spawn(async move {
         tokio::select! {
             result = child.wait() => {
@@ -376,6 +383,8 @@ pub async fn run_cli_login(
                 let _ = child.kill().await;
             }
         }
+        // Clear the stored stdin handle once the process is done.
+        *state_for_cleanup.cli_login_stdin.lock() = None;
     });
 
     Ok(serde_json::json!({ "auth_url": auth_url }))

--- a/agentmux-cef/src/commands/providers.rs
+++ b/agentmux-cef/src/commands/providers.rs
@@ -313,7 +313,7 @@ pub fn get_provider_install_info(args: &serde_json::Value) -> Result<serde_json:
 }
 
 /// Store an auth token for a provider.
-pub fn set_provider_auth(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+pub async fn set_provider_auth(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let provider = args
         .get("provider")
         .and_then(|v| v.as_str())
@@ -323,6 +323,27 @@ pub fn set_provider_auth(state: &Arc<AppState>, args: &serde_json::Value) -> Res
         .and_then(|v| v.as_str())
         .ok_or_else(|| "Missing token".to_string())?;
 
+    // For Claude (and any CLI-based provider), deliver the auth code directly
+    // to the running login process via its piped stdin. The CLI prints the
+    // OAuth URL, then waits for the user to paste the device code on stdin.
+    // Without this, the code went to our own config file (wrong) and the CLI
+    // never received it, so the polling loop ran forever.
+    let maybe_stdin = state.cli_login_stdin.lock().take();
+    if let Some(mut child_stdin) = maybe_stdin {
+        tracing::info!(provider = %provider, "set_provider_auth: delivering code to CLI stdin");
+        use tokio::io::AsyncWriteExt;
+        let payload = format!("{}\n", token);
+        if let Err(e) = child_stdin.write_all(payload.as_bytes()).await {
+            tracing::warn!(error = %e, "set_provider_auth: failed to write to CLI stdin");
+            return Err(format!("Failed to deliver auth code to CLI: {e}"));
+        }
+        let _ = child_stdin.flush().await;
+        // Don't put stdin back — it's single-use (one code per login flow).
+        return Ok(serde_json::Value::Null);
+    }
+
+    // Fallback for providers that use AgentMux's own config-file auth
+    // (non-CLI providers, or when no login process is running).
     tracing::info!("Setting auth token for provider: {}", provider);
     let cfg_dir = get_config_dir(state)?;
     let mut config = load_config(&cfg_dir)?;

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -256,7 +256,7 @@ async fn route_command(
         "get_provider_config" => commands::providers::get_provider_config(state),
         "save_provider_config" => commands::providers::save_provider_config(state, args),
         "get_provider_install_info" => commands::providers::get_provider_install_info(args),
-        "set_provider_auth" => commands::providers::set_provider_auth(state, args),
+        "set_provider_auth" => commands::providers::set_provider_auth(state, args).await,
         "clear_provider_auth" => commands::providers::clear_provider_auth(state, args),
         "get_provider_auth_status" => commands::providers::get_provider_auth_status(state, args),
         "check_cli_auth_status" => commands::providers::check_cli_auth_status(args).await,

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -162,6 +162,10 @@ pub struct AppState {
     /// Cancellation channel for an in-progress CLI login process
     pub cli_login_cancel: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 
+    /// Stdin handle for the running CLI login child process.
+    /// Written to by `set_provider_auth` to deliver the OAuth device code.
+    pub cli_login_stdin: Mutex<Option<tokio::process::ChildStdin>>,
+
     /// IPC HTTP server port
     pub ipc_port: Mutex<u16>,
 
@@ -209,6 +213,7 @@ impl Default for AppState {
             window_init_status: Mutex::new(String::new()),
             window_instance_registry: Mutex::new(WindowInstanceRegistry::new()),
             cli_login_cancel: Mutex::new(None),
+            cli_login_stdin: Mutex::new(None),
             ipc_port: Mutex::new(0),
             ipc_token: uuid::Uuid::new_v4().to_string(),
             browsers: Mutex::new(HashMap::new()),

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.177"
+version = "0.33.178"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.177"
+version = "0.33.178"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.177"
+version = "0.33.178"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -88,10 +88,15 @@
         transition: background 0.1s;
 
         &:hover {
-            white-space: pre-wrap;
+            // Keep single-line — overflow horizontally, never change height.
+            // pre-wrap caused the line to reflow into multiple rows on hover,
+            // shifting every sibling and "twitching" the whole log panel.
+            white-space: nowrap;
             overflow: visible;
             text-overflow: clip;
             background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+            position: relative;
+            z-index: 5;
         }
 
         &--error {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.177",
+  "version": "0.33.178",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.177",
+      "version": "0.33.178",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.177",
+  "version": "0.33.178",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

### Auth code paste — actual fix

The polling loop showed \"credentials found, validating via CLI\" every 2s forever because the pasted code was never reaching the Claude CLI.

**Root cause:** `run_cli_login` spawned the CLI with `stdin(Stdio::null())`. The CLI prints the OAuth URL then waits for the device code on stdin. With null stdin it gets EOF immediately and either hangs or fails silently. `setProviderAuth` was writing to the AgentMux config file (wrong place entirely).

**Fix (CEF host):**
- `run_cli_login`: `stdin(Stdio::piped())` — store `child.stdin` in `AppState.cli_login_stdin`
- `set_provider_auth`: now `async`; takes the stored stdin and writes `code\n` to it directly
- Falls back to config-file write when no login process is running (other providers)
- stdin handle cleared when child exits

### Log line hover — no more twitching

Hovering a log line was switching `white-space: nowrap → pre-wrap` which changed the element's height, pushing all sibling lines down. This caused the whole log panel to jump/twitch.

**Fix:** Keep `white-space: nowrap` on hover. Add `position: relative; z-index: 5` so the text overflows horizontally over adjacent content — zero height change, zero layout shift.

## Test plan

- [ ] Start login flow → browser opens → paste device code → Submit → auth completes (polling loop stops within one cycle)
- [ ] Hover a long log line → text overflows right without shifting sibling lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)