### PR TITLE
feat: log hover Portal overlay (full text, no twitching), browser-open feedback (v0.33.180)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.179"
+version = "0.33.180"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.179"
+version = "0.33.180"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.179"
+version = "0.33.180"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.179"
+version = "0.33.180"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.179 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.177 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.175 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |
 | 0.33.173 | 2026-04-15 | 158.3 MiB | 330.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.179"
+version = "0.33.180"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.179"
+version = "0.33.180"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.179"
+version = "0.33.180"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.179"
+version = "0.33.180"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -88,15 +88,7 @@
         transition: background 0.1s;
 
         &:hover {
-            // Keep single-line — overflow horizontally, never change height.
-            // pre-wrap caused the line to reflow into multiple rows on hover,
-            // shifting every sibling and "twitching" the whole log panel.
-            white-space: nowrap;
-            overflow: visible;
-            text-overflow: clip;
             background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
-            position: relative;
-            z-index: 5;
         }
 
         &--error {
@@ -3082,6 +3074,31 @@
         border-radius: 3px 3px 0 0;
         box-shadow: 0 -6px 20px rgba(0, 0, 0, 0.35);
     }
+}
+
+// ── Log line full-text hover overlay ─────────────────────────────────────────
+// Portal-rendered (document.body) so it escapes the scroll container's
+// overflow:auto clipping. Appears at the exact position of the hovered line
+// and extends rightward to show the full text. No height change in the log
+// panel — zero layout shift ("twitching").
+
+.agent-log-hover-overlay {
+    position: fixed; // set inline via style; this is for z-index / stacking
+    z-index: 300;
+    white-space: nowrap;
+    font-family: var(--fixed-font, monospace);
+    font-size: 12px;
+    line-height: 1.3;
+    color: var(--secondary-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 2px;
+    padding: 1px 4px;
+    box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
+    pointer-events: auto;
+
+    &--error { color: var(--error-color); }
+    &--warn  { color: var(--warning-color); }
 }
 
 // ── AgentIdentityPanel (Step 4 of SPEC_AGENT_IDENTITY_RESTRUCTURE) ────────────

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -8,6 +8,7 @@
  */
 
 import { createEffect, createSignal, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
+import { Portal } from "solid-js/web";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, LogLine, SubagentLinkNode } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
@@ -57,6 +58,24 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
     let autoScroll = true;
     // Guard against concurrent older-history fetches triggered by scroll
     let loadingOlderInFlight = false;
+
+    // Shared hover state for log line full-text overlay.
+    // One Portal renders the active line's full text at its viewport position.
+    // Using a single shared signal (not per-line) avoids creating N signals in <For>.
+    type LogHover = { text: string; level?: "error" | "warn"; top: number; left: number; width: number };
+    const [logHover, setLogHover] = createSignal<LogHover | null>(null);
+    let logLeavePending = 0;
+    const handleLogEnter = (e: MouseEvent, line: LogLine) => {
+        if (logLeavePending) { clearTimeout(logLeavePending); logLeavePending = 0; }
+        const el = e.currentTarget as HTMLElement;
+        const r = el.getBoundingClientRect();
+        setLogHover({ text: `[${line.tag}] ${line.text}`, level: line.level, top: r.top, left: r.left, width: r.width });
+    };
+    const handleLogLeave = () => {
+        if (logLeavePending) clearTimeout(logLeavePending);
+        logLeavePending = window.setTimeout(() => { logLeavePending = 0; setLogHover(null); }, 80);
+    };
+    onCleanup(() => { if (logLeavePending) clearTimeout(logLeavePending); });
 
     // Scroll to a node by its data-node-id attribute.
     // Exposed to the parent via scrollToNodeRef so BookmarksPanel can call it.
@@ -230,11 +249,39 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                     "agent-status-line--error": line.level === "error",
                                     "agent-status-line--warn": line.level === "warn",
                                 }}
+                                onMouseEnter={(e) => handleLogEnter(e, line)}
+                                onMouseLeave={handleLogLeave}
                             >
                                 <span class="agent-status-tag">[{line.tag}]</span> {line.text}
                             </div>
                         )}
                     </For>
+                    {/* Full-text hover overlay — Portal escapes the scroll container's
+                        overflow:auto clipping so the complete line text is visible. */}
+                    <Show when={logHover()}>
+                        {(h) => (
+                            <Portal>
+                                <div
+                                    class="agent-log-hover-overlay"
+                                    classList={{
+                                        "agent-log-hover-overlay--error": h().level === "error",
+                                        "agent-log-hover-overlay--warn": h().level === "warn",
+                                    }}
+                                    style={{
+                                        position: "fixed",
+                                        top: `${h().top}px`,
+                                        left: `${h().left}px`,
+                                        "min-width": `${h().width}px`,
+                                        "max-width": `calc(100vw - ${h().left}px - 16px)`,
+                                    }}
+                                    onMouseEnter={() => { if (logLeavePending) { clearTimeout(logLeavePending); logLeavePending = 0; } }}
+                                    onMouseLeave={handleLogLeave}
+                                >
+                                    {h().text}
+                                </div>
+                            </Portal>
+                        )}
+                    </Show>
                     <Show when={authUrl?.()}>
                         {(url) => {
                             const [pasteCode, setPasteCode] = createSignal("");

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -186,13 +186,17 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             );
             if (loginUrl) {
                 setAuthUrl(loginUrl);
-                // Open the URL in the system browser. If it doesn't open,
-                // the user can copy from the URL box above the composer.
-                try { getApi().openExternal(loginUrl); } catch { /* non-fatal */ }
-                log("auth", "browser opened — complete login there");
-                log("auth", "if it didn't open, copy the URL from the box above");
+                log("auth", "opening browser...");
+                try {
+                    getApi().openExternal(loginUrl);
+                    log("auth", "browser opened — complete login there");
+                } catch (err: any) {
+                    log("auth", `browser did not open: ${err?.message ?? String(err)}`, "warn");
+                    log("auth", "copy the URL from the box above and open it manually", "warn");
+                }
             } else {
-                log("auth", "a browser window should have opened — complete login there");
+                log("auth", "attempting to open browser for login...");
+                log("auth", "if no browser opened, run the login command manually", "warn");
             }
 
             // Poll until authenticated, cancelled, or timed out (5 minutes)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.179",
+  "version": "0.33.180",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.179",
+      "version": "0.33.180",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.179",
+  "version": "0.33.180",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

### Log line full-text hover — Portal approach

`overflow: visible` on a child element cannot escape a parent with `overflow: auto` (the scroll container). Previous fix only stopped the twitching but the text was still clipped.

**Fix:** Same Portal pattern as `ToolBlock`. A single shared `logHover` signal tracks the active line. On `mouseenter`, measures the line's `getBoundingClientRect()` and sets the signal. A `<Portal>` renders a `position: fixed` overlay at that exact position with `white-space: nowrap` — no max-width, full text visible, no layout shift. 80ms leave debounce prevents flicker when cursor moves to the overlay.

### Browser-open feedback

Users had no way to know if the browser opened or silently failed.

**Fix:** `launch-flow.ts` now logs:
- `"opening browser..."` before calling `openExternal`
- `"browser opened — complete login there"` on success  
- `"browser did not open: <reason>"` (warn) on exception
- Fallback message when no URL was captured from the CLI

## Test plan

- [ ] Hover a short log line → border overlay appears at line position showing full text
- [ ] Hover a long truncated log line → full text visible, no vertical shift
- [ ] Move cursor off line → overlay disappears after 80ms
- [ ] Start login → log shows "opening browser..." then result
- [ ] If browser blocked → warn log appears, URL box still usable

🤖 Generated with [Claude Code](https://claude.com/claude-code)