### PR TITLE
fix: prevent duplicate agent responses (history/stream race) (v0.33.181)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.180"
+version = "0.33.181"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.180"
+version = "0.33.181"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.180"
+version = "0.33.181"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.180"
+version = "0.33.181"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.180"
+version = "0.33.181"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.180"
+version = "0.33.181"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.180"
+version = "0.33.181"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.180"
+version = "0.33.181"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -100,12 +100,24 @@ export function useAgentStream({
                 }
             }
 
-            // Append new nodes
+            // Append new nodes — but guard against the race where a
+            // documentVersion rebuild placed the node into the doc externally
+            // (e.g. history load completed between the node entering pendingNew
+            // and this RAF firing). If nodeIndexMap already has a valid entry
+            // for the node, update in-place instead of appending to prevent
+            // duplicates.
             if (batchNew.length > 0) {
-                const baseIdx = result.length;
                 for (let i = 0; i < batchNew.length; i++) {
-                    nodeIndexMap.set(batchNew[i].id, baseIdx + i);
-                    result.push(batchNew[i]);
+                    const n = batchNew[i];
+                    const existingIdx = nodeIndexMap.get(n.id);
+                    if (existingIdx != null && existingIdx < result.length) {
+                        // Already in doc (placed by an external mutation while
+                        // this node was queued). Update in-place.
+                        result[existingIdx] = n;
+                    } else {
+                        nodeIndexMap.set(n.id, result.length);
+                        result.push(n);
+                    }
                 }
                 mutated = true;
             }
@@ -171,7 +183,16 @@ export function useAgentStream({
         if (documentVersion != null) {
             createEffect(() => {
                 documentVersion();
+                // Re-add IDs from pending buffers AFTER rebuilding from the
+                // document so subsequent stream events for in-flight nodes are
+                // still routed as updates (not new nodes). Without this, a
+                // rebuild clears their dedup protection and the next delta
+                // creates a second entry for the same node.
+                const beforePendingNew = pendingNew.slice();
+                const beforePendingUpdates = pendingUpdates.slice();
                 rebuildIndicesFromDocument();
+                for (const n of beforePendingNew) nodeIdSet.add(n.id);
+                for (const n of beforePendingUpdates) nodeIdSet.add(n.id);
             });
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.180",
+  "version": "0.33.181",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.180",
+      "version": "0.33.181",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.180",
+  "version": "0.33.181",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Root cause

When the async history load (`useHistoryPagination`) completed between a streaming event entering `pendingNew` and the RAF flush firing, `rebuildIndicesFromDocument` would place those same node IDs into the document. The subsequent RAF flush then saw those nodes in `batchNew`, didn't check if they were already in the document, and **appended them a second time** — producing the duplicated responses the user observed.

The \"sometimes\" nature is a timing race: it only triggers when history loads fast enough to beat the first animation frame (common on cache-warm sessions or short histories).

## Fixes

**1. `flushPendingNodes` — check before appending**
Before pushing a node from `batchNew`, consult `nodeIndexMap`. If the node already exists at a valid index (placed there by an external mutation like the history load), update it in-place instead of appending.

**2. `rebuildIndicesFromDocument` effect — restore pending buffer IDs**
After rebuilding `nodeIdSet` from the document, re-add any IDs that are currently in `pendingNew` or `pendingUpdates`. Without this, stream deltas arriving after a rebuild would lose dedup protection for in-flight nodes and route as new entries.

## Test plan
- [ ] Open an agent pane with existing history — verify no duplicate messages on initial load
- [ ] Send a message and receive a response — verify no duplication
- [ ] Scroll up to trigger `loadOlder` mid-stream — verify live updates continue correctly and no duplicates appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)