### PR TITLE
fix: surface agent-not-responding health events (v0.33.183)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.182"
+version = "0.33.183"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.182"
+version = "0.33.183"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.182"
+version = "0.33.183"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.182"
+version = "0.33.183"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.182"
+version = "0.33.183"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.182"
+version = "0.33.183"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.182"
+version = "0.33.183"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.182"
+version = "0.33.183"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -242,6 +242,12 @@ impl PersistentSubprocessController {
         })?;
 
         let pid = child.id().unwrap_or(0);
+
+        // Notify health monitor that a turn is starting. This arms the Stalled
+        // (30 s) and Dead (120 s) thresholds so the frontend learns the agent
+        // is not responding rather than silently waiting forever.
+        self.health_monitor.set_active_turn(true);
+
         tracing::info!(
             block_id = %self.block_id,
             pid = pid,
@@ -417,11 +423,28 @@ impl PersistentSubprocessController {
             tracing::info!(block_id = %block_id_read, "persistent stdout reader finished");
         });
 
+        // Spawn health watchdog — checks every 5 s while turn is active.
+        // Emits `agenthealth` WPS events when the process stalls (30 s) or
+        // dies (120 s) without producing meaningful output, giving the
+        // frontend enough signal to show a "not responding" warning.
+        let health_watchdog = Arc::clone(&self.health_monitor);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(5));
+            loop {
+                interval.tick().await;
+                if !health_watchdog.is_active_turn() {
+                    break;
+                }
+                health_watchdog.check();
+            }
+        });
+
         // Spawn process waiter task
         let block_id_wait = self.block_id.clone();
         let inner_wait = Arc::clone(&self.inner);
         let broker_wait = self.broker.clone();
         let wstore_wait = self.wstore.clone();
+        let health_wait = Arc::clone(&self.health_monitor);
 
         tokio::spawn(async move {
             tokio::select! {
@@ -432,6 +455,9 @@ impl PersistentSubprocessController {
                         exit_code = exit_code,
                         "persistent process exited"
                     );
+
+                    // Notify health monitor so Stalled/Dead watchdog stops.
+                    health_wait.set_exited(exit_code);
 
                     let mut inner = inner_wait.lock().unwrap();
                     inner.proc_exit_code = exit_code;
@@ -481,6 +507,8 @@ impl PersistentSubprocessController {
                             }
                         }
                     }
+
+                    health_wait.set_exited(-1);
 
                     let mut inner = inner_wait.lock().unwrap();
                     inner.proc_exit_code = -1;

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -7,7 +7,8 @@
  * the resulting DocumentNodes into SolidJS signals.
  */
 
-import { getFileSubject } from "@/app/store/wps";
+import { getFileSubject, waveEventSubscribe } from "@/app/store/wps";
+import * as WOS from "@/app/store/wos";
 import { base64ToArray } from "@/util/util";
 import { createEffect, onCleanup, onMount, untrack } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
@@ -331,9 +332,41 @@ export function useAgentStream({
             }
         });
 
+        // Subscribe to agenthealth WPS events so "Stalled" (30 s) and "Dead"
+        // (120 s) transitions surface as visible log messages rather than
+        // silently leaving the user staring at a spinner forever.
+        const healthScope = WOS.makeORef("block", blockId);
+        const unsubHealth = waveEventSubscribe({
+            eventType: "agenthealth",
+            scope: healthScope,
+            handler: (event: any) => {
+                const health: string = event?.data?.health ?? "";
+                const detail: string = event?.data?.detail ?? "";
+                if (health === "stalled") {
+                    pendingNew.push({
+                        id: `health-stalled-${Date.now()}`,
+                        type: "markdown",
+                        content: `**Agent is taking longer than expected.** ${detail} — it may be waiting for authentication or blocked on a startup prompt.`,
+                        metadata: { level: "warn" },
+                    } as any);
+                    scheduleFlush();
+                } else if (health === "dead") {
+                    pendingNew.push({
+                        id: `health-dead-${Date.now()}`,
+                        type: "markdown",
+                        content: `**Agent is not responding.** ${detail} — try clicking Retry, or check that your authentication is still valid.`,
+                        metadata: { level: "error" },
+                    } as any);
+                    scheduleFlush();
+                    setTurnActive(false);
+                }
+            },
+        });
+
         onCleanup(() => {
             if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
             subscription.unsubscribe();
+            unsubHealth();
             setStreaming((prev) => ({ ...prev, active: false }));
             // Clear turn-active on teardown so a crash/exit without session_end
             // doesn't leave the status line showing "Working…" permanently.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.182",
+  "version": "0.33.183",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.182",
+      "version": "0.33.183",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.182",
+  "version": "0.33.183",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Root cause

The persistent subprocess controller (used by all agent panes) never wired up the health monitor. `set_active_turn()`, the periodic watchdog, and `set_exited()` were only in `subprocess.rs`. So `Stalled` (30 s) and `Dead` (120 s) WPS events never fired — users were left staring at a spinner with zero feedback.

## What happened in the logs

Process `pid=6636` spawned at 11:03:30, produced **zero output** for the rest of the session. Most likely cause: fresh per-version `CLAUDE_CONFIG_DIR` triggered a first-run setup prompt (TOS / onboarding wizard) in the Claude CLI before it entered stream-json mode. Since the prompt is interactive and the process has no TTY, it blocks silently forever. The health events would have caught this at 30 s.

## Fixes

**`persistent.rs`**
- Call `set_active_turn(true)` immediately after the process spawns
- Spawn a 5-second health watchdog (identical to `subprocess.rs`)
- Call `set_exited()` on both normal exit and kill paths so the watchdog stops

**`useAgentStream.ts`**
- Subscribe to `agenthealth` WPS events for the block (alongside the existing file-subject subscription)
- `stalled` (30 s): log a visible amber warning: "Agent is taking longer than expected…"
- `dead` (120 s): log a red error: "Agent is not responding. Try clicking Retry…" and clear `turnActive` so the spinner stops

## Test plan
- [ ] Start a fresh agent pane — agent responds normally, no health warnings appear
- [ ] Simulate a stuck process (e.g. wrong env): after 30 s the stalled warning appears; after 120 s the dead error appears and the spinner clears
- [ ] Clicking Retry re-runs the launch flow cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)