### PR TITLE
feat: ACP controller + OpenClaw provider

### DIFF
--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.201"
+version = "0.33.202"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.201"
+version = "0.33.202"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.201"
+version = "0.33.202"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.201"
+version = "0.33.202"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/acp.rs
+++ b/agentmux-srv/src/backend/blockcontroller/acp.rs
@@ -400,6 +400,27 @@ impl AcpController {
                 _ = kill_rx => {
                     let _ = child.kill().await;
                     tracing::info!(block_id = %block_id_wait, "ACP process killed");
+
+                    let mut inner = inner_wait.lock().unwrap();
+                    inner.stdin_tx = None;
+                    inner.current_pid = None;
+                    AcpController::set_status(&mut inner, STATUS_DONE);
+                    drop(inner);
+
+                    health_wait.set_active_turn(false);
+
+                    if let Some(ref broker) = broker_wait {
+                        let status = BlockControllerRuntimeStatus {
+                            blockid: block_id_wait.clone(),
+                            version: 0,
+                            shellprocstatus: STATUS_DONE.to_string(),
+                            shellprocconnname: "local".to_string(),
+                            shellprocexitcode: -1,
+                            spawn_ts_ms: None,
+                            is_agent_pane: true,
+                        };
+                        super::publish_controller_status(broker, &status);
+                    }
                 }
                 status = child.wait() => {
                     let exit_code = status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
@@ -527,28 +548,30 @@ impl Controller for AcpController {
                 return Ok(());
             }
 
-            // For ACP, we need the CLI command info to spawn if not running.
-            // If already running, just send the prompt.
-            if self.is_running() {
-                let session_id = {
-                    let inner = self.inner.lock().unwrap();
-                    inner.session_id.clone().unwrap_or_default()
-                };
-                let req = self.make_request("session/prompt", serde_json::json!({
-                    "sessionId": session_id,
-                    "prompt": {
-                        "type": "text",
-                        "text": message,
-                    }
-                }));
-                self.health_monitor.set_active_turn(true);
-                let inner = self.inner.lock().unwrap();
-                if let Some(ref tx) = inner.stdin_tx {
-                    tx.try_send(req)
-                        .map_err(|e| format!("ACP stdin send failed: {e}"))?;
-                }
+            if !self.is_running() {
+                // Process not running — stash as pending so start() picks it up.
+                let mut inner = self.inner.lock().unwrap();
+                inner.pending_prompt = Some(message);
+                return Err("ACP process not running — message queued for next start()".to_string());
             }
-            // If not running, the process will be spawned on next start()
+
+            let session_id = {
+                let inner = self.inner.lock().unwrap();
+                inner.session_id.clone().unwrap_or_default()
+            };
+            let req = self.make_request("session/prompt", serde_json::json!({
+                "sessionId": session_id,
+                "prompt": {
+                    "type": "text",
+                    "text": message,
+                }
+            }));
+            self.health_monitor.set_active_turn(true);
+            let inner = self.inner.lock().unwrap();
+            if let Some(ref tx) = inner.stdin_tx {
+                tx.try_send(req)
+                    .map_err(|e| format!("ACP stdin send failed: {e}"))?;
+            }
         }
 
         if let Some(sig) = input.sig_name {

--- a/agentmux-srv/src/backend/blockcontroller/acp.rs
+++ b/agentmux-srv/src/backend/blockcontroller/acp.rs
@@ -1,0 +1,545 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! AcpController: manages agent CLIs that speak the Agent Client Protocol (ACP).
+//!
+//! ACP is a JSON-RPC 2.0 protocol over stdin/stdout — the "LSP for AI agents."
+//! Instead of custom per-provider output parsing, ACP provides a standardized
+//! protocol for session management, prompting, and streaming events.
+//!
+//! Lifecycle:
+//!   1. Spawn the ACP agent process (e.g., `gemini --acp`, `acpx --agent openclaw`)
+//!   2. Send `initialize` request, receive capabilities
+//!   3. Send `initialized` notification
+//!   4. Create a session via `session/create`
+//!   5. For each user turn: send `session/prompt`, stream `session/update` notifications
+//!   6. On close: send `shutdown` + `exit`
+//!
+//! I/O model (similar to PersistentSubprocessController):
+//!   - stdin_writer: sends JSON-RPC requests/notifications to agent
+//!   - stdout_reader: reads JSON-RPC responses/notifications, persists + broadcasts
+//!   - process_waiter: monitors process lifecycle
+//!
+//! See: https://github.com/agentclientprotocol/agent-client-protocol
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::mpsc;
+
+use super::{
+    BlockControllerRuntimeStatus, BlockInputUnion, Controller, STATUS_DONE, STATUS_INIT,
+    STATUS_RUNNING,
+};
+use super::health::HealthMonitor;
+use crate::backend::eventbus::EventBus;
+use crate::backend::storage::filestore::FileStore;
+use crate::backend::storage::wstore::WaveStore;
+use crate::backend::wps;
+
+/// WPS file subject name for ACP output.
+pub const ACP_OUTPUT_SUBJECT: &str = "output";
+
+/// Controller type constant.
+pub const BLOCK_CONTROLLER_ACP: &str = "acp";
+
+/// Inner state protected by mutex.
+struct AcpInner {
+    proc_status: String,
+    proc_exit_code: i32,
+    status_version: i32,
+    session_id: Option<String>,
+    current_pid: Option<u32>,
+    stdin_tx: Option<mpsc::Sender<String>>,
+    kill_tx: Option<tokio::sync::oneshot::Sender<bool>>,
+}
+
+/// AcpController manages an ACP-speaking agent process.
+pub struct AcpController {
+    #[allow(dead_code)]
+    tab_id: String,
+    block_id: String,
+    inner: Arc<Mutex<AcpInner>>,
+    broker: Option<Arc<wps::Broker>>,
+    event_bus: Option<Arc<EventBus>>,
+    wstore: Option<Arc<WaveStore>>,
+    filestore: Option<Arc<FileStore>>,
+    health_monitor: Arc<HealthMonitor>,
+    /// Monotonically increasing JSON-RPC request ID.
+    next_rpc_id: AtomicU64,
+}
+
+impl AcpController {
+    pub fn new(
+        tab_id: String,
+        block_id: String,
+        broker: Option<Arc<wps::Broker>>,
+        event_bus: Option<Arc<EventBus>>,
+        wstore: Option<Arc<WaveStore>>,
+        filestore: Option<Arc<FileStore>>,
+    ) -> Self {
+        let health_monitor = Arc::new(HealthMonitor::new(
+            block_id.clone(),
+            broker.clone(),
+        ));
+        Self {
+            tab_id,
+            block_id,
+            inner: Arc::new(Mutex::new(AcpInner {
+                proc_status: STATUS_INIT.to_string(),
+                proc_exit_code: 0,
+                status_version: 0,
+                session_id: None,
+                current_pid: None,
+                stdin_tx: None,
+                kill_tx: None,
+            })),
+            broker,
+            event_bus,
+            wstore,
+            filestore,
+            health_monitor,
+            next_rpc_id: AtomicU64::new(1),
+        }
+    }
+
+    fn next_id(&self) -> u64 {
+        self.next_rpc_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn set_status(inner: &mut AcpInner, status: &str) {
+        inner.proc_status = status.to_string();
+        inner.status_version += 1;
+    }
+
+    fn get_status_snapshot(&self) -> BlockControllerRuntimeStatus {
+        let inner = self.inner.lock().unwrap();
+        BlockControllerRuntimeStatus {
+            blockid: self.block_id.clone(),
+            version: inner.status_version,
+            shellprocstatus: inner.proc_status.clone(),
+            shellprocconnname: "local".to_string(),
+            shellprocexitcode: inner.proc_exit_code,
+            spawn_ts_ms: None,
+            is_agent_pane: true,
+        }
+    }
+
+    fn publish_status(&self) {
+        if let Some(ref broker) = self.broker {
+            let status = self.get_status_snapshot();
+            super::publish_controller_status(broker, &status);
+        }
+    }
+
+    fn is_running(&self) -> bool {
+        let inner = self.inner.lock().unwrap();
+        inner.stdin_tx.is_some()
+    }
+
+    /// Build a JSON-RPC 2.0 request.
+    fn make_request(&self, method: &str, params: serde_json::Value) -> String {
+        let id = self.next_id();
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }).to_string()
+    }
+
+    /// Build a JSON-RPC 2.0 notification (no id field).
+    fn make_notification(&self, method: &str, params: serde_json::Value) -> String {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        }).to_string()
+    }
+
+    /// Send a user message via ACP session/prompt.
+    /// If the process isn't spawned yet, spawns it first.
+    pub fn send_message(&self, message: String, cli_command: String, cli_args: Vec<String>, working_dir: String, env_vars: HashMap<String, String>) -> Result<(), String> {
+        if !self.is_running() {
+            self.spawn_process(cli_command, cli_args, working_dir, env_vars)?;
+        }
+
+        let session_id = {
+            let inner = self.inner.lock().unwrap();
+            inner.session_id.clone().unwrap_or_default()
+        };
+
+        // Send session/prompt request
+        let req = self.make_request("session/prompt", serde_json::json!({
+            "sessionId": session_id,
+            "prompt": {
+                "type": "text",
+                "text": message,
+            }
+        }));
+
+        self.health_monitor.set_active_turn(true);
+
+        let inner = self.inner.lock().unwrap();
+        let tx = inner.stdin_tx.as_ref()
+            .ok_or("ACP process not running after spawn")?;
+        tx.try_send(req)
+            .map_err(|e| format!("ACP stdin send failed: {e}"))
+    }
+
+    /// Spawn the ACP agent process and perform the initialize handshake.
+    fn spawn_process(&self, cli_command: String, cli_args: Vec<String>, working_dir: String, env_vars: HashMap<String, String>) -> Result<(), String> {
+        let mut cmd = crate::server::cli_handlers::make_cli_cmd(&cli_command);
+        cmd.args(&cli_args);
+
+        // Working directory
+        if !working_dir.is_empty() {
+            let expanded_dir = if working_dir.starts_with("~/") || working_dir == "~" {
+                if let Some(home) = dirs::home_dir() {
+                    home.join(working_dir.trim_start_matches("~/")).to_string_lossy().to_string()
+                } else {
+                    working_dir.clone()
+                }
+            } else {
+                working_dir.clone()
+            };
+            let dir_path = std::path::Path::new(&expanded_dir);
+            if !dir_path.exists() {
+                if let Err(e) = std::fs::create_dir_all(dir_path) {
+                    tracing::warn!(
+                        block_id = %self.block_id,
+                        dir = %expanded_dir,
+                        error = %e,
+                        "failed to create working directory for ACP agent"
+                    );
+                }
+            }
+            if dir_path.exists() {
+                cmd.current_dir(&expanded_dir);
+            }
+        }
+
+        // Environment variables
+        for (k, v) in &env_vars {
+            let expanded = crate::backend::base::expand_home_dir_safe(v);
+            cmd.env(k, expanded.to_string_lossy().as_ref());
+        }
+
+        cmd.stdin(std::process::Stdio::piped());
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(|e| {
+            tracing::error!(block_id = %self.block_id, error = %e, "ACP process spawn failed");
+            format!("failed to spawn ACP process: {e}")
+        })?;
+
+        let pid = child.id().unwrap_or(0);
+
+        tracing::info!(
+            block_id = %self.block_id,
+            pid = pid,
+            cmd = %cli_command,
+            args = ?cli_args,
+            "ACP agent process spawned"
+        );
+
+        let (kill_tx, kill_rx) = tokio::sync::oneshot::channel::<bool>();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take();
+
+        // Drain stderr
+        if let Some(stderr_pipe) = stderr {
+            let block_id_stderr = self.block_id.clone();
+            tokio::spawn(async move {
+                let mut reader = BufReader::new(stderr_pipe).lines();
+                while let Ok(Some(line)) = reader.next_line().await {
+                    tracing::warn!(
+                        block_id = %block_id_stderr,
+                        line = %line,
+                        "ACP agent stderr"
+                    );
+                }
+            });
+        }
+
+        // Stdin writer channel
+        let (msg_tx, mut msg_rx) = mpsc::channel::<String>(32);
+
+        {
+            let mut inner = self.inner.lock().unwrap();
+            inner.current_pid = Some(pid);
+            inner.kill_tx = Some(kill_tx);
+            inner.stdin_tx = Some(msg_tx.clone());
+            Self::set_status(&mut inner, STATUS_RUNNING);
+        }
+        self.publish_status();
+
+        // Spawn stdin writer task
+        let block_id_stdin = self.block_id.clone();
+        tokio::spawn(async move {
+            let mut stdin = tokio::io::BufWriter::new(stdin);
+            while let Some(line) = msg_rx.recv().await {
+                if let Err(e) = stdin.write_all(line.as_bytes()).await {
+                    tracing::error!(block_id = %block_id_stdin, error = %e, "ACP stdin write error");
+                    break;
+                }
+                if let Err(e) = stdin.write_all(b"\n").await {
+                    tracing::error!(block_id = %block_id_stdin, error = %e, "ACP stdin newline error");
+                    break;
+                }
+                if let Err(e) = stdin.flush().await {
+                    tracing::error!(block_id = %block_id_stdin, error = %e, "ACP stdin flush error");
+                    break;
+                }
+            }
+        });
+
+        // Spawn stdout reader task — reads NDJSON lines and broadcasts via WPS
+        let block_id_stdout = self.block_id.clone();
+        let broker_clone = self.broker.clone();
+        let filestore_clone = self.filestore.clone();
+        let inner_clone = self.inner.clone();
+        let health_clone = self.health_monitor.clone();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                if line.is_empty() {
+                    continue;
+                }
+
+                // Parse as JSON to check for session/update notifications
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(&line) {
+                    // Extract session ID from initialize result or session/create result
+                    if let Some(result) = json.get("result") {
+                        if let Some(sid) = result.get("sessionId").and_then(|v| v.as_str()) {
+                            let mut inner = inner_clone.lock().unwrap();
+                            inner.session_id = Some(sid.to_string());
+                            tracing::info!(
+                                block_id = %block_id_stdout,
+                                session_id = %sid,
+                                "ACP session established"
+                            );
+                        }
+                    }
+
+                    // Reset health monitor on prompt result (turn complete)
+                    if json.get("id").is_some() && json.get("result").is_some() {
+                        // This is a response to a request (e.g., session/prompt result)
+                        if let Some(result) = json.get("result") {
+                            if result.get("stopReason").is_some() {
+                                health_clone.set_active_turn(false);
+                            }
+                        }
+                    }
+                }
+
+                // Persist to .jsonl file
+                if let Some(ref fstore) = filestore_clone {
+                    let _ = fstore.append_line(&block_id_stdout, ACP_OUTPUT_SUBJECT, &line);
+                }
+
+                // Broadcast via WPS so the frontend receives the event
+                if let Some(ref broker) = broker_clone {
+                    let event = wps::WaveEvent {
+                        event: wps::EVENT_BLOCKFILE.to_string(),
+                        scopes: vec![format!("block:{}", block_id_stdout)],
+                        sender: String::new(),
+                        persist: 0,
+                        data: Some(serde_json::json!({
+                            "zoneid": "",
+                            "blockid": block_id_stdout,
+                            "name": ACP_OUTPUT_SUBJECT,
+                            "data": line,
+                        })),
+                    };
+                    broker.publish(event);
+                }
+            }
+        });
+
+        // Spawn process waiter task
+        let block_id_wait = self.block_id.clone();
+        let inner_wait = self.inner.clone();
+        let broker_wait = self.broker.clone();
+        let health_wait = self.health_monitor.clone();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = kill_rx => {
+                    let _ = child.kill();
+                    tracing::info!(block_id = %block_id_wait, "ACP process killed");
+                }
+                status = async { child.wait() } => {
+                    let exit_code = status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
+                    tracing::info!(
+                        block_id = %block_id_wait,
+                        exit_code = exit_code,
+                        "ACP process exited"
+                    );
+                    let mut inner = inner_wait.lock().unwrap();
+                    inner.proc_exit_code = exit_code;
+                    inner.stdin_tx = None;
+                    AcpController::set_status(&mut inner, STATUS_DONE);
+                    drop(inner);
+
+                    health_wait.set_active_turn(false);
+
+                    if let Some(ref broker) = broker_wait {
+                        let status = BlockControllerRuntimeStatus {
+                            blockid: block_id_wait.clone(),
+                            version: 0,
+                            shellprocstatus: STATUS_DONE.to_string(),
+                            shellprocconnname: "local".to_string(),
+                            shellprocexitcode: exit_code,
+                            spawn_ts_ms: None,
+                            is_agent_pane: true,
+                        };
+                        super::publish_controller_status(broker, &status);
+                    }
+                }
+            }
+        });
+
+        // Send ACP initialize handshake
+        let init_req = self.make_request("initialize", serde_json::json!({
+            "clientInfo": {
+                "name": "AgentMux",
+                "version": env!("CARGO_PKG_VERSION"),
+            },
+            "capabilities": {
+                "tools": true,
+                "fileAccess": true,
+            },
+            "workspaceRoots": [working_dir],
+        }));
+        let init_notification = self.make_notification("initialized", serde_json::json!({}));
+        let session_req = self.make_request("session/create", serde_json::json!({
+            "cwd": working_dir,
+        }));
+
+        // Queue the handshake messages
+        let inner = self.inner.lock().unwrap();
+        if let Some(ref tx) = inner.stdin_tx {
+            let _ = tx.try_send(init_req);
+            let _ = tx.try_send(init_notification);
+            let _ = tx.try_send(session_req);
+        }
+
+        Ok(())
+    }
+}
+
+impl Controller for AcpController {
+    fn start(
+        &self,
+        block_meta: super::super::obj::MetaMapType,
+        _rt_opts: Option<serde_json::Value>,
+        _force: bool,
+    ) -> Result<(), String> {
+        // Extract spawn config from block metadata
+        let cmd = super::super::obj::meta_get_string(&block_meta, super::META_KEY_CMD, "");
+        let cwd = super::super::obj::meta_get_string(&block_meta, super::META_KEY_CMD_CWD, "");
+        let args_str = super::super::obj::meta_get_string(&block_meta, super::META_KEY_CMD_ARGS, "[]");
+        let env_str = super::super::obj::meta_get_string(&block_meta, super::META_KEY_CMD_ENV, "{}");
+
+        if cmd.is_empty() {
+            return Err("ACP controller: no cmd specified in block meta".to_string());
+        }
+
+        let args: Vec<String> = serde_json::from_str(&args_str).unwrap_or_default();
+        let env_vars: HashMap<String, String> = serde_json::from_str(&env_str).unwrap_or_default();
+
+        self.spawn_process(cmd, args, cwd, env_vars)
+    }
+
+    fn stop(&self, _graceful: bool, _new_status: &str) -> Result<(), String> {
+        // Send shutdown request before killing
+        {
+            let inner = self.inner.lock().unwrap();
+            if let Some(ref tx) = inner.stdin_tx {
+                let shutdown = self.make_request("shutdown", serde_json::json!({}));
+                let exit = self.make_notification("exit", serde_json::json!({}));
+                let _ = tx.try_send(shutdown);
+                let _ = tx.try_send(exit);
+            }
+        }
+
+        // Kill the process
+        let kill_tx = {
+            let mut inner = self.inner.lock().unwrap();
+            inner.stdin_tx = None;
+            inner.kill_tx.take()
+        };
+        if let Some(tx) = kill_tx {
+            let _ = tx.send(true);
+        }
+
+        {
+            let mut inner = self.inner.lock().unwrap();
+            Self::set_status(&mut inner, STATUS_DONE);
+        }
+        self.publish_status();
+        Ok(())
+    }
+
+    fn get_runtime_status(&self) -> BlockControllerRuntimeStatus {
+        self.get_status_snapshot()
+    }
+
+    fn send_input(&self, input: BlockInputUnion) -> Result<(), String> {
+        if let Some(data) = input.input_data {
+            // Raw input from the frontend — treat as a user message.
+            // The frontend sends the user prompt as UTF-8 bytes.
+            let message = String::from_utf8_lossy(&data).to_string();
+            if message.trim().is_empty() {
+                return Ok(());
+            }
+
+            // For ACP, we need the CLI command info to spawn if not running.
+            // If already running, just send the prompt.
+            if self.is_running() {
+                let session_id = {
+                    let inner = self.inner.lock().unwrap();
+                    inner.session_id.clone().unwrap_or_default()
+                };
+                let req = self.make_request("session/prompt", serde_json::json!({
+                    "sessionId": session_id,
+                    "prompt": {
+                        "type": "text",
+                        "text": message,
+                    }
+                }));
+                self.health_monitor.set_active_turn(true);
+                let inner = self.inner.lock().unwrap();
+                if let Some(ref tx) = inner.stdin_tx {
+                    tx.try_send(req)
+                        .map_err(|e| format!("ACP stdin send failed: {e}"))?;
+                }
+            }
+            // If not running, the process will be spawned on next start()
+        }
+
+        if let Some(sig) = input.sig_name {
+            if sig == "SIGTERM" || sig == "SIGINT" {
+                return self.stop(true, STATUS_DONE);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn controller_type(&self) -> &str {
+        BLOCK_CONTROLLER_ACP
+    }
+
+    fn block_id(&self) -> &str {
+        &self.block_id
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/agentmux-srv/src/backend/blockcontroller/acp.rs
+++ b/agentmux-srv/src/backend/blockcontroller/acp.rs
@@ -54,6 +54,8 @@ struct AcpInner {
     current_pid: Option<u32>,
     stdin_tx: Option<mpsc::Sender<String>>,
     kill_tx: Option<tokio::sync::oneshot::Sender<bool>>,
+    /// First user prompt, deferred until session/create completes.
+    pending_prompt: Option<String>,
 }
 
 /// AcpController manages an ACP-speaking agent process.
@@ -68,7 +70,7 @@ pub struct AcpController {
     filestore: Option<Arc<FileStore>>,
     health_monitor: Arc<HealthMonitor>,
     /// Monotonically increasing JSON-RPC request ID.
-    next_rpc_id: AtomicU64,
+    next_rpc_id: Arc<AtomicU64>,
 }
 
 impl AcpController {
@@ -95,13 +97,14 @@ impl AcpController {
                 current_pid: None,
                 stdin_tx: None,
                 kill_tx: None,
+                pending_prompt: None,
             })),
             broker,
             event_bus,
             wstore,
             filestore,
             health_monitor,
-            next_rpc_id: AtomicU64::new(1),
+            next_rpc_id: Arc::new(AtomicU64::new(1)),
         }
     }
 
@@ -160,18 +163,26 @@ impl AcpController {
     }
 
     /// Send a user message via ACP session/prompt.
-    /// If the process isn't spawned yet, spawns it first.
+    /// If the process isn't spawned yet, spawns it first (the first prompt is
+    /// deferred until the session is established — see `pending_prompt`).
     pub fn send_message(&self, message: String, cli_command: String, cli_args: Vec<String>, working_dir: String, env_vars: HashMap<String, String>) -> Result<(), String> {
         if !self.is_running() {
-            self.spawn_process(cli_command, cli_args, working_dir, env_vars)?;
+            // First turn: spawn and stash the prompt — the stdout reader will
+            // send it once the session/create response arrives.
+            {
+                let mut inner = self.inner.lock().unwrap();
+                inner.pending_prompt = Some(message.clone());
+            }
+            self.health_monitor.set_active_turn(true);
+            return self.spawn_process(cli_command, cli_args, working_dir, env_vars);
         }
 
+        // Subsequent turns: session_id is already populated.
         let session_id = {
             let inner = self.inner.lock().unwrap();
             inner.session_id.clone().unwrap_or_default()
         };
 
-        // Send session/prompt request
         let req = self.make_request("session/prompt", serde_json::json!({
             "sessionId": session_id,
             "prompt": {
@@ -304,6 +315,7 @@ impl AcpController {
         let filestore_clone = self.filestore.clone();
         let inner_clone = self.inner.clone();
         let health_clone = self.health_monitor.clone();
+        let rpc_id_clone = self.next_rpc_id.clone();
         tokio::spawn(async move {
             let mut reader = BufReader::new(stdout).lines();
             while let Ok(Some(line)) = reader.next_line().await {
@@ -323,6 +335,23 @@ impl AcpController {
                                 session_id = %sid,
                                 "ACP session established"
                             );
+
+                            // Flush pending prompt now that session is ready.
+                            if let Some(prompt) = inner.pending_prompt.take() {
+                                let id = rpc_id_clone.fetch_add(1, Ordering::Relaxed);
+                                let req = serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "id": id,
+                                    "method": "session/prompt",
+                                    "params": {
+                                        "sessionId": sid,
+                                        "prompt": { "type": "text", "text": prompt },
+                                    }
+                                }).to_string();
+                                if let Some(ref tx) = inner.stdin_tx {
+                                    let _ = tx.try_send(req);
+                                }
+                            }
                         }
                     }
 
@@ -369,10 +398,10 @@ impl AcpController {
         tokio::spawn(async move {
             tokio::select! {
                 _ = kill_rx => {
-                    let _ = child.kill();
+                    let _ = child.kill().await;
                     tracing::info!(block_id = %block_id_wait, "ACP process killed");
                 }
-                status = async { child.wait() } => {
+                status = child.wait() => {
                     let exit_code = status.map(|s| s.code().unwrap_or(-1)).unwrap_or(-1);
                     tracing::info!(
                         block_id = %block_id_wait,

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -11,6 +11,7 @@
 //! - ShellController handles "shell" and "cmd" block types
 //! - Controllers dispatch I/O between the user and the process/service
 
+pub mod acp;
 pub mod health;
 pub mod persistent;
 pub mod pidregistry;
@@ -46,6 +47,7 @@ pub const BLOCK_CONTROLLER_CMD: &str = "cmd";
 pub const BLOCK_CONTROLLER_TSUNAMI: &str = "tsunami";
 pub const BLOCK_CONTROLLER_SUBPROCESS: &str = "subprocess";
 pub const BLOCK_CONTROLLER_PERSISTENT: &str = "persistent";
+pub const BLOCK_CONTROLLER_ACP: &str = "acp";
 
 // ---- Block metadata key constants (match Go) ----
 
@@ -365,6 +367,19 @@ pub fn resync_controller(
         }
         BLOCK_CONTROLLER_PERSISTENT => {
             let ctrl = persistent::PersistentSubprocessController::new(
+                tab_id.to_string(),
+                block_id.to_string(),
+                broker,
+                event_bus,
+                wstore,
+                filestore,
+            );
+            let ctrl = Arc::new(ctrl);
+            register_controller(block_id, ctrl.clone());
+            ctrl.start(block_meta.clone(), rt_opts, force)
+        }
+        BLOCK_CONTROLLER_ACP => {
+            let ctrl = acp::AcpController::new(
                 tab_id.to_string(),
                 block_id.to_string(),
                 broker,

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -198,6 +198,26 @@ static OPENCLAW: ProviderConfig = ProviderConfig {
     docs_url: "https://docs.openclaw.ai",
 };
 
+static PI: ProviderConfig = ProviderConfig {
+    id: "pi",
+    display_name: "Pi",
+    cli_command: "pi",
+    controller_type: ControllerType::Acp,
+    launch_args: &["--json"],
+    persistent_launch_args: None,
+    resume_flag: None,
+    session_id_field: "sessionId",
+    styled_output_format: "acp",
+    auth_config_dir_env_var: "PI_HOME",
+    auth_dir_name: "pi",
+    auth_extra_env: &[],
+    unset_env: &[],
+    npm_package: "@mariozechner/pi-coding-agent",
+    pinned_version: "latest",
+    icon: "terminal",
+    docs_url: "https://github.com/badlogic/pi-mono",
+};
+
 // ─── Static registry ─────────────────────────────────────────────────────────
 
 static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = LazyLock::new(|| {
@@ -206,6 +226,7 @@ static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = Lazy
     m.insert(CODEX.id, &CODEX);
     m.insert(GEMINI.id, &GEMINI);
     m.insert(OPENCLAW.id, &OPENCLAW);
+    m.insert(PI.id, &PI);
     m
 });
 
@@ -255,7 +276,7 @@ pub fn get_provider(id: &str) -> Option<&'static ProviderConfig> {
 /// Return an iterator over all registered providers in insertion order.
 pub fn get_provider_list() -> impl Iterator<Item = &'static ProviderConfig> {
     // Stable canonical order matches the TypeScript PROVIDERS object order.
-    static ORDER: &[&str] = &["claude", "codex", "gemini", "openclaw"];
+    static ORDER: &[&str] = &["claude", "codex", "gemini", "openclaw", "pi"];
     ORDER.iter().filter_map(|id| REGISTRY.get(*id).copied())
 }
 
@@ -288,8 +309,8 @@ mod tests {
     }
 
     #[test]
-    fn provider_list_has_four_entries() {
-        assert_eq!(get_provider_list().count(), 4);
+    fn provider_list_has_five_entries() {
+        assert_eq!(get_provider_list().count(), 5);
     }
 
     #[test]
@@ -322,5 +343,15 @@ mod tests {
         assert_eq!(p.controller_type_str(), "acp");
         assert_eq!(p.styled_output_format, "acp");
         assert!(p.resume_flag.is_none());
+    }
+
+    #[test]
+    fn pi_is_acp_controller() {
+        let p = get_provider("pi").unwrap();
+        assert_eq!(p.controller_type, ControllerType::Acp);
+        assert_eq!(p.controller_type_str(), "acp");
+        assert_eq!(p.styled_output_format, "acp");
+        assert_eq!(p.cli_command, "pi");
+        assert_eq!(p.npm_package, "@mariozechner/pi-coding-agent");
     }
 }

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -21,6 +21,9 @@ pub enum ControllerType {
     /// A fresh subprocess is spawned for every turn; prior sessions are
     /// resumed via `resume_flag`.
     Subprocess,
+    /// Agent Client Protocol (ACP): JSON-RPC 2.0 over stdio.
+    /// Sessions are managed by the protocol — no resume flags needed.
+    Acp,
 }
 
 // ─── ProviderConfig ──────────────────────────────────────────────────────────
@@ -82,6 +85,7 @@ impl ProviderConfig {
         match self.controller_type {
             ControllerType::Persistent => "persistent",
             ControllerType::Subprocess => "subprocess",
+            ControllerType::Acp => "acp",
         }
     }
 }
@@ -173,6 +177,27 @@ static GEMINI: ProviderConfig = ProviderConfig {
     docs_url: "https://ai.google.dev/gemini-cli",
 };
 
+static OPENCLAW: ProviderConfig = ProviderConfig {
+    id: "openclaw",
+    display_name: "OpenClaw",
+    cli_command: "acpx",
+    controller_type: ControllerType::Acp,
+    launch_args: &["--agent", "openclaw"],
+    persistent_launch_args: None,
+    // ACP handles sessions natively — no resume flag or session ID parsing needed
+    resume_flag: None,
+    session_id_field: "sessionId",
+    styled_output_format: "acp",
+    auth_config_dir_env_var: "OPENCLAW_HOME",
+    auth_dir_name: "openclaw",
+    auth_extra_env: &[],
+    unset_env: &[],
+    npm_package: "@openclaw/acpx",
+    pinned_version: "latest",
+    icon: "lobster",
+    docs_url: "https://docs.openclaw.ai",
+};
+
 // ─── Static registry ─────────────────────────────────────────────────────────
 
 static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = LazyLock::new(|| {
@@ -180,6 +205,7 @@ static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = Lazy
     m.insert(CLAUDE.id, &CLAUDE);
     m.insert(CODEX.id, &CODEX);
     m.insert(GEMINI.id, &GEMINI);
+    m.insert(OPENCLAW.id, &OPENCLAW);
     m
 });
 
@@ -190,6 +216,8 @@ static ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(||
     m.insert("claude_code", "claude");
     m.insert("codex-cli", "codex");
     m.insert("gemini-cli", "gemini");
+    m.insert("openclaw-cli", "openclaw");
+    m.insert("open-claw", "openclaw");
     m
 });
 
@@ -227,7 +255,7 @@ pub fn get_provider(id: &str) -> Option<&'static ProviderConfig> {
 /// Return an iterator over all registered providers in insertion order.
 pub fn get_provider_list() -> impl Iterator<Item = &'static ProviderConfig> {
     // Stable canonical order matches the TypeScript PROVIDERS object order.
-    static ORDER: &[&str] = &["claude", "codex", "gemini"];
+    static ORDER: &[&str] = &["claude", "codex", "gemini", "openclaw"];
     ORDER.iter().filter_map(|id| REGISTRY.get(*id).copied())
 }
 
@@ -242,6 +270,7 @@ mod tests {
         assert!(get_provider("claude").is_some());
         assert!(get_provider("codex").is_some());
         assert!(get_provider("gemini").is_some());
+        assert!(get_provider("openclaw").is_some());
     }
 
     #[test]
@@ -250,6 +279,7 @@ mod tests {
         assert_eq!(get_provider("claude_code").unwrap().id, "claude");
         assert_eq!(get_provider("codex-cli").unwrap().id, "codex");
         assert_eq!(get_provider("gemini-cli").unwrap().id, "gemini");
+        assert_eq!(get_provider("openclaw-cli").unwrap().id, "openclaw");
     }
 
     #[test]
@@ -258,8 +288,8 @@ mod tests {
     }
 
     #[test]
-    fn provider_list_has_three_entries() {
-        assert_eq!(get_provider_list().count(), 3);
+    fn provider_list_has_four_entries() {
+        assert_eq!(get_provider_list().count(), 4);
     }
 
     #[test]
@@ -283,5 +313,14 @@ mod tests {
             .auth_extra_env
             .iter()
             .any(|(k, v)| *k == "GEMINI_FORCE_FILE_STORAGE" && *v == "true"));
+    }
+
+    #[test]
+    fn openclaw_is_acp_controller() {
+        let p = get_provider("openclaw").unwrap();
+        assert_eq!(p.controller_type, ControllerType::Acp);
+        assert_eq!(p.controller_type_str(), "acp");
+        assert_eq!(p.styled_output_format, "acp");
+        assert!(p.resume_flag.is_none());
     }
 }

--- a/frontend/app/view/agent/commands/providers/index.ts
+++ b/frontend/app/view/agent/commands/providers/index.ts
@@ -9,7 +9,9 @@
 
 import type { SlashCommand } from "../types";
 import { CLAUDE_COMMANDS } from "./claude";
+import { OPENCLAW_COMMANDS } from "./openclaw";
 
 export const SLASH_COMMANDS_BY_PROVIDER: Record<string, SlashCommand[]> = {
     claude: CLAUDE_COMMANDS,
+    openclaw: OPENCLAW_COMMANDS,
 };

--- a/frontend/app/view/agent/commands/providers/openclaw.ts
+++ b/frontend/app/view/agent/commands/providers/openclaw.ts
@@ -1,0 +1,10 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SlashCommand } from "../types";
+
+/**
+ * OpenClaw-specific slash commands.
+ * OpenClaw uses ACP — most interaction is protocol-native.
+ */
+export const OPENCLAW_COMMANDS: SlashCommand[] = [];

--- a/frontend/app/view/agent/providers/acp-translator.ts
+++ b/frontend/app/view/agent/providers/acp-translator.ts
@@ -1,0 +1,86 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { StreamEvent, ToolCallEvent, ToolResultEvent } from "../types";
+import type { OutputTranslator } from "./translator";
+
+/**
+ * Universal translator for agents speaking the Agent Client Protocol (ACP).
+ *
+ * ACP uses JSON-RPC 2.0 over stdio. Streaming events arrive as `session/update`
+ * notifications with a `type` field indicating the event kind:
+ *
+ *   agent_message_chunk  — incremental text from the agent
+ *   agent_thought_chunk  — reasoning/thinking content
+ *   tool_call            — agent invokes a tool
+ *   tool_result          — tool execution result
+ *
+ * This single translator handles all ACP-compatible agents (OpenClaw, Kiro,
+ * Gemini --acp, and any future ACP agent) without per-agent customization.
+ *
+ * See: https://github.com/agentclientprotocol/agent-client-protocol
+ */
+export class AcpTranslator implements OutputTranslator {
+    // Map tool call IDs to tool names for result correlation
+    private toolNameById: Map<string, string> = new Map();
+
+    translate(rawEvent: any): StreamEvent[] {
+        if (!rawEvent || typeof rawEvent !== "object") return [];
+
+        // ACP session/update notifications carry params with a type field.
+        // The raw event may be the full JSON-RPC envelope or just the params.
+        const params = rawEvent.params ?? rawEvent;
+        const type: string = params.type ?? "";
+
+        switch (type) {
+            case "agent_message_chunk": {
+                const content: string = params.content ?? params.text ?? "";
+                if (!content) return [];
+                return [{ type: "text", content }];
+            }
+
+            case "agent_thought_chunk": {
+                const content: string = params.content ?? params.text ?? "";
+                if (!content) return [];
+                return [{ type: "thinking", content }];
+            }
+
+            case "tool_call": {
+                const toolName: string = params.toolName ?? params.name ?? "unknown";
+                const toolId: string = params.toolCallId ?? params.id ?? `tool-${Date.now()}`;
+                const toolParams: Record<string, any> = params.input ?? params.parameters ?? {};
+                this.toolNameById.set(toolId, toolName);
+                const ev: ToolCallEvent = {
+                    type: "tool_call",
+                    tool: toolName,
+                    id: toolId,
+                    params: toolParams,
+                };
+                return [ev];
+            }
+
+            case "tool_result": {
+                const toolId: string = params.toolCallId ?? params.id ?? "";
+                const toolName = this.toolNameById.get(toolId) ?? params.toolName ?? "unknown";
+                const isError = params.isError === true || params.status === "error";
+                const output = params.content ?? params.output ?? "";
+                const ev: ToolResultEvent = {
+                    type: "tool_result",
+                    tool: toolName,
+                    id: toolId,
+                    status: isError ? "failed" : "success",
+                    result: typeof output === "string" ? { output } : output,
+                };
+                return [ev];
+            }
+
+            default:
+                // Discard lifecycle events (initialize, session/create results, etc.)
+                return [];
+        }
+    }
+
+    reset(): void {
+        this.toolNameById.clear();
+    }
+}

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -7,8 +7,8 @@ export interface ProviderDefinition {
     cliCommand: string;
     defaultArgs: string[];
     styledArgs: string[];        // CLI flags for JSON streaming mode (documentation; use launchArgs for actual invocation)
-    outputFormat: "claude-stream-json" | "gemini-json" | "codex-json" | "raw";
-    styledOutputFormat: "claude-stream-json" | "gemini-json" | "codex-json";
+    outputFormat: "claude-stream-json" | "gemini-json" | "codex-json" | "acp" | "raw";
+    styledOutputFormat: "claude-stream-json" | "gemini-json" | "codex-json" | "acp";
     authType: "oauth" | "api-key";
     authCheckCommand: string[];  // e.g. ["auth", "status", "--json"]
     authLoginCommand: string[];  // e.g. ["auth", "login"]
@@ -32,8 +32,9 @@ export interface ProviderDefinition {
     // JSON field name containing the session/thread ID in the CLI's init event.
     sessionIdField: string;
     // Controller type: "persistent" keeps a long-running process with stdin streaming,
-    // "subprocess" spawns a fresh process per turn with --resume.
-    controllerType: "persistent" | "subprocess";
+    // "subprocess" spawns a fresh process per turn with --resume,
+    // "acp" uses the Agent Client Protocol (JSON-RPC 2.0 over stdio).
+    controllerType: "persistent" | "subprocess" | "acp";
     // Launch args for persistent mode (--input-format stream-json, no -p).
     // Only used when controllerType is "persistent".
     persistentLaunchArgs?: string[];
@@ -120,6 +121,31 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "session_id",
         controllerType: "subprocess",
     },
+    openclaw: {
+        id: "openclaw",
+        displayName: "OpenClaw",
+        cliCommand: "acpx",
+        defaultArgs: [],
+        // ACP agents use JSON-RPC 2.0 over stdio — no custom CLI flags needed
+        styledArgs: ["--agent", "openclaw"],
+        outputFormat: "acp",
+        styledOutputFormat: "acp",
+        authType: "api-key",
+        authCheckCommand: ["openclaw", "doctor"],
+        authLoginCommand: ["openclaw", "onboard"],
+        npmPackage: "@openclaw/acpx",
+        pinnedVersion: "latest",
+        docsUrl: "https://docs.openclaw.ai",
+        windowsInstallCommand: "npm install -g @openclaw/acpx",
+        unixInstallCommand: "npm install -g @openclaw/acpx",
+        icon: "lobster",
+        authConfigDirEnvVar: "OPENCLAW_HOME",
+        authDirName: "openclaw",
+        launchArgs: ["--agent", "openclaw"],
+        resumeFlag: null,           // ACP handles sessions natively
+        sessionIdField: "sessionId", // ACP protocol field
+        controllerType: "acp",
+    },
 };
 
 // Aliases for provider IDs from older databases or alternate naming
@@ -128,6 +154,8 @@ const PROVIDER_ALIASES: Record<string, string> = {
     "claude_code": "claude",
     "codex-cli": "codex",
     "gemini-cli": "gemini",
+    "openclaw-cli": "openclaw",
+    "open-claw": "openclaw",
 };
 
 export function resolveProviderAlias(id: string): string {

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -121,12 +121,14 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "session_id",
         controllerType: "subprocess",
     },
+    // OpenClaw via gateway daemon (detected if `openclaw` is installed and gateway is running).
+    // Uses acpx as the ACP bridge to the running OpenClaw gateway.
+    // Full OpenClaw features: skills, external messaging channels, memory, multi-agent.
     openclaw: {
         id: "openclaw",
         displayName: "OpenClaw",
         cliCommand: "acpx",
         defaultArgs: [],
-        // ACP agents use JSON-RPC 2.0 over stdio — no custom CLI flags needed
         styledArgs: ["--agent", "openclaw"],
         outputFormat: "acp",
         styledOutputFormat: "acp",
@@ -142,8 +144,35 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         authConfigDirEnvVar: "OPENCLAW_HOME",
         authDirName: "openclaw",
         launchArgs: ["--agent", "openclaw"],
-        resumeFlag: null,           // ACP handles sessions natively
-        sessionIdField: "sessionId", // ACP protocol field
+        resumeFlag: null,
+        sessionIdField: "sessionId",
+        controllerType: "acp",
+    },
+    // Pi — the lightweight coding agent that powers OpenClaw.
+    // Standalone CLI, no gateway required. Pure coding agent with read/write/bash/edit tools.
+    // Ideal when users want a fast, self-contained coding agent without the full OpenClaw stack.
+    pi: {
+        id: "pi",
+        displayName: "Pi",
+        cliCommand: "pi",
+        defaultArgs: [],
+        styledArgs: ["--json"],
+        outputFormat: "acp",
+        styledOutputFormat: "acp",
+        authType: "api-key",
+        authCheckCommand: ["config", "get", "provider"],
+        authLoginCommand: ["config"],
+        npmPackage: "@mariozechner/pi-coding-agent",
+        pinnedVersion: "latest",
+        docsUrl: "https://github.com/badlogic/pi-mono",
+        windowsInstallCommand: "npm install -g @mariozechner/pi-coding-agent",
+        unixInstallCommand: "npm install -g @mariozechner/pi-coding-agent",
+        icon: "terminal",
+        authConfigDirEnvVar: "PI_HOME",
+        authDirName: "pi",
+        launchArgs: ["--json"],
+        resumeFlag: null,
+        sessionIdField: "sessionId",
         controllerType: "acp",
     },
 };

--- a/frontend/app/view/agent/providers/translator-factory.ts
+++ b/frontend/app/view/agent/providers/translator-factory.ts
@@ -5,6 +5,7 @@ import type { OutputTranslator } from "./translator";
 import { ClaudeTranslator } from "./claude-translator";
 import { GeminiTranslator } from "./gemini-translator";
 import { CodexTranslator } from "./codex-translator";
+import { AcpTranslator } from "./acp-translator";
 
 /**
  * Create an OutputTranslator for the given output format.
@@ -17,6 +18,8 @@ export function createTranslator(outputFormat: string): OutputTranslator {
             return new GeminiTranslator();
         case "codex-json":
             return new CodexTranslator();
+        case "acp":
+            return new AcpTranslator();
         default:
             console.warn(`[translator-factory] Unknown output format "${outputFormat}", falling back to Claude translator`);
             return new ClaudeTranslator();

--- a/frontend/app/view/forge/forge-constants.ts
+++ b/frontend/app/view/forge/forge-constants.ts
@@ -6,4 +6,5 @@ export const PROVIDERS = [
     { id: "codex", label: "Codex CLI", cmd: "codex --full-auto" },
     { id: "gemini", label: "Gemini CLI", cmd: "gemini --yolo" },
     { id: "openclaw", label: "OpenClaw", cmd: "acpx --agent openclaw" },
+    { id: "pi", label: "Pi", cmd: "pi --json" },
 ] as const;

--- a/frontend/app/view/forge/forge-constants.ts
+++ b/frontend/app/view/forge/forge-constants.ts
@@ -5,4 +5,5 @@ export const PROVIDERS = [
     { id: "claude", label: "Claude Code", cmd: "claude --output-format stream-json" },
     { id: "codex", label: "Codex CLI", cmd: "codex --full-auto" },
     { id: "gemini", label: "Gemini CLI", cmd: "gemini --yolo" },
+    { id: "openclaw", label: "OpenClaw", cmd: "acpx --agent openclaw" },
 ] as const;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.201",
+  "version": "0.33.202",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_ACP_CONTROLLER_2026_04_16.md
+++ b/specs/SPEC_ACP_CONTROLLER_2026_04_16.md
@@ -1,0 +1,553 @@
+# SPEC: ACP Controller — Universal Agent Client Protocol Support
+
+**Date:** 2026-04-16
+**Author:** Agent1
+**Status:** Draft
+**Priority:** High — strategic differentiator
+**Supersedes:** `docs/specs/openclaw-agent-runtime.md` (TUI/PTY approach)
+**Related:** `docs/specs/integration-vision.md`, `docs/specs/openclaw-widget.md`
+
+---
+
+## Summary
+
+Add a new `acp` controller type to AgentMux that speaks the [Agent Client Protocol](https://github.com/agentclientprotocol/agent-client-protocol) (ACP), enabling AgentMux to host **any ACP-compatible coding agent** with zero per-agent integration work.
+
+ACP is a JSON-RPC 2.0 protocol over stdio — the "LSP for AI agents." AgentMux currently has custom translators for each provider (Claude, Codex, Gemini). An ACP controller replaces this N-integrations problem with a single universal protocol layer.
+
+### Why ACP Instead of TUI/PTY
+
+The prior spec (`openclaw-agent-runtime.md`) proposed running `openclaw tui` in a PTY terminal pane — the same pattern used for Claude/Codex/Gemini today. This works but has fundamental limitations:
+
+| PTY Approach (Prior Spec) | ACP Approach (This Spec) |
+|---------------------------|--------------------------|
+| Scrape terminal output, parse ANSI | Structured JSON-RPC messages |
+| Per-agent output format parsing | One universal protocol |
+| Only works for OpenClaw | Works for any ACP agent |
+| No programmatic tool call visibility | First-class tool call events |
+| Session management via CLI flags | Protocol-native sessions |
+| Gateway must be running first | ACP process is self-contained |
+
+The TUI approach remains valid as a fallback for agents without ACP support, but ACP is the strategic direction. The `openclaw-widget.md` spec (WebView dashboard) is unaffected — the widget and ACP controller serve different purposes and coexist.
+
+---
+
+## Motivation
+
+### Current State
+
+Each agent provider requires:
+- A static `ProviderConfig` in Rust (`providers.rs`)
+- A `ProviderDefinition` in TypeScript (`providers/index.ts`)
+- A custom output translator (`claude-translator.ts`, etc.)
+- Custom launch args, auth handling, resume logic
+- CEF-layer detection and installation code
+
+**Adding one agent = 5-7 files changed.** This doesn't scale.
+
+### With ACP
+
+Any agent that speaks ACP works automatically:
+- One `AcpController` handles all ACP agents
+- One `AcpTranslator` converts ACP events to `StreamEvent`
+- New agents = config entry only (CLI command + args)
+
+### Industry Adoption
+
+| Agent | ACP Support | Method |
+|-------|------------|--------|
+| Gemini CLI | Native | `gemini --acp` |
+| Kiro CLI | Native | Built-in |
+| OpenClaw | Native | Via `acpx` / built-in ACP bridge |
+| Claude Code | Community bridge | `claude-agent-acp` (Zed), `claude-code-acp` (PyPI) |
+| Codex CLI | Community bridge | `codex-acp` (Zed, cola-io) |
+| GitHub Copilot | Public preview | Native |
+| Augment Code | Native | Built-in |
+| Goose | Native | Built-in |
+| Junie (JetBrains) | Native | Built-in |
+| Cline | Native | Built-in |
+
+Claude Code and Codex have open feature requests for native ACP (#6686 and #9085 respectively). Native support is likely coming.
+
+---
+
+## ACP Protocol Overview
+
+### Transport
+
+- **Wire format:** JSON-RPC 2.0 over stdin/stdout
+- **Lifecycle:** Client spawns agent process, communicates via stdio
+- **Framing:** Newline-delimited JSON (NDJSON)
+
+### Core Flow
+
+```
+Client (AgentMux)                    Agent (e.g., gemini --acp)
+       |                                      |
+       |--- initialize ---------------------->|
+       |<-- initialize result ----------------|
+       |--- initialized notification -------->|
+       |                                      |
+       |--- session/create ------------------>|
+       |<-- session id -----------------------|
+       |                                      |
+       |--- session/prompt ------------------>|
+       |<-- session/update (streaming) -------|  (multiple)
+       |<-- session/update (streaming) -------|
+       |<-- session/prompt result ------------|
+       |                                      |
+       |--- session/prompt (turn 2) --------->|
+       |<-- session/update (streaming) -------|
+       |<-- session/prompt result ------------|
+       |                                      |
+       |--- shutdown ------------------------>|
+       |<-- shutdown result ------------------|
+       |--- exit ---------------------------->|
+```
+
+### Key Message Types
+
+#### Initialize
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "clientInfo": {
+      "name": "AgentMux",
+      "version": "0.33.0"
+    },
+    "capabilities": {
+      "tools": true,
+      "fileAccess": true
+    },
+    "workspaceRoots": ["/path/to/project"]
+  }
+}
+```
+
+#### Session Create
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "session/create",
+  "params": {
+    "cwd": "/path/to/project"
+  }
+}
+```
+
+#### Session Prompt
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "session/prompt",
+  "params": {
+    "sessionId": "uuid",
+    "prompt": {
+      "type": "text",
+      "text": "Fix the failing test in auth.test.ts"
+    }
+  }
+}
+```
+
+#### Session Update (Streaming Notification)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "session/update",
+  "params": {
+    "sessionId": "uuid",
+    "type": "agent_message_chunk",
+    "content": "I'll look at the test file..."
+  }
+}
+```
+
+Other update types: `tool_call`, `tool_result`, `agent_thought_chunk`
+
+#### Prompt Result
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "stopReason": "end_turn",
+    "usage": {
+      "inputTokens": 1200,
+      "outputTokens": 450
+    }
+  }
+}
+```
+
+---
+
+## Architecture
+
+### New Controller: `AcpController`
+
+```
+┌─────────────────────────────────────────────────┐
+│                  AgentMux                        │
+│                                                  │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐      │
+│  │ Persistent│  │Subprocess│  │   ACP    │ NEW  │
+│  │Controller │  │Controller│  │Controller│◄─────│
+│  └─────┬─────┘  └─────┬────┘  └─────┬────┘      │
+│        │               │             │           │
+│   stdin/stdout    per-turn      JSON-RPC 2.0     │
+│   raw stream      spawn        over stdio        │
+│        │               │             │           │
+│  ┌─────┴─────┐  ┌─────┴────┐  ┌─────┴────┐      │
+│  │  Claude   │  │  Codex   │  │ Any ACP  │      │
+│  │  (native) │  │  (native)│  │  Agent   │      │
+│  └───────────┘  └──────────┘  └──────────┘      │
+└─────────────────────────────────────────────────┘
+```
+
+The ACP controller is a **persistent** process — one spawn per agent pane, multiple turns via `session/prompt`. No need for `--resume` flags or session ID parsing from output.
+
+### Backend (Rust)
+
+#### `agentmux-srv/src/backend/blockcontroller/acp.rs` (NEW)
+
+```rust
+pub struct AcpController {
+    session_id: Option<String>,
+    child: Option<Child>,
+    stdin: Option<ChildStdin>,
+    stdout_reader: Option<BufReader<ChildStdout>>,
+    next_rpc_id: AtomicU64,
+}
+
+impl AcpController {
+    /// Spawn the ACP agent process and perform initialize handshake
+    pub async fn start(&mut self, cmd: &str, args: &[&str], cwd: &str) -> Result<()> {
+        // 1. Spawn process with stdin/stdout pipes
+        // 2. Send initialize request
+        // 3. Wait for initialize result
+        // 4. Send initialized notification
+        // 5. Create session
+        // 6. Store session_id
+    }
+
+    /// Send a user prompt and stream back updates
+    pub async fn prompt(&mut self, text: &str) -> Result<PromptStream> {
+        // 1. Send session/prompt request
+        // 2. Return stream that yields session/update notifications
+        // 3. Complete when prompt result arrives
+    }
+
+    /// Graceful shutdown
+    pub async fn stop(&mut self) -> Result<()> {
+        // 1. Send shutdown request
+        // 2. Send exit notification
+        // 3. Wait for process to exit
+    }
+}
+```
+
+#### `agentmux-srv/src/backend/blockcontroller/mod.rs` (MODIFIED)
+
+Add `Acp` variant to controller type enum:
+
+```rust
+pub enum ControllerType {
+    Persistent,
+    Subprocess,
+    Acp,          // NEW
+}
+```
+
+Route to `AcpController` when block metadata has `controller: "acp"`.
+
+### Frontend (TypeScript)
+
+#### `frontend/app/view/agent/providers/acp-translator.ts` (NEW)
+
+Single translator that handles all ACP agents:
+
+```typescript
+export class AcpTranslator implements OutputTranslator {
+    translate(rawEvent: AcpSessionUpdate): StreamEvent[] {
+        switch (rawEvent.type) {
+            case "agent_message_chunk":
+                return [{ type: "text", content: rawEvent.content }];
+
+            case "agent_thought_chunk":
+                return [{ type: "thinking", content: rawEvent.content }];
+
+            case "tool_call":
+                return [{
+                    type: "tool_use",
+                    id: rawEvent.toolCallId,
+                    name: rawEvent.toolName,
+                    input: rawEvent.input,
+                }];
+
+            case "tool_result":
+                return [{
+                    type: "tool_result",
+                    id: rawEvent.toolCallId,
+                    content: rawEvent.content,
+                }];
+
+            default:
+                return [];
+        }
+    }
+
+    reset(): void { /* no state to reset */ }
+}
+```
+
+#### `frontend/app/view/agent/providers/index.ts` (MODIFIED)
+
+Add ACP provider definitions — these are lightweight since the protocol handles everything:
+
+```typescript
+// ACP agents only need: id, displayName, cliCommand, acp flag + args
+openclaw: {
+    id: "openclaw",
+    displayName: "OpenClaw",
+    cliCommand: "acpx",                    // or "openclaw-cli"
+    controllerType: "acp",                 // NEW controller type
+    launchArgs: ["--agent", "openclaw"],
+    styledOutputFormat: "acp",             // universal ACP translator
+    icon: "lobster",
+    docsUrl: "https://docs.openclaw.ai",
+    npmPackage: "@openclaw/acpx",
+    // ... auth fields
+},
+
+kiro: {
+    id: "kiro",
+    displayName: "Kiro CLI",
+    cliCommand: "kiro",
+    controllerType: "acp",
+    launchArgs: ["--acp"],
+    styledOutputFormat: "acp",
+    icon: "kiro",
+    docsUrl: "https://kiro.dev/docs/cli/acp/",
+    npmPackage: "@anthropic-ai/kiro",
+    // ... auth fields
+},
+```
+
+#### `frontend/app/view/agent/providers/translator-factory.ts` (MODIFIED)
+
+```typescript
+case "acp":
+    return new AcpTranslator();
+```
+
+### Provider Config Changes
+
+#### `agentmux-srv/src/backend/providers.rs` (MODIFIED)
+
+Add `ControllerType::Acp` and ACP-specific provider entries:
+
+```rust
+pub enum ControllerType {
+    Persistent,
+    Subprocess,
+    Acp,
+}
+
+static OPENCLAW: ProviderConfig = ProviderConfig {
+    id: "openclaw",
+    display_name: "OpenClaw",
+    cli_command: "acpx",
+    controller_type: ControllerType::Acp,
+    launch_args: &["--agent", "openclaw"],
+    // ACP handles sessions natively — no resume_flag or session_id_field needed
+    resume_flag: None,
+    session_id_field: "",
+    styled_output_format: "acp",
+    // ...
+};
+```
+
+---
+
+## Relationship to Existing Specs
+
+### `docs/specs/integration-vision.md`
+
+The integration vision already identified three messaging layers including ACP sub-agents, OpenClaw as a first-class runtime, and the ContextEngine interface. This spec implements the ACP layer as a universal controller rather than an OpenClaw-specific feature.
+
+Key items from the vision that this spec enables:
+- **"Agent spawning/streaming — OpenClaw ACP"** → generalized to any ACP agent
+- **"OpenClaw replaces a5af/claw"** → still true, but via ACP not TUI
+- **Context engine integration** → deferred to a separate spec, not blocked by controller choice
+
+### `docs/specs/openclaw-agent-runtime.md`
+
+This spec **supersedes** the TUI/PTY approach for OpenClaw. Specifically:
+- `forge-seed.json` entries (AgentClaw, Agent4) → still needed, but `provider: "openclaw"` now routes to ACP controller
+- `shellexec.rs` changes → not needed; ACP controller handles spawn
+- Phase 3 "ACP sub-agent surfacing" → becomes Phase 1 since we're ACP-native from the start
+
+### `docs/specs/openclaw-widget.md`
+
+**Unaffected.** The widget (WebView at `localhost:18789`) and ACP controller serve different purposes:
+- Widget = dashboard/config UI for OpenClaw's gateway, channels, skills
+- ACP controller = structured agent interaction in an agent pane
+
+Both coexist and can connect to the same OpenClaw gateway instance.
+
+---
+
+## Migration Path
+
+ACP doesn't replace existing controllers — it runs alongside them. Existing providers keep working as-is.
+
+### Phase 1: ACP Controller + OpenClaw (This Spec)
+
+- Implement `AcpController` in Rust
+- Implement `AcpTranslator` in TypeScript
+- Add OpenClaw as first ACP provider (via `acpx` or native ACP bridge)
+- Add Kiro CLI as second ACP provider
+- Update `forge-seed.json` with AgentClaw entries (from openclaw-agent-runtime.md)
+
+### Phase 2: Migrate Gemini to ACP
+
+Gemini CLI has native ACP (`gemini --acp`). Switch Gemini from `Subprocess` controller to `Acp`:
+- Remove `gemini-translator.ts`
+- Remove Gemini-specific launch args / resume logic
+- Change `controllerType: "acp"`, `launchArgs: ["--acp"]`
+- Validate feature parity
+
+### Phase 3: Migrate Claude + Codex to ACP (When Native Support Ships)
+
+Once Claude Code and Codex CLI ship native ACP:
+- Switch to ACP controller
+- Remove custom translators
+- Simplify provider configs
+
+At that point, all providers use the same controller and translator. Adding a new agent = one config entry.
+
+### Phase 4: ACP Agent Discovery + Sub-Agent Surfacing
+
+- Scan PATH for known ACP-compatible CLIs
+- Auto-populate agent picker with discovered agents
+- Allow user-defined ACP agents via Forge config
+- Surface ACP sub-agents (e.g., OpenClaw's `coding-agent` skill spawning Claude Code) as ephemeral panes
+
+---
+
+## Files Changed
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `agentmux-srv/src/backend/blockcontroller/acp.rs` | ACP controller (Rust) — JSON-RPC client over stdio |
+| `frontend/app/view/agent/providers/acp-translator.ts` | Universal ACP event translator |
+| `frontend/app/view/agent/commands/providers/openclaw.ts` | OpenClaw slash commands (initially empty) |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `agentmux-srv/src/backend/blockcontroller/mod.rs` | Add `Acp` variant, route to `AcpController` |
+| `agentmux-srv/src/backend/providers.rs` | Add `ControllerType::Acp`, add OpenClaw + Kiro providers |
+| `agentmux-cef/src/commands/providers.rs` | Add OpenClaw + Kiro npm packages, versions, auth checks |
+| `frontend/app/view/agent/providers/index.ts` | Add OpenClaw + Kiro `ProviderDefinition` entries |
+| `frontend/app/view/agent/providers/translator-factory.ts` | Add `"acp"` case returning `AcpTranslator` |
+| `frontend/app/view/agent/commands/providers/index.ts` | Register OpenClaw slash commands |
+| `frontend/app/view/forge/forge-constants.ts` | Add OpenClaw + Kiro to Forge provider list |
+
+---
+
+## Dependencies
+
+### Rust
+
+- `serde_json` — already in use for JSON parsing
+- `tokio` — already in use for async I/O
+- No new crates needed; JSON-RPC 2.0 is simple enough to implement inline
+
+### TypeScript
+
+- No new dependencies; ACP messages are plain JSON objects
+
+### External
+
+- `acpx` (npm: `@openclaw/acpx`) — for OpenClaw ACP bridge
+- `kiro` (npm: `@anthropic-ai/kiro`) — for Kiro CLI
+- `gemini` already installed — just needs `--acp` flag in Phase 2
+
+---
+
+## ACP vs Custom Translators — Comparison
+
+| Aspect | Custom Translators (Current) | ACP Controller (Proposed) |
+|--------|------------------------------|---------------------------|
+| New agent effort | 5-7 files, custom translator | 1 config entry |
+| Output format | Different per agent | Standardized JSON-RPC |
+| Session management | Per-agent (resume flags, session IDs) | Protocol-native |
+| Streaming | Custom NDJSON parsing per agent | Standardized `session/update` |
+| Tool calls | Different schemas per agent | Standardized `tool_call` / `tool_result` |
+| Auth | Custom per agent | Still per agent (ACP doesn't cover auth) |
+| Thinking/reasoning | Custom per agent | Standardized `agent_thought_chunk` |
+| Multi-turn | Custom (resume flag vs persistent stdin) | Protocol-native (same session) |
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| ACP spec is still evolving | Pin to a specific ACP version; abstract behind internal types |
+| Claude/Codex may never ship native ACP | Community bridges exist today; custom controllers remain as fallback |
+| ACP agents may have different capability levels | Capability negotiation is part of the `initialize` handshake |
+| Performance overhead of JSON-RPC vs raw streams | Negligible — we're already parsing JSON streams |
+
+---
+
+## Success Criteria
+
+- [ ] `AcpController` can spawn, initialize, and prompt an ACP agent
+- [ ] Streaming `session/update` events render in real-time in agent pane
+- [ ] Multi-turn conversations work within a single ACP session
+- [ ] OpenClaw works as first ACP agent in AgentMux
+- [ ] Kiro CLI works as second ACP agent
+- [ ] Tool calls display correctly in agent pane
+- [ ] Graceful shutdown on pane close
+- [ ] No regressions on existing Claude/Codex/Gemini providers
+
+---
+
+## Landing Page Impact
+
+This is a headline feature for agentmux.ai:
+
+> **"Any Agent. One Protocol."**
+> AgentMux now supports the Agent Client Protocol — connect any ACP-compatible coding agent with zero configuration. OpenClaw, Kiro, Gemini, and more work out of the box.
+
+Update the comparison table to show ACP support as a differentiator no competitor has.
+
+---
+
+## References
+
+- [Agent Client Protocol Specification](https://github.com/agentclientprotocol/agent-client-protocol)
+- [ACP Compatible Agents](https://agentclientprotocol.com/get-started/agents)
+- [Gemini CLI ACP Mode](https://geminicli.com/docs/cli/acp-mode/)
+- [Kiro CLI ACP Docs](https://kiro.dev/docs/cli/acp/)
+- [OpenClaw acpx](https://github.com/openclaw/acpx)
+- [Claude Code ACP Request #6686](https://github.com/anthropics/claude-code/issues/6686)
+- [Codex CLI ACP Request #9085](https://github.com/openai/codex/issues/9085)
+- [Zed External Agents (ACP)](https://zed.dev/docs/ai/external-agents)
+- [JetBrains ACP Agent Registry](https://blog.jetbrains.com/ai/2026/01/acp-agent-registry/)

--- a/specs/SPEC_ACP_CONTROLLER_2026_04_16.md
+++ b/specs/SPEC_ACP_CONTROLLER_2026_04_16.md
@@ -317,16 +317,31 @@ Add ACP provider definitions — these are lightweight since the protocol handle
 
 ```typescript
 // ACP agents only need: id, displayName, cliCommand, acp flag + args
+// OpenClaw — full-featured, gateway daemon backed (detected if preinstalled)
 openclaw: {
     id: "openclaw",
     displayName: "OpenClaw",
-    cliCommand: "acpx",                    // or "openclaw-cli"
-    controllerType: "acp",                 // NEW controller type
+    cliCommand: "acpx",
+    controllerType: "acp",
     launchArgs: ["--agent", "openclaw"],
-    styledOutputFormat: "acp",             // universal ACP translator
+    styledOutputFormat: "acp",
     icon: "lobster",
     docsUrl: "https://docs.openclaw.ai",
     npmPackage: "@openclaw/acpx",
+    // ... auth fields
+},
+
+// Pi — lightweight standalone coding agent, no gateway required
+pi: {
+    id: "pi",
+    displayName: "Pi",
+    cliCommand: "pi",
+    controllerType: "acp",
+    launchArgs: ["--json"],
+    styledOutputFormat: "acp",
+    icon: "terminal",
+    docsUrl: "https://github.com/badlogic/pi-mono",
+    npmPackage: "@mariozechner/pi-coding-agent",
     // ... auth fields
 },
 
@@ -364,15 +379,28 @@ pub enum ControllerType {
     Acp,
 }
 
+// OpenClaw — gateway daemon backed (full features: skills, messaging, multi-agent)
 static OPENCLAW: ProviderConfig = ProviderConfig {
     id: "openclaw",
     display_name: "OpenClaw",
     cli_command: "acpx",
     controller_type: ControllerType::Acp,
     launch_args: &["--agent", "openclaw"],
-    // ACP handles sessions natively — no resume_flag or session_id_field needed
     resume_flag: None,
-    session_id_field: "",
+    session_id_field: "sessionId",
+    styled_output_format: "acp",
+    // ...
+};
+
+// Pi — standalone coding agent (no gateway, pure read/write/bash/edit tools)
+static PI: ProviderConfig = ProviderConfig {
+    id: "pi",
+    display_name: "Pi",
+    cli_command: "pi",
+    controller_type: ControllerType::Acp,
+    launch_args: &["--json"],
+    resume_flag: None,
+    session_id_field: "sessionId",
     styled_output_format: "acp",
     // ...
 };
@@ -412,12 +440,19 @@ Both coexist and can connect to the same OpenClaw gateway instance.
 
 ACP doesn't replace existing controllers — it runs alongside them. Existing providers keep working as-is.
 
-### Phase 1: ACP Controller + OpenClaw (This Spec)
+### Phase 1: ACP Controller + OpenClaw + Pi (This Spec)
 
 - Implement `AcpController` in Rust
 - Implement `AcpTranslator` in TypeScript
-- Add OpenClaw as first ACP provider (via `acpx` or native ACP bridge)
-- Add Kiro CLI as second ACP provider
+- Add **two** ACP providers from the OpenClaw ecosystem:
+  - **OpenClaw** — full-featured agent orchestrator backed by the OpenClaw gateway daemon.
+    Detected if `openclaw` is installed and gateway is running at `ws://127.0.0.1:18789`.
+    Uses `acpx` (`@openclaw/acpx`) as ACP bridge. Provides skills, external messaging
+    channels, memory, multi-agent orchestration.
+  - **Pi** — lightweight standalone coding agent (`@mariozechner/pi-coding-agent`).
+    No gateway required. Pure coding agent with read/write/bash/edit tools.
+    Ideal for users who want a fast, self-contained coding agent without the full OpenClaw stack.
+- Add Kiro CLI as third ACP provider
 - Update `forge-seed.json` with AgentClaw entries (from openclaw-agent-runtime.md)
 
 ### Phase 2: Migrate Gemini to ACP
@@ -461,12 +496,12 @@ At that point, all providers use the same controller and translator. Adding a ne
 | File | Change |
 |------|--------|
 | `agentmux-srv/src/backend/blockcontroller/mod.rs` | Add `Acp` variant, route to `AcpController` |
-| `agentmux-srv/src/backend/providers.rs` | Add `ControllerType::Acp`, add OpenClaw + Kiro providers |
-| `agentmux-cef/src/commands/providers.rs` | Add OpenClaw + Kiro npm packages, versions, auth checks |
-| `frontend/app/view/agent/providers/index.ts` | Add OpenClaw + Kiro `ProviderDefinition` entries |
+| `agentmux-srv/src/backend/providers.rs` | Add `ControllerType::Acp`, add OpenClaw + Pi + Kiro providers |
+| `agentmux-cef/src/commands/providers.rs` | Add OpenClaw + Pi + Kiro npm packages, versions, auth checks |
+| `frontend/app/view/agent/providers/index.ts` | Add OpenClaw + Pi + Kiro `ProviderDefinition` entries |
 | `frontend/app/view/agent/providers/translator-factory.ts` | Add `"acp"` case returning `AcpTranslator` |
 | `frontend/app/view/agent/commands/providers/index.ts` | Register OpenClaw slash commands |
-| `frontend/app/view/forge/forge-constants.ts` | Add OpenClaw + Kiro to Forge provider list |
+| `frontend/app/view/forge/forge-constants.ts` | Add OpenClaw + Pi + Kiro to Forge provider list |
 
 ---
 
@@ -484,7 +519,8 @@ At that point, all providers use the same controller and translator. Adding a ne
 
 ### External
 
-- `acpx` (npm: `@openclaw/acpx`) — for OpenClaw ACP bridge
+- `acpx` (npm: `@openclaw/acpx`) — for OpenClaw ACP bridge (gateway-backed)
+- `pi` (npm: `@mariozechner/pi-coding-agent`) — standalone coding agent (no gateway needed)
 - `kiro` (npm: `@anthropic-ai/kiro`) — for Kiro CLI
 - `gemini` already installed — just needs `--acp` flag in Phase 2
 
@@ -521,8 +557,9 @@ At that point, all providers use the same controller and translator. Adding a ne
 - [ ] `AcpController` can spawn, initialize, and prompt an ACP agent
 - [ ] Streaming `session/update` events render in real-time in agent pane
 - [ ] Multi-turn conversations work within a single ACP session
-- [ ] OpenClaw works as first ACP agent in AgentMux
-- [ ] Kiro CLI works as second ACP agent
+- [ ] OpenClaw works as ACP agent in AgentMux (gateway daemon + acpx)
+- [ ] Pi works as standalone ACP coding agent (no gateway needed)
+- [ ] Kiro CLI works as ACP agent
 - [ ] Tool calls display correctly in agent pane
 - [ ] Graceful shutdown on pane close
 - [ ] No regressions on existing Claude/Codex/Gemini providers
@@ -534,7 +571,7 @@ At that point, all providers use the same controller and translator. Adding a ne
 This is a headline feature for agentmux.ai:
 
 > **"Any Agent. One Protocol."**
-> AgentMux now supports the Agent Client Protocol — connect any ACP-compatible coding agent with zero configuration. OpenClaw, Kiro, Gemini, and more work out of the box.
+> AgentMux now supports the Agent Client Protocol — connect any ACP-compatible coding agent with zero configuration. OpenClaw, Pi, Kiro, Gemini, and more work out of the box.
 
 Update the comparison table to show ACP support as a differentiator no competitor has.
 


### PR DESCRIPTION
## Summary

- Add universal **ACP (Agent Client Protocol)** controller — JSON-RPC 2.0 over stdio, the "LSP for AI agents"
- Add **two providers** from the OpenClaw ecosystem:
  - **OpenClaw** — full-featured agent orchestrator backed by the gateway daemon (detected if preinstalled). Uses `acpx` as ACP bridge. Skills, external messaging channels, memory, multi-agent.
  - **Pi** — lightweight standalone coding agent (`@mariozechner/pi-coding-agent`). No gateway required. Pure coding agent with read/write/bash/edit tools.
- One `AcpTranslator` handles all ACP agents universally — no per-agent output parsing needed
- Any future ACP-compatible agent (Kiro, Gemini `--acp`, etc.) = config entry only

## Files Changed

### New
- `agentmux-srv/src/backend/blockcontroller/acp.rs` — Rust ACP controller (JSON-RPC lifecycle, stdio streaming, graceful shutdown)
- `frontend/app/view/agent/providers/acp-translator.ts` — Universal ACP event translator
- `frontend/app/view/agent/commands/providers/openclaw.ts` — OpenClaw slash commands (placeholder)
- `specs/SPEC_ACP_CONTROLLER_2026_04_16.md` — Full spec with protocol overview, architecture, migration path

### Modified
- `agentmux-srv/src/backend/blockcontroller/mod.rs` — Route `acp` controller type to `AcpController`
- `agentmux-srv/src/backend/providers.rs` — Add `ControllerType::Acp`, OpenClaw + Pi providers, tests
- `frontend/app/view/agent/providers/index.ts` — Add `openclaw` + `pi` provider definitions
- `frontend/app/view/agent/providers/translator-factory.ts` — Add `"acp"` case
- `frontend/app/view/agent/commands/providers/index.ts` — Register OpenClaw commands
- `frontend/app/view/forge/forge-constants.ts` — Add OpenClaw + Pi to Forge provider list

## Test plan
- [ ] Rust tests pass (`provider_list_has_five_entries`, `pi_is_acp_controller`, `openclaw_is_acp_controller`)
- [ ] TypeScript compiles without errors
- [ ] Existing Claude/Codex/Gemini providers unaffected
- [ ] ACP controller can spawn and communicate with an ACP agent process

🤖 Generated with [Claude Code](https://claude.com/claude-code)