### PR TITLE
feat: structured agent startup sequence from Forge + Identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.200"
+version = "0.33.201"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.200"
+version = "0.33.201"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.200"
+version = "0.33.201"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.200"
+version = "0.33.201"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -3363,9 +3363,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.200"
+version = "0.33.201"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.200"
+version = "0.33.201"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.200"
+version = "0.33.201"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.200"
+version = "0.33.201"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_AGENT_STARTUP_SEQUENCE_2026_04_16.md
+++ b/docs/specs/SPEC_AGENT_STARTUP_SEQUENCE_2026_04_16.md
@@ -1,0 +1,282 @@
+# SPEC: Agent Startup Sequence
+
+**Date:** 2026-04-16
+**Status:** Draft
+**Branch:** TBD
+
+---
+
+## Problem
+
+When an agent session starts, the CLI subprocess (Claude, Codex, Gemini) launches
+with zero context about who it is, what accounts it owns, or what its role is. The
+user's first message has to carry all of this — or the agent fumbles until it
+reads CLAUDE.md (which itself doesn't contain runtime identity or credential info).
+
+Today the launch flow writes static config files (CLAUDE.md, .mcp.json, hooks.json)
+to the working directory and sets environment variables. But the **first turn of the
+conversation** receives no structured context. The agent doesn't know:
+
+- Its own identity (name, slug, description, role)
+- Which accounts/credentials are assigned to it and how to use them
+- What project it's operating in or what working directory it has
+- What other agents exist in the swarm and how to reach them
+- What date it is or what version of AgentMux is running
+
+This information exists across Forge (agent config + content) and Identity
+(account assignments) but is never assembled into a startup payload.
+
+---
+
+## Goal
+
+On the first turn of a new session (not `--resume`), automatically inject a
+structured **startup message** as the opening user turn before any human input.
+The message is assembled from Forge + Identity data and is transparently visible
+in the conversation — the user sees exactly what the agent was told.
+
+---
+
+## Design
+
+### 1. Startup Payload Assembly
+
+The startup message is a Markdown document assembled at launch time from the
+following sources, in order:
+
+```
+# Session Context
+
+## Identity
+- **Name:** {{agent.name}}
+- **Slug:** {{agent.slug}}
+- **Provider:** {{provider.displayName}}
+- **Working Directory:** {{workDir}}
+- **AgentMux Version:** {{version}}
+- **Date:** {{YYYY-MM-DD}}
+
+## Description
+{{agent.description}}
+
+## Assigned Accounts
+{{#each assignedAccounts}}
+### {{provider}} — {{account.name}}
+- **Kind:** {{account.kind}} ({{account.provider}})
+- **Access:** {{account.secret_ref.backend}} → {{envVarOrPath}}
+{{#if context}}
+- **GitHub User:** {{context.github_username}}
+- **AWS Region:** {{context.aws_region}}
+- ...provider-specific context fields
+{{/if}}
+{{/each}}
+
+{{#if noAccounts}}
+No accounts assigned. Use the Identity panel to assign credentials.
+{{/if}}
+
+## Forge Startup Instructions
+{{forgeContent["startup"]}}
+
+## Peer Agents
+{{#each peerAgents}}
+- **{{name}}** ({{provider}}) — {{description}}
+{{/each}}
+```
+
+### 2. Data Sources
+
+| Section | Source | API |
+|---------|--------|-----|
+| Identity fields | `ForgeAgent` row | Already in `agent-model.ts` at launch time |
+| Description | `ForgeAgent.description` | Same |
+| Assigned accounts | `ForgeAgent.accounts` JSON + Identity `Account[]` from localStorage | `parseAgentAccounts()` in `identity-model.ts` |
+| Account details | `Account` objects keyed by ID | `IdentityViewModel.accounts` signal |
+| Startup instructions | `ForgeContent` with `content_type: "startup"` | `RpcApi.GetForgeContentCommand` |
+| Peer agents | All `ForgeAgent` rows except self | `RpcApi.GetForgeAgentsCommand` |
+| Version | `getApi().getAboutModalDetails().version` | Host API |
+| Date | `new Date().toISOString().slice(0, 10)` | Runtime |
+
+### 3. Where It Runs
+
+**Location:** `agent-view.tsx`, inside the `onReadyFn` callback (added in v0.33.200).
+
+**Current state (v0.33.200):** `onReadyFn` fetches `ForgeContent("startup")` and
+sends it raw via `handleSendMessage`. This spec replaces that with structured
+assembly.
+
+**New flow:**
+
+```
+onReady()
+  → skip if block.meta["agent:sessionid"] exists (resumed session)
+  → assembleStartupPayload(agentId, block, provider)
+      → read ForgeAgent (already have it as `currentAgent()`)
+      → read assigned accounts from ForgeAgent.accounts + Identity localStorage
+      → read ForgeContent("startup") for custom instructions
+      → read peer agents from forge agent list (already have `forgeAgents()`)
+      → read version from host API
+      → template the Markdown document
+  → handleSendMessage(payload)
+```
+
+### 4. New Module: `buildStartupPayload.ts`
+
+Create `frontend/app/view/agent/startup/buildStartupPayload.ts`:
+
+```typescript
+interface StartupPayloadOpts {
+    agent: ForgeAgent;
+    provider: ProviderDefinition;
+    workDir: string;
+    version: string;
+    accounts: ResolvedAccount[];   // Hydrated from Identity + ForgeAgent.accounts
+    peerAgents: ForgeAgent[];      // All agents except self
+    startupContent: string | null; // ForgeContent "startup" blob
+}
+
+function buildStartupPayload(opts: StartupPayloadOpts): string
+```
+
+This is a pure function — no RPC calls, no signals. The caller assembles the
+inputs from existing reactive state and passes them in. Testable in isolation.
+
+### 5. Account Resolution
+
+The `ForgeAgent.accounts` field is a JSON string like:
+```json
+{"github": "acct-1713000000-abc", "aws": null}
+```
+
+To hydrate this into useful context for the startup payload:
+
+1. Parse via `parseAgentAccounts()` (already in `identity-model.ts`)
+2. For each non-null account ID, look up the `Account` object from the
+   Identity store (localStorage)
+3. Build a `ResolvedAccount` with the provider, name, kind, and relevant
+   context fields (username, region, etc.)
+4. **Never include secrets or tokens** — only metadata. The agent accesses
+   credentials through the env vars / secret refs at runtime, not through
+   the startup message.
+
+```typescript
+interface ResolvedAccount {
+    provider: string;        // "github", "aws", "anthropic", "custom"
+    name: string;            // Human label
+    kind: string;            // "pat", "role", "api_key", "env_ref"
+    accessMethod: string;    // "env:GITHUB_TOKEN" or "secrets_manager:path"
+    context: Record<string, string>;  // Provider-specific metadata
+}
+```
+
+### 6. Template Variables
+
+Reuse the existing `expandTemplate()` function from `agent-model.ts` for the
+custom `startup` content section. Template variables available:
+
+| Variable | Value |
+|----------|-------|
+| `{{AGENT}}` | agent.name |
+| `{{AGENT_SLUG}}` | agent.slug |
+| `{{AGENT_ID}}` | agent.id |
+| `{{AGENT_DISPLAY}}` | agent.name |
+| `{{WORKING_DIR}}` | resolved working directory |
+| `{{DATE}}` | YYYY-MM-DD |
+| `{{VERSION}}` | AgentMux version string |
+| `{{PROVIDER}}` | provider.displayName |
+
+### 7. Conversation Visibility
+
+The startup message is sent via `handleSendMessage()` which:
+1. Appends a `user_message` node to the document (visible in conversation)
+2. Calls `AgentInputCommand` to send to the subprocess
+
+The user sees the full startup payload in the conversation as the first
+message. This is intentional — transparency over magic.
+
+**Visual distinction (future):** A `user_message` node with
+`metadata.isStartup: true` could receive distinct styling (muted header,
+collapsed by default). Not required for v1.
+
+### 8. Opt-out
+
+If no `ForgeContent("startup")` exists AND the agent has no assigned accounts
+AND no description, the startup payload is still sent with the minimal Identity
++ Peer Agents sections. To fully disable startup for an agent, add a
+`ForgeContent("startup")` with content `__SKIP__` — the assembly function
+checks for this sentinel and returns null.
+
+### 9. Resume Sessions
+
+On `--resume` (session ID exists in block meta), the startup message is NOT
+re-sent. The agent already has context from the prior session. This is the
+existing guard in `onReadyFn`.
+
+---
+
+## Implementation Plan
+
+### PR 1: `buildStartupPayload` + account resolution
+
+1. Create `frontend/app/view/agent/startup/buildStartupPayload.ts`
+   - Pure function, Markdown templating
+   - Account resolution helper
+2. Create `frontend/app/view/agent/startup/buildStartupPayload.test.ts`
+   - Unit tests with mock ForgeAgent + Account data
+3. Export `resolveAccounts()` from the startup module
+
+### PR 2: Wire into `onReadyFn`
+
+1. Update `agent-view.tsx` `onReadyFn`:
+   - Gather inputs from existing signals (`currentAgent()`, `forgeAgents()`, etc.)
+   - Call `buildStartupPayload()`
+   - Send via `handleSendMessage()`
+2. Update `useAgentControllerStatus.ts` if any timing changes needed
+
+### PR 3: UI polish (optional)
+
+1. Add `metadata.isStartup` to the user_message node
+2. Style startup messages with muted header / collapse-by-default
+3. Add "Re-send startup" button to the control bar
+
+---
+
+## Non-Goals
+
+- **Injecting secrets into the startup message.** Credentials are accessed via
+  env vars and secret refs at runtime, never pasted into conversation.
+- **Modifying CLAUDE.md generation.** The startup message is a separate channel
+  from the static config files written to disk. CLAUDE.md continues to carry
+  soul + agentmd + memory + skills.
+- **Backend changes.** All assembly happens in the frontend. The backend
+  already has all the APIs needed (GetForgeContent, GetForgeAgents, etc.).
+- **Provider-specific startup formats.** v1 sends plain Markdown to all
+  providers. Provider-specific structured formats (e.g., system prompts via
+  API) are a future enhancement.
+
+---
+
+## Security Considerations
+
+- Account `secret_ref.value` (plaintext_dev secrets) must NEVER appear in the
+  startup payload. Only the access method (`env:VAR_NAME`, `sm:path`) is shown.
+- The startup message is stored in the filestore (same as all conversation
+  history). If the filestore is on shared storage, account metadata (usernames,
+  ARNs) is visible. This is acceptable — it's the same data shown in the
+  Identity panel UI.
+
+---
+
+## Open Questions
+
+1. **Should the startup message be a system prompt instead of a user turn?**
+   Claude Code's `-p` mode doesn't support system prompts via stdin — everything
+   is a user turn. For providers that support system prompts natively (future),
+   this could be a config option on the provider definition.
+
+2. **Max payload size?** With many accounts and many peer agents, the startup
+   message could grow large. Consider truncating peer agents to the 10 most
+   recently used, or omitting agents with no description.
+
+3. **Should memory content be included?** Currently memory goes into CLAUDE.md.
+   Including it in the startup message too would be redundant. Keep it in
+   CLAUDE.md only unless there's a reason to duplicate.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -32,7 +32,10 @@ import { BookmarksPanel } from "./components/BookmarksPanel";
 import { SessionDigestBanner } from "./components/SessionDigestBanner";
 import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
+import { getApi } from "@/app/store/global";
 import { ContextMenuModel } from "@/app/store/contextmenu";
+import { parseAgentAccounts } from "@/app/view/identity/identity-model";
+import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";
 import "./agent-view.scss";
 
 /**
@@ -195,24 +198,52 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     };
 
     // ── Startup sequence ────────────────────────────────────────────────────────
-    // On first connect (no existing session), fetch forge content type "startup"
-    // for this agent and auto-send it as the opening message. Skipped on
-    // session resume so the sequence isn't replayed every reconnect.
+    // On first connect (no existing session), assemble a structured startup
+    // payload from Forge + Identity data and send it as the opening turn.
+    // See docs/specs/SPEC_AGENT_STARTUP_SEQUENCE_2026_04_16.md
     onReadyFn = async () => {
         // Skip if this is a resumed session
         if (block()?.meta?.["agent:sessionid"]) return;
+
         try {
-            const startupContent = await RpcApi.GetForgeContentCommand(TabRpcClient, {
-                agent_id: agentId,
-                content_type: "startup",
+            const agent = currentAgent();
+            if (!agent) return;
+
+            // Gather inputs in parallel where possible
+            const [startupContentResult, version] = await Promise.all([
+                RpcApi.GetForgeContentCommand(TabRpcClient, {
+                    agent_id: agentId,
+                    content_type: "startup",
+                }).catch(() => null),
+                Promise.resolve(getApi().getAboutModalDetails().version),
+            ]);
+
+            // Resolve assigned accounts from Identity localStorage
+            const agentAccounts = parseAgentAccounts(agent);
+            const STORAGE_KEY = "agentmux:identity:accounts";
+            let allAccounts: any[] = [];
+            try {
+                const raw = localStorage.getItem(STORAGE_KEY);
+                if (raw) allAccounts = JSON.parse(raw);
+            } catch { /* no accounts stored */ }
+            const accounts = resolveAccounts(agentAccounts, allAccounts);
+
+            const payload = buildStartupPayload({
+                agent,
+                providerDisplayName: provider()?.displayName ?? providerKey(),
+                workDir: block()?.meta?.["cmd:cwd"] ?? "",
+                version,
+                accounts,
+                peerAgents: forgeAgents(),
+                startupContent: startupContentResult?.content ?? null,
             });
-            const msg = startupContent?.content?.trim();
-            if (msg) {
+
+            if (payload) {
                 log("agent", "sending startup sequence");
-                await handleSendMessage(msg);
+                await handleSendMessage(payload);
             }
-        } catch {
-            // no startup content configured — that's fine
+        } catch (err) {
+            log("warn", `startup sequence failed: ${err}`, "warn");
         }
     };
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -34,7 +34,7 @@ import { RpcApi } from "@/app/store/wshclientapi";
 import { TabRpcClient } from "@/app/store/wshrpcutil";
 import { getApi } from "@/app/store/global";
 import { ContextMenuModel } from "@/app/store/contextmenu";
-import { parseAgentAccounts } from "@/app/view/identity/identity-model";
+import { parseAgentAccounts, loadAccounts } from "@/app/view/identity/identity-model";
 import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";
 import "./agent-view.scss";
 
@@ -220,13 +220,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
             // Resolve assigned accounts from Identity localStorage
             const agentAccounts = parseAgentAccounts(agent);
-            const STORAGE_KEY = "agentmux:identity:accounts";
-            let allAccounts: any[] = [];
-            try {
-                const raw = localStorage.getItem(STORAGE_KEY);
-                if (raw) allAccounts = JSON.parse(raw);
-            } catch { /* no accounts stored */ }
-            const accounts = resolveAccounts(agentAccounts, allAccounts);
+            const accounts = resolveAccounts(agentAccounts, loadAccounts());
 
             const payload = buildStartupPayload({
                 agent,

--- a/frontend/app/view/agent/startup/buildStartupPayload.test.ts
+++ b/frontend/app/view/agent/startup/buildStartupPayload.test.ts
@@ -1,0 +1,216 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { buildStartupPayload, resolveAccounts, type ResolvedAccount, type StartupPayloadOpts } from "./buildStartupPayload";
+
+function makeAgent(overrides: Partial<ForgeAgent> = {}): ForgeAgent {
+    return {
+        id: "test-agent",
+        slug: "test-agent",
+        name: "TestAgent",
+        icon: "robot",
+        provider: "claude",
+        description: "A test agent for unit tests.",
+        working_directory: "/home/user/project",
+        shell: "",
+        provider_flags: "",
+        auto_start: 0,
+        restart_on_crash: 0,
+        idle_timeout_minutes: 0,
+        created_at: 1700000000000,
+        agent_type: "host",
+        environment: "",
+        agent_bus_id: "",
+        is_seeded: 0,
+        accounts: "",
+        ...overrides,
+    };
+}
+
+function makeOpts(overrides: Partial<StartupPayloadOpts> = {}): StartupPayloadOpts {
+    return {
+        agent: makeAgent(),
+        providerDisplayName: "Claude Code",
+        workDir: "/home/user/project",
+        version: "0.33.200",
+        accounts: [],
+        peerAgents: [],
+        startupContent: null,
+        ...overrides,
+    };
+}
+
+describe("buildStartupPayload", () => {
+    it("includes identity section with agent info", () => {
+        const result = buildStartupPayload(makeOpts());
+        expect(result).toContain("# Session Context");
+        expect(result).toContain("**Name:** TestAgent");
+        expect(result).toContain("**Provider:** Claude Code");
+        expect(result).toContain("**Working Directory:** /home/user/project");
+        expect(result).toContain("**AgentMux Version:** 0.33.200");
+    });
+
+    it("includes agent description when present", () => {
+        const result = buildStartupPayload(makeOpts());
+        expect(result).toContain("## Description");
+        expect(result).toContain("A test agent for unit tests.");
+    });
+
+    it("omits description section when empty", () => {
+        const result = buildStartupPayload(makeOpts({
+            agent: makeAgent({ description: "" }),
+        }));
+        expect(result).not.toContain("## Description");
+    });
+
+    it("includes assigned accounts", () => {
+        const accounts: ResolvedAccount[] = [
+            {
+                provider: "github",
+                name: "My GitHub PAT",
+                kind: "pat",
+                accessMethod: "env:GITHUB_TOKEN",
+                context: { github_username: "testuser" },
+            },
+        ];
+        const result = buildStartupPayload(makeOpts({ accounts }));
+        expect(result).toContain("## Assigned Accounts");
+        expect(result).toContain("### github — My GitHub PAT");
+        expect(result).toContain("**Kind:** pat");
+        expect(result).toContain("**Access:** env:GITHUB_TOKEN");
+        expect(result).toContain("**Github Username:** testuser");
+    });
+
+    it("omits accounts section when none assigned", () => {
+        const result = buildStartupPayload(makeOpts({ accounts: [] }));
+        expect(result).not.toContain("## Assigned Accounts");
+    });
+
+    it("includes peer agents", () => {
+        const peers = [
+            makeAgent({ id: "other-1", name: "AlphaBot", provider: "claude", description: "Handles deploys" }),
+            makeAgent({ id: "other-2", name: "BetaBot", provider: "gemini", description: "" }),
+        ];
+        const result = buildStartupPayload(makeOpts({ peerAgents: peers }));
+        expect(result).toContain("## Peer Agents");
+        expect(result).toContain("**AlphaBot** (claude) — Handles deploys");
+        expect(result).toContain("**BetaBot** (gemini)");
+    });
+
+    it("excludes self from peer agents", () => {
+        const self = makeAgent({ id: "test-agent", name: "TestAgent" });
+        const result = buildStartupPayload(makeOpts({
+            agent: self,
+            peerAgents: [self, makeAgent({ id: "other", name: "Other" })],
+        }));
+        expect(result).not.toContain("**TestAgent** (claude)");
+        expect(result).toContain("**Other** (claude)");
+    });
+
+    it("caps peer agents at 10", () => {
+        const peers = Array.from({ length: 15 }, (_, i) =>
+            makeAgent({ id: `peer-${i}`, name: `Peer${i}` })
+        );
+        const result = buildStartupPayload(makeOpts({ peerAgents: peers }));
+        expect(result).toContain("**Peer0**");
+        expect(result).toContain("**Peer9**");
+        expect(result).not.toContain("**Peer10**");
+        expect(result).toContain("...and 5 more");
+    });
+
+    it("includes startup instructions with template expansion", () => {
+        const result = buildStartupPayload(makeOpts({
+            startupContent: "Hello {{AGENT}}, you are running on {{PROVIDER}}.",
+        }));
+        expect(result).toContain("## Startup Instructions");
+        expect(result).toContain("Hello TestAgent, you are running on Claude Code.");
+    });
+
+    it("returns null when startup content is __SKIP__", () => {
+        const result = buildStartupPayload(makeOpts({
+            startupContent: "__SKIP__",
+        }));
+        expect(result).toBeNull();
+    });
+
+    it("omits slug line when slug equals name", () => {
+        const result = buildStartupPayload(makeOpts({
+            agent: makeAgent({ name: "TestAgent", slug: "TestAgent" }),
+        }));
+        expect(result).not.toContain("**Slug:**");
+    });
+
+    it("includes slug line when different from name", () => {
+        const result = buildStartupPayload(makeOpts({
+            agent: makeAgent({ name: "Test Agent", slug: "test-agent" }),
+        }));
+        expect(result).toContain("**Slug:** test-agent");
+    });
+});
+
+describe("resolveAccounts", () => {
+    const mockAccounts = [
+        {
+            id: "acct-github-1",
+            name: "Work GitHub",
+            provider: "github",
+            kind: "pat",
+            secret_ref: { backend: "env", env_var: "GITHUB_TOKEN" },
+            context: { github_username: "octocat", github_scopes: ["repo", "read:org"] },
+        },
+        {
+            id: "acct-aws-1",
+            name: "Prod AWS",
+            provider: "aws",
+            kind: "role",
+            secret_ref: { backend: "secrets_manager", sm_path: "/prod/aws/key" },
+            context: { aws_region: "us-east-1", aws_role_arn: "arn:aws:iam::role/deploy" },
+        },
+    ];
+
+    it("resolves matching accounts", () => {
+        const result = resolveAccounts(
+            { github: "acct-github-1", aws: "acct-aws-1" },
+            mockAccounts,
+        );
+        expect(result).toHaveLength(2);
+        expect(result[0].provider).toBe("github");
+        expect(result[0].name).toBe("Work GitHub");
+        expect(result[0].accessMethod).toBe("env:GITHUB_TOKEN");
+        expect(result[0].context.github_username).toBe("octocat");
+    });
+
+    it("skips null assignments", () => {
+        const result = resolveAccounts(
+            { github: "acct-github-1", aws: null },
+            mockAccounts,
+        );
+        expect(result).toHaveLength(1);
+        expect(result[0].provider).toBe("github");
+    });
+
+    it("skips unresolvable account IDs", () => {
+        const result = resolveAccounts(
+            { github: "acct-does-not-exist" },
+            mockAccounts,
+        );
+        expect(result).toHaveLength(0);
+    });
+
+    it("describes secrets_manager access method", () => {
+        const result = resolveAccounts(
+            { aws: "acct-aws-1" },
+            mockAccounts,
+        );
+        expect(result[0].accessMethod).toBe("secrets_manager:/prod/aws/key");
+    });
+
+    it("flattens array context values", () => {
+        const result = resolveAccounts(
+            { github: "acct-github-1" },
+            mockAccounts,
+        );
+        expect(result[0].context.github_scopes).toBe("repo, read:org");
+    });
+});

--- a/frontend/app/view/agent/startup/buildStartupPayload.ts
+++ b/frontend/app/view/agent/startup/buildStartupPayload.ts
@@ -1,0 +1,197 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * buildStartupPayload — assembles the structured Markdown document sent as
+ * the first user turn of a new agent session.
+ *
+ * Pure function: no RPC calls, no signals, no side effects. The caller
+ * gathers inputs from existing reactive state and passes them in.
+ *
+ * See docs/specs/SPEC_AGENT_STARTUP_SEQUENCE_2026_04_16.md
+ */
+
+import type { AccountProvider } from "@/app/view/identity/identity-model";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** Hydrated account info safe for inclusion in the startup message. */
+export interface ResolvedAccount {
+    provider: string;
+    name: string;
+    kind: string;
+    accessMethod: string;
+    context: Record<string, string>;
+}
+
+export interface StartupPayloadOpts {
+    agent: ForgeAgent;
+    providerDisplayName: string;
+    workDir: string;
+    version: string;
+    accounts: ResolvedAccount[];
+    peerAgents: ForgeAgent[];
+    startupContent: string | null;
+}
+
+/** Sentinel value in ForgeContent("startup") that disables the startup message. */
+const SKIP_SENTINEL = "__SKIP__";
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Assemble the startup payload. Returns null if the agent has opted out
+ * via the __SKIP__ sentinel.
+ */
+export function buildStartupPayload(opts: StartupPayloadOpts): string | null {
+    if (opts.startupContent?.trim() === SKIP_SENTINEL) return null;
+
+    const parts: string[] = [];
+    const date = new Date().toISOString().slice(0, 10);
+
+    // ── Identity ─────────────────────────────────────────────────────────
+    parts.push("# Session Context\n");
+    parts.push("## Identity\n");
+    parts.push(`- **Name:** ${opts.agent.name}\n`);
+    if (opts.agent.slug && opts.agent.slug !== opts.agent.name) {
+        parts.push(`- **Slug:** ${opts.agent.slug}\n`);
+    }
+    parts.push(`- **Provider:** ${opts.providerDisplayName}\n`);
+    if (opts.workDir) {
+        parts.push(`- **Working Directory:** ${opts.workDir}\n`);
+    }
+    parts.push(`- **AgentMux Version:** ${opts.version}\n`);
+    parts.push(`- **Date:** ${date}\n`);
+
+    // ── Description ──────────────────────────────────────────────────────
+    if (opts.agent.description?.trim()) {
+        parts.push("\n## Description\n");
+        parts.push(opts.agent.description.trim() + "\n");
+    }
+
+    // ── Assigned Accounts ────────────────────────────────────────────────
+    if (opts.accounts.length > 0) {
+        parts.push("\n## Assigned Accounts\n");
+        for (const acct of opts.accounts) {
+            parts.push(`\n### ${acct.provider} — ${acct.name}\n`);
+            parts.push(`- **Kind:** ${acct.kind}\n`);
+            parts.push(`- **Access:** ${acct.accessMethod}\n`);
+            for (const [key, val] of Object.entries(acct.context)) {
+                if (val) {
+                    parts.push(`- **${formatContextKey(key)}:** ${val}\n`);
+                }
+            }
+        }
+    }
+
+    // ── Custom Startup Instructions ──────────────────────────────────────
+    if (opts.startupContent?.trim()) {
+        const vars = buildTemplateVars(opts, date);
+        const expanded = expandTemplate(opts.startupContent.trim(), vars);
+        parts.push("\n## Startup Instructions\n");
+        parts.push(expanded + "\n");
+    }
+
+    // ── Peer Agents ──────────────────────────────────────────────────────
+    const peers = opts.peerAgents.filter((a) => a.id !== opts.agent.id);
+    if (peers.length > 0) {
+        parts.push("\n## Peer Agents\n");
+        // Cap at 10 to keep payload reasonable
+        const shown = peers.slice(0, 10);
+        for (const peer of shown) {
+            const desc = peer.description?.trim() ? ` — ${peer.description.trim()}` : "";
+            parts.push(`- **${peer.name}** (${peer.provider})${desc}\n`);
+        }
+        if (peers.length > 10) {
+            parts.push(`- ...and ${peers.length - 10} more\n`);
+        }
+    }
+
+    return parts.join("");
+}
+
+// ── Account Resolution ───────────────────────────────────────────────────────
+
+/**
+ * Resolve a ForgeAgent's account assignments into hydrated ResolvedAccount
+ * objects. Reads from the Identity localStorage store.
+ *
+ * Never includes secrets — only metadata and access method descriptors.
+ */
+export function resolveAccounts(
+    agentAccounts: Partial<Record<AccountProvider, string | null>>,
+    allAccounts: { id: string; name: string; provider: string; kind: string; secret_ref: any; context: any }[],
+): ResolvedAccount[] {
+    const resolved: ResolvedAccount[] = [];
+
+    for (const [provider, accountId] of Object.entries(agentAccounts)) {
+        if (!accountId) continue;
+        const account = allAccounts.find((a) => a.id === accountId);
+        if (!account) continue;
+
+        resolved.push({
+            provider,
+            name: account.name,
+            kind: account.kind,
+            accessMethod: describeAccessMethod(account.secret_ref),
+            context: flattenContext(account.context),
+        });
+    }
+
+    return resolved;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function describeAccessMethod(ref: any): string {
+    if (!ref) return "unknown";
+    switch (ref.backend) {
+        case "env":
+            return ref.env_var ? `env:${ref.env_var}` : "env (unspecified)";
+        case "secrets_manager":
+            return ref.sm_path ? `secrets_manager:${ref.sm_path}` : "secrets_manager";
+        case "plaintext_dev":
+            return "plaintext (dev-only)";
+        default:
+            return ref.backend || "unknown";
+    }
+}
+
+function flattenContext(ctx: any): Record<string, string> {
+    if (!ctx || typeof ctx !== "object") return {};
+    const flat: Record<string, string> = {};
+    for (const [key, val] of Object.entries(ctx)) {
+        if (val == null) continue;
+        if (typeof val === "string" && val) {
+            flat[key] = val;
+        } else if (Array.isArray(val) && val.length > 0) {
+            flat[key] = val.join(", ");
+        }
+    }
+    return flat;
+}
+
+function formatContextKey(key: string): string {
+    return key
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function buildTemplateVars(opts: StartupPayloadOpts, date: string): Record<string, string> {
+    return {
+        AGENT: opts.agent.name,
+        AGENT_DISPLAY: opts.agent.name,
+        AGENT_SLUG: opts.agent.slug || opts.agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-"),
+        AGENT_ID: opts.agent.id,
+        WORKING_DIR: opts.workDir,
+        DATE: date,
+        VERSION: opts.version,
+        PROVIDER: opts.providerDisplayName,
+    };
+}
+
+function expandTemplate(content: string, vars: Record<string, string>): string {
+    return content.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+        return vars[key] ?? match;
+    });
+}

--- a/frontend/app/view/identity/identity-model.ts
+++ b/frontend/app/view/identity/identity-model.ts
@@ -111,7 +111,7 @@ export const KIND_LABELS: Record<AccountKind, string> = {
 
 const STORAGE_KEY = "agentmux:identity:accounts";
 
-function loadAccounts(): Account[] {
+export function loadAccounts(): Account[] {
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (!raw) return [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.200",
+  "version": "0.33.201",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.200",
+      "version": "0.33.201",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.200",
+  "version": "0.33.201",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Assembles a structured Markdown startup payload from ForgeAgent identity, resolved Identity accounts, peer agent roster, and optional `ForgeContent("startup")` instructions
- Sent as the first user turn on new sessions; skipped on `--resume`
- Pure `buildStartupPayload()` function with 17 unit tests covering all sections, template expansion, account resolution, opt-out sentinel, and peer agent capping

## What the agent sees on first turn
```markdown
# Session Context
## Identity
- **Name:** AgentX
- **Provider:** Claude Code
- **Working Directory:** /home/user/project
- **AgentMux Version:** 0.33.201
- **Date:** 2026-04-16

## Description
Handles deployments and monitoring.

## Assigned Accounts
### github — Work GitHub
- **Kind:** pat
- **Access:** env:GITHUB_TOKEN
- **Github Username:** octocat

## Startup Instructions
(custom content from ForgeContent "startup")

## Peer Agents
- **BetaBot** (gemini) — Handles testing
```

## Test plan
- [x] 17 vitest unit tests pass (buildStartupPayload + resolveAccounts)
- [x] `tsc --noEmit` clean
- [ ] Manual: open agent pane on fresh session, verify startup payload appears as first message
- [ ] Manual: resume session (`--resume`), verify startup is NOT re-sent
- [ ] Manual: set ForgeContent startup to `__SKIP__`, verify no startup sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)