### PR TITLE
fix: ACP controller Windows pipe, stdout logging, filestore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.203"
+version = "0.33.204"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.203"
+version = "0.33.204"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.203"
+version = "0.33.204"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.203"
+version = "0.33.204"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.203"
+version = "0.33.204"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.203"
+version = "0.33.204"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.203"
+version = "0.33.204"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.203"
+version = "0.33.204"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/acp.rs
+++ b/agentmux-srv/src/backend/blockcontroller/acp.rs
@@ -238,6 +238,15 @@ impl AcpController {
             cmd.env(k, expanded.to_string_lossy().as_ref());
         }
 
+        // On Windows: suppress console-window allocation. Without CREATE_NO_WINDOW,
+        // node.exe spawned from a windowless sidecar may try to create/attach to a
+        // console, causing stdout to go to that console rather than the pipe.
+        #[cfg(windows)]
+        {
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+
         cmd.stdin(std::process::Stdio::piped());
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
@@ -262,17 +271,28 @@ impl AcpController {
         let stdout = child.stdout.take().unwrap();
         let stderr = child.stderr.take();
 
-        // Drain stderr
+        // Drain stderr with explicit error/EOF logging
         if let Some(stderr_pipe) = stderr {
             let block_id_stderr = self.block_id.clone();
             tokio::spawn(async move {
                 let mut reader = BufReader::new(stderr_pipe).lines();
-                while let Ok(Some(line)) = reader.next_line().await {
-                    tracing::warn!(
-                        block_id = %block_id_stderr,
-                        line = %line,
-                        "ACP agent stderr"
-                    );
+                loop {
+                    match reader.next_line().await {
+                        Err(e) => {
+                            tracing::warn!(block_id = %block_id_stderr, error = %e, "ACP stderr read error");
+                            break;
+                        }
+                        Ok(None) => break,
+                        Ok(Some(line)) => {
+                            if !line.trim().is_empty() {
+                                tracing::warn!(
+                                    block_id = %block_id_stderr,
+                                    line = %line,
+                                    "ACP agent stderr"
+                                );
+                            }
+                        }
+                    }
                 }
             });
         }
@@ -318,7 +338,20 @@ impl AcpController {
         let rpc_id_clone = self.next_rpc_id.clone();
         tokio::spawn(async move {
             let mut reader = BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = reader.next_line().await {
+            tracing::info!(block_id = %block_id_stdout, "ACP stdout_reader started");
+
+            loop {
+                let line = match reader.next_line().await {
+                    Err(e) => {
+                        tracing::warn!(block_id = %block_id_stdout, error = %e, "ACP stdout read error");
+                        break;
+                    }
+                    Ok(None) => {
+                        tracing::info!(block_id = %block_id_stdout, "ACP stdout EOF");
+                        break;
+                    }
+                    Ok(Some(l)) => l,
+                };
                 if line.is_empty() {
                     continue;
                 }
@@ -366,26 +399,16 @@ impl AcpController {
                     }
                 }
 
-                // Persist to .jsonl file
-                if let Some(ref fstore) = filestore_clone {
-                    let _ = fstore.append_line(&block_id_stdout, ACP_OUTPUT_SUBJECT, &line);
-                }
-
-                // Broadcast via WPS so the frontend receives the event
+                // Persist + broadcast via the shared helper (same as subprocess.rs)
                 if let Some(ref broker) = broker_clone {
-                    let event = wps::WaveEvent {
-                        event: wps::EVENT_BLOCKFILE.to_string(),
-                        scopes: vec![format!("block:{}", block_id_stdout)],
-                        sender: String::new(),
-                        persist: 0,
-                        data: Some(serde_json::json!({
-                            "zoneid": "",
-                            "blockid": block_id_stdout,
-                            "name": ACP_OUTPUT_SUBJECT,
-                            "data": line,
-                        })),
-                    };
-                    broker.publish(event);
+                    let line_with_newline = format!("{}\n", line);
+                    super::shell::handle_append_block_file(
+                        broker,
+                        &block_id_stdout,
+                        ACP_OUTPUT_SUBJECT,
+                        line_with_newline.as_bytes(),
+                        filestore_clone.as_ref(),
+                    );
                 }
             }
         });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.203",
+  "version": "0.33.204",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Follow-up to PR #407 (ACP controller). Applies the same fixes that were already done in `subprocess.rs`:

- **CREATE_NO_WINDOW** on Windows — prevents zero-stdout when node.exe spawned from windowless sidecar allocates a console
- **Explicit stdout/stderr reader logging** — replaces silent `while let Ok(Some(line))` with `loop { match }` that logs EOF and read errors
- **Fix compile errors** — `EVENT_BLOCKFILE` didn't exist, `append_line` didn't exist on FileStore. Now uses `handle_append_block_file` helper (same as subprocess.rs) for atomic WPS broadcast + filestore persistence

## Test plan
- [x] `cargo check -p agentmux-srv` clean
- [ ] ACP agent spawns on Windows without zero-stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)