### PR TITLE
fix: PR #413 review issues — test + action directive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.209"
+version = "0.33.210"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.209"
+version = "0.33.210"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.209"
+version = "0.33.210"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.209"
+version = "0.33.210"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.209"
+version = "0.33.210"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.209"
+version = "0.33.210"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.209"
+version = "0.33.210"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.209"
+version = "0.33.210"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -850,8 +850,14 @@ mod tests {
         };
 
         let result = ctrl.spawn_turn(config);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("already running"));
+        // spawn_turn now queues instead of rejecting when busy
+        assert!(result.is_ok());
+
+        // Verify the message was queued
+        let inner = ctrl.inner.lock().unwrap();
+        assert_eq!(inner.pending_messages.len(), 1);
+        assert_eq!(inner.pending_messages[0].message, "test");
+        drop(inner);
 
         // Release lock
         ctrl.run_lock.store(false, Ordering::SeqCst);

--- a/frontend/app/view/agent/startup/buildStartupPayload.ts
+++ b/frontend/app/view/agent/startup/buildStartupPayload.ts
@@ -112,8 +112,7 @@ export function buildStartupPayload(opts: StartupPayloadOpts): string | null {
     // payload as informational context and responds "Ready to help."
     if (opts.startupContent?.trim()) {
         parts.push("\n---\n");
-        parts.push("**ACTION REQUIRED:** Execute the verification round above now. ");
-        parts.push("Run each check, fix any failures, and report the status table before proceeding.\n");
+        parts.push("**ACTION REQUIRED:** Execute the startup instructions above now before proceeding.\n");
     }
 
     return parts.join("");

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.209",
+  "version": "0.33.210",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
Follow-up to #413 which was incorrectly merged with a stale CHANGES_REQUESTED review. This fixes the two issues the bot flagged:

1. **Test `test_subprocess_controller_concurrent_spawn_blocked`** — updated to match new queue behavior: asserts `Ok` (queued) instead of `Err` ("already running"), verifies message is in `pending_messages`
2. **Action directive too specific** — changed from "Execute the verification round above now" to generic "Execute the startup instructions above now" so custom startup content doesn't get a misleading prompt

## Test plan
- [x] `cargo check` clean
- [x] `tsc --noEmit` clean
- [ ] `cargo test -p agentmux-srv` — concurrent spawn test passes with queue assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)