### PR TITLE
feat: editor pane with CodeMirror 6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.210"
+version = "0.33.211"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.210"
+version = "0.33.211"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.210"
+version = "0.33.211"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.210"
+version = "0.33.211"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.210"
+version = "0.33.211"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.210"
+version = "0.33.211"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.210"
+version = "0.33.211"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.210"
+version = "0.33.211"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -30,6 +30,18 @@
             }
         }
     },
+    "defwidget@editor": {
+        "display:order": 3,
+        "icon": "file-code",
+        "label": "editor",
+        "description": "Code editor with syntax highlighting",
+        "blockdef": {
+            "meta": {
+                "view": "editor",
+                "file": ""
+            }
+        }
+    },
     "defwidget@terminal": {
         "display:order": 5,
         "display:pinned": true,

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -30,6 +30,18 @@
             }
         }
     },
+    "defwidget@browser": {
+        "display:order": 2,
+        "icon": "globe",
+        "label": "browser",
+        "description": "Embedded web browser",
+        "blockdef": {
+            "meta": {
+                "view": "browser",
+                "url": ""
+            }
+        }
+    },
     "defwidget@editor": {
         "display:order": 3,
         "icon": "file-code",

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -926,23 +926,26 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let expanded = expand_home_dir_safe(&cmd.path);
                 let path = expanded.as_path();
 
-                // Path safety: must be an existing file (no creating new files
-                // in arbitrary locations) or inside user's home directory
+                // Path safety: restrict writes to under the user's home directory.
+                // Allowlist approach — safer than an incomplete denylist.
+                let home = dirs::home_dir()
+                    .ok_or("writeeditorfile: cannot determine home directory")?;
+                let canonical_home = home.canonicalize()
+                    .map_err(|e| format!("writeeditorfile: home dir: {e}"))?;
+
+                // Resolve the target path (canonicalize existing, or parent + filename for new files)
                 let canonical = path.canonicalize().or_else(|_| {
-                    // File doesn't exist yet — check parent exists
                     path.parent()
                         .and_then(|p| p.canonicalize().ok())
                         .map(|p| p.join(path.file_name().unwrap_or_default()))
                         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "invalid path"))
                 }).map_err(|e| format!("writeeditorfile: {e}"))?;
 
-                // Block writes to sensitive directories
-                let canonical_str = canonical.to_string_lossy().to_lowercase();
-                let blocked = [".ssh", "authorized_keys", ".gnupg", ".aws/credentials"];
-                for pattern in &blocked {
-                    if canonical_str.contains(pattern) {
-                        return Err(format!("writeeditorfile: write to {} blocked", pattern));
-                    }
+                if !canonical.starts_with(&canonical_home) {
+                    return Err(format!(
+                        "writeeditorfile: path {} is outside home directory",
+                        canonical.display()
+                    ));
                 }
 
                 std::fs::write(&canonical, &cmd.content)

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -877,6 +877,58 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
         }),
     );
 
+    // readeditorfile → read file from disk for the editor pane
+    engine.register_handler(
+        "readeditorfile",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { path: String }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("readeditorfile: {e}"))?;
+                let expanded = expand_home_dir_safe(&cmd.path);
+                let path = expanded.as_path();
+
+                // Size guard: reject files > 10MB
+                let metadata = std::fs::metadata(path)
+                    .map_err(|e| format!("readeditorfile: {e}"))?;
+                if metadata.len() > 10_000_000 {
+                    return Err("File too large (>10MB)".to_string());
+                }
+
+                let content = std::fs::read_to_string(path)
+                    .map_err(|e| format!("readeditorfile: {e}"))?;
+                let read_only = metadata.permissions().readonly();
+
+                Ok(Some(serde_json::json!({
+                    "content": content,
+                    "read_only": read_only,
+                })))
+            })
+        }),
+    );
+
+    // writeeditorfile → write file to disk from the editor pane
+    engine.register_handler(
+        "writeeditorfile",
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                struct Cmd { path: String, content: String }
+                let cmd: Cmd = serde_json::from_value(data)
+                    .map_err(|e| format!("writeeditorfile: {e}"))?;
+                let expanded = expand_home_dir_safe(&cmd.path);
+                let path = expanded.as_path();
+
+                std::fs::write(path, &cmd.content)
+                    .map_err(|e| format!("writeeditorfile: {e}"))?;
+                tracing::info!(path = %path.display(), bytes = cmd.content.len(), "editor file saved");
+
+                Ok(None)
+            })
+        }),
+    );
+
     // CLI handlers (resolvecli, checkcliauth, runclilogin)
     super::cli_handlers::register_cli_handlers(engine, &state);
 

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -917,12 +917,37 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 struct Cmd { path: String, content: String }
                 let cmd: Cmd = serde_json::from_value(data)
                     .map_err(|e| format!("writeeditorfile: {e}"))?;
+
+                // Size guard: match readeditorfile's 10MB limit
+                if cmd.content.len() > 10_000_000 {
+                    return Err("Content too large (>10MB)".to_string());
+                }
+
                 let expanded = expand_home_dir_safe(&cmd.path);
                 let path = expanded.as_path();
 
-                std::fs::write(path, &cmd.content)
+                // Path safety: must be an existing file (no creating new files
+                // in arbitrary locations) or inside user's home directory
+                let canonical = path.canonicalize().or_else(|_| {
+                    // File doesn't exist yet — check parent exists
+                    path.parent()
+                        .and_then(|p| p.canonicalize().ok())
+                        .map(|p| p.join(path.file_name().unwrap_or_default()))
+                        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "invalid path"))
+                }).map_err(|e| format!("writeeditorfile: {e}"))?;
+
+                // Block writes to sensitive directories
+                let canonical_str = canonical.to_string_lossy().to_lowercase();
+                let blocked = [".ssh", "authorized_keys", ".gnupg", ".aws/credentials"];
+                for pattern in &blocked {
+                    if canonical_str.contains(pattern) {
+                        return Err(format!("writeeditorfile: write to {} blocked", pattern));
+                    }
+                }
+
+                std::fs::write(&canonical, &cmd.content)
                     .map_err(|e| format!("writeeditorfile: {e}"))?;
-                tracing::info!(path = %path.display(), bytes = cmd.content.len(), "editor file saved");
+                tracing::info!(path = %canonical.display(), bytes = cmd.content.len(), "editor file saved");
 
                 Ok(None)
             })

--- a/docs/specs/SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16.md
+++ b/docs/specs/SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16.md
@@ -1,0 +1,298 @@
+# SPEC: Browser and Editor Panes
+
+**Date:** 2026-04-16
+**Status:** Draft
+**Priority:** Medium — enables agent workflows that need web access and file editing
+
+---
+
+## Problem
+
+Agents frequently need to:
+- Browse documentation, review PRs in GitHub, check dashboards
+- Edit files with syntax highlighting, find/replace, go-to-line
+- Preview HTML/Markdown output
+
+Currently they can only do this via terminal tools (`curl`, `gh`, vim in a
+terminal pane) or by asking the user to open an external window. There's no
+in-pane browser or editor. This breaks the agent's flow — context switches
+to external apps lose focus and break the single-window workflow.
+
+---
+
+## Goal
+
+Add two new pane types to AgentMux:
+
+1. **Browser pane** — embedded web browser for documentation, dashboards,
+   PR reviews, OAuth flows
+2. **Editor pane** — code/text editor with syntax highlighting, LSP support,
+   file operations
+
+Both render inside the existing pane layout system (split, resize, drag)
+alongside terminal and agent panes.
+
+---
+
+## Browser Pane
+
+### Approach: CEF Sub-Browser
+
+AgentMux already runs inside CEF (Chromium). A browser pane creates a
+**second CefBrowser instance** inside the same window, rendered into the
+pane's DOM region.
+
+**Two viable implementations:**
+
+#### Option A: Native CefBrowserView (recommended)
+
+Use CEF's Views framework to create a `CefBrowserView` as an overlay or
+child view positioned over the pane's DOM rect.
+
+```
+AgentMux Window (CefBrowser #1 — main UI)
+  └─ Pane layout
+       ├─ Terminal pane (xterm.js in main browser)
+       ├─ Agent pane (SolidJS in main browser)
+       └─ Browser pane → CefBrowser #2 (separate process)
+                          └─ navigates to any URL
+```
+
+**Pros:**
+- Full Chromium rendering (not a sandboxed iframe)
+- Separate process — crashes don't affect main UI
+- Full DevTools per browser instance
+- Native address bar, back/forward, reload
+
+**Cons:**
+- Higher memory (each CefBrowser ≈ 50-100MB)
+- Position sync: must track pane DOM rect and reposition the native view
+- Focus management between main browser and sub-browser
+
+**Implementation in Rust (`agentmux-cef`):**
+- `BrowserPaneView` struct wrapping `CefBrowserView`
+- IPC command: `create_browser_pane(block_id, url)` → creates CefBrowser,
+  positions over the block's DOM rect
+- Resize observer in frontend sends rect updates → Rust repositions the view
+- Navigation events (URL changes, title) piped back to frontend via IPC
+
+#### Option B: iframe (simpler, limited)
+
+Render an `<iframe>` inside the pane's DOM.
+
+**Pros:**
+- Pure frontend, no Rust changes
+- Works immediately with existing pane system
+
+**Cons:**
+- Same-origin restrictions block many sites (X-Frame-Options)
+- No address bar (must build in frontend)
+- Shared process with main UI
+- Cookie/storage conflicts
+
+**Recommendation:** Start with **Option A (CefBrowserView)** for full
+capability. Fall back to iframe for internal pages (help docs, settings).
+
+### Browser Pane Features
+
+| Feature | Priority | Notes |
+|---------|----------|-------|
+| URL navigation (address bar) | P0 | Type URL, Enter to navigate |
+| Back / Forward / Reload | P0 | Standard browser controls |
+| Tab title from page title | P0 | Pane header shows page title |
+| Open link from agent | P0 | Agent can open URLs in browser pane |
+| DevTools for browser pane | P1 | Right-click → Inspect |
+| Bookmarks | P2 | Quick access to common pages |
+| Cookie isolation | P1 | Separate cookie jar per pane |
+| Print / Save as PDF | P3 | |
+
+### Widget Definition
+
+```json
+{
+    "defwidget@browser": {
+        "display:order": 3,
+        "display:pinned": true,
+        "icon": "globe",
+        "label": "browser",
+        "description": "Embedded web browser",
+        "blockdef": {
+            "meta": {
+                "view": "browser",
+                "url": "https://github.com"
+            }
+        }
+    }
+}
+```
+
+### Agent Integration
+
+Agents can open URLs in browser panes via MCP or RPC:
+
+```typescript
+// From agent pane, open a URL in a split browser pane
+RpcApi.OpenBrowserPaneCommand(TabRpcClient, {
+    url: "https://github.com/agentmuxai/agentmux/pull/413",
+    position: "right",  // split right of current pane
+});
+```
+
+---
+
+## Editor Pane
+
+### Approach: CodeMirror 6
+
+CodeMirror 6 is the best fit for an embedded editor in a CEF app:
+
+| | CodeMirror 6 | Monaco | Ace |
+|---|---|---|---|
+| Bundle size | ~124KB gzipped | ~15MB full | ~1MB |
+| Modularity | Excellent (plugins) | Monolithic | Moderate |
+| Mobile support | Yes | No | Partial |
+| LSP support | Via plugin | Built-in | Via plugin |
+| Actively maintained | Yes | Yes (Microsoft) | Legacy |
+| License | MIT | MIT | BSD |
+
+Monaco is what VS Code uses, but it's 100x larger and designed for a full
+IDE — overkill for a pane-embedded editor. CodeMirror 6 gives us syntax
+highlighting, search, and extensibility at a fraction of the cost.
+
+### Editor Pane Features
+
+| Feature | Priority | Notes |
+|---------|----------|-------|
+| Open file by path | P0 | Agent or user specifies file |
+| Syntax highlighting | P0 | Language auto-detected from extension |
+| Line numbers | P0 | |
+| Find / Replace | P0 | Ctrl+F / Ctrl+H |
+| Go to line | P0 | Ctrl+G |
+| Save (write back to disk) | P0 | Ctrl+S → backend writes file |
+| Read-only mode | P1 | For viewing without edit risk |
+| Multiple cursors | P1 | |
+| Minimap | P2 | |
+| LSP diagnostics | P2 | Errors/warnings inline |
+| LSP autocomplete | P2 | |
+| Diff view | P2 | Side-by-side or inline |
+| Git gutter (changed lines) | P3 | |
+
+### Architecture
+
+```
+Frontend (SolidJS)
+  └─ EditorView component
+       └─ CodeMirror 6 instance
+            ├─ Language extensions (auto-loaded)
+            ├─ Theme (matches AgentMux dark theme)
+            └─ File sync via RPC
+
+Backend (Rust sidecar)
+  └─ FileEditorService
+       ├─ read_file(path) → content + metadata
+       ├─ write_file(path, content) → ok/error
+       ├─ watch_file(path) → change notifications
+       └─ Optional: LSP proxy (spawn language server, bridge JSON-RPC)
+```
+
+### Widget Definition
+
+```json
+{
+    "defwidget@editor": {
+        "display:order": 4,
+        "icon": "file-code",
+        "label": "editor",
+        "description": "Code editor with syntax highlighting",
+        "blockdef": {
+            "meta": {
+                "view": "editor",
+                "file": ""
+            }
+        }
+    }
+}
+```
+
+### Agent Integration
+
+Agents can open files in editor panes:
+
+```typescript
+// Open a file in a split editor pane
+RpcApi.OpenEditorPaneCommand(TabRpcClient, {
+    file: "/path/to/file.ts",
+    line: 42,           // optional: scroll to line
+    position: "right",  // split position
+    readOnly: false,
+});
+```
+
+This replaces the pattern where agents say "open this file in your editor"
+— instead they open it directly in a pane next to the conversation.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Editor Pane (frontend-only)
+
+1. Install CodeMirror 6 + language packages
+2. Create `EditorViewModel` + `EditorView` component
+3. Add `editor` to `BlockRegistry` and `widgets.json`
+4. Backend: `ReadFileCommand` / `WriteFileCommand` RPC handlers
+5. File open via pane header or agent command
+
+**Effort:** 3-4 days. No Rust CEF changes needed.
+
+### Phase 2: Browser Pane (CEF changes required)
+
+1. `BrowserPaneManager` in `agentmux-cef` — creates/destroys CefBrowserViews
+2. IPC commands: `create_browser_pane`, `navigate`, `resize`, `close`
+3. Frontend: `BrowserViewModel` + position sync via ResizeObserver
+4. Add `browser` to `BlockRegistry` and `widgets.json`
+
+**Effort:** 5-7 days. Requires CEF Views API work in Rust.
+
+### Phase 3: Agent Integration
+
+1. `OpenEditorPaneCommand` / `OpenBrowserPaneCommand` RPC handlers
+2. Wire into agent tool results (e.g., Read tool → "open in editor" button)
+3. MCP tool: `mcp__agentmux__open_browser`, `mcp__agentmux__open_editor`
+
+**Effort:** 1-2 days.
+
+### Phase 4: LSP Integration (optional)
+
+1. LSP proxy in Rust sidecar — spawn language servers, bridge JSON-RPC
+2. CodeMirror LSP client extension
+3. Diagnostics, autocomplete, hover info
+
+**Effort:** 3-5 days.
+
+---
+
+## Security Considerations
+
+### Browser Pane
+- Each CefBrowser runs in a sandboxed renderer process
+- Cookie jar should be isolated per pane (prevent cross-site leakage)
+- Consider blocking navigation to `file://` URLs
+- JavaScript execution is sandboxed — cannot access host filesystem
+
+### Editor Pane
+- `WriteFileCommand` must validate paths — no writing outside the agent's
+  working directory
+- Read-only mode should be enforced server-side, not just client-side
+- Large files (>10MB) should be rejected or streamed
+
+---
+
+## Non-Goals
+
+- **Full IDE.** The editor pane is for quick edits and file viewing, not a
+  replacement for VS Code. Complex refactoring still happens in the agent's
+  terminal or via agent tool calls.
+- **Tab management in browser pane.** Each browser pane is one page. Multiple
+  pages = multiple panes (use the existing split/tab system).
+- **Browser extensions.** CEF sub-browsers don't support Chrome extensions.

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -15,6 +15,7 @@ import { AgentViewModel } from "@/app/view/agent";
 import { SubagentViewModel } from "@/app/view/subagent/subagent";
 import { SwarmViewModel } from "@/app/view/swarm/swarm";
 import { EditorViewModel } from "@/app/view/editor/editor";
+import { BrowserViewModel } from "@/app/view/browser/browser";
 import { ErrorBoundary } from "@/element/errorboundary";
 import { CenteredDiv } from "@/element/quickelems";
 import { NodeModel, useDebouncedNodeInnerRect } from "@/layout/index";
@@ -46,6 +47,7 @@ BlockRegistry.set("agent", AgentViewModel as any);
 BlockRegistry.set("subagent", SubagentViewModel as any);
 BlockRegistry.set("swarm", SwarmViewModel as any);
 BlockRegistry.set("editor", EditorViewModel as any);
+BlockRegistry.set("browser", BrowserViewModel as any);
 
 function makeViewModel(blockId: string, blockView: string, nodeModel: NodeModel): ViewModel {
     // Migration shim (v0.33.197): forge and identity are no longer standalone

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -14,6 +14,7 @@ import { SysinfoViewModel } from "@/app/view/sysinfo/sysinfo";
 import { AgentViewModel } from "@/app/view/agent";
 import { SubagentViewModel } from "@/app/view/subagent/subagent";
 import { SwarmViewModel } from "@/app/view/swarm/swarm";
+import { EditorViewModel } from "@/app/view/editor/editor";
 import { ErrorBoundary } from "@/element/errorboundary";
 import { CenteredDiv } from "@/element/quickelems";
 import { NodeModel, useDebouncedNodeInnerRect } from "@/layout/index";
@@ -44,6 +45,7 @@ BlockRegistry.set("launcher", LauncherViewModel as any);
 BlockRegistry.set("agent", AgentViewModel as any);
 BlockRegistry.set("subagent", SubagentViewModel as any);
 BlockRegistry.set("swarm", SwarmViewModel as any);
+BlockRegistry.set("editor", EditorViewModel as any);
 
 function makeViewModel(blockId: string, blockView: string, nodeModel: NodeModel): ViewModel {
     // Migration shim (v0.33.197): forge and identity are no longer standalone

--- a/frontend/app/store/wshclientapi.ts
+++ b/frontend/app/store/wshclientapi.ts
@@ -574,6 +574,16 @@ class RpcApiType {
         return client.wshRpcCall("writeagentconfig", data, opts);
     }
 
+    // command "readeditorfile" [call]
+    ReadEditorFileCommand(client: WshClient, data: CommandReadEditorFileData, opts?: RpcOpts): Promise<CommandReadEditorFileResult> {
+        return client.wshRpcCall("readeditorfile", data, opts);
+    }
+
+    // command "writeeditorfile" [call]
+    WriteEditorFileCommand(client: WshClient, data: CommandWriteEditorFileData, opts?: RpcOpts): Promise<void> {
+        return client.wshRpcCall("writeeditorfile", data, opts);
+    }
+
     // command "resolvecli" [call]
     ResolveCliCommand(client: WshClient, data: CommandResolveCliData, opts?: RpcOpts): Promise<ResolveCliResult> {
         return client.wshRpcCall("resolvecli", data, opts);

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -1,0 +1,153 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// NOTE: Browser is a pane-level view for embedded web browsing.
+// Phase 1 uses an iframe (works for most sites). Phase 2 will add
+// native CefBrowserView for sites that block iframes.
+
+import { BlockNodeModel } from "@/app/block/blocktypes";
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
+import { createMemo, createSignal, type Accessor } from "solid-js";
+
+export class BrowserViewModel implements ViewModel {
+    viewType = "browser";
+    blockId: string;
+    nodeModel: BlockNodeModel;
+
+    viewIcon: Accessor<string> = () => "globe";
+    viewName: Accessor<string>;
+    viewText: Accessor<string | HeaderElem[]> = () => [];
+    noPadding: Accessor<boolean> = () => true;
+
+    viewComponent: ViewComponent = null; // set by barrel
+
+    private _url = createSignal<string>("");
+    urlAtom: Accessor<string> = this._url[0];
+    setUrl = this._url[1];
+
+    private _title = createSignal<string>("Browser");
+    titleAtom: Accessor<string> = this._title[0];
+    setTitle = this._title[1];
+
+    private _loading = createSignal<boolean>(false);
+    loadingAtom: Accessor<boolean> = this._loading[0];
+    setLoading = this._loading[1];
+
+    private _canGoBack = createSignal<boolean>(false);
+    canGoBackAtom: Accessor<boolean> = this._canGoBack[0];
+    setCanGoBack = this._canGoBack[1];
+
+    private _canGoForward = createSignal<boolean>(false);
+    canGoForwardAtom: Accessor<boolean> = this._canGoForward[0];
+    setCanGoForward = this._canGoForward[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    // Navigation history (iframe doesn't expose browser history)
+    private history: string[] = [];
+    private historyIndex = -1;
+
+    blockAtom: Accessor<Block | undefined>;
+
+    constructor(blockId: string, nodeModel: BlockNodeModel) {
+        this.blockId = blockId;
+        this.nodeModel = nodeModel;
+
+        this.blockAtom = getWaveObjectAtom<Block>(makeORef("block", blockId));
+
+        this.viewName = createMemo(() => {
+            const title = this.titleAtom();
+            return title || "Browser";
+        });
+
+        // Load URL from block meta on init
+        const meta = this.blockAtom()?.meta;
+        if (meta?.["url"]) {
+            this.navigate(meta["url"] as string);
+        }
+    }
+
+    navigate(url: string): void {
+        // Normalize URL
+        let normalized = url.trim();
+        if (!normalized) return;
+        if (!normalized.match(/^https?:\/\//i) && !normalized.startsWith("about:")) {
+            if (normalized.includes(".") && !normalized.includes(" ")) {
+                normalized = `https://${normalized}`;
+            } else {
+                // Treat as search query
+                normalized = `https://www.google.com/search?q=${encodeURIComponent(normalized)}`;
+            }
+        }
+
+        this.setUrl(normalized);
+        this.setError(null);
+        this.setLoading(true);
+
+        // Update history
+        if (this.historyIndex < this.history.length - 1) {
+            this.history = this.history.slice(0, this.historyIndex + 1);
+        }
+        this.history.push(normalized);
+        this.historyIndex = this.history.length - 1;
+        this.setCanGoBack(this.historyIndex > 0);
+        this.setCanGoForward(false);
+
+        // Persist URL to block meta
+        RpcApi.SetMetaCommand(TabRpcClient, {
+            oref: makeORef("block", this.blockId),
+            meta: { url: normalized },
+        }).catch(() => {});
+    }
+
+    goBack(): void {
+        if (this.historyIndex > 0) {
+            this.historyIndex--;
+            this.setUrl(this.history[this.historyIndex]);
+            this.setCanGoBack(this.historyIndex > 0);
+            this.setCanGoForward(true);
+            this.setLoading(true);
+        }
+    }
+
+    goForward(): void {
+        if (this.historyIndex < this.history.length - 1) {
+            this.historyIndex++;
+            this.setUrl(this.history[this.historyIndex]);
+            this.setCanGoBack(true);
+            this.setCanGoForward(this.historyIndex < this.history.length - 1);
+            this.setLoading(true);
+        }
+    }
+
+    reload(): void {
+        const url = this.urlAtom();
+        if (url) {
+            this.setUrl("");
+            // Force iframe reload by briefly clearing then re-setting
+            requestAnimationFrame(() => {
+                this.setUrl(url);
+                this.setLoading(true);
+            });
+        }
+    }
+
+    onLoad(): void {
+        this.setLoading(false);
+    }
+
+    onError(msg: string): void {
+        this.setLoading(false);
+        this.setError(msg);
+    }
+
+    giveFocus(): boolean {
+        return false;
+    }
+
+    dispose(): void {}
+}

--- a/frontend/app/view/browser/browser-view.scss
+++ b/frontend/app/view/browser/browser-view.scss
@@ -1,0 +1,121 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.browser-view {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+    background: var(--block-bg-color, #1e1e1e);
+}
+
+.browser-nav-bar {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 8px;
+    background: var(--header-bg-color, #252525);
+    border-bottom: 1px solid var(--border-color, #333);
+    flex-shrink: 0;
+}
+
+.browser-nav-btn {
+    width: 28px;
+    height: 28px;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--main-text-color, #ccc);
+    font-size: 14px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover:not(:disabled) {
+        background: var(--highlight-bg-color, #333);
+    }
+
+    &:disabled {
+        opacity: 0.3;
+        cursor: default;
+    }
+}
+
+.browser-go-btn {
+    width: auto;
+    padding: 0 10px;
+    font-size: 12px;
+}
+
+.browser-address-bar {
+    flex: 1;
+    height: 28px;
+    padding: 0 10px;
+    border: 1px solid var(--border-color, #444);
+    border-radius: 14px;
+    background: var(--input-bg-color, #1a1a1a);
+    color: var(--main-text-color, #ddd);
+    font-family: var(--termfontfamily, "JetBrains Mono", monospace);
+    font-size: 12px;
+
+    &:focus {
+        outline: none;
+        border-color: var(--accent-color, #58a6ff);
+    }
+}
+
+.browser-loading-bar {
+    height: 2px;
+    background: var(--accent-color, #58a6ff);
+    animation: browser-loading 1.5s ease-in-out infinite;
+    flex-shrink: 0;
+}
+
+@keyframes browser-loading {
+    0% { width: 0; margin-left: 0; }
+    50% { width: 60%; margin-left: 20%; }
+    100% { width: 0; margin-left: 100%; }
+}
+
+.browser-error {
+    padding: 12px 16px;
+    background: rgba(255, 80, 80, 0.1);
+    color: #ff6b6b;
+    font-size: 13px;
+    border-bottom: 1px solid rgba(255, 80, 80, 0.2);
+    flex-shrink: 0;
+}
+
+.browser-error-hint {
+    font-size: 11px;
+    color: var(--secondary-text-color, #888);
+    margin-top: 4px;
+}
+
+.browser-iframe {
+    flex: 1;
+    width: 100%;
+    border: none;
+    background: #fff;
+}
+
+.browser-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    gap: 12px;
+    color: var(--secondary-text-color, #666);
+}
+
+.browser-empty-icon {
+    font-size: 48px;
+    opacity: 0.5;
+}
+
+.browser-empty-text {
+    font-size: 14px;
+}

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -1,0 +1,105 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createSignal, Show, type JSX } from "solid-js";
+import type { BrowserViewModel } from "./browser-model";
+import "./browser-view.scss";
+
+export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>): JSX.Element {
+    const model = props.model;
+    const [addressBar, setAddressBar] = createSignal(model.urlAtom() || "");
+
+    const handleNavigate = () => {
+        const url = addressBar().trim();
+        if (url) model.navigate(url);
+    };
+
+    const handleAddressKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            handleNavigate();
+        }
+    };
+
+    return (
+        <div class="browser-view">
+            {/* Navigation bar */}
+            <div class="browser-nav-bar">
+                <button
+                    class="browser-nav-btn"
+                    disabled={!model.canGoBackAtom()}
+                    onClick={() => model.goBack()}
+                    title="Back"
+                >
+                    {"\u2190"}
+                </button>
+                <button
+                    class="browser-nav-btn"
+                    disabled={!model.canGoForwardAtom()}
+                    onClick={() => model.goForward()}
+                    title="Forward"
+                >
+                    {"\u2192"}
+                </button>
+                <button
+                    class="browser-nav-btn"
+                    onClick={() => model.reload()}
+                    title="Reload"
+                >
+                    {"\u21BB"}
+                </button>
+                <input
+                    class="browser-address-bar"
+                    type="text"
+                    value={addressBar()}
+                    onInput={(e) => setAddressBar(e.currentTarget.value)}
+                    onKeyDown={handleAddressKeyDown}
+                    onFocus={(e) => e.currentTarget.select()}
+                    placeholder="Enter URL or search..."
+                />
+                <button class="browser-nav-btn browser-go-btn" onClick={handleNavigate}>
+                    Go
+                </button>
+            </div>
+
+            {/* Loading indicator */}
+            <Show when={model.loadingAtom()}>
+                <div class="browser-loading-bar" />
+            </Show>
+
+            {/* Error message */}
+            <Show when={model.errorAtom()}>
+                <div class="browser-error">
+                    {model.errorAtom()}
+                    <div class="browser-error-hint">
+                        This site may block embedding. Try opening in an external browser.
+                    </div>
+                </div>
+            </Show>
+
+            {/* iframe content */}
+            <Show when={model.urlAtom()}>
+                <iframe
+                    class="browser-iframe"
+                    src={model.urlAtom()}
+                    sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+                    referrerpolicy="no-referrer"
+                    onLoad={() => {
+                        model.onLoad();
+                        // Update address bar to match current URL
+                        setAddressBar(model.urlAtom());
+                    }}
+                    onError={() => model.onError("Failed to load page")}
+                />
+            </Show>
+
+            {/* Empty state */}
+            <Show when={!model.urlAtom()}>
+                <div class="browser-empty">
+                    <div class="browser-empty-icon">{"\uD83C\uDF10"}</div>
+                    <div class="browser-empty-text">Enter a URL above to browse</div>
+                </div>
+            </Show>
+        </div>
+    );
+}

--- a/frontend/app/view/browser/browser.tsx
+++ b/frontend/app/view/browser/browser.tsx
@@ -1,0 +1,15 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Browser module barrel — wires viewComponent onto BrowserViewModel.
+
+import { BrowserViewModel } from "./browser-model";
+import { BrowserViewComponent } from "./browser-view";
+
+Object.defineProperty(BrowserViewModel.prototype, "viewComponent", {
+    get() {
+        return BrowserViewComponent;
+    },
+});
+
+export { BrowserViewModel };

--- a/frontend/app/view/editor/editor-model.ts
+++ b/frontend/app/view/editor/editor-model.ts
@@ -1,0 +1,176 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// NOTE: Editor is a pane-level view for editing files with syntax highlighting.
+// It is NOT a standalone IDE — complex editing happens in the agent's terminal
+// or via agent tool calls. This covers quick edits, file viewing, and diffing.
+
+import { BlockNodeModel } from "@/app/block/blocktypes";
+import { RpcApi } from "@/app/store/wshclientapi";
+import { TabRpcClient } from "@/app/store/wshrpcutil";
+import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
+import { createMemo, createSignal, type Accessor } from "solid-js";
+
+export class EditorViewModel implements ViewModel {
+    viewType = "editor";
+    blockId: string;
+    nodeModel: BlockNodeModel;
+
+    viewIcon: Accessor<string> = () => "file-code";
+    viewName: Accessor<string>;
+    viewText: Accessor<string | HeaderElem[]> = () => [];
+    noPadding: Accessor<boolean> = () => true;
+
+    viewComponent: ViewComponent = null; // set by barrel
+
+    // Editor state
+    private _filePath = createSignal<string>("");
+    filePathAtom: Accessor<string> = this._filePath[0];
+    setFilePath = this._filePath[1];
+
+    private _content = createSignal<string>("");
+    contentAtom: Accessor<string> = this._content[0];
+    setContent = this._content[1];
+
+    private _language = createSignal<string>("");
+    languageAtom: Accessor<string> = this._language[0];
+
+    private _loading = createSignal<boolean>(false);
+    loadingAtom: Accessor<boolean> = this._loading[0];
+
+    private _dirty = createSignal<boolean>(false);
+    dirtyAtom: Accessor<boolean> = this._dirty[0];
+    setDirty = this._dirty[1];
+
+    private _readOnly = createSignal<boolean>(false);
+    readOnlyAtom: Accessor<boolean> = this._readOnly[0];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+
+    blockAtom: Accessor<Block | undefined>;
+
+    constructor(blockId: string, nodeModel: BlockNodeModel) {
+        this.blockId = blockId;
+        this.nodeModel = nodeModel;
+
+        this.blockAtom = getWaveObjectAtom<Block>(makeORef("block", blockId));
+
+        // Derive view name from file path
+        this.viewName = createMemo(() => {
+            const fp = this.filePathAtom();
+            if (!fp) return "Editor";
+            const name = fp.split("/").pop() || fp.split("\\").pop() || fp;
+            return this.dirtyAtom() ? `${name} *` : name;
+        });
+
+        // Load file from block meta on init
+        const meta = this.blockAtom()?.meta;
+        if (meta?.["file"]) {
+            this.openFile(meta["file"] as string);
+        }
+    }
+
+    async openFile(filePath: string): Promise<void> {
+        this._loading[1](true);
+        this._error[1](null);
+        this.setFilePath(filePath);
+        this._language[1](detectLanguage(filePath));
+
+        try {
+            const result = await RpcApi.ReadEditorFileCommand(TabRpcClient, {
+                path: filePath,
+            });
+            this.setContent(result?.content ?? "");
+            this._readOnly[1](result?.read_only ?? false);
+            this._dirty[1](false);
+
+            // Store file path in block meta
+            await RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: makeORef("block", this.blockId),
+                meta: { file: filePath },
+            });
+        } catch (e: any) {
+            this._error[1](e?.message ?? String(e));
+        } finally {
+            this._loading[1](false);
+        }
+    }
+
+    async saveFile(): Promise<void> {
+        if (this.readOnlyAtom()) return;
+        const filePath = this.filePathAtom();
+        if (!filePath) return;
+
+        try {
+            await RpcApi.WriteEditorFileCommand(TabRpcClient, {
+                path: filePath,
+                content: this.contentAtom(),
+            });
+            this._dirty[1](false);
+            this._error[1](null);
+        } catch (e: any) {
+            this._error[1](`Save failed: ${e?.message ?? String(e)}`);
+        }
+    }
+
+    onContentChange(content: string): void {
+        this.setContent(content);
+        this._dirty[1](true);
+    }
+
+    giveFocus(): boolean {
+        return false;
+    }
+
+    dispose(): void {}
+}
+
+// ── Language detection ──────────────────────────────────────────────────────
+
+const EXTENSION_MAP: Record<string, string> = {
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".py": "python",
+    ".rs": "rust",
+    ".html": "html",
+    ".htm": "html",
+    ".css": "css",
+    ".scss": "css",
+    ".json": "json",
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".toml": "toml",
+    ".sh": "shell",
+    ".bash": "shell",
+    ".zsh": "shell",
+    ".ps1": "powershell",
+    ".sql": "sql",
+    ".go": "go",
+    ".java": "java",
+    ".c": "c",
+    ".cpp": "cpp",
+    ".h": "c",
+    ".hpp": "cpp",
+    ".xml": "html",
+    ".svg": "html",
+};
+
+function detectLanguage(filePath: string): string {
+    const lower = filePath.toLowerCase();
+    for (const [ext, lang] of Object.entries(EXTENSION_MAP)) {
+        if (lower.endsWith(ext)) return lang;
+    }
+    // Special filenames
+    const name = lower.split("/").pop() || "";
+    if (name === "dockerfile") return "shell";
+    if (name === "makefile") return "shell";
+    if (name === "cargo.toml" || name === "cargo.lock") return "toml";
+    return "text";
+}

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -1,0 +1,91 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+.editor-view {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+    background: var(--block-bg-color, #1e1e1e);
+}
+
+.editor-open-prompt {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    gap: 12px;
+    color: var(--secondary-text-color, #888);
+}
+
+.editor-open-label {
+    font-size: 14px;
+}
+
+.editor-open-row {
+    display: flex;
+    gap: 8px;
+}
+
+.editor-open-input {
+    width: 350px;
+    padding: 6px 10px;
+    border: 1px solid var(--border-color, #444);
+    border-radius: 4px;
+    background: var(--input-bg-color, #2a2a2a);
+    color: var(--main-text-color, #ddd);
+    font-family: var(--termfontfamily, "JetBrains Mono", monospace);
+    font-size: 13px;
+
+    &:focus {
+        outline: none;
+        border-color: var(--accent-color, #58a6ff);
+    }
+}
+
+.editor-open-btn {
+    padding: 6px 16px;
+    border: 1px solid var(--border-color, #444);
+    border-radius: 4px;
+    background: var(--accent-color, #58a6ff);
+    color: #fff;
+    cursor: pointer;
+    font-size: 13px;
+
+    &:hover {
+        opacity: 0.9;
+    }
+}
+
+.editor-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: var(--secondary-text-color, #888);
+    font-size: 13px;
+}
+
+.editor-error {
+    padding: 8px 12px;
+    background: rgba(255, 80, 80, 0.15);
+    color: #ff6b6b;
+    font-size: 12px;
+    border-bottom: 1px solid rgba(255, 80, 80, 0.3);
+}
+
+.editor-codemirror {
+    flex: 1;
+    overflow: hidden;
+
+    .cm-editor {
+        height: 100%;
+    }
+
+    .cm-scroller {
+        font-family: var(--termfontfamily, "JetBrains Mono", monospace);
+        font-size: 13px;
+    }
+}

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -117,13 +117,18 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
         }
     });
 
-    // Rebuild when content is loaded from a new file
+    // Rebuild only when a NEW file is opened (path changes), not on every
+    // keystroke. Tracking contentAtom here would destroy + recreate the
+    // CodeMirror instance on every keypress, losing cursor position.
     createEffect(() => {
-        const content = model.contentAtom();
-        const lang = model.languageAtom();
-        const readOnly = model.readOnlyAtom();
+        const _path = model.filePathAtom(); // reactive dependency
         const loading = model.loadingAtom();
-        if (!loading && containerRef) {
+        if (!loading && _path && containerRef) {
+            // Read content/language/readOnly non-reactively — we only
+            // want this effect to fire on path changes, not content.
+            const content = model.contentAtom();
+            const lang = model.languageAtom();
+            const readOnly = model.readOnlyAtom();
             void setupEditor(content, lang, readOnly);
         }
     });

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createSignal, onCleanup, onMount, Show, untrack, type JSX } from "solid-js";
 import { EditorView, basicSetup } from "codemirror";
 import { EditorState, type Extension } from "@codemirror/state";
 import { keymap } from "@codemirror/view";
@@ -118,18 +118,20 @@ export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>):
     });
 
     // Rebuild only when a NEW file is opened (path changes), not on every
-    // keystroke. Tracking contentAtom here would destroy + recreate the
-    // CodeMirror instance on every keypress, losing cursor position.
+    // keystroke. contentAtom is updated by onContentChange on every keypress —
+    // reading it inside a tracked effect would destroy+recreate CodeMirror
+    // on every keystroke. untrack() prevents SolidJS from subscribing to
+    // those inner reads.
     createEffect(() => {
         const _path = model.filePathAtom(); // reactive dependency
-        const loading = model.loadingAtom();
+        const loading = model.loadingAtom(); // reactive dependency
         if (!loading && _path && containerRef) {
-            // Read content/language/readOnly non-reactively — we only
-            // want this effect to fire on path changes, not content.
-            const content = model.contentAtom();
-            const lang = model.languageAtom();
-            const readOnly = model.readOnlyAtom();
-            void setupEditor(content, lang, readOnly);
+            untrack(() => {
+                const content = model.contentAtom();
+                const lang = model.languageAtom();
+                const readOnly = model.readOnlyAtom();
+                void setupEditor(content, lang, readOnly);
+            });
         }
     });
 

--- a/frontend/app/view/editor/editor-view.tsx
+++ b/frontend/app/view/editor/editor-view.tsx
@@ -1,0 +1,181 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { EditorView, basicSetup } from "codemirror";
+import { EditorState, type Extension } from "@codemirror/state";
+import { keymap } from "@codemirror/view";
+import { oneDark } from "@codemirror/theme-one-dark";
+import { search } from "@codemirror/search";
+import type { EditorViewModel } from "./editor-model";
+import "./editor-view.scss";
+
+// ── Language loader ─────────────────────────────────────────────────────────
+// Lazy-load language extensions to keep initial bundle small.
+
+async function loadLanguage(lang: string): Promise<Extension | null> {
+    try {
+        switch (lang) {
+            case "typescript":
+            case "javascript": {
+                const { javascript } = await import("@codemirror/lang-javascript");
+                return javascript({ typescript: lang === "typescript", jsx: true });
+            }
+            case "python": {
+                const { python } = await import("@codemirror/lang-python");
+                return python();
+            }
+            case "rust": {
+                const { rust } = await import("@codemirror/lang-rust");
+                return rust();
+            }
+            case "html": {
+                const { html } = await import("@codemirror/lang-html");
+                return html();
+            }
+            case "css": {
+                const { css } = await import("@codemirror/lang-css");
+                return css();
+            }
+            case "json": {
+                const { json } = await import("@codemirror/lang-json");
+                return json();
+            }
+            case "markdown": {
+                const { markdown } = await import("@codemirror/lang-markdown");
+                return markdown();
+            }
+            default:
+                return null;
+        }
+    } catch {
+        return null;
+    }
+}
+
+// ── Editor View Component ───────────────────────────────────────────────────
+
+export function EditorViewComponent(props: ViewComponentProps<EditorViewModel>): JSX.Element {
+    const model = props.model;
+    let containerRef: HTMLDivElement | undefined;
+    let cmView: EditorView | null = null;
+    const [fileInput, setFileInput] = createSignal("");
+
+    // Build or rebuild CodeMirror when content/language changes
+    const setupEditor = async (content: string, language: string, readOnly: boolean) => {
+        if (!containerRef) return;
+
+        // Destroy previous instance
+        if (cmView) {
+            cmView.destroy();
+            cmView = null;
+        }
+
+        const extensions: Extension[] = [
+            basicSetup,
+            oneDark,
+            search(),
+            EditorView.lineWrapping,
+            EditorView.updateListener.of((update) => {
+                if (update.docChanged) {
+                    model.onContentChange(update.state.doc.toString());
+                }
+            }),
+            // Ctrl+S → save
+            keymap.of([{
+                key: "Mod-s",
+                run: () => {
+                    void model.saveFile();
+                    return true;
+                },
+            }]),
+        ];
+
+        if (readOnly) {
+            extensions.push(EditorState.readOnly.of(true));
+        }
+
+        // Load language extension
+        const langExt = await loadLanguage(language);
+        if (langExt) extensions.push(langExt);
+
+        cmView = new EditorView({
+            state: EditorState.create({
+                doc: content,
+                extensions,
+            }),
+            parent: containerRef,
+        });
+    };
+
+    onMount(() => {
+        const content = model.contentAtom();
+        const lang = model.languageAtom();
+        const readOnly = model.readOnlyAtom();
+        if (content || model.filePathAtom()) {
+            void setupEditor(content, lang, readOnly);
+        }
+    });
+
+    // Rebuild when content is loaded from a new file
+    createEffect(() => {
+        const content = model.contentAtom();
+        const lang = model.languageAtom();
+        const readOnly = model.readOnlyAtom();
+        const loading = model.loadingAtom();
+        if (!loading && containerRef) {
+            void setupEditor(content, lang, readOnly);
+        }
+    });
+
+    onCleanup(() => {
+        cmView?.destroy();
+        cmView = null;
+    });
+
+    const handleOpenFile = () => {
+        const path = fileInput().trim();
+        if (path) {
+            void model.openFile(path);
+        }
+    };
+
+    return (
+        <div class="editor-view">
+            <Show when={!model.filePathAtom()}>
+                <div class="editor-open-prompt">
+                    <div class="editor-open-label">Open a file</div>
+                    <div class="editor-open-row">
+                        <input
+                            class="editor-open-input"
+                            type="text"
+                            placeholder="/path/to/file.ts"
+                            value={fileInput()}
+                            onInput={(e) => setFileInput(e.currentTarget.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") handleOpenFile();
+                            }}
+                        />
+                        <button class="editor-open-btn" onClick={handleOpenFile}>
+                            Open
+                        </button>
+                    </div>
+                </div>
+            </Show>
+
+            <Show when={model.loadingAtom()}>
+                <div class="editor-loading">Loading...</div>
+            </Show>
+
+            <Show when={model.errorAtom()}>
+                <div class="editor-error">{model.errorAtom()}</div>
+            </Show>
+
+            <div
+                class="editor-codemirror"
+                ref={containerRef}
+                style={{ display: model.filePathAtom() && !model.loadingAtom() ? "block" : "none" }}
+            />
+        </div>
+    );
+}

--- a/frontend/app/view/editor/editor.tsx
+++ b/frontend/app/view/editor/editor.tsx
@@ -1,0 +1,15 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Editor module barrel — wires viewComponent onto EditorViewModel.
+
+import { EditorViewModel } from "./editor-model";
+import { EditorViewComponent } from "./editor-view";
+
+Object.defineProperty(EditorViewModel.prototype, "viewComponent", {
+    get() {
+        return EditorViewComponent;
+    },
+});
+
+export { EditorViewModel };

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1603,6 +1603,23 @@ declare global {
         files: AgentConfigFile[];
     };
 
+    // wshrpc.CommandReadEditorFileData
+    type CommandReadEditorFileData = {
+        path: string;
+    };
+
+    // wshrpc.CommandReadEditorFileResult
+    type CommandReadEditorFileResult = {
+        content: string;
+        read_only: boolean;
+    };
+
+    // wshrpc.CommandWriteEditorFileData
+    type CommandWriteEditorFileData = {
+        path: string;
+        content: string;
+    };
+
     // wshrpc.CommandResolveCliData
     type CommandResolveCliData = {
         provider_id: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.208",
+  "version": "0.33.210",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.208",
+      "version": "0.33.210",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -14,6 +14,15 @@
       "dependencies": {
         "@ai-sdk/react": "^2.0.114",
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+        "@codemirror/lang-css": "^6.3.1",
+        "@codemirror/lang-html": "^6.4.11",
+        "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/lang-json": "^6.0.2",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/lang-rust": "^6.0.2",
+        "@codemirror/search": "^6.6.0",
+        "@codemirror/theme-one-dark": "^6.1.3",
         "@floating-ui/react": "^0.27.16",
         "@observablehq/plot": "^0.6.17",
         "@radix-ui/react-label": "^2.1.8",
@@ -41,6 +50,7 @@
         "base64-js": "^1.5.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "codemirror": "^6.0.2",
         "color": "^4.2.3",
         "colord": "^2.9.3",
         "css-tree": "^3.1.0",
@@ -675,6 +685,192 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
       "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+      "integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+      "integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-json": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
+      "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/json": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.0.tgz",
+      "integrity": "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-python": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+      "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.3.2",
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/python": "^1.1.4"
+      }
+    },
+    "node_modules/@codemirror/lang-rust": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-6.0.2.tgz",
+      "integrity": "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@lezer/rust": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+      "integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+      "integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.35.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+      "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+      "integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.6.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1574,6 +1770,112 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+      "integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@lezer/json/-/json-1.0.3.tgz",
+      "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.9.tgz",
+      "integrity": "sha512-mF6irshW4nRJEhdR0HOAxxTDGss+rQFqA0nLRlZsPh14q+DB9Fqp0YbOvyRSOeKPLfUL/w5wPQAcETvkQ1VApg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.6.3.tgz",
+      "integrity": "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/python": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.18.tgz",
+      "integrity": "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/rust": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-1.0.2.tgz",
+      "integrity": "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
     },
     "node_modules/@mermaid-js/parser": {
       "version": "1.0.0",
@@ -5232,6 +5534,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -5392,6 +5709,12 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -10926,6 +11249,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -12535,6 +12864,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.210",
+  "version": "0.33.211",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.210",
+      "version": "0.33.211",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.210",
+  "version": "0.33.211",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"
@@ -72,6 +72,15 @@
   "dependencies": {
     "@ai-sdk/react": "^2.0.114",
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+    "@codemirror/lang-css": "^6.3.1",
+    "@codemirror/lang-html": "^6.4.11",
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/lang-json": "^6.0.2",
+    "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/lang-rust": "^6.0.2",
+    "@codemirror/search": "^6.6.0",
+    "@codemirror/theme-one-dark": "^6.1.3",
     "@floating-ui/react": "^0.27.16",
     "@observablehq/plot": "^0.6.17",
     "@radix-ui/react-label": "^2.1.8",
@@ -99,6 +108,7 @@
     "base64-js": "^1.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "codemirror": "^6.0.2",
     "color": "^4.2.3",
     "colord": "^2.9.3",
     "css-tree": "^3.1.0",


### PR DESCRIPTION
## Summary
Phase 1 of the browser + editor pane spec. Adds a new **editor** pane type with CodeMirror 6 for file viewing and editing inside AgentMux.

**Frontend:**
- `EditorViewModel` — file open/save lifecycle, language auto-detection from extension, dirty state tracking
- `EditorViewComponent` — CodeMirror 6 with one-dark theme, Ctrl+S save, search (Ctrl+F), line wrapping
- Language extensions lazy-loaded: TypeScript, JavaScript, Python, Rust, HTML, CSS, JSON, Markdown
- Registered in `BlockRegistry` as `"editor"` view + widget in sidebar

**Backend:**
- `readeditorfile` RPC — reads file from disk, returns content + read_only flag, rejects >10MB files
- `writeeditorfile` RPC — writes file to disk, logs path + size

**Bundle impact:** CodeMirror 6 core is ~124KB gzipped. Language extensions are lazy-loaded (only fetched when a file of that type is opened).

## Test plan
- [x] `cargo check` clean
- [x] `tsc --noEmit` clean
- [ ] Open editor pane from widget bar
- [ ] Type a file path → file loads with syntax highlighting
- [ ] Ctrl+S saves changes back to disk
- [ ] Large file (>10MB) shows error
- [ ] Read-only file shows read-only mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)