### PR TITLE
fix(browser-pane): reagent review fixes from #422 (paneCreated signal, devicePixelRatio, close)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.238"
+version = "0.33.239"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.238"
+version = "0.33.239"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.238"
+version = "0.33.239"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.238"
+version = "0.33.239"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.237"
+version = "0.33.238"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.237"
+version = "0.33.238"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.237"
+version = "0.33.238"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.237"
+version = "0.33.238"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.237"
+version = "0.33.238"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.238"
+version = "0.33.239"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -106,7 +106,17 @@ impl BrowserPaneManager {
             Some(l) => l,
             None => return,
         };
-        if let Some(browser) = state.browsers.lock().get(&label).cloned() {
+        // Pull the browser out of state.browsers AND release the map lock
+        // before calling close_browser — leaving it in the map would cause
+        // create() to later find a stale destroyed browser and try to
+        // navigate it instead of creating a fresh pane. on_before_close
+        // handles the actual entry removal when CEF fires that callback,
+        // but we remove here eagerly to avoid the race.
+        let browser = {
+            let mut browsers = state.browsers.lock();
+            browsers.remove(&label)
+        };
+        if let Some(browser) = browser {
             if let Some(host) = browser.host() {
                 host.close_browser(1);
             }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.238"
+version = "0.33.239"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.237"
+version = "0.33.238"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.238"
+version = "0.33.239"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.237"
+version = "0.33.238"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.237"
+version = "0.33.238"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.238"
+version = "0.33.239"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -16,9 +16,10 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     // when the pane is created and hides the empty-state placeholder.
     const [paneCreated, setPaneCreated] = createSignal(false);
 
-    // getBoundingClientRect() returns CSS pixels; CEF / SetWindowPos expect
-    // device-independent pixels. On high-DPI displays (devicePixelRatio > 1)
-    // the pane would be mispositioned/missized without this correction.
+    // getBoundingClientRect() returns CSS pixels (device-INdependent); CEF
+    // and Win32 SetWindowPos expect physical / device pixels. Multiply by
+    // devicePixelRatio to convert. On HiDPI displays (dpr > 1) the pane
+    // would be mispositioned/missized without this.
     const paneRect = () => {
         const r = placeholderRef!.getBoundingClientRect();
         const dpr = window.devicePixelRatio || 1;

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -12,33 +12,41 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     let placeholderRef: HTMLDivElement | undefined;
     let resizeObserver: ResizeObserver | null = null;
     let positionInterval: ReturnType<typeof setInterval> | null = null;
-    let paneCreated = false;
+    // SolidJS signal — must be reactive so <Show when={!paneCreated()}> re-runs
+    // when the pane is created and hides the empty-state placeholder.
+    const [paneCreated, setPaneCreated] = createSignal(false);
+
+    // getBoundingClientRect() returns CSS pixels; CEF / SetWindowPos expect
+    // device-independent pixels. On high-DPI displays (devicePixelRatio > 1)
+    // the pane would be mispositioned/missized without this correction.
+    const paneRect = () => {
+        const r = placeholderRef!.getBoundingClientRect();
+        const dpr = window.devicePixelRatio || 1;
+        return {
+            x: Math.round(r.x * dpr),
+            y: Math.round(r.y * dpr),
+            width: Math.round(r.width * dpr),
+            height: Math.round(r.height * dpr),
+        };
+    };
 
     const syncPosition = () => {
-        if (!placeholderRef || !paneCreated) return;
-        const rect = placeholderRef.getBoundingClientRect();
+        if (!placeholderRef || !paneCreated()) return;
         invokeCommand("browser_pane_resize", {
             block_id: model.blockId,
-            x: Math.round(rect.x),
-            y: Math.round(rect.y),
-            width: Math.round(rect.width),
-            height: Math.round(rect.height),
+            ...paneRect(),
         }).catch(() => {});
     };
 
     const createPane = async (url: string) => {
         if (!placeholderRef) return;
-        const rect = placeholderRef.getBoundingClientRect();
         try {
             await invokeCommand("browser_pane_create", {
                 block_id: model.blockId,
                 url: url || "about:blank",
-                x: Math.round(rect.x),
-                y: Math.round(rect.y),
-                width: Math.round(rect.width),
-                height: Math.round(rect.height),
+                ...paneRect(),
             });
-            paneCreated = true;
+            setPaneCreated(true);
             model.onLoad();
         } catch (e) {
             model.onError(`Failed to create browser pane: ${e}`);
@@ -61,7 +69,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
         model.navigate(normalized);
         setAddressBar(normalized);
 
-        if (paneCreated) {
+        if (paneCreated()) {
             invokeCommand("browser_pane_navigate", {
                 block_id: model.blockId,
                 url: normalized,
@@ -91,7 +99,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     onCleanup(() => {
         resizeObserver?.disconnect();
         if (positionInterval) clearInterval(positionInterval);
-        if (paneCreated) {
+        if (paneCreated()) {
             invokeCommand("browser_pane_close", { block_id: model.blockId }).catch(() => {});
         }
     });
@@ -146,12 +154,12 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     // OS-level keyboard focus to the pane when the cursor is over
                     // it. Without this, wheel events go to main's widget and the
                     // embedded page can't scroll.
-                    if (paneCreated) {
+                    if (paneCreated()) {
                         invokeCommand("browser_pane_focus", { block_id: model.blockId }).catch(() => {});
                     }
                 }}
             >
-                <Show when={!model.urlAtom() && !paneCreated}>
+                <Show when={!model.urlAtom() && !paneCreated()}>
                     <div class="browser-empty">
                         <div class="browser-empty-icon">{"\uD83C\uDF10"}</div>
                         <div class="browser-empty-text">Enter a URL above to browse</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.237",
+  "version": "0.33.238",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.237",
+      "version": "0.33.238",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.238",
+  "version": "0.33.239",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.238",
+      "version": "0.33.239",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.237",
+  "version": "0.33.238",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.238",
+  "version": "0.33.239",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Follow-up to #422 — addresses the three remaining `CHANGES_REQUESTED` items that `reagentx-workflow[bot]` kept flagging across 7 re-reviews on the original PR but weren't fixed before merge.

**@reagentx-workflow** — please re-review with full context of both PRs; these are the line items that were still open when #422 landed:

## Fixes

1. **`frontend/app/view/browser/browser-view.tsx:15` — `paneCreated` was a plain `let`, not a SolidJS signal.** `<Show when={!model.urlAtom() && !paneCreated}>` didn't re-evaluate when the flag flipped, so the empty-state placeholder persisted after the pane was created. Converted to `createSignal<boolean>(false)` and updated all read sites to `paneCreated()`.

2. **`frontend/app/view/browser/browser-view.tsx:19-26` — `getBoundingClientRect()` returns CSS pixels but CEF/`SetWindowPos` expect device-independent pixels.** On high-DPI monitors (`devicePixelRatio > 1`) the pane was mispositioned and sized too small. Multiplied rect values by `window.devicePixelRatio` in a shared `paneRect()` helper used by both `create_pane` and `syncPosition`. The spec in the original PR explicitly called this out.

3. **`agentmux-cef/src/browser_panes.rs` — `close()` left the browser in `state.browsers`.** A subsequent `create()` for the same `block_id` found the stale destroyed browser and tried to navigate it via `frame.load_url()` instead of creating a fresh pane. `close()` now removes the entry from `state.browsers` eagerly, before calling `host.close_browser(1)`.

## Test plan
- [x] `cargo check -p agentmux-cef` clean
- [ ] Visual test: on a high-DPI display, verify pane sizing matches placeholder DIV
- [ ] Close pane and re-open same block — should get a fresh pane, not reuse a destroyed one
- [ ] Empty-state `Enter a URL above to browse` disappears immediately when pane is created

Generated with Claude Code
