### PR TITLE
fix(browser-pane): close-closes-app + address bar focus after navigating

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.240"
+version = "0.33.241"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.240"
+version = "0.33.241"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.240"
+version = "0.33.241"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.240"
+version = "0.33.241"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.239"
+version = "0.33.240"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.239"
+version = "0.33.240"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.239"
+version = "0.33.240"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.239"
+version = "0.33.240"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.240 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |
 | 0.33.234 | 2026-04-17 | 158.6 MiB | 330.8 MiB | |
 | 0.33.233 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |
 | 0.33.232 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.240"
+version = "0.33.241"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.239"
+version = "0.33.240"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -106,21 +106,25 @@ impl BrowserPaneManager {
             Some(l) => l,
             None => return,
         };
-        // Pull the browser out of state.browsers AND release the map lock
-        // before calling close_browser — leaving it in the map would cause
-        // create() to later find a stale destroyed browser and try to
-        // navigate it instead of creating a fresh pane. on_before_close
-        // handles the actual entry removal when CEF fires that callback,
-        // but we remove here eagerly to avoid the race.
+        // Clone the browser out of state.browsers WITHOUT removing it —
+        // removing here made on_before_close's label lookup fail (it uses
+        // is_same against entries in state.browsers to find the closing
+        // browser), which skipped the per-browser cleanup path and left
+        // the main browser's on_before_close as the only one that found a
+        // match. Let CEF fire on_before_close and remove the entry
+        // naturally there.
         let browser = {
-            let mut browsers = state.browsers.lock();
-            browsers.remove(&label)
+            let browsers = state.browsers.lock();
+            browsers.get(&label).cloned()
         };
         if let Some(browser) = browser {
             if let Some(host) = browser.host() {
-                host.close_browser(1);
+                // force_close=0 (graceful) — force_close=1 was cascading into
+                // the main browser's on_before_close and quitting the whole
+                // app. A graceful close closes only this browser.
+                host.close_browser(0);
             }
-            tracing::info!(block_id, "browser pane closed");
+            tracing::info!(block_id, "browser pane close requested");
         }
     }
 

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -218,10 +218,13 @@ impl AgentMuxHandler {
 
         dlog(&format!("browser_list after remove: {}", self.browser_list.len()));
 
-        if self.browser_list.is_empty() {
+        if self.browser_list.is_empty() && !self.is_pane {
             dlog("last window — calling quit_message_loop");
             // Last window — quit the message loop.
             // The Job Object kills agentmux-srv which kills all shell processes.
+            // Only the MAIN client's handler should trigger app exit — pane
+            // clients own only their own pane browser and their list emptying
+            // just means the user closed the pane, not the whole app.
             quit_message_loop();
         } else {
             // Notify remaining windows of the new count.

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.239"
+version = "0.33.240"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.240"
+version = "0.33.241"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.240"
+version = "0.33.241"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.239"
+version = "0.33.240"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.240"
+version = "0.33.241"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.239"
+version = "0.33.240"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_MULTIWINDOW_TASKBAR_GROUPING.md
+++ b/docs/specs/SPEC_MULTIWINDOW_TASKBAR_GROUPING.md
@@ -1,0 +1,304 @@
+# SPEC: Multi-Window Taskbar Behaviour — Full Instances + Sub-Windows
+
+**Status:** Decision made — two distinct window types.
+**Date:** 2026-04-17
+**Owner:** AgentA
+**Files:** `agentmux-cef/src/commands/window.rs`, `agentmux-cef/src/ui_tasks.rs`,
+`agentmux-cef/src/client.rs`, `agentmux-cef/src/main.rs`,
+`agentmux-cef/src/state.rs`, `frontend/app/status-bar/`
+
+---
+
+## 0. Decision (read this first)
+
+AgentMux supports **two window types** with explicit, distinct taskbar behaviour:
+
+| Type | Who opens it | Taskbar entry | Alt-Tab | Pinning | Close cascade |
+|------|--------------|---------------|---------|---------|---------------|
+| **Full instance** (default, all user-facing paths) | second `agentmux.exe` launch, status-bar version click, Ctrl+Shift+N, any future "New Window"/"New Instance" menu item | own entry, groups with siblings | yes | yes | independent |
+| **Sub-window** (agent / internal only, not exposed in user UI) | Rust/backend API `open_subwindow(...)` invoked by agent operations — e.g. auxiliary view surfaced by a tool, transient panel attached to an agent task | **none** (hidden from taskbar) | yes | n/a | tied to its parent instance |
+
+Mechanism:
+
+1. **Process AUMID** (`AgentMuxCorp.AgentMux`) set once in `main.rs` before CEF `initialize()` — groups *full instances* under one pinned identity when the user's OS grouping setting permits.
+2. **Full instances** do nothing beyond the shared AUMID. They show in the taskbar exactly like today. Every user-driven "open in new window" flow — including the status-bar version click in the bottom-right — resolves to `NewWindowMode::FullInstance`.
+3. **Sub-windows** (agent-only) get `ITaskbarList::DeleteTab(hwnd)` applied after creation. They are fully functional top-level HWNDs — Alt-Tab works, they take focus, they render normally — but the shell never paints a taskbar button for them regardless of "Combine taskbar buttons" setting.
+4. Sub-windows track their parent's `parent_instance_id`. When the parent closes, its sub-windows close with it.
+5. There is **no user-visible UI for creating a sub-window.** The in-app "Windows (N)" switcher and `Ctrl+\`` cycle from the previous spec revision are dropped — sub-windows are not a first-class user concept. If we later need to expose sub-windows, we reintroduce the switcher at that point.
+
+Why the asymmetry: users reason about new windows as "another AgentMux" — Chrome/VS Code semantics, own taskbar button, Alt-Tab parity. They don't need or want a hidden second window. Agents, on the other hand, may legitimately want to surface transient UI (a diff view, a confirmation prompt, a debug panel) that shouldn't pollute the taskbar and whose lifetime is tied to the agent task. Sub-windows serve that internal use case only.
+
+---
+
+## 1. Current State
+
+`commands::window::open_new_window` (`window.rs:~424`) generates
+`window-<uuid>`, posts `CreateWindowTask` to the CEF UI thread
+(`ui_tasks.rs:160-212`). `CreateWindowTask::execute()` calls
+`window_create_top_level(...)` which `CreateWindowEx`-es a standalone
+top-level HWND. No AUMID, no parent relationship, no taskbar treatment
+→ Explorer paints one button per HWND with whatever grouping the OS
+decides.
+
+There is currently **no distinction** between "full instance" and
+"sub-window" at the API or state level. Both concepts collapse into a
+single `open_new_window` command today.
+
+---
+
+## 2. Window Types — Full Specification
+
+### 2.1 Full instance
+
+- Independent conceptual scope. Own layout tree, own workspace, own
+  agent identity (future). Survives other instances' closure.
+- Opened by **every user-visible path**:
+  - second `agentmux.exe` launch (forwarded via the existing single-instance IPC in `main.rs`)
+  - status-bar version click (bottom-right)
+  - `Ctrl+Shift+N`
+  - any future "New Window" / "New Instance" menu item
+- HWND treatment: shared process AUMID, otherwise untouched. Windows
+  paints a taskbar button. Grouping follows the user's OS setting.
+- Data: full `AppState.browsers` entry with `label = "main"` for the
+  first instance, `label = "main-<uuid>"` for subsequent ones.
+- On close: no cascade.
+
+### 2.2 Sub-window (internal / agent-only)
+
+- Belongs to a specific *parent instance*. Independent top-level HWND
+  for OS purposes (alt-tab, focus, paint) but scoped to the parent at
+  the app level.
+- **Not exposed in user UI.** Only reachable via the Rust/backend API
+  `open_subwindow(parent_instance_id, url, geom)`. Agent-driven tool
+  calls are the intended callers (e.g. an agent pops an auxiliary view
+  while a task runs).
+- HWND treatment: shared process AUMID **and** `ITaskbarList::DeleteTab(hwnd)` right after `set_window_icon` in `on_after_created`.
+- Data: `AppState.browsers` entry with `label = "sub-<uuid>"` and a `parent_instance_id` pointing to the owning full instance's label.
+- Close cascade: when the parent full instance closes, cascade-close its sub-windows. Sub-window closed by user/agent → no cascade.
+- Discovery: Alt-Tab still exposes them at OS level. **No in-app switcher in v1** — revisit if user-visible sub-windows become a product need.
+
+### 2.3 Promotion (edge case)
+
+If the user closes a full instance while it has sub-windows, two sane options — spec picks (a):
+
+- **(a) Cascade close** sub-windows with the parent. Matches Electron's `parent:` option semantics. Simplest for the user. **Ship this.**
+- **(b) Promote** the oldest sub-window to a full instance (`ITaskbarList::AddTab(hwnd)`, relabel, reparent others to it). More forgiving of accidental parent close but introduces taskbar pop-in UX jank.
+
+Option (b) can be revisited if telemetry shows accidental closes are common.
+
+---
+
+## 3. API Design
+
+Rename `open_new_window` to make the mode explicit.
+
+```rust
+// agentmux-cef/src/commands/window.rs
+pub enum NewWindowMode {
+    /// Independent AgentMux instance — own taskbar entry, own lifecycle.
+    FullInstance,
+    /// Sub-window of an existing instance — hidden from taskbar, dies with parent.
+    Subwindow { parent_instance_id: String },
+}
+
+pub fn open_new_window(
+    state: &Arc<AppState>,
+    mode: NewWindowMode,
+    url: &str,
+    geom: Option<(i32, i32, i32, i32)>,
+) -> Result<String, String>;
+```
+
+Add a new field on `AppState.browsers` entry (or a sibling map) to
+record the window type + parent link:
+
+```rust
+// agentmux-cef/src/state.rs
+pub enum WindowType { FullInstance, Subwindow }
+
+pub struct WindowMeta {
+    pub label: String,
+    pub kind: WindowType,
+    pub parent_instance_id: Option<String>, // Some only for Subwindow
+    pub created_at: SystemTime,
+}
+pub browsers: HashMap<String, (Browser, WindowMeta)>;
+```
+
+Frontend IPC:
+
+- `open_new_window({ url })` → maps to `NewWindowMode::FullInstance`. All user-facing triggers use this. The status-bar version-number click, `Ctrl+Shift+N`, second `agentmux.exe` launch — all resolve here.
+- `open_subwindow({ url, parent_instance_id })` → `NewWindowMode::Subwindow`. **Not wired to any UI element.** Reserved for agent-tool / backend callers. If the frontend ever needs it, it goes through an agent-mediated path, not a user button.
+
+---
+
+## 4. Implementation
+
+### 4.1 Process AUMID — `main.rs`, before CEF `initialize()`
+
+```rust
+#[cfg(target_os = "windows")]
+unsafe {
+    use windows_sys::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
+    let aumid: Vec<u16> = "AgentMuxCorp.AgentMux\0".encode_utf16().collect();
+    let _ = SetCurrentProcessExplicitAppUserModelID(aumid.as_ptr());
+}
+```
+
+Cargo: `windows-sys = { ..., features = [..., "Win32_UI_Shell", "Win32_System_Com"] }`. Use a **version-stable** AUMID (no patch number) so pinning survives updates. Pin the constant in `agentmux-common`.
+
+### 4.2 `skip_taskbar` helper — `client.rs`
+
+Place next to `set_window_icon`:
+
+```rust
+#[cfg(target_os = "windows")]
+unsafe fn skip_taskbar(hwnd: *mut std::ffi::c_void) {
+    use windows_sys::Win32::System::Com::{CoCreateInstance, CLSCTX_INPROC_SERVER};
+    use windows_sys::Win32::UI::Shell::{ITaskbarList, TaskbarList};
+    use windows_sys::core::{GUID, Interface};
+
+    let mut tbl: *mut ITaskbarList = std::ptr::null_mut();
+    let hr = CoCreateInstance(
+        &TaskbarList as *const GUID,
+        std::ptr::null_mut(),
+        CLSCTX_INPROC_SERVER,
+        &<ITaskbarList as Interface>::IID,
+        &mut tbl as *mut _ as *mut _,
+    );
+    if hr < 0 || tbl.is_null() { return; }
+    ((*(*tbl).lpVtbl).HrInit)(tbl);
+    ((*(*tbl).lpVtbl).DeleteTab)(tbl, hwnd);
+    ((*(*tbl).lpVtbl).Release)(tbl as *mut _);
+}
+```
+
+### 4.3 Conditional dispatch in `on_after_created`
+
+After `set_window_icon`:
+
+```rust
+let meta = self.state.browsers_meta.lock().get(&label).cloned();
+if matches!(meta.map(|m| m.kind), Some(WindowType::Subwindow)) {
+    unsafe { skip_taskbar(hwnd); }
+}
+```
+
+Full instances skip this branch and appear in the taskbar normally.
+
+### 4.4 Parent-close cascade
+
+In the main handler's `on_before_close`, after unregistration logic:
+
+```rust
+if matches!(closing_meta.kind, WindowType::FullInstance) {
+    // Close every sub-window tied to this parent.
+    let children: Vec<String> = self.state.browsers_meta.lock()
+        .values()
+        .filter(|m| m.parent_instance_id.as_deref() == Some(&closing_meta.label))
+        .map(|m| m.label.clone())
+        .collect();
+    for lbl in children {
+        post_close_window(&self.state, &lbl);
+    }
+}
+```
+
+### 4.5 `TaskbarCreated` broadcast — Explorer restart survival
+
+Listen for `RegisterWindowMessageW("TaskbarCreated")` in the top-level
+window's subclassed WndProc (same trick Electron uses in
+`native_window_views.cc:~335`). On receipt, re-apply `skip_taskbar` to
+every HWND whose meta says `WindowType::Subwindow`.
+
+### 4.6 Installer AUMID stamp
+
+`.lnk` shortcuts pinned to the taskbar must carry
+`System.AppUserModel.ID = AgentMuxCorp.AgentMux` in their property
+store, or pinning forks. Update the Inno Setup / MSI script to stamp
+this; document for manual-install flows.
+
+---
+
+## 5. Production Reference
+
+| App | Strategy | Maps to our model |
+|-----|----------|-------------------|
+| VS Code | shared AUMID, all windows in taskbar | "new window" is always a full instance |
+| Chrome | per-profile AUMID, every window in taskbar | full instance per profile; no sub-window concept |
+| Slack / Discord (Electron) | shared AUMID + `setSkipTaskbar` on small overlays (mini-player, HUDs) | sub-window pattern |
+| Obsidian | no AUMID set → inconsistent grouping ([forum complaints][obs]) | don't |
+| Electron `BrowserWindow({ parent, skipTaskbar })` | built-in primitive for our sub-window concept | exact semantic match |
+
+Key code:
+
+Electron `shell/browser/native_window_views.cc:~1970`:
+
+```cpp
+void NativeWindowViews::SetSkipTaskbar(bool skip) {
+  Microsoft::WRL::ComPtr<ITaskbarList> taskbar;
+  if (FAILED(::CoCreateInstance(CLSID_TaskbarList, nullptr,
+                                CLSCTX_INPROC_SERVER,
+                                IID_PPV_ARGS(&taskbar))) ||
+      FAILED(taskbar->HrInit())) return;
+  if (skip) taskbar->DeleteTab(GetAcceleratedWidget());
+  else      taskbar->AddTab(GetAcceleratedWidget());
+}
+```
+
+Electron `shell/common/application_info_win.cc`:
+
+```cpp
+void SetAppUserModelID(const std::wstring& name) {
+  SetCurrentProcessExplicitAppUserModelID(name.c_str());
+}
+```
+
+VS Code `src/vs/code/electron-main/app.ts`:
+
+```ts
+if (isWindows && win32AppUserModelId) {
+  app.setAppUserModelId(win32AppUserModelId);
+}
+```
+
+---
+
+## 6. Verification
+
+1. Second `agentmux.exe` launch → **two** AgentMux taskbar buttons. With OS grouping enabled they collapse under one icon (flyout shows both); with "Never combine" they appear as two adjacent buttons — matches Chrome/VS Code behaviour, acceptable for full instances.
+2. Click status-bar version (bottom-right) → third full instance opens; third taskbar button appears (or joins the grouped flyout); Alt-Tab shows 3 AgentMux windows.
+3. Pin main AgentMux to taskbar, restart OS → pin survives and launches AgentMux with the shared AUMID.
+4. Invoke `open_subwindow(...)` from a backend test harness or agent → no new taskbar button appears; Alt-Tab shows the sub-window; closing the parent full instance closes the sub-window.
+5. Flip Settings → Personalization → Taskbar → Combine taskbar buttons between Always / When taskbar is full / Never. Full-instance count follows the setting. Sub-windows never appear in any mode.
+6. Kill Explorer (`taskkill /f /im explorer.exe` + relaunch) → sub-windows remain hidden after taskbar restart (via `TaskbarCreated` re-apply).
+
+---
+
+## 7. Risks & Mitigations
+
+- **Sub-window without parent.** Can't happen at the API level — `NewWindowMode::Subwindow` requires a `parent_instance_id`. Reject the IPC if the label isn't in `browsers_meta` or isn't a `FullInstance`.
+- **Agent leaves sub-windows orphaned.** Mitigation: parent-close cascade closes them. Also expose a `close_all_subwindows(parent_instance_id)` internal API for agent cleanup.
+- **Accessibility for sub-windows.** Screen readers enumerate taskbar buttons, so sub-windows are invisible to AT via that path. Since sub-windows are agent-driven transient UI, the agent should surface whatever content they contain through the normal AgentMux chat/log stream in parallel. Alt-Tab still exposes them at OS level.
+- **Explorer restart.** `TaskbarCreated` broadcast handler re-applies `DeleteTab` to every HWND whose meta says `WindowType::Subwindow`.
+- **Future user-visible sub-windows.** If product direction changes and sub-windows need to be user-created, reintroduce the status-bar "Windows (N)" switcher + `Ctrl+\`` cycle from the previous revision. The underlying mechanism is identical; only the UI surface changes.
+
+---
+
+## 8. References
+
+- [Application User Model IDs][appids] — MSDN grouping semantics
+- [`SetCurrentProcessExplicitAppUserModelID`][spec-mupcai]
+- [`ITaskbarList` interface][itbl] — `AddTab` / `DeleteTab`
+- [Windows 11 "Never combine" Q&A][ms-qa]
+- Electron `shell/browser/native_window_views.cc` — `SetSkipTaskbar`
+- Electron `shell/common/application_info_win.cc` — `SetAppUserModelID`
+- Chromium `ui/base/win/shell.cc` — `SetAppIdForWindow`
+- VS Code `src/vs/code/electron-main/app.ts` — `app.setAppUserModelId`
+- AgentMux hooks: `agentmux-cef/src/client.rs:97` (`on_after_created`), `agentmux-cef/src/commands/window.rs:239` (`find_own_top_level_window`), `agentmux-cef/src/commands/window.rs:424` (`open_new_window`).
+
+[appids]: https://learn.microsoft.com/en-us/windows/win32/shell/appids
+[spec-mupcai]: https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-setcurrentprocessexplicitappusermodelid
+[itbl]: https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nn-shobjidl_core-itaskbarlist
+[ms-qa]: https://learn.microsoft.com/en-us/answers/questions/5617750/windows-11-taskbar-behaviour-never-combine
+[obs]: https://forum.obsidian.md/t/opening-multiple-vaults-creates-multiple-taskbar-icons-is-this-intended-windows-11/55346

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -137,7 +137,13 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     value={addressBar()}
                     onInput={(e) => setAddressBar(e.currentTarget.value)}
                     onKeyDown={handleAddressKeyDown}
-                    onFocus={(e) => e.currentTarget.select()}
+                    onFocus={(e) => {
+                        e.currentTarget.select();
+                        // Take OS-level keyboard focus away from the pane so
+                        // keystrokes reach this address-bar input. The pane may
+                        // have held HWND focus from an earlier hover.
+                        invokeCommand("main_window_focus", {}).catch(() => {});
+                    }}
                     placeholder="Enter URL or search..."
                 />
                 <button class="browser-nav-btn browser-go-btn" onClick={handleNavigate}>Go</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.239",
+  "version": "0.33.240",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.239",
+      "version": "0.33.240",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.240",
+  "version": "0.33.241",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.240",
+      "version": "0.33.241",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.240",
+  "version": "0.33.241",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.239",
+  "version": "0.33.240",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Two regressions reported against v0.33.240 (merged from #422 + #423):

1. **Closing a browser pane closed the entire AgentMux app.**
   `AgentMuxHandler::on_before_close` unconditionally calls `quit_message_loop()` when its `browser_list` empties. Pane clients get their own handler (via `new_with_pane`), and their list only ever contains the pane browser — so closing the pane triggers `quit_message_loop` and CEF shuts down.
   **Fix:** skip `quit_message_loop` for pane handlers (`is_pane == true`). Only the main client's handler should trigger app exit.

2. **Typing in the pane's address bar stopped working after navigating inside the embedded page.**
   `BrowserViewModel.giveFocus()` calls `main_window_focus` IPC when the active DOM element is a main-window input, but `giveFocus` only runs when a block becomes newly-focused. If the pane was already the focused block, clicking the URL bar didn't retrigger `giveFocus` — so OS-level keyboard focus stayed on the pane HWND (from an earlier hover-to-focus) and keystrokes got routed to the page instead of the input. The host log showed `setFocusedChild input.browser-address-bar` firing 4× with zero `[ipc] main_window_focus` IPC calls.
   **Fix:** add an `onFocus` handler on the address-bar input that directly sends `main_window_focus` IPC so the top-level window reclaims OS focus.

Follow-up to #422 and #423.

## Test plan
- [x] `cargo check` clean
- [ ] Close a browser pane → AgentMux stays open
- [ ] Load google.com, click in page, navigate via link, click address bar → typing lands in address bar (not page)
