### PR TITLE
feat(window): full-instance / sub-window model + shared AUMID + skipTaskbar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.241"
+version = "0.33.242"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.241"
+version = "0.33.242"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.241"
+version = "0.33.242"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.241"
+version = "0.33.242"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -55,6 +55,8 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Ole",
     "Win32_System_SystemInformation",
     "Win32_System_ProcessStatus",
+    "Win32_UI_Shell",
+    "Win32_System_Com",
 ] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.241"
+version = "0.33.242"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -1219,8 +1219,6 @@ unsafe fn install_frameless_resize_hook(hwnd: *mut std::ffi::c_void) {
     tracing::info!("Installed frameless resize hook (WM_NCCALCSIZE + WM_NCHITTEST)");
 }
 
-/// Load the app icon from the exe's embedded resource and set it on the window.
-/// This makes the icon appear in the taskbar and Alt+Tab switcher instead of
 /// Hide the given top-level HWND from the Windows taskbar via
 /// `ITaskbarList::DeleteTab`. The window remains fully usable — Alt-Tab still
 /// finds it, it takes focus, repaints, etc. — but the shell paints no taskbar
@@ -1300,6 +1298,8 @@ unsafe fn skip_taskbar(hwnd: *mut std::ffi::c_void) {
     (vtbl.release)(tbl);
 }
 
+/// Load the app icon from the exe's embedded resource and set it on the window.
+/// This makes the icon appear in the taskbar and Alt+Tab switcher instead of
 /// the default CEF/Chromium icon.
 #[cfg(target_os = "windows")]
 unsafe fn set_window_icon(hwnd: *mut std::ffi::c_void) {

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -10,7 +10,7 @@ use cef::*;
 use std::sync::Arc;
 use parking_lot::Mutex;
 
-use crate::state::AppState;
+use crate::state::{AppState, WindowKind};
 
 /// Write a debug line to `%TEMP%\agentmux-close-debug.txt`.
 ///
@@ -102,7 +102,7 @@ impl AgentMuxHandler {
 
         // Register browser in the multi-window map.
         // First browser is "main"; additional browsers get labels from their URL params.
-        {
+        let label = {
             let mut browsers = self.state.browsers.lock();
             let label = if browsers.is_empty() {
                 "main".to_string()
@@ -117,26 +117,69 @@ impl AgentMuxHandler {
             };
             tracing::info!("Registered browser: label={} (total: {})", label, browsers.len() + 1);
             dlog(&format!("on_after_created: registered label={} total={}", label, browsers.len() + 1));
-            browsers.insert(label, browser.clone());
+            browsers.insert(label.clone(), browser.clone());
+            label
+        };
+
+        // Ensure WindowMeta exists for this browser so downstream code (taskbar
+        // treatment here, cascade-close below) can classify it. If the creator
+        // didn't pre-register a meta (legacy callers, or the very first "main"
+        // window), default to FullInstance. Browser panes use `browser-pane-*`
+        // labels which are intentionally absent from window_meta — they're
+        // child HWNDs, not top-level windows, and skipping the taskbar logic
+        // below for them is correct.
+        let is_top_level_window = !label.starts_with("browser-pane-");
+        if is_top_level_window {
+            let mut metas = self.state.window_meta.lock();
+            metas.entry(label.clone()).or_insert_with(|| {
+                crate::state::WindowMeta {
+                    label: label.clone(),
+                    kind: WindowKind::FullInstance,
+                    parent_instance_id: None,
+                }
+            });
         }
 
         // No DwmExtendFrameIntoClientArea — it causes the white flash.
         // CEF Views handles frameless + resize via its delegate.
 
-        // Set the taskbar/title bar icon from the embedded exe resource.
+        // Set the taskbar/title bar icon from the embedded exe resource, and
+        // for `Subwindow` top-levels, hide them from the taskbar via
+        // ITaskbarList::DeleteTab.
         #[cfg(target_os = "windows")]
         {
-            // For native windows, use the browser's HWND; for CEF Views, enumerate.
-            let hwnd = browser.host()
-                .and_then(|h| {
-                    let wh = h.window_handle();
-                    if wh.0.is_null() { None } else { Some(wh.0 as *mut std::ffi::c_void) }
-                })
-                .unwrap_or_else(|| unsafe {
-                    crate::commands::window::find_own_top_level_window()
-                });
+            // Prefer CEF Views' `Window::window_handle()` — it targets the
+            // specific top-level window for THIS browser, avoiding the
+            // `find_own_top_level_window` fallback's "first visible HWND"
+            // ambiguity when multiple windows exist.
+            let mut browser_mut = browser.clone();
+            let views_top_hwnd = browser_view_get_for_browser(Some(&mut browser_mut))
+                .and_then(|bv| bv.window())
+                .map(|w| w.window_handle().0 as *mut std::ffi::c_void)
+                .filter(|p| !p.is_null());
+
+            let hwnd = views_top_hwnd.unwrap_or_else(|| {
+                browser.host()
+                    .and_then(|h| {
+                        let wh = h.window_handle();
+                        if wh.0.is_null() { None } else { Some(wh.0 as *mut std::ffi::c_void) }
+                    })
+                    .unwrap_or_else(|| unsafe {
+                        crate::commands::window::find_own_top_level_window()
+                    })
+            });
+
             if !hwnd.is_null() {
                 unsafe { set_window_icon(hwnd); }
+
+                // Subwindow? Hide from taskbar. Full instances and browser-pane
+                // child HWNDs skip this branch.
+                if is_top_level_window {
+                    let kind = self.state.window_meta.lock().get(&label).map(|m| m.kind);
+                    if kind == Some(WindowKind::Subwindow) {
+                        unsafe { skip_taskbar(hwnd); }
+                    }
+                }
             }
         }
 
@@ -205,6 +248,36 @@ impl AgentMuxHandler {
             dlog(&format!("window_id_map.remove({:?}) => {:?}", lbl, wid));
             wid
         });
+
+        // Pull and remove the closing window's meta; if it's a FullInstance,
+        // cascade-close every Subwindow whose parent_instance_id points to it.
+        // See `docs/specs/SPEC_MULTIWINDOW_TASKBAR_GROUPING.md` §2.3.
+        let closing_meta = label
+            .as_deref()
+            .and_then(|lbl| self.state.window_meta.lock().remove(lbl));
+        if let Some(meta) = &closing_meta {
+            if meta.kind == WindowKind::FullInstance {
+                let child_labels: Vec<String> = self
+                    .state
+                    .window_meta
+                    .lock()
+                    .values()
+                    .filter(|m| {
+                        m.kind == WindowKind::Subwindow
+                            && m.parent_instance_id.as_deref() == Some(&meta.label)
+                    })
+                    .map(|m| m.label.clone())
+                    .collect();
+                for child_label in child_labels {
+                    if let Some(mut child) = self.state.browsers.lock().get(&child_label).cloned() {
+                        if let Some(host) = child.host() {
+                            tracing::info!(parent = %meta.label, child = %child_label, "[subwindow-cascade] closing sub-window");
+                            host.close_browser(1);
+                        }
+                    }
+                }
+            }
+        }
 
         dlog(&format!("backend_window_id: {:?}", backend_window_id));
 
@@ -1148,6 +1221,85 @@ unsafe fn install_frameless_resize_hook(hwnd: *mut std::ffi::c_void) {
 
 /// Load the app icon from the exe's embedded resource and set it on the window.
 /// This makes the icon appear in the taskbar and Alt+Tab switcher instead of
+/// Hide the given top-level HWND from the Windows taskbar via
+/// `ITaskbarList::DeleteTab`. The window remains fully usable — Alt-Tab still
+/// finds it, it takes focus, repaints, etc. — but the shell paints no taskbar
+/// button for it regardless of the user's "Combine taskbar buttons" setting.
+///
+/// Used only for `WindowKind::Subwindow` top-level windows. Must be called
+/// once the HWND exists (post-`on_after_created`) and re-applied on the
+/// `TaskbarCreated` broadcast after Explorer restarts.
+///
+/// Same primitive Electron uses in `NativeWindowViews::SetSkipTaskbar`
+/// (`shell/browser/native_window_views.cc`).
+#[cfg(target_os = "windows")]
+unsafe fn skip_taskbar(hwnd: *mut std::ffi::c_void) {
+    use windows_sys::Win32::System::Com::{CoCreateInstance, CLSCTX_INPROC_SERVER};
+    use windows_sys::core::GUID;
+
+    // CLSID_TaskbarList
+    const CLSID_TASKBAR_LIST: GUID = GUID {
+        data1: 0x56FDF344,
+        data2: 0xFD6D,
+        data3: 0x11D0,
+        data4: [0x95, 0x8A, 0x00, 0x60, 0x97, 0xC9, 0xA0, 0x90],
+    };
+    // IID_ITaskbarList
+    const IID_TASKBAR_LIST: GUID = GUID {
+        data1: 0x56FDF342,
+        data2: 0xFD6D,
+        data3: 0x11D0,
+        data4: [0x95, 0x8A, 0x00, 0x60, 0x97, 0xC9, 0xA0, 0x90],
+    };
+
+    // Hand-rolled vtable — `windows-sys` doesn't expose `ITaskbarList` types
+    // at this feature level, and pulling in the full `windows` crate for one
+    // COM interface is overkill.
+    #[repr(C)]
+    struct ITaskbarList {
+        lp_vtbl: *const ITaskbarListVtbl,
+    }
+    #[repr(C)]
+    struct ITaskbarListVtbl {
+        query_interface: unsafe extern "system" fn(*mut ITaskbarList, *const GUID, *mut *mut core::ffi::c_void) -> i32,
+        add_ref: unsafe extern "system" fn(*mut ITaskbarList) -> u32,
+        release: unsafe extern "system" fn(*mut ITaskbarList) -> u32,
+        hr_init: unsafe extern "system" fn(*mut ITaskbarList) -> i32,
+        add_tab: unsafe extern "system" fn(*mut ITaskbarList, *mut core::ffi::c_void) -> i32,
+        delete_tab: unsafe extern "system" fn(*mut ITaskbarList, *mut core::ffi::c_void) -> i32,
+        activate_tab: unsafe extern "system" fn(*mut ITaskbarList, *mut core::ffi::c_void) -> i32,
+        set_active_alt: unsafe extern "system" fn(*mut ITaskbarList, *mut core::ffi::c_void) -> i32,
+    }
+
+    let mut tbl: *mut ITaskbarList = std::ptr::null_mut();
+    let hr = CoCreateInstance(
+        &CLSID_TASKBAR_LIST as *const GUID,
+        std::ptr::null_mut(),
+        CLSCTX_INPROC_SERVER,
+        &IID_TASKBAR_LIST as *const GUID,
+        &mut tbl as *mut _ as *mut _,
+    );
+    if hr < 0 || tbl.is_null() {
+        tracing::warn!("[skip_taskbar] CoCreateInstance(TaskbarList) failed: hr=0x{:x}", hr);
+        return;
+    }
+
+    let vtbl = &*(*tbl).lp_vtbl;
+    let hr = (vtbl.hr_init)(tbl);
+    if hr < 0 {
+        tracing::warn!("[skip_taskbar] HrInit failed: hr=0x{:x}", hr);
+        (vtbl.release)(tbl);
+        return;
+    }
+    let hr = (vtbl.delete_tab)(tbl, hwnd);
+    if hr < 0 {
+        tracing::warn!("[skip_taskbar] DeleteTab failed: hr=0x{:x}", hr);
+    } else {
+        tracing::info!("[skip_taskbar] hid HWND {:p} from taskbar", hwnd);
+    }
+    (vtbl.release)(tbl);
+}
+
 /// the default CEF/Chromium icon.
 #[cfg(target_os = "windows")]
 unsafe fn set_window_icon(hwnd: *mut std::ffi::c_void) {

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -301,6 +301,17 @@ pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) 
         url.push_str(&format!("&workspaceId={}", workspace_id));
     }
 
+    // Tear-off windows are full AgentMux instances — record meta so
+    // on_after_created leaves them in the taskbar alongside main.
+    state.window_meta.lock().insert(
+        label.clone(),
+        crate::state::WindowMeta {
+            label: label.clone(),
+            kind: crate::state::WindowKind::FullInstance,
+            parent_instance_id: None,
+        },
+    );
+
     // Push label before posting — on_after_created pops it to register
     // the browser under the same label baked into the window URL.
     state.pending_window_labels.lock().push_back(label.clone());

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -419,9 +419,48 @@ pub(crate) fn resolve_frontend_base_url(ipc_port: u16) -> String {
     }
 }
 
-/// Open a new window (Ctrl+Shift+N or StatusBar click).
-/// Creates a new CEF Views window with the same frameless style as the main window.
+/// Open a new full AgentMux instance (status-bar version click, Ctrl+Shift+N,
+/// second `agentmux.exe` launch). Independent top-level window, own taskbar
+/// entry, independent lifecycle. See
+/// `docs/specs/SPEC_MULTIWINDOW_TASKBAR_GROUPING.md`.
 pub fn open_new_window(state: &Arc<AppState>) -> Result<serde_json::Value, String> {
+    open_window_with_kind(state, crate::state::WindowKind::FullInstance, None)
+}
+
+/// Open a sub-window tied to `parent_instance_id`. **Not exposed to users** —
+/// reserved for agent / backend callers that need a transient auxiliary
+/// top-level window (tool-spawned panels, diff views, etc.). Sub-windows are
+/// hidden from the taskbar via `ITaskbarList::DeleteTab` and close when their
+/// parent full instance closes.
+pub fn open_subwindow(
+    state: &Arc<AppState>,
+    parent_instance_id: String,
+) -> Result<serde_json::Value, String> {
+    // Reject if the parent isn't a known FullInstance — prevents orphan
+    // sub-windows and enforces the lifecycle rule in the spec.
+    let parent_ok = state
+        .window_meta
+        .lock()
+        .get(&parent_instance_id)
+        .map(|m| m.kind == crate::state::WindowKind::FullInstance)
+        .unwrap_or(false);
+    if !parent_ok {
+        return Err(format!(
+            "open_subwindow: unknown or non-full-instance parent label={parent_instance_id}"
+        ));
+    }
+    open_window_with_kind(
+        state,
+        crate::state::WindowKind::Subwindow,
+        Some(parent_instance_id),
+    )
+}
+
+fn open_window_with_kind(
+    state: &Arc<AppState>,
+    kind: crate::state::WindowKind,
+    parent_instance_id: Option<String>,
+) -> Result<serde_json::Value, String> {
     let window_id = uuid::Uuid::new_v4();
     let label = format!("window-{}", window_id.simple());
 
@@ -435,7 +474,18 @@ pub fn open_new_window(state: &Arc<AppState>) -> Result<serde_json::Value, Strin
         base_url, separator, ipc_port, ipc_token, label
     );
 
-    tracing::info!(label = %label, "[window] open_new_window");
+    tracing::info!(label = %label, kind = ?kind, parent = ?parent_instance_id, "[window] open window");
+
+    // Record WindowMeta BEFORE the browser is created so on_after_created can
+    // read it and apply the right taskbar treatment.
+    state.window_meta.lock().insert(
+        label.clone(),
+        crate::state::WindowMeta {
+            label: label.clone(),
+            kind,
+            parent_instance_id,
+        },
+    );
 
     // Register instance number BEFORE creating the browser, so the new window's
     // frontend can query its instance number immediately on load.

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -217,6 +217,16 @@ async fn route_command(
         "is_main_window" => Ok(commands::window::is_main_window(args)),
         "get_window_label" => Ok(commands::window::get_window_label(args)),
         "open_new_window" => commands::window::open_new_window(state),
+        "open_subwindow" => {
+            // Agent / backend-only API — creates a sub-window tied to a full
+            // instance. Hidden from the taskbar. Not exposed in user UI.
+            let parent = args
+                .get("parent_instance_id")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| "open_subwindow: parent_instance_id required".to_string())?
+                .to_string();
+            commands::window::open_subwindow(state, parent)
+        }
         "get_instance_number" => Ok(commands::window::get_instance_number(state, args)),
         "get_window_count" => Ok(commands::window::get_window_count(state)),
         "register_backend_window" => Ok(commands::window::register_backend_window(state, args)),

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -104,6 +104,18 @@ fn main() {
     // Browser process initialization
     // -----------------------------------------------------------------------
 
+    // Set the Application User Model ID before any UI is created. This lets
+    // Windows group our windows under one pinned identity and is required for
+    // the `DeleteTab` + per-HWND AppID treatment used by the full-instance /
+    // sub-window model (see docs/specs/SPEC_MULTIWINDOW_TASKBAR_GROUPING.md).
+    // Use a VERSION-STABLE ID — never embed the patch number or pinning forks.
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use windows_sys::Win32::UI::Shell::SetCurrentProcessExplicitAppUserModelID;
+        let aumid: Vec<u16> = "AgentMuxCorp.AgentMux\0".encode_utf16().collect();
+        let _ = SetCurrentProcessExplicitAppUserModelID(aumid.as_ptr());
+    }
+
     let version = env!("CARGO_PKG_VERSION");
     let is_dev = std::env::var("AGENTMUX_DEV").is_ok();
     let version_slug = version.replace('.', "-");

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -115,6 +115,34 @@ pub struct BackendEndpoints {
     pub web_endpoint: String,
 }
 
+/// Window role in the AgentMux multi-window model.
+///
+/// Two distinct types with different taskbar treatment:
+/// - `FullInstance`: independent AgentMux window (like Chrome/VS Code new window).
+///   Appears in the Windows taskbar. All user-facing "new window" paths (status-bar
+///   version click, second `agentmux.exe` launch, `Ctrl+Shift+N`) create one.
+/// - `Subwindow`: hidden from the taskbar via `ITaskbarList::DeleteTab`. Only
+///   reachable through the backend `open_subwindow` API — reserved for agent /
+///   internal use cases (transient auxiliary views, tool-spawned panels). Closes
+///   when its parent full instance closes.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowKind {
+    FullInstance,
+    Subwindow,
+}
+
+/// Per-window metadata held alongside the CEF `Browser`. See `WindowKind` for
+/// the semantics of `kind` and `parent_instance_id`.
+#[derive(Clone, Debug)]
+pub struct WindowMeta {
+    pub label: String,
+    pub kind: WindowKind,
+    /// For `Subwindow` only: label of the `FullInstance` that owns this window.
+    /// `None` for `FullInstance`.
+    pub parent_instance_id: Option<String>,
+}
+
 /// Shared application state for the CEF host.
 ///
 /// Unlike the Tauri version, this uses `Arc<AppState>` directly instead of
@@ -177,6 +205,12 @@ pub struct AppState {
     /// "main" is the primary window; tear-off windows get "window-{UUID}" labels.
     pub browsers: Mutex<HashMap<String, Browser>>,
 
+    /// Per-window metadata (kind, parent linkage). Maintained in parallel with
+    /// `browsers` — any `browsers.insert()` for a real window must also record
+    /// a `WindowMeta` here so on_after_created knows whether to hide the HWND
+    /// from the taskbar and so on_before_close can cascade sub-window closure.
+    pub window_meta: Mutex<HashMap<String, WindowMeta>>,
+
     /// FIFO queue of labels for windows that are about to be created.
     /// Pushed in `open_new_window` / `open_window_at_position` before
     /// `post_create_window`; popped in `on_after_created` so the browser gets
@@ -220,6 +254,7 @@ impl Default for AppState {
             ipc_port: Mutex::new(0),
             ipc_token: uuid::Uuid::new_v4().to_string(),
             browsers: Mutex::new(HashMap::new()),
+            window_meta: Mutex::new(HashMap::new()),
             pending_window_labels: Mutex::new(VecDeque::new()),
             version_data_dir: Mutex::new(None),
             version_config_dir: Mutex::new(None),

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.241"
+version = "0.33.242"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.241"
+version = "0.33.242"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.241"
+version = "0.33.242"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.241",
+  "version": "0.33.242",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.241",
+      "version": "0.33.242",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.241",
+  "version": "0.33.242",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Implements the multi-window / taskbar model specified in `docs/specs/SPEC_MULTIWINDOW_TASKBAR_GROUPING.md`.

**Two distinct window kinds, different taskbar treatment:**

| Kind | Trigger | Taskbar | Alt-Tab | Lifecycle |
|------|---------|---------|---------|-----------|
| `FullInstance` (default) | status-bar version click, `Ctrl+Shift+N`, second `agentmux.exe` launch, tab tear-off | own entry (shared process AUMID groups siblings when OS permits) | yes | independent |
| `Subwindow` (backend / agent-only) | new `open_subwindow(parent_instance_id)` IPC; no user UI | **none** (`ITaskbarList::DeleteTab`) | yes | dies with parent |

## Implementation

- **`state.rs`** — new `WindowKind` enum, `WindowMeta` struct, `AppState.window_meta` map.
- **`main.rs`** — `SetCurrentProcessExplicitAppUserModelID("AgentMuxCorp.AgentMux")` before CEF `initialize()`. Version-stable AUMID so taskbar pinning survives updates.
- **`client.rs`** — new `skip_taskbar()` helper using a hand-rolled `ITaskbarList` vtable + `CoCreateInstance` + `HrInit` + `DeleteTab` (same primitive Electron's `NativeWindowViews::SetSkipTaskbar` uses). Wired into `on_after_created`; prefers CEF Views' `Window::window_handle()` for the correct per-window HWND, with fallback to `browser.host()` / `find_own_top_level_window()`. Called only when meta kind is `Subwindow`.
- **`client.rs`** — `on_before_close` pulls the closing window's meta and, for `FullInstance`, cascade-closes every `Subwindow` whose `parent_instance_id` points to it.
- **`commands/window.rs`** — existing user-facing `open_new_window` keeps `FullInstance` semantics. New `open_subwindow(parent_instance_id)` factored alongside; rejects unknown / non-full-instance parents. Both route through a shared `open_window_with_kind()` that records `WindowMeta` before posting `CreateWindowTask`.
- **`commands/drag.rs`** — tab tear-off records `FullInstance` meta too.
- **`ipc.rs`** — new `"open_subwindow"` IPC command (backend-only; no frontend UI wiring).
- **`Cargo.toml`** — `Win32_UI_Shell` + `Win32_System_Com` feature flags.

## Deferred to a follow-up

- `TaskbarCreated` broadcast re-apply after Explorer restarts (spec §4.5).
- Installer-side AUMID stamp on the pinned `.lnk` (spec §4.6).

## Test plan

- [x] `cargo check` clean.
- [ ] Open a second full instance via status-bar version → two AgentMux taskbar buttons appear (grouped under one icon with OS grouping enabled, side-by-side with "Never combine").
- [ ] Flip "Combine taskbar buttons" across Always / When full / Never → full-instance count in taskbar follows the setting.
- [ ] Pin main AgentMux, restart OS → pin survives, launches AgentMux.
- [ ] Call `open_subwindow({ parent_instance_id: "main" })` via curl against the IPC HTTP server → no new taskbar button, Alt-Tab shows the sub-window, closing the parent closes the sub-window.
- [ ] Explorer restart leaves sub-windows still in the taskbar (known follow-up — needs `TaskbarCreated` handler).
