### PR TITLE
test(providers): cover ACP providers alongside OAuth CLI trio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.243"
+version = "0.33.244"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.243"
+version = "0.33.244"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.243"
+version = "0.33.244"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.243"
+version = "0.33.244"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.243"
+version = "0.33.244"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.243"
+version = "0.33.244"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.243"
+version = "0.33.244"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.243"
+version = "0.33.244"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/providers/index.test.ts
+++ b/frontend/app/view/agent/providers/index.test.ts
@@ -5,13 +5,19 @@ import { describe, test, expect } from "vitest";
 import { PROVIDERS, getProvider, getProviderList } from "./index";
 import type { ProviderDefinition } from "./index";
 
+// Providers split into two classes by how they talk to the backend:
+//   - OAuth CLIs (raw stream): claude, codex, gemini — authType "oauth",
+//     outputFormat "raw", no defaultArgs.
+//   - ACP providers:           openclaw, pi — authType "api-key",
+//     outputFormat "acp".
+const OAUTH_CLI_IDS = ["claude", "codex", "gemini"] as const;
+const ACP_IDS = ["openclaw", "pi"] as const;
+
 describe("PROVIDERS", () => {
-    test("defines exactly 3 providers", () => {
+    test("includes the OAuth CLI trio and the ACP providers", () => {
         const ids = Object.keys(PROVIDERS);
-        expect(ids).toHaveLength(3);
-        expect(ids).toContain("claude");
-        expect(ids).toContain("codex");
-        expect(ids).toContain("gemini");
+        for (const id of OAUTH_CLI_IDS) expect(ids).toContain(id);
+        for (const id of ACP_IDS) expect(ids).toContain(id);
     });
 
     test("all providers have required fields", () => {
@@ -31,16 +37,25 @@ describe("PROVIDERS", () => {
         }
     });
 
-    test("all providers are in raw output mode", () => {
-        for (const provider of Object.values(PROVIDERS)) {
+    test("OAuth CLI providers are in raw output mode with no default args", () => {
+        for (const id of OAUTH_CLI_IDS) {
+            const provider = PROVIDERS[id];
             expect(provider.outputFormat).toBe("raw");
             expect(provider.defaultArgs).toEqual([]);
         }
     });
 
-    test("all providers use OAuth auth type", () => {
-        for (const provider of Object.values(PROVIDERS)) {
-            expect(provider.authType).toBe("oauth");
+    test("OAuth CLI providers use OAuth auth type", () => {
+        for (const id of OAUTH_CLI_IDS) {
+            expect(PROVIDERS[id].authType).toBe("oauth");
+        }
+    });
+
+    test("ACP providers use the ACP output format and api-key auth", () => {
+        for (const id of ACP_IDS) {
+            const provider = PROVIDERS[id];
+            expect(provider.outputFormat).toBe("acp");
+            expect(provider.authType).toBe("api-key");
         }
     });
 });
@@ -112,7 +127,9 @@ describe("getProvider", () => {
 describe("getProviderList", () => {
     test("returns all providers as array", () => {
         const list = getProviderList();
-        expect(list).toHaveLength(3);
-        expect(list.map((p) => p.id)).toEqual(expect.arrayContaining(["claude", "codex", "gemini"]));
+        expect(list).toHaveLength(Object.keys(PROVIDERS).length);
+        expect(list.map((p) => p.id)).toEqual(
+            expect.arrayContaining([...OAUTH_CLI_IDS, ...ACP_IDS]),
+        );
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.243",
+  "version": "0.33.244",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.243",
+      "version": "0.33.244",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.243",
+  "version": "0.33.244",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

The `frontend/app/view/agent/providers/index.test.ts` suite has been failing on `main` since `openclaw` and `pi` joined the providers registry:

- `defines exactly 3 providers` — expected 3, actual 5.
- `all providers are in raw output mode` — `openclaw`/`pi` use `"acp"`.
- `all providers use OAuth auth type` — `openclaw`/`pi` use `"api-key"`.
- `getProviderList returns array of length 3` — actual 5.

Both CI and local `npm test` hit these; they masked real regressions and made every PR look dirty. Fixing them in a standalone PR keeps feature branches clean.

## Changes

Split the assertions into two provider classes:

- `OAUTH_CLI_IDS = [claude, codex, gemini]` — `outputFormat: "raw"`, empty `defaultArgs`, `authType: "oauth"`.
- `ACP_IDS = [openclaw, pi]` — `outputFormat: "acp"`, `authType: "api-key"`.

Added an explicit assertion for the ACP class. Widened `getProviderList` length check to `Object.keys(PROVIDERS).length` so adding/removing providers won't break the suite again.

## Test plan

- [x] `npm test -- --run frontend/app/view/agent/providers/index.test.ts` → **17 passed**.
- [x] Full `npm test` — only pre-existing unrelated failures remain; the 4 provider failures are gone.
