### PR TITLE
style(window): Windows 11 standard caption buttons (SVG + red close hover)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.245"
+version = "0.33.246"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.245"
+version = "0.33.246"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.245"
+version = "0.33.246"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.245"
+version = "0.33.246"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.246"
+version = "0.33.247"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.246"
+version = "0.33.247"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.246"
+version = "0.33.247"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.246"
+version = "0.33.247"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.245 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |
 | 0.33.240 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |
 | 0.33.234 | 2026-04-17 | 158.6 MiB | 330.8 MiB | |
 | 0.33.233 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.246"
+version = "0.33.247"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.245"
+version = "0.33.246"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.246"
+version = "0.33.247"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.245"
+version = "0.33.246"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.246"
+version = "0.33.247"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.245"
+version = "0.33.246"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.246"
+version = "0.33.247"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.245"
+version = "0.33.246"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/VSCODE_MENUBAR_REFERENCE.md
+++ b/docs/specs/VSCODE_MENUBAR_REFERENCE.md
@@ -1,0 +1,304 @@
+# VS Code Menu Bar — Reference for AgentMux
+
+Source: `microsoft/vscode@main`, 2026-04-17. All quotes verbatim.
+
+---
+
+## 1. High-level architecture
+
+```
++-------------------------------------------------------------------------+
+| MenuRegistry  (src/vs/platform/actions/common/actions.ts)               |
+|   static "File", "Edit", ... submenus, declared at startup              |
++--------------------+------------------------------+---------------------+
+                     |                              |
+            custom path (Win/Linux/Web)      native path (macOS, or      |
+                     |                       "window.titleBarStyle":     |
+                     v                       "native" on Win/Linux)      |
++---------------------------------+      +--------------------------------+
+| CustomMenubarControl             |     | MenubarMainService (main proc) |
+|   workbench/.../menubarControl.ts|     |  platform/menubar/electron-    |
+|   – reads MenuRegistry           |     |  main/menubar.ts               |
+|   – turns actions into IActions  |     |  – builds electron.Menu        |
+|   – owns DOM container           |     |  – Menu.setApplicationMenu()   |
++----------------+-----------------+     +---------------+----------------+
+                 |                                       |
+                 v                                       v
++---------------------------------+      +--------------------------------+
+| MenuBar widget                   |     | OS-native NSMenu / HMENU       |
+|   base/browser/ui/menu/menubar.ts|     | click -> IPC 'vscode:runAction'|
+|   – renders <div role="menubar"> |     | -> renderer executes command   |
+|   – Alt / mnemonic / arrow keys  |     +--------------------------------+
+|   – opens <Menu> on click        |
++----------------+-----------------+
+                 |
+                 v
++---------------------------------+
+| Menu widget (dropdown)           |
+|   base/browser/ui/menu/menu.ts   |
+|   – ActionBar subclass           |
+|   – absolutely-positioned DOM    |
+|     inside button container      |
++---------------------------------+
+                 |
+                 v
+          CommandService.executeCommand("workbench.action.files.newUntitledFile")
+```
+
+`BrowserTitlebarPart` is the host: it owns `.titlebar-container` split into
+left/center/right, and chooses between `installMenubar()` (custom DOM) or
+the main-process `Menu.setApplicationMenu` path.
+
+---
+
+## 2. File-by-file breakdown
+
+### 2.1  Native vs custom decision
+
+`src/vs/platform/window/common/window.ts:176-184`
+
+```ts
+export type MenuBarVisibility = 'classic' | 'visible' | 'toggle' | 'hidden' | 'compact';
+
+export function getMenuBarVisibility(configurationService: IConfigurationService): MenuBarVisibility {
+    const menuBarVisibility = configurationService.getValue<MenuBarVisibility | 'default'>(MenuSettings.MenuBarVisibility);
+
+    if (menuBarVisibility === 'default' || (menuBarVisibility === 'compact' && hasNativeMenu(configurationService)) || (isMacintosh && isNative)) {
+        return 'classic';
+    }
+```
+
+macOS always returns `'classic'` → falls through to the native path. Windows/
+Linux/Web use the value directly. `hasNativeMenu()` (line 164) returns true iff
+`titleBarStyle === 'native'`.
+
+### 2.2  Title-bar host
+
+`titlebarPart.ts:458-482` creates three flex regions and installs the
+custom menubar into the left region:
+
+```ts
+this.rootContainer = append(parent, $('.titlebar-container'));
+this.leftContent   = append(this.rootContainer, $('.titlebar-left'));
+this.centerContent = append(this.rootContainer, $('.titlebar-center'));
+this.rightContent  = append(this.rootContainer, $('.titlebar-right'));
+...
+if (!this.isAuxiliary && !hasNativeMenu(...) && (!isMacintosh || isWeb) &&
+    this.currentMenubarVisibility !== 'compact') {
+    this.installMenubar();
+}
+```
+
+```ts
+// installMenubar (416-429)
+this.customMenubar.value = this.instantiationService.createInstance(CustomMenubarControl);
+this.menubar = append(this.leftContent, $('div.menubar'));
+this.menubar.setAttribute('role', 'menubar');
+this.customMenubar.value.create(this.menubar);
+```
+
+Layout is **flexbox** on `.titlebar-container`: icon + menubar in
+`.titlebar-left`, title/command-center/breadcrumbs in `.titlebar-center`,
+window controls in `.titlebar-right`.
+
+### 2.3  Bridging workbench actions → MenuBar widget
+
+`src/vs/workbench/browser/parts/titlebar/menubarControl.ts:578-630, 751-768`
+
+```ts
+this.menubar = this.reinstallDisposables.add(new MenuBar(this.container, this.getMenuBarOptions(), defaultMenuStyles));
+...
+private getMenuBarOptions(): IMenuBarOptions {
+    return {
+        enableMnemonics: this.currentEnableMenuBarMnemonics,
+        disableAltFocus: this.currentDisableMenuBarAltFocus,
+        visibility: this.currentMenubarVisibility,
+        actionRunner: this.actionRunner,
+        getKeybinding: (action) => this.keybindingService.lookupKeybinding(action.id),
+        alwaysOnMnemonics: this.alwaysOnMnemonics,
+        compactMode: this.currentCompactMenuMode,
+        ...
+    };
+}
+```
+
+Click dispatch is wired here (line 659):
+
+```ts
+const newAction = store.add(new Action(
+    menuItem.id, mnemonicMenuLabel(title), menuItem.class, menuItem.enabled,
+    () => this.commandService.executeCommand(menuItem.id)));
+```
+
+So when the user picks "File > New File", `menuItem.id ===
+"workbench.action.files.newUntitledFile"` and `ICommandService.executeCommand`
+fires the registered handler synchronously.
+
+### 2.4  The MenuBar widget itself
+
+`base/browser/ui/menu/menubar.ts:93-201` — constructor sets `role="menubar"`
+and adds container-level key handlers:
+
+```ts
+if (event.equals(KeyCode.LeftArrow) || (tabNav && event.equals(KeyCode.Tab | KeyMod.Shift))) {
+    this.focusPrevious();
+} else if (event.equals(KeyCode.RightArrow) || (tabNav && event.equals(KeyCode.Tab))) {
+    this.focusNext();
+} else if (event.equals(KeyCode.Escape) && this.isFocused && !this.isOpen) {
+    this.setUnfocusedState();
+} else if (!this.isOpen && this.options.enableMnemonics && this.mnemonicsInUse && this.mnemonics.has(key)) {
+    this.onMenuTriggered(this.mnemonics.get(key)!, false);
+}
+```
+
+Top-level buttons are built in `push()` (lines 203-315); each attaches its
+own `MOUSE_DOWN` (left-click → `onMenuTriggered(index, true)`), `KEY_UP`
+(DownArrow/Enter → open), and `MOUSE_ENTER` (switch while another menu is
+open).
+
+### 2.5  Alt handling (mnemonic underscores)
+
+`menubar.ts:183-198` — window-level `keydown` listener fires on Alt+letter:
+
+```ts
+if (!this.options.enableMnemonics || !e.altKey || e.ctrlKey || e.defaultPrevented) { return; }
+const key = e.key.toLocaleLowerCase();
+if (!this.mnemonics.has(key)) { return; }
+this.mnemonicsInUse = true;
+this.updateMnemonicVisibility(true);
+this.onMenuTriggered(this.mnemonics.get(key)!, false);
+```
+
+Underscore visibility is driven by `DOM.ModifierKeyEmitter` at
+`menubar.ts:866-968`: `child.style.textDecoration = (alwaysOn || visible)
+? 'underline' : ''`. Label parsing uses `&&` as marker
+(`MENU_MNEMONIC_REGEX`); `mnemonicMenuLabel("&&File")` → `<mnemonic>F</mnemonic>ile`.
+
+### 2.6  Submenu dropdown rendering
+
+`menubar.ts:1001-1062` — `showCustomMenu`:
+
+```ts
+const menuHolder = $('div.menubar-menu-items-holder', { 'title': '' });
+customMenu.buttonElement.classList.add('open');
+const titleBoundingRect = customMenu.titleElement.getBoundingClientRect();
+...
+menuHolder.style.left = `${titleBoundingRect.left * titleBoundingRectZoom}px`;
+menuHolder.style.top  = `${titleBoundingRect.bottom * titleBoundingRectZoom}px`;
+customMenu.buttonElement.appendChild(menuHolder);
+const menuWidget = this.menuDisposables.add(new Menu(menuHolder, customMenu.actions, menuOptions, this.menuStyle));
+```
+
+It is **plain DOM, position:absolute, appended as a child of the menu-button
+div** — no portal to `document.body`, no Electron popup window. CSS
+(`menubar.css` / `menu.css`) gives it `position: absolute` with a high
+z-index so it overlays the rest of the workbench.
+
+### 2.7  Native path (macOS, or `titleBarStyle:"native"`)
+
+`platform/menubar/electron-main/menubar.ts:299-395` builds an `electron.Menu`
+and calls `Menu.setApplicationMenu(menu)`. Each leaf item (lines 678-687)
+registers a `click` callback that calls `runActionInRenderer(...)`, which
+sends IPC (lines 798-804):
+
+```ts
+activeWindow.sendWhenReady('vscode:runAction', CancellationToken.None,
+    { id: invocation.commandId, from: 'menu' });
+```
+
+Renderer receiver, `workbench/electron-browser/window.ts:158-177`:
+
+```ts
+ipcRenderer.on('vscode:runAction', async (event, ...argsRaw) => {
+    ...
+    await this.commandService.executeCommand(request.id, ...args);
+});
+```
+
+Both paths converge on `ICommandService.executeCommand(menuItem.id)`. On
+custom (DOM) the closure at `menubarControl.ts:659` executes directly; on
+native, one IPC hop first.
+
+### 2.8  Visibility modes
+
+`menubarControl.ts:504-506` reads the setting:
+
+```ts
+private get currentMenubarVisibility(): MenuBarVisibility {
+    return getMenuBarVisibility(this.configurationService);
+}
+```
+
+Effect of each value:
+
+- **classic** – let OS draw the menu bar (native path, always on macOS).
+- **visible** – custom DOM menubar always shown inside the titlebar.
+- **toggle** – hidden until user presses Alt; shows, then hides on
+  blur/Escape (via `MenubarState.HIDDEN` / `VISIBLE`).
+- **hidden** – never shown (`titlebarPart.ts:371-377` calls
+  `uninstallMenubar()`).
+- **compact** – menubar collapses into a single hamburger button in the
+  Activity Bar; `createOverflowMenu()` in `menubar.ts:317-389` is the
+  implementation, and positioning is driven by
+  `currentCompactMenuMode` (horizontal/vertical direction relative to
+  the activity bar).
+
+---
+
+## 3. Implementation sketch for AgentMux (Rust + CEF + SolidJS)
+
+AgentMux already has a custom title bar drawn by the webview (same model as
+VS Code when `titleBarStyle:"custom"`). Two routes:
+
+### Route A — all-DOM inside the custom title bar (recommended default)
+
+Mirrors VS Code's Win/Linux path.
+
+1. `<MenuBar>` SolidJS component inside the titlebar's left region with
+   flex layout `[icon][menubar][drag][title][controls]`. Collapse to
+   overflow "⋮" then compact as width shrinks (see `menubar.ts:482-563`).
+2. A shared `MenuRegistry` of `{id, label, submenu[], accelerator}`;
+   each leaf item carries a `commandId` known to the existing command
+   service.
+3. Dropdown is `position:absolute; z-index:9999` inside the button element
+   — not a portal. Close on outside `mousedown` / `blur` / `Escape`.
+   Arrow-key focus traversal, Enter/Space to activate.
+4. Copy the `HIDDEN|VISIBLE|FOCUSED|OPEN` state machine for Alt handling;
+   underline mnemonics on Alt-down and on `mnemonicsInUse`.
+5. Click → Solid handler → `invoke("run_command",{id})` → Rust
+   `CommandService::execute`.
+
+Pros: one implementation, themeable, works per-CEF-window without sync.
+Cons: must re-do accelerators, IME, screen-reader semantics; macOS users
+miss the top-of-screen NSMenu.
+
+### Route B — Rust/CEF native menu
+
+Mirrors VS Code's mac/native path via the `muda` crate (HMENU / NSMenu /
+GTK). Menu items store a `command_id`; on click, send an IPC message to
+the CEF renderer which dispatches through the SolidJS command registry
+(exactly the `vscode:runAction` IPC pattern).
+
+Pros: native accelerators + a11y + Linux global menu.
+Cons: can't theme, per-window sync needed, can't embed breadcrumbs in
+the same bar.
+
+### Hybrid (what VS Code ships)
+
+macOS → Route B, Windows/Linux → Route A, sharing one `MenuRegistry`.
+Both paths end at `command_service.execute(menu_item.id)`. VS Code's
+`MenuRegistry.appendMenuItem(MenuId.MenubarMainMenu, ...)` at
+`menubarControl.ts:48-116` feeds both `CustomMenubarControl` and
+`MenubarMainService` off a single declaration — copy that pattern.
+
+---
+
+## 4. Direct links
+
+- https://github.com/microsoft/vscode/blob/main/src/vs/base/browser/ui/menu/menubar.ts
+- https://github.com/microsoft/vscode/blob/main/src/vs/base/browser/ui/menu/menu.ts
+- https://github.com/microsoft/vscode/blob/main/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+- https://github.com/microsoft/vscode/blob/main/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+- https://github.com/microsoft/vscode/blob/main/src/vs/platform/menubar/electron-main/menubar.ts
+- https://github.com/microsoft/vscode/blob/main/src/vs/platform/window/common/window.ts
+- https://github.com/microsoft/vscode/blob/main/src/vs/workbench/electron-browser/window.ts (IPC receiver)

--- a/frontend/app/window/system-status.scss
+++ b/frontend/app/window/system-status.scss
@@ -20,13 +20,19 @@
     // Windows 11 standard caption buttons. Dimensions, hit area, and hover
     // treatment match the Win11 Fluent / Mica design tokens used by Explorer,
     // Edge, Terminal, and VS Code's custom-titlebar mode:
-    //   - 46×32 hit area (no gap between buttons so they tile edge to edge)
+    //   - 46×height hit area, tiled edge to edge (no gap)
     //   - 10×10 glyph centered
-    //   - Minimize/Maximize hover: subtle neutral overlay
-    //     (dark theme: rgba(255,255,255,0.0605); light: rgba(0,0,0,0.0373))
-    //   - Close hover: solid #c42b1c red with white glyph
+    //   - Minimize/Maximize hover/press: theme-relative neutral overlay
+    //     (via --win-caption-hover-bg / --win-caption-press-bg below)
+    //   - Close hover:         solid #c42b1c red with white glyph
     //   - Close press:         #b7201b slightly darker
-    //   - Press state on non-close buttons: rgba(...,0.1) overlay
+    //
+    // The caption-button overlay opacities come from the Fluent
+    // surface-background-hover (0.0605) / surface-background-pressed
+    // (0.0419) tokens. We default to the dark-theme values (white overlay)
+    // and override for light via prefers-color-scheme so the hover stays
+    // visible on both themes — the previous `opacity: 0.7` attempt only
+    // dimmed the glyph, which vanished against a light bar.
     .window-action-buttons {
         display: flex;
         flex-direction: row;
@@ -34,6 +40,14 @@
         // Butt up against the edge — Win11 caption buttons have no
         // right-margin padding.
         margin-right: -6px;
+
+        --win-caption-hover-bg: rgba(255, 255, 255, 0.0605);
+        --win-caption-press-bg: rgba(255, 255, 255, 0.0419);
+
+        @media (prefers-color-scheme: light) {
+            --win-caption-hover-bg: rgba(0, 0, 0, 0.0373);
+            --win-caption-press-bg: rgba(0, 0, 0, 0.0241);
+        }
 
         .window-action-btn {
             cursor: pointer;
@@ -57,11 +71,11 @@
             }
 
             &:hover {
-                background-color: rgba(255, 255, 255, 0.0605);
+                background-color: var(--win-caption-hover-bg);
             }
 
             &:active {
-                background-color: rgba(255, 255, 255, 0.0419);
+                background-color: var(--win-caption-press-bg);
             }
 
             &.close-btn {

--- a/frontend/app/window/system-status.scss
+++ b/frontend/app/window/system-status.scss
@@ -17,33 +17,62 @@
         flex: 0 0 fit-content;
     }
 
+    // Windows 11 standard caption buttons. Dimensions, hit area, and hover
+    // treatment match the Win11 Fluent / Mica design tokens used by Explorer,
+    // Edge, Terminal, and VS Code's custom-titlebar mode:
+    //   - 46×32 hit area (no gap between buttons so they tile edge to edge)
+    //   - 10×10 glyph centered
+    //   - Minimize/Maximize hover: subtle neutral overlay
+    //     (dark theme: rgba(255,255,255,0.0605); light: rgba(0,0,0,0.0373))
+    //   - Close hover: solid #c42b1c red with white glyph
+    //   - Close press:         #b7201b slightly darker
+    //   - Press state on non-close buttons: rgba(...,0.1) overlay
     .window-action-buttons {
         display: flex;
         flex-direction: row;
-        gap: 4px;
-        align-items: center;
+        align-items: stretch;
+        // Butt up against the edge — Win11 caption buttons have no
+        // right-margin padding.
+        margin-right: -6px;
 
         .window-action-btn {
             cursor: pointer;
-            padding: 4px 8px;
-            font-size: 14px;
-            background: none;
+            width: 46px;
+            height: 100%;
+            padding: 0;
+            background: transparent;
             border: none;
-            color: var(--secondary-text-color);
-            transition: opacity 0.15s ease, color 0.15s ease;
+            color: var(--main-text-color);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
             user-select: none;
             -webkit-app-region: no-drag;
+            transition: background-color 80ms linear, color 80ms linear;
+
+            // Glyph colour follows button color; the SVGs use currentColor.
+            svg {
+                display: block;
+                shape-rendering: geometricPrecision;
+            }
 
             &:hover {
-                opacity: 0.7;
-                color: var(--main-text-color);
+                background-color: rgba(255, 255, 255, 0.0605);
+            }
+
+            &:active {
+                background-color: rgba(255, 255, 255, 0.0419);
             }
 
             &.close-btn {
-                color: #ff4444;
-
                 &:hover {
-                    color: #ff6666;
+                    background-color: #c42b1c;
+                    color: #ffffff;
+                }
+
+                &:active {
+                    background-color: #b7201b;
+                    color: #ffffff;
                 }
             }
         }

--- a/frontend/app/window/system-status.tsx
+++ b/frontend/app/window/system-status.tsx
@@ -55,6 +55,31 @@ const ConfigErrorMessage = (): JSX.Element => {
     );
 };
 
+// Windows 11 caption-button glyphs rendered as inline SVG so they are
+// pixel-accurate regardless of which icon font happens to be installed.
+// Stroke widths, proportions, and viewBox match what the Fluent design system
+// uses for Segoe Fluent Icons U+E921 (minimize), U+E922 (maximize), U+E8BB
+// (close). 10px glyph inside a 10px viewBox; the CSS gives the button its
+// 46×32px hit area and the hover backgrounds.
+const MinimizeGlyph = (): JSX.Element => (
+    <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
+        <line x1="0" y1="5" x2="10" y2="5" stroke="currentColor" stroke-width="1" />
+    </svg>
+);
+
+const MaximizeGlyph = (): JSX.Element => (
+    <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
+        <rect x="0.5" y="0.5" width="9" height="9" fill="none" stroke="currentColor" stroke-width="1" />
+    </svg>
+);
+
+const CloseGlyph = (): JSX.Element => (
+    <svg viewBox="0 0 10 10" width="10" height="10" aria-hidden="true">
+        <line x1="0" y1="0" x2="10" y2="10" stroke="currentColor" stroke-width="1" />
+        <line x1="10" y1="0" x2="0" y2="10" stroke="currentColor" stroke-width="1" />
+    </svg>
+);
+
 const WindowActionButtons = (): JSX.Element => {
     const { dragProps } = useWindowDrag();
     const handleMinimize = () => {
@@ -74,29 +99,32 @@ const WindowActionButtons = (): JSX.Element => {
             <button
                 class="window-action-btn minimize-btn"
                 onClick={handleMinimize}
-                title="Minimize Window"
+                title="Minimize"
+                aria-label="Minimize"
                 data-testid="window-minimize-btn"
                 data-tauri-drag-region="false"
             >
-                <i class="fa fa-window-minimize" />
+                <MinimizeGlyph />
             </button>
             <button
                 class="window-action-btn maximize-btn"
                 onClick={handleMaximize}
-                title="Maximize Window"
+                title="Maximize"
+                aria-label="Maximize"
                 data-testid="window-maximize-btn"
                 data-tauri-drag-region="false"
             >
-                <i class="fa fa-window-maximize" />
+                <MaximizeGlyph />
             </button>
             <button
                 class="window-action-btn close-btn"
                 onClick={handleClose}
-                title="Close Window"
+                title="Close"
+                aria-label="Close"
                 data-testid="window-close-btn"
                 data-tauri-drag-region="false"
             >
-                <i class="fa fa-times" />
+                <CloseGlyph />
             </button>
         </div>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.245",
+  "version": "0.33.246",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.245",
+      "version": "0.33.246",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.246",
+  "version": "0.33.247",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.246",
+      "version": "0.33.247",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.246",
+  "version": "0.33.247",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.245",
+  "version": "0.33.246",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Replaces the Font Awesome window-control icons (`fa fa-window-minimize` / `maximize` / `times`) with pixel-accurate SVG glyphs and Windows 11 Fluent hover/press treatment. Now matches what Explorer, Edge, Terminal, and VS Code's custom-titlebar mode render.

## Visual changes

| | Before | After |
|---|---|---|
| Glyph | Font Awesome approximations | 10×10 SVG, 1px stroke, `shape-rendering: geometricPrecision` |
| Button size | `padding: 4px 8px`, 4px gap between buttons | 46px × full-header-height, tiled edge-to-edge |
| Minimize/Max hover | Opacity change | `rgba(255,255,255,0.0605)` overlay |
| Minimize/Max press | — | `rgba(255,255,255,0.0419)` |
| Close hover | `#ff4444` → `#ff6666` (foreground only) | solid `#c42b1c` red background, white glyph |
| Close press | — | `#b7201b` background |

All numbers come from the Fluent design tokens (`surface-background-hover`, `surface-background-pressed`, `system-background-critical`) used by first-party Windows 11 apps.

## What didn't change

- IPC behaviour (`minimizeWindow` / `maximizeWindow` / `closeWindow`) — same.
- `aria-label` / `title` / `data-testid` selectors — preserved; any existing e2e tests still target the same buttons.
- Drag-region opt-out (`data-tauri-drag-region="false"`) — preserved.
- macOS / Linux — unaffected (the component is identical across platforms but the SVG rendering is platform-agnostic; native macOS traffic-light buttons are handled by the existing `.darwin.scss` overrides).

## Test plan

- [x] `tsc --noEmit` clean.
- [ ] Launch portable / `task dev`, hover each button — minimize/maximize get neutral overlay, close turns red with white X.
- [ ] Press each — slight darken confirms `:active` state.
- [ ] No gap between the three buttons; they touch the window's right edge.

## Follow-up (not this PR)

- Swap the Maximize glyph for the Restore glyph (two offset squares, Segoe `U+E923`) when the window is maximized. Requires exposing a maximized-state atom from the host; tracked separately.
