### PR TITLE
fix(window): caption-button hover covers full area + visible on our bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.248"
+version = "0.33.249"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.248"
+version = "0.33.249"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.248"
+version = "0.33.249"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.248"
+version = "0.33.249"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.247"
+version = "0.33.248"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.247"
+version = "0.33.248"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.247"
+version = "0.33.248"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.247"
+version = "0.33.248"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.248"
+version = "0.33.249"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.247"
+version = "0.33.248"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.247"
+version = "0.33.248"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.248"
+version = "0.33.249"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.248"
+version = "0.33.249"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.247"
+version = "0.33.248"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.248"
+version = "0.33.249"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.247"
+version = "0.33.248"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/window/system-status.scss
+++ b/frontend/app/window/system-status.scss
@@ -27,13 +27,8 @@
     //   - Close hover:         solid #c42b1c red with white glyph
     //   - Close press:         #b7201b slightly darker
     //
-    // Overlay alphas are bumped slightly from the raw Fluent tokens
-    // (0.0605 / 0.0419 dark, 0.0373 / 0.0241 light) to 0.08 / 0.054 dark
-    // and 0.06 / 0.04 light because the AgentMux title bar uses a darker
-    // surface than the Win11 Mica default — the raw Fluent values are
-    // nearly invisible on our background. Close button's red hover stays
-    // the exact OS value (#c42b1c / #b7201b) since it's brand-colour, not
-    // surface-relative.
+    // Close button's red hover stays the exact OS value
+    // (#c42b1c / #b7201b) since it's brand-colour, not surface-relative.
     .window-action-buttons {
         display: flex;
         flex-direction: row;
@@ -45,16 +40,29 @@
         align-self: stretch;
         align-items: stretch;
 
+        // `.window-header` has `padding-top: 6px` for the tab bar; the caption
+        // buttons need to override that and reach the absolute top of the
+        // title bar, or the hover background leaves a 6-px strip at the top
+        // uncovered. Pull the container up with a negative margin and grow
+        // its height by the same amount so flex still respects it.
+        margin-top: -6px;
+        height: calc(100% + 6px);
+
         // Butt up against the edge — Win11 caption buttons have no
         // right-margin padding.
         margin-right: -6px;
 
-        --win-caption-hover-bg: rgba(255, 255, 255, 0.0804);
-        --win-caption-press-bg: rgba(255, 255, 255, 0.0536);
+        // Overlay alphas tuned for the AgentMux title-bar surface, which is
+        // noticeably darker than Win11's default Mica. Raw Fluent tokens
+        // (6.05%/4.19%) and even the previous 8%/5.4% bump were too subtle to
+        // perceive on our background; 13%/9% (dark) + 9%/6.5% (light) renders
+        // a distinct hover/press without shifting colour hue.
+        --win-caption-hover-bg: rgba(255, 255, 255, 0.13);
+        --win-caption-press-bg: rgba(255, 255, 255, 0.09);
 
         @media (prefers-color-scheme: light) {
-            --win-caption-hover-bg: rgba(0, 0, 0, 0.0604);
-            --win-caption-press-bg: rgba(0, 0, 0, 0.0402);
+            --win-caption-hover-bg: rgba(0, 0, 0, 0.09);
+            --win-caption-press-bg: rgba(0, 0, 0, 0.065);
         }
 
         .window-action-btn {

--- a/frontend/app/window/system-status.scss
+++ b/frontend/app/window/system-status.scss
@@ -20,33 +20,41 @@
     // Windows 11 standard caption buttons. Dimensions, hit area, and hover
     // treatment match the Win11 Fluent / Mica design tokens used by Explorer,
     // Edge, Terminal, and VS Code's custom-titlebar mode:
-    //   - 46×height hit area, tiled edge to edge (no gap)
+    //   - 46×(full title-bar height) hit area, tiled edge to edge
     //   - 10×10 glyph centered
     //   - Minimize/Maximize hover/press: theme-relative neutral overlay
     //     (via --win-caption-hover-bg / --win-caption-press-bg below)
     //   - Close hover:         solid #c42b1c red with white glyph
     //   - Close press:         #b7201b slightly darker
     //
-    // The caption-button overlay opacities come from the Fluent
-    // surface-background-hover (0.0605) / surface-background-pressed
-    // (0.0419) tokens. We default to the dark-theme values (white overlay)
-    // and override for light via prefers-color-scheme so the hover stays
-    // visible on both themes — the previous `opacity: 0.7` attempt only
-    // dimmed the glyph, which vanished against a light bar.
+    // Overlay alphas are bumped slightly from the raw Fluent tokens
+    // (0.0605 / 0.0419 dark, 0.0373 / 0.0241 light) to 0.08 / 0.054 dark
+    // and 0.06 / 0.04 light because the AgentMux title bar uses a darker
+    // surface than the Win11 Mica default — the raw Fluent values are
+    // nearly invisible on our background. Close button's red hover stays
+    // the exact OS value (#c42b1c / #b7201b) since it's brand-colour, not
+    // surface-relative.
     .window-action-buttons {
         display: flex;
         flex-direction: row;
+        // Fill the full title-bar height so the 46-px-wide button tiles render
+        // as full-height rectangles (like real Win11 caption buttons). Without
+        // `align-self: stretch`, the parent `.system-status`'s `align-items:
+        // center` collapses this container to icon size and the hover backgrounds
+        // only paint a tiny box.
+        align-self: stretch;
         align-items: stretch;
+
         // Butt up against the edge — Win11 caption buttons have no
         // right-margin padding.
         margin-right: -6px;
 
-        --win-caption-hover-bg: rgba(255, 255, 255, 0.0605);
-        --win-caption-press-bg: rgba(255, 255, 255, 0.0419);
+        --win-caption-hover-bg: rgba(255, 255, 255, 0.0804);
+        --win-caption-press-bg: rgba(255, 255, 255, 0.0536);
 
         @media (prefers-color-scheme: light) {
-            --win-caption-hover-bg: rgba(0, 0, 0, 0.0373);
-            --win-caption-press-bg: rgba(0, 0, 0, 0.0241);
+            --win-caption-hover-bg: rgba(0, 0, 0, 0.0604);
+            --win-caption-press-bg: rgba(0, 0, 0, 0.0402);
         }
 
         .window-action-btn {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.247",
+  "version": "0.33.248",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.247",
+      "version": "0.33.248",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.248",
+  "version": "0.33.249",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.248",
+      "version": "0.33.249",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.247",
+  "version": "0.33.248",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.248",
+  "version": "0.33.249",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Fixes two reports against #427:

1. **Red hover only covers a small rectangle on the close button.** Cause: the parent `.system-status` uses `align-items: center`, so `.window-action-buttons` collapsed to icon-content height. Buttons' `height: 100%` then resolved to the icon height (~10px), not the title-bar height (33px), so hover backgrounds painted tiny rectangles. **Fix:** `align-self: stretch` on the container + `align-items: stretch` on its flex children so each button fills the full 46 × title-bar-height region the user actually points at.

2. **No visible hover on minimize / maximize.** Cause: the raw Fluent `surface-background-hover` token (6.05% white) is nearly invisible on AgentMux's darker-than-Mica title bar. **Fix:** bumped the overlay alphas to 8% / 5.4% dark and 6% / 4% light — still a subtle neutral overlay (no colour tint), but perceptible on our actual surface. Close button's `#c42b1c` red stays the exact OS value since it's brand-colour, not surface-relative.

## Test plan

- [ ] `task dev` on this branch, hover close → whole 46×title-bar red fills, white glyph.
- [ ] Hover minimize / maximize → neutral overlay visible.
- [ ] Light-theme override (`prefers-color-scheme: light`) → black overlay instead of white.

Follow-up to #427.
