### PR TITLE
chore(backend): remove dead ChangeTabPinning RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.253"
+version = "0.33.254"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.253"
+version = "0.33.254"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.253"
+version = "0.33.254"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.253"
+version = "0.33.254"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.253"
+version = "0.33.254"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.253"
+version = "0.33.254"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.253"
+version = "0.33.254"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.253"
+version = "0.33.254"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/service.rs
+++ b/agentmux-srv/src/backend/service.rs
@@ -321,16 +321,6 @@ pub fn get_method_meta(service: &str, method: &str) -> Option<MethodMeta> {
             arg_names: vec![],
             return_desc: Some("icons".into()),
         }),
-        ("workspace", "ChangeTabPinning") => Some(MethodMeta {
-            desc: Some("change tab pinning state".into()),
-            arg_names: vec![
-                "ctx".into(),
-                "workspaceId".into(),
-                "tabId".into(),
-                "pinned".into(),
-            ],
-            return_desc: None,
-        }),
         ("workspace", "UpdateTabIds") => Some(MethodMeta {
             desc: Some("update tab ordering".into()),
             arg_names: vec![

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -803,34 +803,6 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
                 Err(e) => WebReturnType::error(e.to_string()),
             }
         }
-        ("workspace", "ChangeTabPinning") => {
-            let ws_id: String = match service::get_arg(args, 0) {
-                Ok(v) => v,
-                Err(e) => return WebReturnType::error(e),
-            };
-            let tab_id: String = match service::get_arg(args, 1) {
-                Ok(v) => v,
-                Err(e) => return WebReturnType::error(e),
-            };
-            let pinned: bool = match service::get_arg(args, 2) {
-                Ok(v) => v,
-                Err(e) => return WebReturnType::error(e),
-            };
-            match store.must_get::<Workspace>(&ws_id) {
-                Ok(mut ws) => {
-                    ws.pinnedtabids.retain(|id| id != &tab_id);
-                    if pinned {
-                        ws.pinnedtabids.push(tab_id);
-                    }
-                    match store.update(&mut ws) {
-                        Ok(_) => WebReturnType::success_empty(),
-                        Err(e) => WebReturnType::error(e.to_string()),
-                    }
-                }
-                Err(e) => WebReturnType::error(e.to_string()),
-            }
-        }
-
         // ---- UserInputService ----
         ("userinput", "SendUserInputResponse") => {
             // Accept but drop — user input routing not yet wired

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -125,11 +125,6 @@ export const WindowService = new WindowServiceType();
 
 // workspaceservice.WorkspaceService (workspace)
 class WorkspaceServiceType {
-    // @returns object updates
-    ChangeTabPinning(workspaceId: string, tabId: string, pinned: boolean): Promise<void> {
-        return WOS.callBackendService("workspace", "ChangeTabPinning", Array.from(arguments))
-    }
-
     // @returns CloseTabRtn (and object updates)
     CloseTab(workspaceId: string, tabId: string): Promise<CloseTabRtnType> {
         return WOS.callBackendService("workspace", "CloseTab", Array.from(arguments))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.253",
+  "version": "0.33.254",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.253",
+      "version": "0.33.254",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.253",
+  "version": "0.33.254",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Delete the \`ChangeTabPinning\` backend RPC + its frontend service stub. Both were left dead after #429 stripped the pin UI — no caller since PR #429 merged.

**Removed:**
- \`server/service.rs\` — \`workspace/ChangeTabPinning\` handler (mutated \`ws.pinnedtabids\`).
- \`backend/service.rs\` — its \`MethodMeta\` registration.
- \`frontend/app/store/services.ts\` — \`WorkspaceServiceType.ChangeTabPinning\` method.

**Left in place on purpose:**
- \`Workspace.pinnedtabids\` field on \`obj.rs\` — still deserialized from on-disk workspaces. The frontend's one-time migration in \`TabBar.onMount\` (\`UpdateTabIds(wsId, merged, [])\`) drains it into \`tabids\` on first load. Keeping the field preserves pinned tabs from pre-#429 saves.
- \`pinned\` param on \`CreateTab\` / \`pinned_tab_ids\` on \`UpdateTabIds\` — always passed empty/false from the frontend now, but removing them from the RPC signatures is a coordinated change deferred to a follow-up.
- \`wcore/tab.rs\` / \`wcore/dnd.rs\` / \`wcore/window.rs\` pin-aware branches — unreachable but not yet deleted, to keep this PR scope tight.

3 files changed, 43 deletions.

## Test plan
- [ ] \`cargo check\` in \`agentmux-srv\`: clean.
- [ ] \`npx tsc --noEmit\` frontend: clean.
- [ ] No call-sites reference \`ChangeTabPinning\` (verified via grep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)