### PR TITLE
refactor(pane): PaneCloseOps seam + mock-driven close tests + modularization spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.254"
+version = "0.33.255"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.254"
+version = "0.33.255"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.254"
+version = "0.33.255"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.254"
+version = "0.33.255"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.254"
+version = "0.33.255"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -30,6 +30,66 @@ use crate::state::AppState;
 /// would otherwise find and wipe the NEW entry.
 static PANE_LABEL_SEQ: AtomicU64 = AtomicU64::new(1);
 
+/// Abstraction over the CEF-side operations `close()` performs on the host
+/// process. Production implements this over `&Arc<AppState>` and Win32;
+/// tests implement it with a recording mock so the close-path state machine
+/// can be exercised without real CEF/HWNDs.
+///
+/// Kept minimal (just two methods) to avoid a dependency graph that has to
+/// be updated every time `close()` grows. Other ops (`focus`, `resize`, …)
+/// can gain their own traits when they need testing, or graduate to a
+/// unified `PaneCefBridge` once the shape is stable.
+pub trait PaneCloseOps {
+    /// Remove the Browser for this label from the registry. Return its
+    /// outer HWND as a pointer-sized value, or `None` if there is no
+    /// Browser or no HWND. Dropping the Browser Arc is the implementation's
+    /// responsibility — production drops before returning so Chromium's
+    /// refcount isn't held by our scope.
+    fn take_browser_hwnd(&self, label: &str) -> Option<usize>;
+
+    /// Destroy the given HWND. Production calls Win32 `DestroyWindow`.
+    /// Called only with values returned from `take_browser_hwnd`.
+    fn destroy_hwnd(&self, hwnd: usize);
+}
+
+/// Production implementation of `PaneCloseOps` backed by `AppState.browsers`
+/// and Win32 `DestroyWindow`.
+struct AppStateCloseOps<'a>(&'a Arc<AppState>);
+
+impl<'a> PaneCloseOps for AppStateCloseOps<'a> {
+    fn take_browser_hwnd(&self, label: &str) -> Option<usize> {
+        let browser = self.0.browsers.lock().remove(label)?;
+
+        #[cfg(target_os = "windows")]
+        let hwnd = browser.host().and_then(|h| {
+            let wh = h.window_handle();
+            if wh.0.is_null() {
+                None
+            } else {
+                Some(wh.0 as usize)
+            }
+        });
+        #[cfg(not(target_os = "windows"))]
+        let hwnd: Option<usize> = None;
+
+        // Drop our Arc before returning so Chromium's refcount doesn't wait
+        // for the caller's scope to unwind.
+        drop(browser);
+        hwnd
+    }
+
+    fn destroy_hwnd(&self, hwnd: usize) {
+        #[cfg(target_os = "windows")]
+        unsafe {
+            windows_sys::Win32::UI::WindowsAndMessaging::DestroyWindow(hwnd as _);
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            let _ = hwnd;
+        }
+    }
+}
+
 /// Per-pane lifecycle phase. Simplified from the full state machine in
 /// `SPEC_BROWSER_PANE_LIFECYCLE.md` §6 — the pre-create states are handled
 /// by the panes-map-absent sentinel so we only need to distinguish live
@@ -231,6 +291,12 @@ impl BrowserPaneManager {
     /// user expects to persist across close). If beforeunload becomes
     /// important, revisit.
     pub fn close(&self, block_id: &str, state: &Arc<AppState>) {
+        let ops = AppStateCloseOps(state);
+        self.close_with(block_id, &ops);
+    }
+
+    /// The testable body of `close()`. See `PaneCloseOps` for the seam.
+    fn close_with(&self, block_id: &str, ops: &dyn PaneCloseOps) {
         let label = {
             let mut panes = self.panes.lock();
             let entry = match panes.get_mut(block_id) {
@@ -244,32 +310,14 @@ impl BrowserPaneManager {
             entry.label.clone()
         };
 
-        // Remove from state.browsers up front so focus/resize/defocus_all
-        // lookups miss immediately, in addition to the Closing gate.
-        let browser = state.browsers.lock().remove(&label);
+        // Remove from state.browsers and get the HWND in one go. `take_browser_hwnd`
+        // also drops the Browser Arc, so focus/resize/defocus_all lookups miss
+        // immediately in addition to the Closing gate.
+        let hwnd = ops.take_browser_hwnd(&label);
 
-        if let Some(browser) = browser {
-            #[cfg(target_os = "windows")]
-            let hwnd = browser.host().and_then(|h| {
-                let wh = h.window_handle();
-                if wh.0.is_null() {
-                    None
-                } else {
-                    Some(wh.0 as *mut std::ffi::c_void)
-                }
-            });
-
-            // Drop our Arc before DestroyWindow so Chromium's refcount doesn't
-            // have to wait for this scope to exit.
-            drop(browser);
-
-            #[cfg(target_os = "windows")]
-            if let Some(hwnd) = hwnd {
-                unsafe {
-                    windows_sys::Win32::UI::WindowsAndMessaging::DestroyWindow(hwnd as _);
-                }
-                tracing::info!(block_id, label, "pane HWND destroyed");
-            }
+        if let Some(hwnd) = hwnd {
+            ops.destroy_hwnd(hwnd);
+            tracing::info!(block_id, label, "pane HWND destroyed");
         }
 
         // Drop the lifecycle entry now so the block_id can be reused. If CEF
@@ -447,14 +495,61 @@ wrap_task! {
 // ── Tests ───────────────────────────────────────────────────────────────────
 //
 // Covers the non-CEF pieces of `BrowserPaneManager`: the panes map, label
-// sequencing, and lifecycle-state transitions. CEF-touching paths (`create`'s
-// browser_host_create_browser, `close`'s DestroyWindow, Browser clone/drop)
-// need a `PaneCefBridge` trait extraction — deferred to the follow-up PR
-// described in SPEC_BROWSER_PANE_LIFECYCLE_TESTS.md §9.
+// sequencing, lifecycle-state transitions, AND `close()` itself via a
+// mock `PaneCloseOps` (the trait introduced in this PR). Other CEF-touching
+// paths (`create`'s browser_host_create_browser, `focus`'s SetFocus) will
+// get the same treatment as their own traits are extracted — see
+// SPEC_BROWSER_PANE_MODULARIZATION.md §6 for the phased plan.
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Recording mock for `PaneCloseOps`. Tests inspect `taken` and
+    /// `destroyed` to assert what close() did with the browsers it
+    /// was supposed to tear down.
+    struct MockCloseOps {
+        /// label -> fake HWND. Populated before the test to simulate the
+        /// AppState.browsers map.
+        registered: parking_lot::Mutex<HashMap<String, usize>>,
+        /// Labels `close()` asked us to take (in call order).
+        taken: parking_lot::Mutex<Vec<String>>,
+        /// HWNDs `close()` asked us to destroy (in call order).
+        destroyed: parking_lot::Mutex<Vec<usize>>,
+    }
+
+    impl MockCloseOps {
+        fn new() -> Self {
+            Self {
+                registered: parking_lot::Mutex::new(HashMap::new()),
+                taken: parking_lot::Mutex::new(Vec::new()),
+                destroyed: parking_lot::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn register(&self, label: &str, hwnd: usize) {
+            self.registered.lock().insert(label.to_string(), hwnd);
+        }
+
+        fn taken_labels(&self) -> Vec<String> {
+            self.taken.lock().clone()
+        }
+
+        fn destroyed_hwnds(&self) -> Vec<usize> {
+            self.destroyed.lock().clone()
+        }
+    }
+
+    impl PaneCloseOps for MockCloseOps {
+        fn take_browser_hwnd(&self, label: &str) -> Option<usize> {
+            self.taken.lock().push(label.to_string());
+            self.registered.lock().remove(label)
+        }
+
+        fn destroy_hwnd(&self, hwnd: usize) {
+            self.destroyed.lock().push(hwnd);
+        }
+    }
 
     #[test]
     fn new_manager_is_empty() {
@@ -551,5 +646,127 @@ mod tests {
         let m = BrowserPaneManager::new();
         m.test_insert_live("b1", "custom-label-42");
         assert_eq!(m.test_entry_label("b1").as_deref(), Some("custom-label-42"));
+    }
+
+    // ── close_with tests — drive close() through the PaneCloseOps seam ──
+
+    #[test]
+    fn close_with_live_entry_destroys_hwnd_and_drops_entry() {
+        let m = BrowserPaneManager::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+
+        let ops = MockCloseOps::new();
+        ops.register("browser-pane-b1-1", 0xABCD);
+
+        m.close_with("b1", &ops);
+
+        assert_eq!(ops.taken_labels(), vec!["browser-pane-b1-1"]);
+        assert_eq!(ops.destroyed_hwnds(), vec![0xABCD]);
+        assert!(!m.test_has_entry("b1"),
+            "entry must be drained after close_with");
+    }
+
+    #[test]
+    fn close_with_missing_entry_is_noop() {
+        let m = BrowserPaneManager::new();
+
+        let ops = MockCloseOps::new();
+        m.close_with("never-existed", &ops);
+
+        assert!(ops.taken_labels().is_empty(),
+            "take_browser_hwnd must not be called when entry is absent");
+        assert!(ops.destroyed_hwnds().is_empty());
+    }
+
+    #[test]
+    fn close_with_already_closing_is_noop() {
+        // Second close call must not re-enter the CEF ops — that would
+        // double-destroy the HWND and panic.
+        let m = BrowserPaneManager::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        m.test_mark_closing("b1");
+
+        let ops = MockCloseOps::new();
+        ops.register("browser-pane-b1-1", 0xABCD);
+
+        m.close_with("b1", &ops);
+
+        assert!(ops.taken_labels().is_empty(),
+            "already-Closing pane must not call take_browser_hwnd again");
+        assert!(ops.destroyed_hwnds().is_empty(),
+            "already-Closing pane must not call destroy_hwnd again");
+    }
+
+    #[test]
+    fn close_with_unregistered_browser_still_drains_entry() {
+        // If the Browser was already gone from state.browsers (creation
+        // failed, or on_before_close got there first), close_with must
+        // still drop the lifecycle entry so future creates can reuse
+        // the block_id.
+        let m = BrowserPaneManager::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+
+        let ops = MockCloseOps::new(); // no register() — lookup will miss
+
+        m.close_with("b1", &ops);
+
+        assert_eq!(ops.taken_labels(), vec!["browser-pane-b1-1"],
+            "take_browser_hwnd is still called; returns None");
+        assert!(ops.destroyed_hwnds().is_empty(),
+            "destroy_hwnd skipped when no HWND to destroy");
+        assert!(!m.test_has_entry("b1"),
+            "entry is always drained, Browser-present or not");
+    }
+
+    #[test]
+    fn close_with_two_panes_independently() {
+        let m = BrowserPaneManager::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        m.test_insert_live("b2", "browser-pane-b2-2");
+
+        let ops = MockCloseOps::new();
+        ops.register("browser-pane-b1-1", 0x1111);
+        ops.register("browser-pane-b2-2", 0x2222);
+
+        m.close_with("b1", &ops);
+
+        assert!(!m.test_has_entry("b1"));
+        assert!(m.test_has_entry("b2"),
+            "closing b1 must not affect b2's entry");
+        assert_eq!(ops.destroyed_hwnds(), vec![0x1111],
+            "only b1's HWND destroyed, b2 untouched");
+
+        m.close_with("b2", &ops);
+
+        assert!(!m.test_has_entry("b2"));
+        assert_eq!(ops.destroyed_hwnds(), vec![0x1111, 0x2222]);
+    }
+
+    #[test]
+    fn close_with_flips_to_closing_before_calling_ops() {
+        // Verifies the state transition happens BEFORE any CEF-side op.
+        // An ops impl could theoretically observe lifecycle state via
+        // a shared reference — this test proves it'd see Closing by then.
+        struct StateSpyingOps<'a> {
+            m: &'a BrowserPaneManager,
+            state_on_take: parking_lot::Mutex<Option<PaneLifecycle>>,
+        }
+        impl<'a> PaneCloseOps for StateSpyingOps<'a> {
+            fn take_browser_hwnd(&self, _label: &str) -> Option<usize> {
+                *self.state_on_take.lock() = self.m.test_entry_state("b1");
+                None
+            }
+            fn destroy_hwnd(&self, _hwnd: usize) {}
+        }
+
+        let m = BrowserPaneManager::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        assert_eq!(m.test_entry_state("b1"), Some(PaneLifecycle::Live));
+
+        let ops = StateSpyingOps { m: &m, state_on_take: parking_lot::Mutex::new(None) };
+        m.close_with("b1", &ops);
+
+        assert_eq!(*ops.state_on_take.lock(), Some(PaneLifecycle::Closing),
+            "state must be Closing by the time take_browser_hwnd runs");
     }
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.254"
+version = "0.33.255"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.254"
+version = "0.33.255"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.254"
+version = "0.33.255"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md
+++ b/docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md
@@ -1,0 +1,241 @@
+# SPEC: Browser Pane Code Modularization
+
+Status: draft
+Date: 2026-04-18
+Owner: AgentA
+Motivation: `browser_panes.rs` is 475 lines with four distinct concerns
+(lifecycle state, CEF client integration, Win32 HWND ops, UI-thread task),
+and it tangles with `client.rs` via a true cycle. The pane-related code
+has already been edited 4 times in 48 hours; every edit threads through
+the same tight coupling. Modularization pays for itself if it makes the
+next edit isolated.
+
+## 1. Current dependency graph (post-#432 main)
+
+Actual edges observed via grep, not the static-analysis false positives:
+
+```
+ipc.rs       ──────────────► state.rs
+                                │
+                                ├─ browsers: HashMap<Label, Browser>
+                                ├─ browser_panes: BrowserPaneManager
+                                ├─ window_meta, window_id_map, …
+                                └─ pending_window_labels
+
+browser_panes.rs ─► state::AppState  (input to every method)
+browser_panes.rs ─► client::{AgentMuxHandler, AgentMuxClient, ALLOW_PANE_FOCUS_ONCE}
+browser_panes.rs ─► commands::window::find_own_top_level_window
+
+client.rs        ─► state::{AppState, WindowKind}
+client.rs        ─► state.browser_panes.drain_closed_label(lbl)   ◄── CYCLE
+                                                                  (through AppState field)
+
+commands/window ─► client::dlog                   (one-way, utility ref)
+commands/window ─► ui_tasks, state, events        (one-way, normal)
+
+commands/providers ─► state::AppState            (one-way)
+```
+
+### True cycles
+
+Exactly **one** real cycle exists:
+
+```
+browser_panes.rs ◄──► client.rs
+```
+
+- `browser_panes.rs` imports `client::AgentMuxHandler` (builds the pane's
+  CEF client inside `CreatePaneTask`) and `client::ALLOW_PANE_FOCUS_ONCE`
+  (the focus-redirect bypass flag used by `BrowserPaneManager::focus`).
+- `client.rs` calls `self.state.browser_panes.drain_closed_label(lbl)` in
+  `on_before_close` so a CEF-initiated pane teardown can clean up the
+  lifecycle map.
+
+Everything else the user flagged as "browser_panes ↔ window / state /
+providers / ipc" is one-way composition through `AppState` — that's the
+normal pattern for a shared state object and not actually cyclic at the
+module-import level. Worth tidying but not the core issue.
+
+### Why this cycle matters
+
+- The cycle forces every edit to `BrowserPaneManager` to reach into
+  `client.rs` internals (pane-handler construction, focus-redirect flag).
+- Pane-specific callback logic lives in `client.rs` (the `on_before_close`
+  pane branch, `install_pane_focus_redirect`, `ALLOW_PANE_FOCUS_ONCE`), so
+  reading "how panes work" means opening both files.
+- The last four lifecycle bugs each needed edits to both files.
+
+## 2. Concerns tangled in `browser_panes.rs` today
+
+1. **Lifecycle state** — `PaneEntry { label, state: Live|Closing }`,
+   `PANE_LABEL_SEQ`, the `panes` mutex-map, `drain_closed_label`. Pure
+   data structures; no CEF, no Win32.
+2. **CEF browser ops** — `close()`'s refcount drop, `navigate`'s
+   `load_url`, `go_back/forward/reload`, `defocus_all`, `focus`.
+3. **Win32 HWND ops** — `DestroyWindow`, `SetWindowPos`, `SetFocus`,
+   `notify_move_or_resize_started`. Pure OS, Windows-only.
+4. **UI-thread pane creation** — `CreatePaneTask`: `find_own_top_level_window`,
+   `browser_host_create_browser`, `WindowInfo::set_as_child`, the
+   pane client construction via `AgentMuxHandler::new_with_pane`.
+
+Four concerns, one file. The `PaneCloseOps` trait I just introduced is the
+first step toward splitting concern #2 from concerns #3 and #4 — this spec
+proposes the rest.
+
+## 3. Proposed layout
+
+```
+agentmux-cef/src/pane/
+├── mod.rs              — re-exports the public surface
+├── lifecycle.rs        — PaneEntry, PaneLifecycle, PANE_LABEL_SEQ,
+│                         the state-machine methods (register_live,
+│                         mark_closing, drain, is_closing, …).
+│                         NO CEF, NO Win32. Fully unit-testable today.
+├── manager.rs          — BrowserPaneManager: the orchestration layer.
+│                         Threads state machine + ops + hwnd calls.
+│                         Re-exports the public create/close/navigate/… API
+│                         that ipc.rs calls today.
+├── ops.rs              — PaneCloseOps trait + AppStateCloseOps production
+│                         impl (extend to PaneNavigateOps, PaneFocusOps
+│                         as ops grow tests).
+├── hwnd.rs             — #[cfg(target_os = "windows")] helpers:
+│                         destroy_hwnd(), set_focus_hwnd(),
+│                         reposition_hwnd(), install_pane_focus_redirect(),
+│                         ALLOW_PANE_FOCUS_ONCE static, PANE_WNDPROCS map.
+│                         Moves from client.rs:1000-1138.
+├── creation.rs         — CreatePaneTask. Still needs to import
+│                         AgentMuxHandler + AgentMuxClient from client —
+│                         that stays as a one-way dep, not a cycle
+│                         (manager.rs no longer needs client for this).
+└── callbacks.rs        — Pane-specific CEF callback bodies that today
+                          live inline in client.rs:
+                            • on_after_created pane branch (z-order raise)
+                            • on_before_close pane branch (drain_closed_label)
+                            • on_set_focus pane cancel
+                            • on_load_end pane skip-IPC
+                          Exposed as free functions `client.rs` calls.
+```
+
+Old `browser_panes.rs` becomes a thin re-export shim for one release
+(`pub use crate::pane::*;`) so external call sites (`ipc.rs`,
+`state.rs`, `client.rs`) don't need to change in the same PR. Delete the
+shim in a follow-up.
+
+## 4. Breaking the cycle
+
+The cycle exists because `client.rs::on_before_close` calls
+`state.browser_panes.drain_closed_label()`. After the split:
+
+- `pane::callbacks::on_before_close_pane(state, browser)` becomes the
+  function `client.rs` calls for the pane branch.
+- The function uses `state.browser_panes.drain_closed_label()` — a
+  one-way import from `pane/callbacks.rs` → `state::AppState` →
+  `pane::manager::BrowserPaneManager`. No edge from manager → client.
+- `client.rs` keeps importing `pane::callbacks`. No edge back.
+
+Result:
+
+```
+client.rs ──► pane::{callbacks, creation}
+pane/     ──► state::AppState
+state.rs  ──► pane::BrowserPaneManager  (composition, one-way)
+```
+
+No cycle.
+
+Similarly, `ALLOW_PANE_FOCUS_ONCE` + `install_pane_focus_redirect` move
+from `client.rs` into `pane::hwnd`. `client.rs` no longer owns any
+pane-specific statics; the `on_set_focus` pane branch in `client.rs`
+just calls `pane::callbacks::on_set_focus_pane(...)` which knows about
+the flag.
+
+## 5. Testability gains
+
+Once the split lands:
+
+- **`pane::lifecycle`** — every test I wrote in #431 lives here natively,
+  no `#[cfg(test)]` helpers needed.
+- **`pane::ops`** — the `PaneCloseOps` pattern from #431 becomes the
+  default shape. Add `PaneNavigateOps`, `PaneFocusOps`, `PaneResizeOps` as
+  needed. Tests target `manager::close_with`, `manager::focus_with`, etc.
+- **`pane::callbacks`** — pure functions taking `&Arc<AppState>` and a
+  small event enum. Easy to drive from integration tests with a
+  `#[cfg(test)]` AppState that uses a mock `browser_panes` manager.
+- **`pane::hwnd`** — can't unit-test Win32 calls, but moves them into one
+  file so "touches OS" is visible at a glance. Integration tests (spec
+  `SPEC_BROWSER_PANE_LIFECYCLE_TESTS.md` L4) cover these.
+
+## 6. Phased delivery
+
+Don't do this as one PR — the diff would hide bugs. Four phases, each
+mergeable independently:
+
+### Phase 1 — lift state machine (no behavior change)
+- New `pane/lifecycle.rs` with `PaneEntry`, `PaneLifecycle`,
+  `PANE_LABEL_SEQ`, `PaneStateMachine` struct.
+- `BrowserPaneManager` holds `state: PaneStateMachine` and delegates the
+  pure-state parts. Public API unchanged.
+- Move `browser_panes/tests` into `pane/lifecycle/tests`.
+- Risk: very low. Pure code motion.
+
+### Phase 2 — lift hwnd helpers
+- New `pane/hwnd.rs`. Move `ALLOW_PANE_FOCUS_ONCE`, `PANE_WNDPROCS`,
+  `install_pane_focus_redirect`, `enum_children` helper, the direct
+  Win32 calls from `browser_panes.rs::{resize, focus}` and
+  `browser_panes.rs::close`.
+- `client.rs` keeps using `ALLOW_PANE_FOCUS_ONCE` via re-export until
+  phase 4 moves the set-focus callback.
+- Risk: medium. Pure motion but touches every Win32 call site.
+
+### Phase 3 — lift CreatePaneTask
+- New `pane/creation.rs`. Contains `CreatePaneTask` + the call to
+  `AgentMuxHandler::new_with_pane` + the `browser_host_create_browser`
+  call.
+- Still depends on `client.rs` (for the handler type) — but only
+  one-way. No cycle.
+- Risk: low. Self-contained chunk.
+
+### Phase 4 — lift pane callbacks, close the cycle
+- New `pane/callbacks.rs` with `on_before_close_pane`, `on_after_created_pane`,
+  `on_set_focus_pane`, `on_load_end_pane`.
+- `client.rs` drops the `if self.is_pane` branches and the inline pane
+  logic; the branches become one-liners that call into `pane::callbacks`.
+- Drop the `ALLOW_PANE_FOCUS_ONCE` re-export from `client.rs`.
+- **Cycle broken here.** `client.rs` has no direct code dependency on
+  `browser_panes` — only on `pane::callbacks` and `pane::creation`.
+- Risk: medium. Subclass-install timing is fiddly; land L3 tests from
+  `SPEC_BROWSER_PANE_LIFECYCLE_TESTS.md` §5.1 before this phase so
+  regressions are caught.
+
+## 7. What not to do
+
+- **Don't introduce a new shared state type** (`PaneContext`, etc.) —
+  just move code around `AppState`. New abstractions invite new call
+  sites.
+- **Don't merge `state.browsers` and `state.window_meta` rewrites into
+  this work.** Those are their own cleanup. Stay focused on the pane
+  split.
+- **Don't delete the old file names in phase 1.** Leave `browser_panes.rs`
+  as a re-export shim until phase 4 is merged. Minimizes merge noise on
+  every in-flight PR.
+
+## 8. Done criteria
+
+- `grep -l "pub use crate::pane::" src/browser_panes.rs` is the only
+  match — the original file is a stub.
+- `client.rs` has no references to `browser_panes`, only to
+  `pane::callbacks` / `pane::creation`.
+- `cargo depgraph --no-externals | grep -c "pane -> client"` = 0.
+- L1+L2+L3 tests from `SPEC_BROWSER_PANE_LIFECYCLE_TESTS.md` all green.
+- Next lifecycle bug (there will be one) can be root-caused by reading
+  only `pane/`, without opening `client.rs`.
+
+## 9. Not in scope
+
+- Modularizing `client.rs` itself (multi-window, drag, Subwindow taskbar
+  grouping logic is intertwined with lifecycle logic). Separate spec.
+- Changing `AppState` ownership. `state.rs` grows; that's a different
+  conversation about when to split into `BrowserState` / `PaneState` /
+  `WindowState`.
+- Moving `commands/window.rs` into a `window/` module. Similar smell,
+  separate follow-up.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.254",
+  "version": "0.33.255",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.254",
+      "version": "0.33.255",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.254",
+  "version": "0.33.255",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Two things in one PR, tightly related:

1. **Refactor `close()` behind a `PaneCloseOps` trait** so the state machine + side-effect sequence can be exercised from unit tests. Production behavior unchanged.
2. **Modularization spec** (\`docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md\`) documenting the one true import cycle in the pane code (\`browser_panes ↔ client\`) and a four-phase plan to split \`browser_panes.rs\` into a \`pane/\` module.

## Why

The last four pane lifecycle bugs (cascade guard, stale IPC focus, orphan-after-DestroyWindow, re-create label collision) each required edits to both \`browser_panes.rs\` and \`client.rs\` because the two files participate in a real import cycle. \`close()\` itself was untestable — it reached straight into \`state.browsers\` and made direct Win32 calls. L1 tests in #431 covered the pure state machine but not the code path that actually orphans content in production.

## The trait

\`\`\`rust
pub trait PaneCloseOps {
    fn take_browser_hwnd(&self, label: &str) -> Option<usize>;
    fn destroy_hwnd(&self, hwnd: usize);
}
\`\`\`

Production \`AppStateCloseOps\` wraps \`&Arc<AppState>\` and runs the current logic. Tests use \`MockCloseOps\` that records calls. \`close(block_id, state)\` is now a two-liner that wraps \`close_with(block_id, &ops)\`. IPC signature unchanged.

## New tests (6)

All driven through \`MockCloseOps\`:

| Test | Invariant |
|---|---|
| \`close_with_live_entry_destroys_hwnd_and_drops_entry\` | happy path: take + destroy + drain |
| \`close_with_missing_entry_is_noop\` | unknown block_id: no ops called |
| \`close_with_already_closing_is_noop\` | **the v0.33.252 class** — double-close doesn't re-destroy |
| \`close_with_unregistered_browser_still_drains_entry\` | Browser gone, entry still drained |
| \`close_with_two_panes_independently\` | isolated state, isolated HWND destruction |
| \`close_with_flips_to_closing_before_calling_ops\` | state-before-side-effect invariant |

Total \`browser_panes::tests\` = 15, runtime < 0.01s.

## Spec

\`docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md\` — reads the actual grep-verified dependency graph, confirms only one cycle exists (most of what user-facing static analysis flagged was one-way composition through \`AppState\`), and lays out a four-phase split into \`pane/{lifecycle, manager, ops, hwnd, creation, callbacks}\`. Phases are independently mergeable so no mega-PR.

## Not in this PR
- The actual module split — spec §6 lays out phases.
- \`PaneFocusOps\` / \`PaneNavigateOps\` / \`PaneResizeOps\` — \`PaneCloseOps\` is the template; add others as each op grows tests.
- Moving \`ALLOW_PANE_FOCUS_ONCE\` + \`install_pane_focus_redirect\` out of \`client.rs\` (spec phase 2).

## Test plan
- [ ] \`cargo test browser_panes::tests\` in \`agentmux-cef/\` — 15/15 pass.
- [ ] \`cargo check\` on \`agentmux-cef\` — clean (19 pre-existing warnings, none new).
- [ ] Smoke: \`task dev\` open a browser pane, close it — behavior unchanged from v0.33.253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)