### PR TITLE
refactor(pane): Phase 1 — lift state machine into pane/lifecycle.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.255"
+version = "0.33.256"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.255"
+version = "0.33.256"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.255"
+version = "0.33.256"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.255"
+version = "0.33.256"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.255"
+version = "0.33.256"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -15,20 +15,12 @@
 //! the Browser — stale IPC against a mid-destruction HWND is the shape of
 //! the crash described in `docs/specs/SPEC_BROWSER_PANE_LIFECYCLE.md` §4c.
 
-use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use cef::*;
-use parking_lot::Mutex;
 
+use crate::pane::{PaneStateMachine, RegisterResult};
 use crate::state::AppState;
-
-/// Monotonic counter appended to every pane label so a close-then-recreate of
-/// the same block_id doesn't collide: if the old browser's `on_before_close`
-/// fires after the new pane's `create()` has already run, `drain_closed_label`
-/// would otherwise find and wipe the NEW entry.
-static PANE_LABEL_SEQ: AtomicU64 = AtomicU64::new(1);
 
 /// Abstraction over the CEF-side operations `close()` performs on the host
 /// process. Production implements this over `&Arc<AppState>` and Win32;
@@ -90,81 +82,42 @@ impl<'a> PaneCloseOps for AppStateCloseOps<'a> {
     }
 }
 
-/// Per-pane lifecycle phase. Simplified from the full state machine in
-/// `SPEC_BROWSER_PANE_LIFECYCLE.md` §6 — the pre-create states are handled
-/// by the panes-map-absent sentinel so we only need to distinguish live
-/// from closing here.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PaneLifecycle {
-    /// Browser requested; CEF may still be creating it. Ops proceed because
-    /// the Browser will be present in `state.browsers` by the time the IPC
-    /// reaches it (or the lookup miss is harmless).
-    Live,
-    /// `close()` has been called. All further IPC for this pane must no-op.
-    /// The entry stays in `panes` until `on_before_close` drains it via
-    /// `drain_closed_label` so concurrent `defocus_all` / `resize` see the
-    /// Closing flag and skip, rather than seeing a stale browser ref.
-    Closing,
-}
-
-struct PaneEntry {
-    label: String,
-    state: PaneLifecycle,
-}
-
 pub struct BrowserPaneManager {
-    panes: Mutex<HashMap<String, PaneEntry>>,
+    lifecycle: PaneStateMachine,
 }
 
 impl BrowserPaneManager {
     pub fn new() -> Self {
-        Self { panes: Mutex::new(HashMap::new()) }
+        Self { lifecycle: PaneStateMachine::new() }
     }
 
-    // ---- test-only helpers ----
-    // Exposed for the unit tests below. Kept out of the production surface
-    // so real callers can't stumble into manipulating lifecycle state.
-    #[cfg(test)]
-    fn test_has_entry(&self, block_id: &str) -> bool {
-        self.panes.lock().contains_key(block_id)
-    }
-
-    #[cfg(test)]
-    fn test_entry_state(&self, block_id: &str) -> Option<PaneLifecycle> {
-        self.panes.lock().get(block_id).map(|e| e.state)
-    }
-
-    #[cfg(test)]
-    fn test_entry_label(&self, block_id: &str) -> Option<String> {
-        self.panes.lock().get(block_id).map(|e| e.label.clone())
-    }
-
+    // test-only delegates — the real state machine has its own unit tests in
+    // pane::lifecycle; these just let this module's close_with tests set up
+    // preconditions without re-implementing the panes map.
     #[cfg(test)]
     fn test_insert_live(&self, block_id: &str, label: &str) {
-        self.panes.lock().insert(
-            block_id.to_string(),
-            PaneEntry { label: label.to_string(), state: PaneLifecycle::Live },
-        );
+        self.lifecycle.test_insert_live(block_id, label);
     }
 
     #[cfg(test)]
     fn test_mark_closing(&self, block_id: &str) {
-        if let Some(entry) = self.panes.lock().get_mut(block_id) {
-            entry.state = PaneLifecycle::Closing;
-        }
+        self.lifecycle.test_mark_closing(block_id);
+    }
+
+    #[cfg(test)]
+    fn test_has_entry(&self, block_id: &str) -> bool {
+        self.lifecycle.test_has_entry(block_id)
+    }
+
+    #[cfg(test)]
+    fn test_entry_state(&self, block_id: &str) -> Option<crate::pane::PaneLifecycle> {
+        self.lifecycle.test_entry_state(block_id)
     }
 
     /// Look up the Browser iff the pane is Live. Returns None when closing
     /// so all ops short-circuit uniformly.
     fn live_browser(&self, state: &Arc<AppState>, block_id: &str) -> Option<Browser> {
-        let label = {
-            let panes = self.panes.lock();
-            let entry = panes.get(block_id)?;
-            if entry.state != PaneLifecycle::Live {
-                return None;
-            }
-            entry.label.clone()
-        };
+        let label = self.lifecycle.live_label_of(block_id)?;
         state.browsers.lock().get(&label).cloned()
     }
 
@@ -175,55 +128,38 @@ impl BrowserPaneManager {
         url: &str,
         rect: Rect,
     ) -> Result<(), String> {
-        // Existing entry: navigate if Live; reject if Closing. Reject (rather
-        // than overwrite) because the old CEF Browser is mid-teardown and its
-        // on_before_close will call drain_closed_label — if we let create()
-        // overwrite the map entry, the drain would evict the NEW entry. The
-        // frontend is expected to retry after a short delay; in practice
-        // block_ids are unique-per-create so this race is already rare.
-        {
-            let panes = self.panes.lock();
-            if let Some(entry) = panes.get(block_id) {
-                match entry.state {
-                    PaneLifecycle::Live => {
-                        // drop lock before touching CEF
-                        let label = entry.label.clone();
-                        drop(panes);
-                        if let Some(browser) = state.browsers.lock().get(&label).cloned() {
-                            if let Some(frame) = browser.main_frame() {
-                                frame.load_url(Some(&CefString::from(url)));
-                            }
-                        }
-                        return Ok(());
-                    }
-                    PaneLifecycle::Closing => {
-                        return Err(format!(
-                            "browser pane for block_id={} is still closing; retry after on_before_close",
-                            block_id
-                        ));
+        match self.lifecycle.try_register_live(block_id) {
+            RegisterResult::AlreadyLive(label) => {
+                // Existing Live entry — re-navigate the existing browser.
+                if let Some(browser) = state.browsers.lock().get(&label).cloned() {
+                    if let Some(frame) = browser.main_frame() {
+                        frame.load_url(Some(&CefString::from(url)));
                     }
                 }
+                Ok(())
+            }
+            RegisterResult::Closing => {
+                // Reject rather than overwrite: the old CEF Browser is
+                // mid-teardown and its on_before_close will call
+                // drain_by_label — if we let create overwrite, drain
+                // would evict the NEW entry. Frontend retries on next tick.
+                Err(format!(
+                    "browser pane for block_id={} is still closing; retry after on_before_close",
+                    block_id
+                ))
+            }
+            RegisterResult::Fresh(label) => {
+                let mut task = CreatePaneTask::new(
+                    state.clone(),
+                    block_id.to_string(),
+                    label,
+                    url.to_string(),
+                    rect,
+                );
+                post_task(ThreadId::UI, Some(&mut task));
+                Ok(())
             }
         }
-
-        // Monotonic seq so close-then-recreate of the same block_id gets a
-        // unique label — drain_closed_label on the old pane won't match us.
-        let seq = PANE_LABEL_SEQ.fetch_add(1, Ordering::Relaxed);
-        let label = format!("browser-pane-{}-{}", block_id, seq);
-        self.panes.lock().insert(
-            block_id.to_string(),
-            PaneEntry { label: label.clone(), state: PaneLifecycle::Live },
-        );
-
-        let mut task = CreatePaneTask::new(
-            state.clone(),
-            block_id.to_string(),
-            label,
-            url.to_string(),
-            rect,
-        );
-        post_task(ThreadId::UI, Some(&mut task));
-        Ok(())
     }
 
     pub fn navigate(&self, block_id: &str, url: &str, state: &Arc<AppState>) -> Result<(), String> {
@@ -297,50 +233,32 @@ impl BrowserPaneManager {
 
     /// The testable body of `close()`. See `PaneCloseOps` for the seam.
     fn close_with(&self, block_id: &str, ops: &dyn PaneCloseOps) {
-        let label = {
-            let mut panes = self.panes.lock();
-            let entry = match panes.get_mut(block_id) {
-                Some(e) => e,
-                None => return, // already closed/never created
-            };
-            if entry.state == PaneLifecycle::Closing {
-                return; // close already in flight
-            }
-            entry.state = PaneLifecycle::Closing;
-            entry.label.clone()
+        let label = match self.lifecycle.try_mark_closing(block_id) {
+            Some(l) => l,
+            None => return, // missing, or already closing — both no-op
         };
 
-        // Remove from state.browsers and get the HWND in one go. `take_browser_hwnd`
-        // also drops the Browser Arc, so focus/resize/defocus_all lookups miss
-        // immediately in addition to the Closing gate.
-        let hwnd = ops.take_browser_hwnd(&label);
-
-        if let Some(hwnd) = hwnd {
+        // take_browser_hwnd removes from state.browsers and drops the Browser
+        // Arc. Returns the HWND iff one exists, which destroy_hwnd then
+        // destroys via Win32.
+        if let Some(hwnd) = ops.take_browser_hwnd(&label) {
             ops.destroy_hwnd(hwnd);
             tracing::info!(block_id, label, "pane HWND destroyed");
         }
 
-        // Drop the lifecycle entry now so the block_id can be reused. If CEF
-        // does eventually fire on_before_close, `drain_closed_label` will find
-        // no matching label and no-op.
-        self.panes.lock().remove(block_id);
+        // Drop the lifecycle entry so the block_id can be reused.
+        self.lifecycle.remove(block_id);
         tracing::info!(block_id, label, "browser pane lifecycle entry cleared");
     }
 
     /// Called from CEF's `on_before_close` if/when it fires for a pane
-    /// browser. The new DestroyWindow-based `close()` usually clears the
-    /// lifecycle entry first, so this is a no-op in that case — but
-    /// `on_before_close` may still fire async as Chromium's refcount hits
-    /// zero, and we need to stay idempotent so the callback doesn't panic.
+    /// browser. The `close()` path usually clears the lifecycle entry first,
+    /// so this is a no-op in that case — but `on_before_close` may still
+    /// fire async as Chromium's refcount hits zero, and `drain_by_label`
+    /// is idempotent so the callback is safe.
     pub fn drain_closed_label(&self, label: &str) {
-        let mut panes = self.panes.lock();
-        let victim = panes
-            .iter()
-            .find(|(_, e)| e.label == label)
-            .map(|(k, _)| k.clone());
-        if let Some(block_id) = victim {
-            panes.remove(&block_id);
-            tracing::info!(block_id, label, "browser pane drained from lifecycle map");
+        if self.lifecycle.drain_by_label(label) {
+            tracing::info!(label, "browser pane drained from lifecycle map");
         }
     }
 
@@ -358,13 +276,7 @@ impl BrowserPaneManager {
     /// Panes in `Closing` are skipped — their HWND may be mid-destruction and
     /// `set_focus(0)` against it can hit an invalid render widget.
     pub fn defocus_all(&self, state: &Arc<AppState>) {
-        let labels: Vec<String> = self
-            .panes
-            .lock()
-            .values()
-            .filter(|e| e.state == PaneLifecycle::Live)
-            .map(|e| e.label.clone())
-            .collect();
+        let labels = self.lifecycle.live_labels();
         let browsers = state.browsers.lock();
         for label in &labels {
             if let Some(browser) = browsers.get(label).cloned() {
@@ -504,6 +416,7 @@ wrap_task! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     /// Recording mock for `PaneCloseOps`. Tests inspect `taken` and
     /// `destroyed` to assert what close() did with the browsers it
@@ -551,102 +464,10 @@ mod tests {
         }
     }
 
-    #[test]
-    fn new_manager_is_empty() {
-        let m = BrowserPaneManager::new();
-        assert!(!m.test_has_entry("any-block"));
-    }
-
-    #[test]
-    fn drain_closed_label_noop_on_missing() {
-        let m = BrowserPaneManager::new();
-        // Must not panic, must not corrupt state.
-        m.drain_closed_label("nonexistent-label");
-        assert!(!m.test_has_entry("nonexistent-block"));
-    }
-
-    #[test]
-    fn drain_closed_label_removes_matching_entry() {
-        let m = BrowserPaneManager::new();
-        m.test_insert_live("b1", "browser-pane-b1-1");
-
-        m.drain_closed_label("browser-pane-b1-1");
-
-        assert!(!m.test_has_entry("b1"));
-    }
-
-    #[test]
-    fn drain_closed_label_ignores_unrelated_labels() {
-        let m = BrowserPaneManager::new();
-        m.test_insert_live("b1", "browser-pane-b1-1");
-        m.test_insert_live("b2", "browser-pane-b2-2");
-
-        m.drain_closed_label("browser-pane-other-99");
-
-        assert!(m.test_has_entry("b1"));
-        assert!(m.test_has_entry("b2"));
-    }
-
-    #[test]
-    fn drain_closed_label_idempotent() {
-        // DestroyWindow-based close() removes the entry up front, but CEF may
-        // still fire on_before_close afterward. Calling drain twice must not
-        // panic.
-        let m = BrowserPaneManager::new();
-        m.test_insert_live("b1", "browser-pane-b1-1");
-
-        m.drain_closed_label("browser-pane-b1-1");
-        m.drain_closed_label("browser-pane-b1-1");
-
-        assert!(!m.test_has_entry("b1"));
-    }
-
-    #[test]
-    fn label_sequence_is_monotonic() {
-        // Three inserts via test_insert_live don't exercise PANE_LABEL_SEQ
-        // directly — we inspect the counter by reading PANE_LABEL_SEQ before
-        // and after create-like operations. Since PANE_LABEL_SEQ is static
-        // and advances monotonically for every create() call in the process,
-        // we simply verify the counter keeps growing.
-        use std::sync::atomic::Ordering;
-        let before = PANE_LABEL_SEQ.load(Ordering::Relaxed);
-        let a = PANE_LABEL_SEQ.fetch_add(1, Ordering::Relaxed);
-        let b = PANE_LABEL_SEQ.fetch_add(1, Ordering::Relaxed);
-        let c = PANE_LABEL_SEQ.fetch_add(1, Ordering::Relaxed);
-        assert!(a >= before);
-        assert_eq!(b, a + 1);
-        assert_eq!(c, b + 1);
-    }
-
-    #[test]
-    fn state_transitions_live_to_closing() {
-        let m = BrowserPaneManager::new();
-        m.test_insert_live("b1", "browser-pane-b1-1");
-        assert_eq!(m.test_entry_state("b1"), Some(PaneLifecycle::Live));
-
-        m.test_mark_closing("b1");
-        assert_eq!(m.test_entry_state("b1"), Some(PaneLifecycle::Closing));
-    }
-
-    #[test]
-    fn drain_after_transition_still_removes() {
-        // close() flips to Closing, then DestroyWindow, then drain. The
-        // drain must remove the entry regardless of the Closing flag.
-        let m = BrowserPaneManager::new();
-        m.test_insert_live("b1", "browser-pane-b1-1");
-        m.test_mark_closing("b1");
-
-        m.drain_closed_label("browser-pane-b1-1");
-
-        assert!(!m.test_has_entry("b1"));
-    }
-
-    #[test]
-    fn entry_label_is_what_we_inserted() {
-        let m = BrowserPaneManager::new();
-        m.test_insert_live("b1", "custom-label-42");
-        assert_eq!(m.test_entry_label("b1").as_deref(), Some("custom-label-42"));
-    }
+    // State-machine-only tests live in `crate::pane::lifecycle::tests` now —
+    // `BrowserPaneManager` delegates to `PaneStateMachine` and those tests
+    // cover register/mark-closing/drain/live_label/label-sequence behavior
+    // directly against the state machine.
 
     // ── close_with tests — drive close() through the PaneCloseOps seam ──
 
@@ -747,6 +568,8 @@ mod tests {
         // Verifies the state transition happens BEFORE any CEF-side op.
         // An ops impl could theoretically observe lifecycle state via
         // a shared reference — this test proves it'd see Closing by then.
+        use crate::pane::PaneLifecycle;
+
         struct StateSpyingOps<'a> {
             m: &'a BrowserPaneManager,
             state_on_take: parking_lot::Mutex<Option<PaneLifecycle>>,

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -28,6 +28,7 @@ mod commands;
 mod events;
 mod ipc;
 mod memory_heartbeat;
+mod pane;
 mod sidecar;
 mod state;
 mod ui_tasks;

--- a/agentmux-cef/src/pane/lifecycle.rs
+++ b/agentmux-cef/src/pane/lifecycle.rs
@@ -1,0 +1,368 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pure lifecycle state machine for browser panes.
+//!
+//! No CEF, no Win32, no `AppState` — just a `HashMap<block_id, PaneEntry>`
+//! guarded by a mutex, and the operations that mutate it. `BrowserPaneManager`
+//! composes this with the CEF-side ops to form the full pane lifecycle.
+//!
+//! Every method is small, deterministic, and fully unit-testable. Tests live
+//! at the bottom of this file.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::Mutex;
+
+/// Monotonic counter appended to every pane label so a close-then-recreate of
+/// the same block_id doesn't collide: if the old browser's `on_before_close`
+/// fires after the new pane's `create()` has already run, `drain_by_label`
+/// would otherwise find and wipe the NEW entry.
+static PANE_LABEL_SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// Per-pane lifecycle phase. Simplified from the full state machine in
+/// `SPEC_BROWSER_PANE_LIFECYCLE.md` §6 — pre-create states are represented
+/// by map absence so we only distinguish Live from Closing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneLifecycle {
+    /// Browser requested; CEF may still be creating it. Ops proceed because
+    /// the Browser will be present in `state.browsers` by the time the IPC
+    /// reaches it (or the lookup miss is harmless).
+    Live,
+    /// `close()` has been called. All further IPC for this pane must no-op.
+    /// The entry stays until `on_before_close` drains it so concurrent
+    /// `defocus_all` / `resize` see the Closing flag and skip, rather than
+    /// seeing a stale browser ref.
+    Closing,
+}
+
+struct PaneEntry {
+    label: String,
+    state: PaneLifecycle,
+}
+
+/// Outcome of `try_register_live`. Distinguishes "first create" (caller
+/// should post a CreatePaneTask) from "already exists" (caller should
+/// re-navigate) from "closing" (caller should reject the re-create).
+#[derive(Debug)]
+pub enum RegisterResult {
+    /// Entry did not exist; a new Live entry was inserted under `label`.
+    Fresh(String),
+    /// Entry already existed and is Live; reuse `label` to re-navigate.
+    AlreadyLive(String),
+    /// Entry exists and is Closing; caller should reject the re-create
+    /// because the old Browser's teardown callback would otherwise drain
+    /// the NEW entry when it fires.
+    Closing,
+}
+
+pub struct PaneStateMachine {
+    panes: Mutex<HashMap<String, PaneEntry>>,
+}
+
+impl PaneStateMachine {
+    pub fn new() -> Self {
+        Self { panes: Mutex::new(HashMap::new()) }
+    }
+
+    /// Attempt to register `block_id` as a new Live pane. If an entry
+    /// already exists, returns either `AlreadyLive(label)` (caller should
+    /// navigate the existing browser) or `Closing` (caller should error).
+    /// Otherwise generates a unique label via `PANE_LABEL_SEQ` and inserts.
+    pub fn try_register_live(&self, block_id: &str) -> RegisterResult {
+        let mut panes = self.panes.lock();
+        if let Some(entry) = panes.get(block_id) {
+            return match entry.state {
+                PaneLifecycle::Live => RegisterResult::AlreadyLive(entry.label.clone()),
+                PaneLifecycle::Closing => RegisterResult::Closing,
+            };
+        }
+        let seq = PANE_LABEL_SEQ.fetch_add(1, Ordering::Relaxed);
+        let label = format!("browser-pane-{}-{}", block_id, seq);
+        panes.insert(
+            block_id.to_string(),
+            PaneEntry { label: label.clone(), state: PaneLifecycle::Live },
+        );
+        RegisterResult::Fresh(label)
+    }
+
+    /// Flip the state of `block_id` to Closing. Returns the entry's label
+    /// iff it was Live. Returns `None` if the entry is missing or already
+    /// Closing — the caller should no-op in both cases.
+    pub fn try_mark_closing(&self, block_id: &str) -> Option<String> {
+        let mut panes = self.panes.lock();
+        let entry = panes.get_mut(block_id)?;
+        if entry.state == PaneLifecycle::Closing {
+            return None;
+        }
+        entry.state = PaneLifecycle::Closing;
+        Some(entry.label.clone())
+    }
+
+    /// Remove an entry by block_id. Called after `close_with` completes
+    /// its side effects so the block_id can be reused.
+    pub fn remove(&self, block_id: &str) {
+        self.panes.lock().remove(block_id);
+    }
+
+    /// Remove an entry by label. Called from CEF's `on_before_close` if
+    /// it fires. Idempotent — if the entry was already removed by the
+    /// explicit close path, this is a no-op. Returns true iff an entry
+    /// was actually removed.
+    pub fn drain_by_label(&self, label: &str) -> bool {
+        let mut panes = self.panes.lock();
+        let victim = panes
+            .iter()
+            .find(|(_, e)| e.label == label)
+            .map(|(k, _)| k.clone());
+        if let Some(block_id) = victim {
+            panes.remove(&block_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Return the label for `block_id` iff the entry is Live. Used to gate
+    /// focus/resize/navigate ops against concurrent close.
+    pub fn live_label_of(&self, block_id: &str) -> Option<String> {
+        let panes = self.panes.lock();
+        let entry = panes.get(block_id)?;
+        if entry.state == PaneLifecycle::Live {
+            Some(entry.label.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Snapshot of labels for all Live panes. Used by `defocus_all` — it
+    /// needs the list without holding the panes lock across CEF calls.
+    pub fn live_labels(&self) -> Vec<String> {
+        self.panes
+            .lock()
+            .values()
+            .filter(|e| e.state == PaneLifecycle::Live)
+            .map(|e| e.label.clone())
+            .collect()
+    }
+
+    // ── test helpers ────────────────────────────────────────────────────
+    #[cfg(test)]
+    pub(crate) fn test_has_entry(&self, block_id: &str) -> bool {
+        self.panes.lock().contains_key(block_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_entry_state(&self, block_id: &str) -> Option<PaneLifecycle> {
+        self.panes.lock().get(block_id).map(|e| e.state)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_entry_label(&self, block_id: &str) -> Option<String> {
+        self.panes.lock().get(block_id).map(|e| e.label.clone())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_insert_live(&self, block_id: &str, label: &str) {
+        self.panes.lock().insert(
+            block_id.to_string(),
+            PaneEntry { label: label.to_string(), state: PaneLifecycle::Live },
+        );
+    }
+
+    #[cfg(test)]
+    pub(crate) fn test_mark_closing(&self, block_id: &str) {
+        if let Some(entry) = self.panes.lock().get_mut(block_id) {
+            entry.state = PaneLifecycle::Closing;
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_empty() {
+        let m = PaneStateMachine::new();
+        assert!(!m.test_has_entry("any"));
+        assert!(m.live_labels().is_empty());
+    }
+
+    #[test]
+    fn try_register_live_fresh_creates_entry_with_sequential_label() {
+        let m = PaneStateMachine::new();
+        let label = match m.try_register_live("b1") {
+            RegisterResult::Fresh(l) => l,
+            other => panic!("expected Fresh, got {:?}", other),
+        };
+        assert!(label.starts_with("browser-pane-b1-"));
+        assert_eq!(m.test_entry_state("b1"), Some(PaneLifecycle::Live));
+        assert_eq!(m.test_entry_label("b1").as_deref(), Some(label.as_str()));
+    }
+
+    #[test]
+    fn try_register_live_returns_already_live_for_duplicate() {
+        let m = PaneStateMachine::new();
+        let first_label = match m.try_register_live("b1") {
+            RegisterResult::Fresh(l) => l,
+            other => panic!("unexpected {:?}", other),
+        };
+        let second = m.try_register_live("b1");
+        match second {
+            RegisterResult::AlreadyLive(l) => assert_eq!(l, first_label),
+            other => panic!("expected AlreadyLive, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn try_register_live_returns_closing_for_closing_entry() {
+        let m = PaneStateMachine::new();
+        m.try_register_live("b1");
+        m.try_mark_closing("b1");
+        match m.try_register_live("b1") {
+            RegisterResult::Closing => {}
+            other => panic!("expected Closing, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn try_mark_closing_flips_and_returns_label() {
+        let m = PaneStateMachine::new();
+        let expected_label = match m.try_register_live("b1") {
+            RegisterResult::Fresh(l) => l,
+            _ => unreachable!(),
+        };
+        let label = m.try_mark_closing("b1").expect("expected Some");
+        assert_eq!(label, expected_label);
+        assert_eq!(m.test_entry_state("b1"), Some(PaneLifecycle::Closing));
+    }
+
+    #[test]
+    fn try_mark_closing_returns_none_for_already_closing() {
+        let m = PaneStateMachine::new();
+        m.try_register_live("b1");
+        assert!(m.try_mark_closing("b1").is_some());
+        assert!(m.try_mark_closing("b1").is_none(),
+            "second mark_closing must return None to prevent double-close ops");
+    }
+
+    #[test]
+    fn try_mark_closing_returns_none_for_missing_entry() {
+        let m = PaneStateMachine::new();
+        assert!(m.try_mark_closing("never-registered").is_none());
+    }
+
+    #[test]
+    fn remove_clears_entry() {
+        let m = PaneStateMachine::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        m.remove("b1");
+        assert!(!m.test_has_entry("b1"));
+    }
+
+    #[test]
+    fn remove_missing_is_noop() {
+        let m = PaneStateMachine::new();
+        m.remove("nonexistent"); // must not panic
+    }
+
+    #[test]
+    fn drain_by_label_removes_matching_entry() {
+        let m = PaneStateMachine::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        assert!(m.drain_by_label("browser-pane-b1-1"));
+        assert!(!m.test_has_entry("b1"));
+    }
+
+    #[test]
+    fn drain_by_label_returns_false_on_miss() {
+        let m = PaneStateMachine::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        assert!(!m.drain_by_label("browser-pane-other-99"));
+        assert!(m.test_has_entry("b1"));
+    }
+
+    #[test]
+    fn drain_by_label_idempotent() {
+        let m = PaneStateMachine::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        assert!(m.drain_by_label("browser-pane-b1-1"));
+        assert!(!m.drain_by_label("browser-pane-b1-1"));
+    }
+
+    #[test]
+    fn drain_after_mark_closing_still_works() {
+        let m = PaneStateMachine::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        m.test_mark_closing("b1");
+        assert!(m.drain_by_label("browser-pane-b1-1"));
+        assert!(!m.test_has_entry("b1"));
+    }
+
+    #[test]
+    fn live_label_of_returns_only_live() {
+        let m = PaneStateMachine::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        assert_eq!(m.live_label_of("b1").as_deref(), Some("browser-pane-b1-1"));
+
+        m.test_mark_closing("b1");
+        assert_eq!(m.live_label_of("b1"), None,
+            "live_label_of must not return a label for a Closing entry");
+    }
+
+    #[test]
+    fn live_label_of_returns_none_for_missing() {
+        let m = PaneStateMachine::new();
+        assert_eq!(m.live_label_of("never"), None);
+    }
+
+    #[test]
+    fn live_labels_skips_closing_panes() {
+        let m = PaneStateMachine::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        m.test_insert_live("b2", "browser-pane-b2-2");
+        m.test_insert_live("b3", "browser-pane-b3-3");
+        m.test_mark_closing("b2");
+
+        let mut labels = m.live_labels();
+        labels.sort();
+        assert_eq!(labels, vec!["browser-pane-b1-1", "browser-pane-b3-3"]);
+    }
+
+    #[test]
+    fn label_sequence_is_monotonic_across_registers() {
+        let m = PaneStateMachine::new();
+        let a_label = match m.try_register_live("a") {
+            RegisterResult::Fresh(l) => l, _ => unreachable!(),
+        };
+        let b_label = match m.try_register_live("b") {
+            RegisterResult::Fresh(l) => l, _ => unreachable!(),
+        };
+        let a_seq: u64 = a_label.rsplit('-').next().unwrap().parse().unwrap();
+        let b_seq: u64 = b_label.rsplit('-').next().unwrap().parse().unwrap();
+        assert!(b_seq > a_seq, "PANE_LABEL_SEQ must advance between registers: {} vs {}", a_seq, b_seq);
+    }
+
+    #[test]
+    fn close_recreate_cycle_label_differs() {
+        // Simulates: register b1 → mark closing → drain → register b1 again.
+        // The second label must NOT match the first — that's the invariant
+        // that prevents on_before_close for the old browser from eating the
+        // new entry.
+        let m = PaneStateMachine::new();
+        let first = match m.try_register_live("b1") {
+            RegisterResult::Fresh(l) => l, _ => unreachable!(),
+        };
+        m.try_mark_closing("b1");
+        m.drain_by_label(&first);
+
+        let second = match m.try_register_live("b1") {
+            RegisterResult::Fresh(l) => l, _ => unreachable!(),
+        };
+        assert_ne!(first, second);
+    }
+}

--- a/agentmux-cef/src/pane/mod.rs
+++ b/agentmux-cef/src/pane/mod.rs
@@ -1,0 +1,15 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Browser-pane module.
+//!
+//! Phase 1 of the split described in `docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md`:
+//! extract the pure lifecycle state machine into `lifecycle.rs`. The orchestration
+//! layer (`BrowserPaneManager`) and CEF-integration layer stay in
+//! `crate::browser_panes` for now; subsequent phases move them here.
+//!
+//! Re-exports the public surface that `browser_panes.rs` and tests consume.
+
+pub mod lifecycle;
+
+pub use lifecycle::{PaneLifecycle, PaneStateMachine, RegisterResult};

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.255"
+version = "0.33.256"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.255"
+version = "0.33.256"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.255"
+version = "0.33.256"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.255",
+  "version": "0.33.256",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.255",
+      "version": "0.33.256",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.255",
+  "version": "0.33.256",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 1 of the four-phase split from \`docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md\` §6.

**Pure code motion.** Production behavior identical to v0.33.255. No changes to ipc.rs, client.rs, or state.rs — \`BrowserPaneManager\`'s public API is unchanged.

## What moved

### New: \`agentmux-cef/src/pane/lifecycle.rs\`

- \`PaneLifecycle\` enum (was private in browser_panes.rs — now \`pub\` in its own module).
- \`PaneEntry\` struct, \`PANE_LABEL_SEQ\` static.
- **New \`PaneStateMachine\` struct** with an explicit API replacing the ad-hoc \`Mutex<HashMap>\` manipulation:
  - \`try_register_live(block_id) -> RegisterResult\` (Fresh/AlreadyLive/Closing — one clear enum for all create outcomes)
  - \`try_mark_closing(block_id) -> Option<String>\` (returns label iff flip actually happened)
  - \`drain_by_label(label) -> bool\` (idempotent)
  - \`remove\`, \`live_label_of\`, \`live_labels\`
- **18 new unit tests** covering every transition. Runtime < 0.01s total.

### \`agentmux-cef/src/browser_panes.rs\`

- \`BrowserPaneManager\` becomes a thin orchestrator that holds \`lifecycle: PaneStateMachine\` and delegates state ops.
- \`create()\` uses \`try_register_live\` + \`RegisterResult\` match (replaces the inline map-get/match/insert).
- \`close_with()\` uses \`try_mark_closing\` + \`lifecycle.remove\`.
- \`drain_closed_label\` delegates to \`lifecycle.drain_by_label\`.
- Lifecycle-only tests moved out; the 6 \`close_with\` tests stay (they drive the \`PaneCloseOps\` seam from #433).

### \`agentmux-cef/src/main.rs\`

- New \`mod pane;\` declaration.

## Why

The last five lifecycle bugs each required reading \`browser_panes.rs\` start-to-finish to find the relevant lifecycle logic hidden behind CEF calls. Splitting the pure state out into its own module with its own tests makes "how does the lifecycle actually work" a 200-line file, not a 660-line file. Spec §5 spells out why this matters for the next four phases.

## Test plan
- [ ] \`cargo test\` in \`agentmux-cef/\` — 24/24 pass (18 new \`pane::lifecycle::tests\` + 6 preserved \`browser_panes::tests::close_with_*\`).
- [ ] \`cargo check\` — no new warnings (19 pre-existing).
- [ ] Smoke: \`task dev\` open/close a browser pane — behavior unchanged from v0.33.255.

## Next phases (not in this PR)

Per the spec:
- **Phase 2**: Lift \`ALLOW_PANE_FOCUS_ONCE\` + \`install_pane_focus_redirect\` + Win32 HWND helpers into \`pane/hwnd.rs\`.
- **Phase 3**: Lift \`CreatePaneTask\` into \`pane/creation.rs\`.
- **Phase 4**: Lift pane-specific CEF callbacks out of \`client.rs\` into \`pane/callbacks.rs\`. **This breaks the \`browser_panes ↔ client\` import cycle.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)