### PR TITLE
refactor(pane): Phase 3 — CreatePaneTask into pane/creation.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.257"
+version = "0.33.258"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.257"
+version = "0.33.258"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.257"
+version = "0.33.258"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.257"
+version = "0.33.258"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.257"
+version = "0.33.258"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use cef::*;
 
-use crate::pane::{PaneStateMachine, RegisterResult};
+use crate::pane::{CreatePaneTask, PaneStateMachine, RegisterResult};
 use crate::state::AppState;
 
 /// Abstraction over the CEF-side operations `close()` performs on the host
@@ -320,89 +320,7 @@ impl BrowserPaneManager {
     }
 }
 
-// ── UI thread task: create browser ──────────────────────────────────────────
-
-wrap_task! {
-    pub struct CreatePaneTask {
-        state: Arc<AppState>,
-        block_id: String,
-        label: String,
-        url: String,
-        rect: Rect,
-    }
-
-    impl Task {
-        fn execute(&self) {
-            // Running on the CEF UI thread.
-
-            // Get parent HWND via Win32 enumeration (CEF Views returns null).
-            #[cfg(target_os = "windows")]
-            let parent_hwnd_raw = unsafe {
-                crate::commands::window::find_own_top_level_window()
-            };
-            #[cfg(not(target_os = "windows"))]
-            let parent_hwnd_raw: *mut std::ffi::c_void = std::ptr::null_mut();
-
-            if parent_hwnd_raw.is_null() {
-                tracing::error!(block_id = %self.block_id, "cannot find main window HWND — aborting browser pane creation");
-                return;
-            }
-
-            // Queue label for on_after_created registration (stored in state.browsers)
-            self.state.pending_window_labels.lock().push_back(self.label.clone());
-
-            let handler = crate::client::AgentMuxHandler::new_with_pane(self.state.clone(), 0, true);
-            let mut client = Some(crate::client::AgentMuxClient::new(handler, true));
-
-            let url_cef = CefString::from(self.url.as_str());
-            let settings = BrowserSettings::default();
-
-            #[cfg(target_os = "windows")]
-            let window_info = {
-                let parent_hwnd = sys::HWND(parent_hwnd_raw as *mut _);
-                // Use the clean set_as_child helper — it fills style/parent/bounds
-                // correctly and leaves other fields zeroed (in particular `window`
-                // which is an OUTPUT field filled by CEF).
-                let mut wi = WindowInfo::default().set_as_child(parent_hwnd, &self.rect);
-                // Match the main process runtime style (ALLOY throughout the app).
-                wi.runtime_style = RuntimeStyle::ALLOY;
-                wi
-            };
-
-            #[cfg(not(target_os = "windows"))]
-            {
-                tracing::warn!(block_id = %self.block_id, "browser panes not yet implemented on this platform");
-                return;
-            }
-
-            #[cfg(target_os = "windows")]
-            {
-                let result = browser_host_create_browser(
-                    Some(&window_info),
-                    client.as_mut(),
-                    Some(&url_cef),
-                    Some(&settings),
-                    None, // extra_info
-                    None, // request_context
-                );
-
-                if result == 0 {
-                    tracing::error!(block_id = %self.block_id, "browser_host_create_browser returned 0");
-                    return;
-                }
-
-                tracing::info!(
-                    block_id = %self.block_id,
-                    label = %self.label,
-                    url = %self.url,
-                    x = self.rect.x, y = self.rect.y,
-                    w = self.rect.width, h = self.rect.height,
-                    "browser pane created on UI thread"
-                );
-            }
-        }
-    }
-}
+// `CreatePaneTask` moved to `crate::pane::creation` in Phase 3.
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 //

--- a/agentmux-cef/src/pane/creation.rs
+++ b/agentmux-cef/src/pane/creation.rs
@@ -1,0 +1,110 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! UI-thread task that actually creates a CEF browser pane.
+//!
+//! Moved out of `browser_panes.rs` during Phase 3 of the pane modularization
+//! split (see `docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md` §6). The task
+//! structure here is a straight lift — same pre-flight checks, same
+//! `browser_host_create_browser` call. `BrowserPaneManager::create` still
+//! calls `post_task(ThreadId::UI, ..)` with an instance of this task; the
+//! only change is the import path.
+//!
+//! Dependencies (one-way, no cycle):
+//!   - `cef::*` for CEF types and the `wrap_task!` macro.
+//!   - `crate::state::AppState` for the label queue and the Arc passed to
+//!     the pane's handler.
+//!   - `crate::client::{AgentMuxHandler, AgentMuxClient}` for the pane's
+//!     CEF client. Phase 4 will flip this direction by moving the pane
+//!     callbacks into `pane/callbacks.rs`; until then, `client` is fine as
+//!     a one-way dependency.
+//!   - `crate::commands::window::find_own_top_level_window` for the parent
+//!     HWND (CEF Views returns null on Alloy).
+
+use std::sync::Arc;
+
+use cef::*;
+
+use crate::state::AppState;
+
+wrap_task! {
+    pub struct CreatePaneTask {
+        state: Arc<AppState>,
+        block_id: String,
+        label: String,
+        url: String,
+        rect: Rect,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            // Running on the CEF UI thread.
+
+            // Get parent HWND via Win32 enumeration (CEF Views returns null).
+            #[cfg(target_os = "windows")]
+            let parent_hwnd_raw = unsafe {
+                crate::commands::window::find_own_top_level_window()
+            };
+            #[cfg(not(target_os = "windows"))]
+            let parent_hwnd_raw: *mut std::ffi::c_void = std::ptr::null_mut();
+
+            if parent_hwnd_raw.is_null() {
+                tracing::error!(block_id = %self.block_id, "cannot find main window HWND — aborting browser pane creation");
+                return;
+            }
+
+            // Queue label for on_after_created registration (stored in state.browsers)
+            self.state.pending_window_labels.lock().push_back(self.label.clone());
+
+            let handler = crate::client::AgentMuxHandler::new_with_pane(self.state.clone(), 0, true);
+            let mut client = Some(crate::client::AgentMuxClient::new(handler, true));
+
+            let url_cef = CefString::from(self.url.as_str());
+            let settings = BrowserSettings::default();
+
+            #[cfg(target_os = "windows")]
+            let window_info = {
+                let parent_hwnd = sys::HWND(parent_hwnd_raw as *mut _);
+                // Use the clean set_as_child helper — it fills style/parent/bounds
+                // correctly and leaves other fields zeroed (in particular `window`
+                // which is an OUTPUT field filled by CEF).
+                let mut wi = WindowInfo::default().set_as_child(parent_hwnd, &self.rect);
+                // Match the main process runtime style (ALLOY throughout the app).
+                wi.runtime_style = RuntimeStyle::ALLOY;
+                wi
+            };
+
+            #[cfg(not(target_os = "windows"))]
+            {
+                tracing::warn!(block_id = %self.block_id, "browser panes not yet implemented on this platform");
+                return;
+            }
+
+            #[cfg(target_os = "windows")]
+            {
+                let result = browser_host_create_browser(
+                    Some(&window_info),
+                    client.as_mut(),
+                    Some(&url_cef),
+                    Some(&settings),
+                    None, // extra_info
+                    None, // request_context
+                );
+
+                if result == 0 {
+                    tracing::error!(block_id = %self.block_id, "browser_host_create_browser returned 0");
+                    return;
+                }
+
+                tracing::info!(
+                    block_id = %self.block_id,
+                    label = %self.label,
+                    url = %self.url,
+                    x = self.rect.x, y = self.rect.y,
+                    w = self.rect.width, h = self.rect.height,
+                    "browser pane created on UI thread"
+                );
+            }
+        }
+    }
+}

--- a/agentmux-cef/src/pane/hwnd.rs
+++ b/agentmux-cef/src/pane/hwnd.rs
@@ -32,6 +32,10 @@ static PANE_WNDPROCS: std::sync::LazyLock<
 pub static ALLOW_PANE_FOCUS_ONCE: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+// Phase 4 of the modularization split will wire this into pane
+// `on_after_created` / `on_load_end`. Until then the function is present but
+// unused — keeping it visible avoids importing it back into `client.rs`.
+#[allow(dead_code)]
 /// Subclass a browser pane's outer HWND (and every descendant HWND Chromium
 /// has already created) so `WM_SETFOCUS` is redirected back to the parent
 /// top-level window unless the focus change is user-initiated (see

--- a/agentmux-cef/src/pane/mod.rs
+++ b/agentmux-cef/src/pane/mod.rs
@@ -10,11 +10,25 @@
 //!
 //! Re-exports the public surface that `browser_panes.rs` and tests consume.
 
+pub mod creation;
 pub mod lifecycle;
 #[cfg(target_os = "windows")]
 pub mod hwnd;
 
-pub use lifecycle::{PaneLifecycle, PaneStateMachine, RegisterResult};
+pub use creation::CreatePaneTask;
+pub use lifecycle::{PaneStateMachine, RegisterResult};
+
+// PaneLifecycle is reachable via `crate::pane::lifecycle::PaneLifecycle`
+// for tests that need to assert state; no re-export needed.
+#[cfg(test)]
+pub use lifecycle::PaneLifecycle;
 
 #[cfg(target_os = "windows")]
-pub use hwnd::{ALLOW_PANE_FOCUS_ONCE, install_pane_focus_redirect};
+pub use hwnd::ALLOW_PANE_FOCUS_ONCE;
+
+// install_pane_focus_redirect is defined but not yet wired to any caller;
+// Phase 4 will invoke it from pane `on_after_created` / `on_load_end`.
+// Re-export is ready; flagging suppressed until that lands.
+#[cfg(target_os = "windows")]
+#[allow(unused_imports)]
+pub use hwnd::install_pane_focus_redirect;

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.257"
+version = "0.33.258"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.257"
+version = "0.33.258"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.257"
+version = "0.33.258"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.257",
+  "version": "0.33.258",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.257",
+      "version": "0.33.258",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.257",
+  "version": "0.33.258",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 3 of the four-phase split from \`docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md\` §6.

Move \`CreatePaneTask\` (the \`wrap_task!\` UI-thread browser-creation task) from \`browser_panes.rs\` to the new \`agentmux-cef/src/pane/creation.rs\`. ~80 lines of body + one import update. **Pure code motion.**

## What moved

- **\`pane/creation.rs\`** (new): \`CreatePaneTask\` with its \`execute()\` body intact. Same dependencies as before (\`state::AppState\`, \`client::{AgentMuxHandler, AgentMuxClient}\`, \`commands::window::find_own_top_level_window\`).
- **\`pane/mod.rs\`**: \`pub mod creation;\` + \`pub use creation::CreatePaneTask;\`. Also trimmed an unused \`PaneLifecycle\` re-export and suppressed the \`install_pane_focus_redirect\` dead-code warning (Phase 4 wires it in).
- **\`browser_panes.rs\`**: imports \`CreatePaneTask\` from the new location, ~80 lines removed.

## Cycle progress

- **Phase 1**: state machine extracted. Cycle still exists.
- **Phase 2**: \`ALLOW_PANE_FOCUS_ONCE\` + \`install_pane_focus_redirect\` moved out of \`client.rs\`. \`browser_panes\` no longer imports from \`client\` for the focus flag — **half the cycle gone**.
- **Phase 3 (this PR)**: \`CreatePaneTask\` is now in \`pane/\`. The one-way dep on \`client::AgentMuxHandler\` stays, but it's now a one-way edge from a cleanly-named module instead of tangled inside \`browser_panes\`.
- **Phase 4 (next)**: pane CEF callbacks move out of \`client.rs\`. **This breaks the remaining cycle and wires up \`install_pane_focus_redirect\`** (spec §5 race #5 — post-nav focus steal gap).

## Test plan
- [ ] \`cargo test\` — 27/27 pass (unchanged from Phase 2).
- [ ] \`cargo build\` — 18 warnings, down from 19 pre-Phase-1.
- [ ] Smoke: \`task dev\` open/close a browser pane, then navigate + close — behavior unchanged from v0.33.257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)