### PR TITLE
refactor(window): rename data-tauri-drag-region → data-drag-region

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.261"
+version = "0.33.262"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.261"
+version = "0.33.262"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.261"
+version = "0.33.262"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.261"
+version = "0.33.262"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.261"
+version = "0.33.262"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.261"
+version = "0.33.262"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.261"
+version = "0.33.262"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.261"
+version = "0.33.262"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_RENAME_DRAG_REGION_ATTR.md
+++ b/docs/specs/SPEC_RENAME_DRAG_REGION_ATTR.md
@@ -1,0 +1,63 @@
+# SPEC: Rename `data-tauri-drag-region` → `data-drag-region`
+
+Status: draft
+Date: 2026-04-18
+Owner: AgentA
+Motivation: the attribute is a Tauri-era name. AgentMux has been CEF-only
+since the backend migration. The name misleads readers into thinking it's
+dead code (as it did me earlier today when I reviewed PR #438). The
+underlying mechanism is very much alive — `useWindowDrag.win32.ts` reads
+the attribute at mousedown/dblclick to decide whether to start a window
+drag or fire `maximize_window` — so renaming is a straight find-and-replace
+with no functional change.
+
+## 1. What moves
+
+Plain find-and-replace:
+- `data-tauri-drag-region` → `data-drag-region`
+
+Only the string literal changes. All semantics (values `"true"` / `"false"` /
+missing, parent-walk, which elements opt in/out) stay identical.
+
+## 2. Scope
+
+16 references across 8 files (all in `frontend/`):
+
+**Readers** (the live attribute consumer):
+- `frontend/app/hook/useWindowDrag.win32.ts:5,16,72` — comment, `getAttribute` call, `dragProps` emitter.
+- `frontend/app/hook/useWindowDrag.darwin.ts:5,6,10` — comment + `dragProps` emitter (macOS handles drag at the WebView layer via this same attribute).
+- `frontend/app/hook/useWindowDrag.linux.ts:6` — comment only.
+
+**Producers** (elements opting in/out of drag):
+- `frontend/app/tab/tabbar.tsx:160,163,183` — `add-tab-btn` (false), `tab-bar-scroll` (false), `tab-bar-fill` (true).
+- `frontend/app/tab/tab.tsx:251` — tab root (false).
+- `frontend/app/tab/droppable-tab.tsx:102` — drop wrapper (false).
+- `frontend/app/window/action-widgets.tsx:393` — widget bar container (false). *Added in PR #438 to fix the double-click-maximize bug; the current PR uses the old name.*
+- `frontend/app/window/system-status.tsx:105,115,125` — three status buttons (false).
+
+No backend code touches this — confirmed via `grep -r tauri-drag-region agentmux-cef/src agentmux-srv/src` returns zero matches.
+
+## 3. Verification
+
+- Rename in a single commit so `git blame` for any adjacent line still points where it used to.
+- `grep -r "tauri-drag-region" frontend/` returns zero after the change.
+- `grep -r "data-drag-region" frontend/` returns exactly 16 matches.
+- `npx tsc --noEmit` clean.
+- `task dev`: window-header dblclick still maximizes; widget-button dblclick does NOT maximize (regression check for the #438 fix); tab bar fill still allows window-drag; tabs + widget bar still don't trigger drag on grab.
+
+## 4. Not in scope
+
+- The comment `// Tauri: data-tauri-drag-region is handled at the WebView/OS level`
+  in `useWindowDrag.win32.ts:5` references the old Tauri behavior for context.
+  Updating the comment to reflect current reality is useful cleanup but
+  separate from the attribute rename — it'd touch identical lines in the
+  darwin/linux variants too.
+- Any other Tauri-era stale names (`data-tauri-*`, `invoke` shape changes,
+  `@tauri-apps/*` imports still around). Separate sweep.
+
+## 5. Implementation
+
+One commit, one branch off main. PR description: link to this spec, list
+"no functional change, grep-only rename". After merge, follow-up commit
+to also update the code comments in the three `useWindowDrag.*` files can
+land in the same or a tiny follow-up PR.

--- a/frontend/app/hook/useWindowDrag.darwin.ts
+++ b/frontend/app/hook/useWindowDrag.darwin.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // macOS-specific window drag hook.
-// data-tauri-drag-region is handled at the WebView/OS level (synchronous,
-// before JS runs). Child elements with data-tauri-drag-region="false"
+// data-drag-region is handled at the WebView/OS level (synchronous,
+// before JS runs). Child elements with data-drag-region="false"
 // correctly block drag.
 
 export function useWindowDrag(): { dragProps: Record<string, unknown> } {
-    return { dragProps: { "data-tauri-drag-region": true } };
+    return { dragProps: { "data-drag-region": true } };
 }

--- a/frontend/app/hook/useWindowDrag.linux.ts
+++ b/frontend/app/hook/useWindowDrag.linux.ts
@@ -3,7 +3,7 @@
 //
 // Linux-specific window drag hook.
 // On Linux, drag is handled natively by drag.rs (GTK motion detection).
-// data-tauri-drag-region triggers an immediate Wayland compositor pointer
+// data-drag-region triggers an immediate Wayland compositor pointer
 // grab that swallows button clicks, so no drag attributes are set.
 
 export function useWindowDrag(): { dragProps: Record<string, unknown> } {

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Windows-specific window drag hook.
-// Tauri: data-tauri-drag-region is handled at the WebView/OS level.
+// Tauri: data-drag-region is handled at the WebView/OS level.
 // CEF: JS-driven window move — track mouse delta, set window position via IPC.
 // WM_NCLBUTTONDOWN doesn't work because the async IPC roundtrip loses mouse state.
 
@@ -13,7 +13,7 @@ let cefDragListenerInstalled = false;
 function isInDragRegion(target: HTMLElement | null): boolean {
     let el = target;
     while (el) {
-        const attr = el.getAttribute("data-tauri-drag-region");
+        const attr = el.getAttribute("data-drag-region");
         if (attr === "false") return false;
         if (attr === "true" || attr === "") return true;
         el = el.parentElement;
@@ -69,5 +69,5 @@ function installCefDragListener() {
 
 export function useWindowDrag(): { dragProps: Record<string, unknown> } {
     installCefDragListener();
-    return { dragProps: { "data-tauri-drag-region": true } };
+    return { dragProps: { "data-drag-region": true } };
 }

--- a/frontend/app/tab/droppable-tab.tsx
+++ b/frontend/app/tab/droppable-tab.tsx
@@ -99,7 +99,7 @@ export function DroppableTab(props: DroppableTabProps): JSX.Element {
     return (
         <div
             ref={tabWrapRef!}
-            data-tauri-drag-region="false"
+            data-drag-region="false"
             class={clsx("tab-drop-wrapper", {
                 "tab-dragging": isDragging(),
                 "tab-bouncing": isBouncing(),

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -248,7 +248,7 @@ function Tab(props: TabProps): JSX.Element {
                 onClick={props.onSelect}
                 onContextMenu={handleContextMenu}
                 data-tab-id={props.id}
-                data-tauri-drag-region="false"
+                data-drag-region="false"
             >
                 <div class="tab-inner">
                     <div

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -157,10 +157,10 @@ function TabBar(props: TabBarProps): JSX.Element {
 
     return (
         <div class="tab-bar" {...dragProps}>
-            <button class="add-tab-btn" onClick={createTab} title="New Tab" data-tauri-drag-region="false">
+            <button class="add-tab-btn" onClick={createTab} title="New Tab" data-drag-region="false">
                 <i class="fa fa-plus" />
             </button>
-            <div class="tab-bar-scroll" data-tauri-drag-region="false">
+            <div class="tab-bar-scroll" data-drag-region="false">
                 <For each={tabIds()}>
                     {(tabId, i) => (
                         <DroppableTab
@@ -180,7 +180,7 @@ function TabBar(props: TabBarProps): JSX.Element {
                 </For>
             </div>
             {/* Empty right-side space — draggable so the user can grab the window from here */}
-            <div class="tab-bar-fill" data-tauri-drag-region="true" />
+            <div class="tab-bar-fill" data-drag-region="true" />
         </div>
     );
 }

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -390,7 +390,7 @@ const ActionWidgets = (): JSX.Element => {
                 ref={containerRef}
                 class="action-widgets"
                 data-testid="action-widgets"
-                data-tauri-drag-region="false"
+                data-drag-region="false"
                 onContextMenu={handleBarContextMenu}
             >
                 <For each={pinnedWidgets()}>

--- a/frontend/app/window/system-status.tsx
+++ b/frontend/app/window/system-status.tsx
@@ -102,7 +102,7 @@ const WindowActionButtons = (): JSX.Element => {
                 title="Minimize"
                 aria-label="Minimize"
                 data-testid="window-minimize-btn"
-                data-tauri-drag-region="false"
+                data-drag-region="false"
             >
                 <MinimizeGlyph />
             </button>
@@ -112,7 +112,7 @@ const WindowActionButtons = (): JSX.Element => {
                 title="Maximize"
                 aria-label="Maximize"
                 data-testid="window-maximize-btn"
-                data-tauri-drag-region="false"
+                data-drag-region="false"
             >
                 <MaximizeGlyph />
             </button>
@@ -122,7 +122,7 @@ const WindowActionButtons = (): JSX.Element => {
                 title="Close"
                 aria-label="Close"
                 data-testid="window-close-btn"
-                data-tauri-drag-region="false"
+                data-drag-region="false"
             >
                 <CloseGlyph />
             </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.261",
+  "version": "0.33.262",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.261",
+      "version": "0.33.262",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.261",
+  "version": "0.33.262",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Grep-only rename. The attribute was a Tauri-era name; AgentMux has been CEF-only for months. \`useWindowDrag.win32.ts\` actively reads it to route mousedown/dblclick into window-drag or \`maximize_window\`, so the mechanism is alive — just the prefix is misleading.

**16 references, 8 files.** No semantic change — all attribute values (\`"true"\` / \`"false"\` / absent) and the parent-walk in \`isInDragRegion\` stay identical.

## Files touched

**Readers:**
- \`hook/useWindowDrag.win32.ts\` — the live \`getAttribute\` call + dragProps emitter.
- \`hook/useWindowDrag.darwin.ts\` — dragProps emitter + comments.
- \`hook/useWindowDrag.linux.ts\` — comment only.

**Producers:**
- \`tab/tabbar.tsx\`, \`tab/tab.tsx\`, \`tab/droppable-tab.tsx\`
- \`window/action-widgets.tsx\`, \`window/system-status.tsx\`

Zero backend refs (confirmed via grep).

Spec: \`docs/specs/SPEC_RENAME_DRAG_REGION_ATTR.md\`.

## Test plan
- [ ] \`grep -r tauri-drag-region frontend/\` returns zero.
- [ ] \`grep -r data-drag-region frontend/\` returns 16.
- [ ] \`npx tsc --noEmit\` clean.
- [ ] \`task dev\`: window-header dblclick still maximizes; widget-button dblclick does NOT (#438's fix); tab-bar-fill still allows window drag; tabs + widgets don't start a window drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)