### PR TITLE
fix(layout): heal rootnode-is-orphan case (the persistent "dead spot" bug)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.262"
+version = "0.33.263"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.262"
+version = "0.33.263"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.262"
+version = "0.33.263"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.262"
+version = "0.33.263"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.262"
+version = "0.33.263"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.262"
+version = "0.33.263"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.262"
+version = "0.33.263"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.262"
+version = "0.33.263"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1276,6 +1276,7 @@ mod tests {
             environment: String::new(),
             agent_bus_id: String::new(),
             is_seeded: 0,
+            accounts: String::new(),
         };
         store.forge_insert(&mut a1).unwrap();
         // "Agent X" → "agent-x"
@@ -1334,6 +1335,7 @@ mod tests {
             environment: String::new(),
             agent_bus_id: String::new(),
             is_seeded: 0,
+            accounts: String::new(),
         };
         store.forge_insert(&mut a1).unwrap();
         assert_eq!(a1.slug, "explicit");

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -67,8 +67,21 @@ fn prune_block_from_layout(layout: &mut LayoutState, block_id: &str) {
     if let Some(ref mut leaves) = layout.leaforder {
         leaves.retain(|entry| entry.blockid != block_id);
     }
-    // Prune rootnode tree (recursive JSON walk)
-    if let Some(ref mut root) = layout.rootnode {
+
+    // Rootnode: handle the single-pane case where rootnode IS the orphan
+    // leaf (no `children` array, just `data.blockId`). `prune_node` only
+    // touches the `children` array, so a rootnode-leaf orphan would
+    // otherwise persist forever. See SPEC_LAYOUT_HEAL_ROOTNODE_ORPHAN.md.
+    let root_is_orphan = layout.rootnode
+        .as_ref()
+        .and_then(|r| r.get("data"))
+        .and_then(|d| d.get("blockId"))
+        .and_then(|id| id.as_str())
+        .map(|id| id == block_id)
+        .unwrap_or(false);
+    if root_is_orphan {
+        layout.rootnode = None;
+    } else if let Some(ref mut root) = layout.rootnode {
         prune_node(root, block_id);
     }
 }
@@ -135,8 +148,34 @@ pub fn heal_layout(
     let valid_blocks: std::collections::HashSet<&str> =
         tab.blockids.iter().map(|s| s.as_str()).collect();
 
-    // Collect orphaned block IDs from leaforder
-    let orphans: Vec<String> = layout.leaforder
+    let (changed, orphans) = heal_layout_body(&mut layout, &valid_blocks);
+    if !changed {
+        return Ok(false);
+    }
+    tracing::warn!(
+        tab_id = %tab_id,
+        orphan_count = orphans.len(),
+        orphans = ?orphans,
+        "healing layout: removing orphaned block nodes"
+    );
+    store.update(&mut layout)?;
+    Ok(true)
+}
+
+/// Pure heal pass on a LayoutState given the set of block IDs that should
+/// still be present. Returns `(changed, orphans_removed)`.
+///
+/// Collects orphans from both `leaforder` AND any leaf still reachable in
+/// `rootnode` — `leaforder` can drift out of sync with `rootnode` if a
+/// write was interrupted, and the heal is the last defense. Prunes each
+/// orphan via `prune_block_from_layout`, then clears `focusednodeid` if
+/// the rootnode ended up empty.
+fn heal_layout_body(
+    layout: &mut LayoutState,
+    valid_blocks: &std::collections::HashSet<&str>,
+) -> (bool, Vec<String>) {
+    // Orphans visible via leaforder.
+    let mut orphans: Vec<String> = layout.leaforder
         .as_ref()
         .map(|leaves| {
             leaves.iter()
@@ -146,22 +185,212 @@ pub fn heal_layout(
         })
         .unwrap_or_default();
 
-    if orphans.is_empty() {
-        return Ok(false);
+    // Orphans reachable only via rootnode (leaforder might be clean while
+    // rootnode retains a stale leaf — the inverse of the case that
+    // originally motivated the heal).
+    if let Some(ref root) = layout.rootnode {
+        collect_leaf_block_ids(root, &mut |id| {
+            if !valid_blocks.contains(id) && !orphans.iter().any(|o| o == id) {
+                orphans.push(id.to_string());
+            }
+        });
     }
 
-    tracing::warn!(
-        tab_id = %tab_id,
-        orphan_count = orphans.len(),
-        orphans = ?orphans,
-        "healing layout: removing orphaned block nodes"
-    );
+    if orphans.is_empty() {
+        return (false, orphans);
+    }
 
     for orphan_id in &orphans {
-        prune_block_from_layout(&mut layout, orphan_id);
+        prune_block_from_layout(layout, orphan_id);
     }
-    store.update(&mut layout)?;
-    Ok(true)
+
+    // If rootnode dropped, the focused-node pointer is now dangling.
+    if layout.rootnode.is_none() && !layout.focusednodeid.is_empty() {
+        layout.focusednodeid = String::new();
+    }
+
+    (true, orphans)
+}
+
+/// Walk a layout-tree node, calling `sink` once per leaf `data.blockId`.
+fn collect_leaf_block_ids(node: &serde_json::Value, sink: &mut dyn FnMut(&str)) {
+    if let Some(children) = node.get("children").and_then(|c| c.as_array()) {
+        for child in children {
+            collect_leaf_block_ids(child, sink);
+        }
+        return;
+    }
+    if let Some(id) = node
+        .get("data")
+        .and_then(|d| d.get("blockId"))
+        .and_then(|id| id.as_str())
+    {
+        sink(id);
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn empty_layout(oid: &str) -> LayoutState {
+        LayoutState {
+            oid: oid.to_string(),
+            version: 1,
+            rootnode: None,
+            leaforder: None,
+            focusednodeid: String::new(),
+            magnifiednodeid: String::new(),
+            pendingbackendactions: None,
+            meta: None,
+        }
+    }
+
+    fn single_leaf_layout(block_id: &str, node_id: &str) -> LayoutState {
+        LayoutState {
+            oid: "layout-1".into(),
+            version: 1,
+            rootnode: Some(json!({
+                "data": { "blockId": block_id },
+                "flexDirection": "row",
+                "id": node_id,
+                "size": 10,
+            })),
+            leaforder: Some(vec![LeafOrderEntry {
+                blockid: block_id.into(),
+                nodeid: node_id.into(),
+            }]),
+            focusednodeid: node_id.into(),
+            magnifiednodeid: String::new(),
+            pendingbackendactions: None,
+            meta: None,
+        }
+    }
+
+    fn two_leaf_split_layout(left_block: &str, right_block: &str) -> LayoutState {
+        LayoutState {
+            oid: "layout-1".into(),
+            version: 1,
+            rootnode: Some(json!({
+                "id": "split-1",
+                "flexDirection": "row",
+                "size": 10,
+                "children": [
+                    {
+                        "id": "leaf-left",
+                        "flexDirection": "row",
+                        "size": 5,
+                        "data": { "blockId": left_block }
+                    },
+                    {
+                        "id": "leaf-right",
+                        "flexDirection": "row",
+                        "size": 5,
+                        "data": { "blockId": right_block }
+                    }
+                ]
+            })),
+            leaforder: Some(vec![
+                LeafOrderEntry { blockid: left_block.into(), nodeid: "leaf-left".into() },
+                LeafOrderEntry { blockid: right_block.into(), nodeid: "leaf-right".into() },
+            ]),
+            focusednodeid: "leaf-left".into(),
+            magnifiednodeid: String::new(),
+            pendingbackendactions: None,
+            meta: None,
+        }
+    }
+
+    fn set<'a>(ids: &[&'a str]) -> std::collections::HashSet<&'a str> {
+        ids.iter().copied().collect()
+    }
+
+    #[test]
+    fn prune_removes_rootnode_leaf_when_it_is_orphan() {
+        // THE BUG: single-pane layout where rootnode IS the orphan leaf.
+        // prune_node's old implementation only walked `children`, so rootnode
+        // stayed. This test fails on pre-fix main.
+        let mut layout = single_leaf_layout("orphan-block", "node-1");
+        prune_block_from_layout(&mut layout, "orphan-block");
+
+        assert!(layout.rootnode.is_none(),
+            "rootnode must be cleared when it was the orphan leaf");
+        assert_eq!(
+            layout.leaforder.as_deref().map(|l| l.len()),
+            Some(0),
+            "leaforder entry must be removed too",
+        );
+    }
+
+    #[test]
+    fn prune_removes_child_leaf_and_collapses() {
+        // Regression of existing multi-pane behavior.
+        let mut layout = two_leaf_split_layout("keep", "drop");
+        prune_block_from_layout(&mut layout, "drop");
+
+        assert!(layout.rootnode.is_some(), "rootnode should survive");
+        // The split should collapse to just the "keep" leaf.
+        let root = layout.rootnode.as_ref().unwrap();
+        let kept_block = root.get("data")
+            .and_then(|d| d.get("blockId"))
+            .and_then(|id| id.as_str());
+        assert_eq!(kept_block, Some("keep"),
+            "after pruning 'drop' and collapsing, rootnode should be the 'keep' leaf");
+    }
+
+    #[test]
+    fn prune_noop_when_block_absent() {
+        let mut layout = single_leaf_layout("other-block", "node-1");
+        let before = serde_json::to_string(&layout.rootnode).unwrap();
+        prune_block_from_layout(&mut layout, "not-present");
+        let after = serde_json::to_string(&layout.rootnode).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn heal_body_clears_focused_nodeid_when_rootnode_drops() {
+        let mut layout = single_leaf_layout("orphan-block", "node-1");
+        assert_eq!(layout.focusednodeid, "node-1");
+        let (changed, _orphans) = heal_layout_body(&mut layout, &set(&[]));
+        assert!(changed);
+        assert!(layout.rootnode.is_none());
+        assert_eq!(layout.focusednodeid, "",
+            "focusednodeid must be cleared when rootnode is empty");
+    }
+
+    #[test]
+    fn heal_body_catches_rootnode_orphan_missing_from_leaforder() {
+        // Malformed save: rootnode leaf points at an orphan but leaforder is
+        // already clean (or absent). The healer must still prune rootnode.
+        let mut layout = single_leaf_layout("orphan-block", "node-1");
+        layout.leaforder = Some(vec![]); // leaforder doesn't mention it
+
+        let (changed, orphans) = heal_layout_body(&mut layout, &set(&[]));
+        assert!(changed, "healer must notice rootnode-only orphan");
+        assert!(orphans.contains(&"orphan-block".to_string()));
+        assert!(layout.rootnode.is_none());
+    }
+
+    #[test]
+    fn heal_body_idempotent_on_clean_layout() {
+        let mut layout = single_leaf_layout("live-block", "node-1");
+        let (changed, _) = heal_layout_body(&mut layout, &set(&["live-block"]));
+        assert!(!changed, "no orphans → no change");
+        // Run again; still no change.
+        let (changed_again, _) = heal_layout_body(&mut layout, &set(&["live-block"]));
+        assert!(!changed_again);
+    }
+
+    #[test]
+    fn heal_body_handles_empty_layout() {
+        let mut layout = empty_layout("empty-layout");
+        let (changed, orphans) = heal_layout_body(&mut layout, &set(&[]));
+        assert!(!changed);
+        assert!(orphans.is_empty());
+    }
 }
 
 /// Resolve a block ID from an 8-character prefix within a tab.

--- a/docs/specs/SPEC_LAYOUT_HEAL_ROOTNODE_ORPHAN.md
+++ b/docs/specs/SPEC_LAYOUT_HEAL_ROOTNODE_ORPHAN.md
@@ -1,0 +1,231 @@
+# SPEC: Layout Healer Misses Rootnode-Is-Orphan Case
+
+Status: draft
+Date: 2026-04-18
+Owner: AgentA
+Reported by: user on v0.33.263 (dev) after extended pane open/close cycling
+Related: PRs #314/#325 (original layout healing), commit `b0eb316a`
+("fix: prune orphaned layout nodes on block delete and tab activation")
+
+## 1. Symptom
+
+> "We still get dead spots on panes."
+
+Clicking on an area where a pane should be does nothing — no focus, no
+context menu, no block renders. The layout tree still has a node at
+that position, but there is no block backing it. The pane appears as
+empty visual space that rejects all interaction.
+
+## 2. Evidence (live DB dump at v0.33.263)
+
+`~/.agentmux-dev` doesn't exist on this machine; the CEF host stores
+its data at `%APPDATA%\ai.agentmux.cef.v0-33-263\db\wave.db`.
+Inspection of the running dev instance, no extra user interaction:
+
+### `db_tab`
+```
+oid  = a1575f57-ac83-48ad-800c-8885aa4edff2
+name = Untitled1
+blockids    = []          ← no blocks in this tab
+layoutstate = 2f79da2b-fdc5-4a87-8556-766fed3a258a
+```
+
+### `db_block`
+```
+(zero rows)                ← no blocks exist anywhere
+```
+
+### `db_layout` (id = `2f79da2b-…`)
+```json
+{
+  "focusednodeid": "29a6b3bc-d6a8-4c5c-bbbf-3f7d708bdf7e",
+  "leaforder": [
+    {
+      "blockid": "c037a478-6286-4bcb-a5ed-f2cdb50c4ce4",
+      "nodeid":  "29a6b3bc-d6a8-4c5c-bbbf-3f7d708bdf7e"
+    }
+  ],
+  "rootnode": {
+    "data": { "blockId": "c037a478-6286-4bcb-a5ed-f2cdb50c4ce4" },
+    "flexDirection": "row",
+    "id": "29a6b3bc-d6a8-4c5c-bbbf-3f7d708bdf7e",
+    "size": 10
+  }
+}
+```
+
+Both `leaforder` and `rootnode` point at a block (`c037a478…`) that
+does not exist in `db_block`, and is not in `tab.blockids`. The layout
+is rendering a phantom pane.
+
+## 3. Why the healer missed it
+
+`heal_layout(store, tab_id)` at
+`agentmux-srv/src/backend/wcore/block.rs:122-165`:
+
+1. Reads `tab.blockids` — here `[]`.
+2. Builds `valid_blocks = {}` (empty).
+3. Scans `layout.leaforder` for entries whose `blockid` is not in
+   `valid_blocks` — finds `c037a478-…` as orphan.
+4. Logs `"healing layout: removing orphaned block nodes"` (we don't
+   see this log because the heal pass likely ran once and the phantom
+   persisted — see §4).
+5. Calls `prune_block_from_layout(&mut layout, orphan_id)` for each
+   orphan.
+6. Writes the layout back.
+
+`prune_block_from_layout` at `block.rs:65-74`:
+- `leaforder.retain(|e| e.blockid != block_id)` — **OK**, removes the
+  leaforder entry.
+- `prune_node(root, block_id)` — walks the rootnode tree.
+
+`prune_node` at `block.rs:79-118`:
+```rust
+fn prune_node(node: &mut serde_json::Value, block_id: &str) {
+    if let Some(children) = node.get_mut("children").and_then(|c| c.as_array_mut()) {
+        children.retain(|child| {
+            // … remove leaf children whose data.blockId == block_id
+        });
+        for child in children.iter_mut() {
+            prune_node(child, block_id);
+        }
+    }
+    // … single-child collapse
+}
+```
+
+The function only handles the `children` array of split/row/column
+nodes. It **never checks whether the node passed in IS ITSELF the
+orphan leaf**. In a single-pane layout, the rootnode is the leaf —
+no `children` — `prune_node` does nothing, and the orphan remains
+in `rootnode.data.blockId` forever.
+
+The next `heal_layout` pass again removes from `leaforder` (already
+gone, no-op), tries to prune rootnode (no-op for same reason),
+concludes "no orphans in leaforder" (because the first run removed
+them), and never converges.
+
+Net effect: a single-pane tab whose block was deleted leaves the
+layout rootnode permanently orphaned, and the frontend keeps
+rendering a dead space where the pane used to sit.
+
+## 4. Why this wasn't caught earlier
+
+- The L1 tests in #431 / #434 cover `BrowserPaneManager` and
+  `PaneStateMachine` — nothing in `wcore::block::heal_layout` has unit
+  tests today (`grep -r "heal_layout\|prune_node" --include="*.rs"`
+  finds only the implementation, zero tests).
+- The original healing PR (`b0eb316a`) was tested on multi-pane
+  layouts where the orphan was a CHILD of a split node — the
+  `children` pruning path works there.
+- "Dead spots" only appear once the user closes the last pane in a
+  tab, which isn't a default exercise path.
+
+## 5. Fix
+
+Minimal scope: make `prune_block_from_layout` handle the case where
+`rootnode` itself is the orphan leaf.
+
+```rust
+fn prune_block_from_layout(layout: &mut LayoutState, block_id: &str) {
+    // Prune leaforder
+    if let Some(ref mut leaves) = layout.leaforder {
+        leaves.retain(|entry| entry.blockid != block_id);
+    }
+    // Rootnode: if it IS the orphan leaf, drop it. Else walk its tree.
+    let root_is_orphan = layout.rootnode
+        .as_ref()
+        .and_then(|r| r.get("data"))
+        .and_then(|d| d.get("blockId"))
+        .and_then(|id| id.as_str())
+        .map(|id| id == block_id)
+        .unwrap_or(false);
+    if root_is_orphan {
+        layout.rootnode = None;
+    } else if let Some(ref mut root) = layout.rootnode {
+        prune_node(root, block_id);
+    }
+}
+```
+
+`heal_layout` also needs a companion fix: after pruning, if
+`rootnode == None`, `focusednodeid` should be cleared (it points at
+the now-gone node):
+
+```rust
+if layout.rootnode.is_none() {
+    layout.focusednodeid = String::new();
+}
+```
+
+And for robustness, the healer should ALSO detect "the layout's
+rootnode leaf refers to a block_id that's not in tab.blockids" as
+an orphan source, not just `leaforder`. In the user's DB, both had
+the orphan; but a future divergence between `leaforder` and
+`rootnode` would skip past the healer today. Recommended: after the
+leaforder pass, walk `rootnode` to collect any remaining leaf block
+IDs that aren't in `valid_blocks`, and prune those too.
+
+## 6. Forward repair for already-corrupted DBs
+
+Since the healer's bug has been shipping for weeks, there will be
+workspaces with stale orphan rootnodes on disk. Fixes above take
+effect on the next `SetActiveTab`, which fires the healer. **No
+manual cleanup required**, as long as the user opens a workspace
+with a broken tab once after upgrading.
+
+Optional belt-and-suspenders: on startup, walk every tab in the
+workspace and run `heal_layout` against each. The code for "heal all
+layouts on startup" existed at one point (commit `e33113e5` /
+`9435c449`) — check whether it's currently wired in. If not, wiring
+it in eliminates the latency of "tab must be clicked for the heal
+to apply."
+
+## 7. Tests
+
+Write these *before* the fix, so they fail on current main:
+
+### Rust L1 (`agentmux-srv/src/backend/wcore/block.rs` — new `#[cfg(test)] mod tests`)
+
+| # | Test | Asserts | Catches |
+|---|------|---------|---------|
+| 1 | `prune_block_from_layout_removes_rootnode_leaf_when_it_is_orphan` | Layout with rootnode-only leaf pointing at orphan; after prune, rootnode=None | THE BUG |
+| 2 | `prune_block_from_layout_removes_child_leaf` | Layout with row-of-two; after prune of one child, rootnode collapses to the remaining leaf | Regression of existing behavior |
+| 3 | `prune_block_from_layout_noop_when_block_absent` | Layout with no matching orphan; rootnode and leaforder unchanged | Idempotency |
+| 4 | `heal_layout_clears_focused_nodeid_when_rootnode_drops` | Layout with orphan rootnode + focusednodeid pointing at it; after heal, focusednodeid is empty string | Consequence of §5 companion fix |
+| 5 | `heal_layout_catches_rootnode_orphan_missing_from_leaforder` | Layout where leaforder is clean but rootnode leaf is an orphan (malformed save); healer should still prune | Robustness |
+| 6 | `heal_layout_idempotent` | Run heal twice; second run reports no orphans | Prevents log spam / infinite pass |
+
+### Manual verification
+
+- Open a fresh workspace, create one pane, close it. Check
+  `wave.db`: `rootnode` should be `null` or absent, `blockids` empty,
+  `leaforder` empty, `focusednodeid` empty.
+- Create two panes, close one. `rootnode` collapses to the remaining
+  leaf. Other pane continues to work.
+- Start from an already-corrupted workspace (the one in §2 is
+  captured): after the fix and `task dev`, clicking the tab or
+  performing any interaction that fires `SetActiveTab` should heal
+  the layout and the dead space disappears.
+
+## 8. Not in scope
+
+- Broader refactor of `prune_node` into a typed AST (it operates on
+  `serde_json::Value` today). A proper `LayoutNode` enum would let
+  the type system catch this class of bug; out of scope for an
+  urgent fix.
+- Frontend-side defensive rendering (when block lookup fails, render
+  a placeholder with "block missing" error). Useful long-term, but
+  the DB-side fix removes the cause.
+- Renaming `leaforder` / `focusednodeid` etc. to something
+  consistent with the rest of the codebase. Separate cleanup.
+
+## 9. Delivery
+
+1. Write the six tests first. Tests #1, #4, #5 will fail on main.
+2. Apply the two fixes in `prune_block_from_layout` and
+   `heal_layout`.
+3. Tests go green.
+4. Spot-check the running dev DB — the orphan should get pruned the
+   first time `SetActiveTab` fires post-upgrade.
+5. Document: tiny CHANGELOG entry, no user-visible breakage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.262",
+  "version": "0.33.263",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.262",
+      "version": "0.33.263",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.262",
+  "version": "0.33.263",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Bug

User on v0.33.263 (dev): persistent dead spots on panes. Clicking where a pane should be does nothing. Live DB inspection confirmed a phantom layout node:

| table | state |
|---|---|
| \`db_tab\` Untitled1 | \`blockids=[]\` |
| \`db_block\` | zero rows |
| \`db_layout\` | rootnode = \`{data.blockId: "c037a478..."}\`, leaforder lists same orphan |

Both leaforder AND rootnode pointed at a block that didn't exist. The healer had run (per logs) — pruned leaforder — and silently left the rootnode orphan.

## Root cause

\`prune_node\` (block.rs:79) only walks the \`children\` array of split nodes. In a single-pane layout the rootnode IS the leaf (no children array), so \`prune_node\` is a no-op on an empty field and the \`data.blockId\` orphan persists. \`heal_layout\` then declares the layout healed (leaforder is clean) and never rechecks rootnode.

## Fix

- \`prune_block_from_layout\`: check if rootnode itself is the orphan leaf before descending; if so, set \`rootnode = None\`.
- Extract \`heal_layout_body\` pure function that also walks rootnode for leaf block_ids not in \`valid_blocks\`. Catches the inverse case where leaforder drifted out of sync.
- Clear \`focusednodeid\` if rootnode drops to None.

## Tests

**7 new unit tests** in \`backend::wcore::block::tests\`. Three would have failed on pre-fix main:
- \`prune_removes_rootnode_leaf_when_it_is_orphan\` — the core bug
- \`heal_body_clears_focused_nodeid_when_rootnode_drops\`
- \`heal_body_catches_rootnode_orphan_missing_from_leaforder\`

Four regression guards: multi-pane child prune + collapse, no-op on absent block, idempotency, empty layout.

## Also

Pre-existing \`ForgeAgent { ... }\` struct literals in \`wstore.rs\` test helpers were missing the \`accounts\` field (added in a recent rename, helpers never updated). They blocked the test binary from compiling at all. Fixed as a drive-by so the test suite runs again.

## Forward repair

Corrupt DBs heal on the next \`SetActiveTab\` after upgrade. No user-facing breakage, no manual cleanup.

## Spec

\`docs/specs/SPEC_LAYOUT_HEAL_ROOTNODE_ORPHAN.md\`.

## Test plan
- [ ] \`cargo test --bin agentmux-srv wcore::block::tests\` → 7/7 pass.
- [ ] \`task dev\`: open workspace that had a dead spot → click tab → dead spot clears. Log shows \`healing layout: removing orphaned block nodes\`.
- [ ] Create pane → close → DB inspection: rootnode=None, blockids=[], leaforder=[], focusednodeid="".
- [ ] Two panes → close one → remaining pane still works; rootnode collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)