### PR TITLE
fix(pane): hover-focus cooldown — don't re-grab after main reclaims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.263"
+version = "0.33.264"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.263"
+version = "0.33.264"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.263"
+version = "0.33.264"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.263"
+version = "0.33.264"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
  "serde_core",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.263"
+version = "0.33.264"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -340,22 +340,43 @@ async fn route_command(
             Ok(serde_json::json!(true))
         }
         "main_window_focus" => {
-            // Move OS-level keyboard focus back to the main window's top-level
-            // HWND. Used by the frontend when the user clicks a main-DOM input
-            // (e.g. a browser block's URL bar) to reclaim focus from a pane
-            // that previously held it.
+            // Move keyboard focus back to the main browser when the user
+            // clicks a main-DOM input (address bar, etc). Previously this
+            // called SetFocus(top_level) where top_level was the outer CEF
+            // Views window — which does NOT route keyboard to the embedded
+            // render widget. Keys kept arriving at the pane's HWND.
+            //
+            // Correct path: tell Chromium that main's Browser has focus.
+            // CEF internally calls SetFocus on the right Chrome_RenderWidgetHostHWND.
+            // Also defocus every pane browser so Chromium stops routing input
+            // to them.
             tracing::info!("[ipc] main_window_focus");
-            #[cfg(target_os = "windows")]
-            unsafe {
-                let top = crate::commands::window::find_own_top_level_window();
-                if !top.is_null() {
-                    windows_sys::Win32::UI::Input::KeyboardAndMouse::SetFocus(top as _);
-                    tracing::info!("[ipc] main_window_focus: SetFocus on top={:p}", top);
-                }
-                // Also explicitly defocus ALL panes' browsers at the Chromium
-                // level so the renderer stops routing keystrokes to them.
-                state.browser_panes.defocus_all(state);
+
+            // Main browser is the one NOT prefixed with browser-pane-. Find
+            // it by excluding pane labels. There's always exactly one "main".
+            let main_browser = {
+                let browsers = state.browsers.lock();
+                browsers
+                    .iter()
+                    .find(|(k, _)| !k.starts_with("browser-pane-"))
+                    .map(|(k, b)| (k.clone(), b.clone()))
+            };
+
+            if let Some((label, _browser)) = main_browser {
+                // Full focus reclaim has to run on the CEF UI thread:
+                // `browser_view_get_for_browser`, `host.set_focus`, and
+                // walking the HWND tree all require it. The task also
+                // handles `defocus_all` on panes.
+                let mut task = crate::ui_tasks::MainFocusReclaimTask::new(
+                    state.clone(),
+                    label.clone(),
+                );
+                cef::post_task(cef::ThreadId::UI, Some(&mut task));
+                tracing::info!("[ipc] main_window_focus: posted MainFocusReclaimTask for label={}", label);
+            } else {
+                tracing::warn!("[ipc] main_window_focus: no non-pane browser found in state.browsers");
             }
+
             Ok(serde_json::json!(true))
         }
 
@@ -363,3 +384,4 @@ async fn route_command(
         _ => Err(format!("Unknown command: {}", cmd)),
     }
 }
+

--- a/agentmux-cef/src/pane/hwnd.rs
+++ b/agentmux-cef/src/pane/hwnd.rs
@@ -51,7 +51,7 @@ pub unsafe fn install_pane_focus_redirect(hwnd: *mut std::ffi::c_void) {
     use std::sync::atomic::Ordering;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         CallWindowProcW, GetAncestor, SetWindowLongPtrW, GA_ROOT, GWLP_WNDPROC,
-        WM_SETFOCUS, WM_KILLFOCUS,
+        WM_SETFOCUS, WM_KILLFOCUS, WM_LBUTTONDOWN,
     };
     use windows_sys::Win32::UI::Input::KeyboardAndMouse::SetFocus;
 
@@ -79,6 +79,20 @@ pub unsafe fn install_pane_focus_redirect(hwnd: *mut std::ffi::c_void) {
                 tracing::info!("[pane-wndproc] WM_KILLFOCUS hwnd={:p}", hwnd);
             }
             _ => {}
+        }
+
+        // A click inside the pane HWND is the explicit "user wants to
+        // interact with the embedded page" signal. Chromium's own handler
+        // will call SetFocus(pane) next — arm ALLOW_PANE_FOCUS_ONCE so
+        // the WM_SETFOCUS branch below doesn't redirect it. Without this,
+        // clicks on the pane never transfer keyboard focus to Chromium
+        // (cursor works, typing goes nowhere — reported by user after
+        // the onMouseEnter→onMouseDown switch broke hover-focus-grab but
+        // the DOM-level mousedown never fires because the pane HWND
+        // intercepts the click at Win32 level, not DOM level).
+        if msg == WM_LBUTTONDOWN {
+            ALLOW_PANE_FOCUS_ONCE.store(true, Ordering::Relaxed);
+            tracing::info!("[pane-wndproc] WM_LBUTTONDOWN — arming focus allow");
         }
 
         if msg == WM_SETFOCUS {

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -268,3 +268,143 @@ pub fn post_show_dev_tools(state: &Arc<AppState>, label: &str) {
     let mut task = ShowDevToolsTask::new(state.clone(), label.to_string());
     post_task(ThreadId::UI, Some(&mut task));
 }
+
+// ── Main-focus reclaim ────────────────────────────────────────────────────
+//
+// Reclaim keyboard focus for the main browser when the user clicks a
+// main-DOM input (address bar, etc). Runs on the CEF UI thread because:
+//   - host.set_focus / browser_view_get_for_browser require the UI thread
+//   - walking the HWND tree via EnumChildWindows is safer post-setup when
+//     Chromium has published all of its render widgets
+//
+// On Windows, after the Chromium-level focus flip we also walk the Views
+// window for the Chrome_RenderWidgetHostHWND and Win32-SetFocus it — without
+// that explicit Win32 SetFocus, keyboard events keep routing to whichever
+// pane HWND currently holds Win32 focus even though Chromium "thinks" main
+// is focused. Observed on v0.33.264: host.set_focus(1) on main left pane
+// keystrokes arriving at the pane HWND for >2 seconds.
+
+wrap_task! {
+    pub struct MainFocusReclaimTask {
+        state: Arc<AppState>,
+        label: String,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let mut browser = match self.state.browsers.lock().get(&self.label).cloned() {
+                Some(b) => b,
+                None => {
+                    tracing::warn!("[main-focus-reclaim] no browser for label={}", self.label);
+                    return;
+                }
+            };
+
+            if let Some(host) = browser.host() {
+                host.set_focus(1);
+                tracing::info!("[main-focus-reclaim] host.set_focus(1) on label={}", self.label);
+            }
+
+            #[cfg(target_os = "windows")]
+            {
+                let views_top_hwnd = browser_view_get_for_browser(Some(&mut browser))
+                    .and_then(|bv| bv.window())
+                    .map(|w| w.window_handle().0 as *mut std::ffi::c_void)
+                    .filter(|p| !p.is_null());
+
+                // Collect every pane's outer HWND so we can skip render widgets
+                // that descend from them. Panes are siblings of main under the
+                // Views top-level, so a naive EnumChildWindows would pick up
+                // their Chrome_RenderWidgetHostHWND and SetFocus on the wrong
+                // target.
+                let pane_outer_hwnds: Vec<*mut std::ffi::c_void> = {
+                    let browsers = self.state.browsers.lock();
+                    browsers
+                        .iter()
+                        .filter(|(k, _)| k.starts_with("browser-pane-"))
+                        .filter_map(|(_, b)| {
+                            let mut b = b.clone();
+                            b.host().and_then(|h| {
+                                let wh = h.window_handle();
+                                if wh.0.is_null() { None } else { Some(wh.0 as *mut std::ffi::c_void) }
+                            })
+                        })
+                        .collect()
+                };
+
+                match views_top_hwnd {
+                    Some(top_hwnd) => unsafe {
+                        let render = find_main_render_widget(top_hwnd, &pane_outer_hwnds);
+                        let target = render.unwrap_or(top_hwnd);
+                        windows_sys::Win32::UI::Input::KeyboardAndMouse::SetFocus(target as _);
+                        tracing::info!(
+                            "[main-focus-reclaim] Win32 SetFocus target={:p} render_found={} panes_excluded={}",
+                            target,
+                            render.is_some(),
+                            pane_outer_hwnds.len(),
+                        );
+                    },
+                    None => {
+                        tracing::warn!(
+                            "[main-focus-reclaim] could not resolve Views top-level HWND for label={}",
+                            self.label,
+                        );
+                    }
+                }
+            }
+
+            // Defocus all live panes at the Chromium level too.
+            self.state.browser_panes.defocus_all(&self.state);
+        }
+    }
+}
+
+/// Walk descendants of `root` and return the first Chrome_RenderWidgetHostHWND
+/// whose ancestor chain does NOT pass through any of `pane_outer_hwnds`.
+/// Panes are siblings of main under the Views top-level, so without this
+/// filter the walk would happily pick a pane's render widget.
+#[cfg(target_os = "windows")]
+unsafe fn find_main_render_widget(
+    root: *mut std::ffi::c_void,
+    pane_outer_hwnds: &[*mut std::ffi::c_void],
+) -> Option<*mut std::ffi::c_void> {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        EnumChildWindows, GetClassNameW, GetParent,
+    };
+
+    struct Finder<'a> {
+        found: *mut std::ffi::c_void,
+        panes: &'a [*mut std::ffi::c_void],
+    }
+    let mut finder = Finder { found: std::ptr::null_mut(), panes: pane_outer_hwnds };
+
+    unsafe extern "system" fn cb(hwnd: *mut std::ffi::c_void, lparam: isize) -> i32 {
+        let finder = &mut *(lparam as *mut Finder);
+        let mut buf = [0u16; 64];
+        let n = GetClassNameW(hwnd, buf.as_mut_ptr(), buf.len() as i32);
+        if n > 0 {
+            let class = String::from_utf16_lossy(&buf[..n as usize]);
+            if class == "Chrome_RenderWidgetHostHWND" {
+                // Walk ancestors; if we pass through any pane outer HWND,
+                // this widget belongs to a pane, not main.
+                let mut descends_from_pane = false;
+                let mut cursor = GetParent(hwnd);
+                while !cursor.is_null() {
+                    if finder.panes.iter().any(|p| *p == cursor) {
+                        descends_from_pane = true;
+                        break;
+                    }
+                    cursor = GetParent(cursor);
+                }
+                if !descends_from_pane {
+                    finder.found = hwnd;
+                    return 0; // stop
+                }
+            }
+        }
+        1
+    }
+
+    EnumChildWindows(root, Some(cb), &mut finder as *mut _ as isize);
+    if finder.found.is_null() { None } else { Some(finder.found) }
+}

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.263"
+version = "0.33.264"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.263"
+version = "0.33.264"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.263"
+version = "0.33.264"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_PANE_FOCUS_STRESS_TEST.md
+++ b/docs/specs/SPEC_PANE_FOCUS_STRESS_TEST.md
@@ -1,0 +1,282 @@
+# SPEC: Pane Focus Stress Test
+
+Status: draft
+Date: 2026-04-18
+Owner: AgentA
+Motivation: single pane-click → address-bar-click → type passes smoke test
+at v0.33.264 (via `MainFocusReclaimTask`). User reports that under a
+multi-pane, multi-round switching workload the focus routing eventually
+breaks ("typing stops moving"). Current smoke drive via windows-mcp is
+too thin to find the bug. This spec defines the workload that must pass
+and the automation scaffolding for running it reliably.
+
+## 1. The workload that must pass
+
+### 1.1 Layout
+
+Three panes side-by-side in a single tab, from left to right:
+
+| Pane | View type | Initial state |
+|------|-----------|---------------|
+| **P1** | browser  | navigated to `https://google.com` |
+| **T**  | terminal | shell prompt at `C:\Users\...` |
+| **P2** | browser  | navigated to `https://google.com` |
+
+Rationale: two browser panes plus a terminal exercises every relevant
+focus edge — pane ↔ main, pane ↔ pane, pane ↔ terminal, and the terminal's
+own xterm.js focus machinery which is separate from main's address bar.
+
+### 1.2 Round definitions — distinct orderings per round
+
+Three rounds, each with a **different ordering** to exercise a
+different transition type. A fourth "reverse" round flips round 1.
+After each step, assert where the characters ended up.
+
+Typed-text tokens use a unique prefix per step so a misroute is
+visible in whichever destination *did* receive the characters.
+
+**Round 1 — left-to-right sweep, then addr→addr, then back to search.**
+Exercises the basic pane→terminal→pane→address chain.
+
+| # | Click target        | Type     | Must land in       |
+|---|---------------------|----------|--------------------|
+| 1 | P1 search box       | `r1a`    | P1 search          |
+| 2 | T terminal prompt   | `r1b`    | Terminal buffer    |
+| 3 | P2 search box       | `r1c`    | P2 search          |
+| 4 | P1 address bar      | `r1d`    | P1 address         |
+| 5 | P2 address bar      | `r1e`    | P2 address         |
+| 6 | P1 search box       | `r1f`    | P1 search          |
+
+**Round 2 — pane ↔ pane bouncing, terminal interleaved.**
+Catches the specific failure mode where direct pane→pane transitions
+leak focus via stale `ALLOW_PANE_FOCUS_ONCE`.
+
+| # | Click target        | Type     | Must land in       |
+|---|---------------------|----------|--------------------|
+| 1 | P2 search box       | `r2a`    | P2 search          |
+| 2 | P1 search box       | `r2b`    | P1 search          |
+| 3 | P2 search box       | `r2c`    | P2 search          |
+| 4 | P1 address bar      | `r2d`    | P1 address         |
+| 5 | T terminal prompt   | `r2e`    | Terminal buffer    |
+| 6 | P2 address bar      | `r2f`    | P2 address         |
+
+**Round 3 — terminal-heavy, same-target repeats, closing with a search.**
+Catches stale main-focus state and duplicate-target idempotency.
+
+| # | Click target        | Type     | Must land in       |
+|---|---------------------|----------|--------------------|
+| 1 | T terminal prompt   | `r3a`    | Terminal buffer    |
+| 2 | T terminal prompt   | `r3b`    | Terminal buffer (same target twice) |
+| 3 | P1 search box       | `r3c`    | P1 search          |
+| 4 | T terminal prompt   | `r3d`    | Terminal buffer    |
+| 5 | P2 search box       | `r3e`    | P2 search          |
+| 6 | P1 address bar      | `r3f`    | P1 address         |
+
+**Round 4 — reverse of round 1.** Catches left-right asymmetry
+(any "only one direction works" bug).
+
+| # | Click target        | Type     | Must land in       |
+|---|---------------------|----------|--------------------|
+| 1 | P1 search box       | `r4a`    | P1 search          |
+| 2 | P2 address bar      | `r4b`    | P2 address         |
+| 3 | P1 address bar      | `r4c`    | P1 address         |
+| 4 | P2 search box       | `r4d`    | P2 search          |
+| 5 | T terminal prompt   | `r4e`    | Terminal buffer    |
+| 6 | P1 search box       | `r4f`    | P1 search          |
+
+24 click→type cycles total across the four rounds. Each round covers
+a different transition shape:
+
+| Transition         | R1 | R2 | R3 | R4 |
+|--------------------|----|----|----|----|
+| P1 → T             | ✓ |    | ✓ |    |
+| T → P2             | ✓ |    |    |    |
+| T → P1             |    |    | ✓ |    |
+| P1 → P2 (direct)   |    | ✓ |    |    |
+| P2 → P1 (direct)   |    | ✓ |    |    |
+| P1 → P1 addr       | ✓ |    |    | ✓ |
+| P2 → P2 addr       |    |    |    |    |
+| P1 addr → P2 addr  | ✓ |    |    |    |
+| P2 addr → P1 addr  |    |    |    | ✓ |
+| P1 addr → T        |    | ✓ |    |    |
+| T → T (idempotent) |    |    | ✓ |    |
+| P2 → P1 addr       |    | ✓ |    |    |
+| P2 → T             |    |    |    | ✓ |
+
+### 1.3 Pass criteria
+
+- Every step's typed text ends up in the asserted destination, character-
+  for-character. No drops, no misroutes.
+- No `[pane-wndproc] key msg=` log entry is attributable to a step
+  targeting a non-pane destination (address bar, terminal, or other
+  pane). Keys reaching the "wrong" pane HWND is the failure mode.
+- `main-focus-reclaim` log entries show `render_found=true` on every
+  fire. Any `render_found=false` is a bug.
+- No `[main-focus-reclaim] could not resolve Views top-level HWND`
+  warnings.
+
+## 2. Why the current single-path smoke test isn't enough
+
+Single-click-into-browser-then-address-bar passes because only one pane
+exists. The failure mode only shows up when:
+
+- **The "which render widget is main's" walk picks the wrong one** because
+  multiple Chrome_RenderWidgetHostHWNDs are siblings. The fix excludes
+  pane outer HWNDs from the walk — but only panes currently in
+  `state.browsers` with the `browser-pane-*` prefix. A second pane
+  created after the walker ran and cached something stale would escape.
+- **The WM_LBUTTONDOWN subclass arms `ALLOW_PANE_FOCUS_ONCE` once per
+  click** — but the flag is a single global `AtomicBool`. Two panes
+  clicked in rapid succession race on that flag. Second pane's click
+  may arm → first pane's still-in-flight WM_SETFOCUS consumes → second
+  pane never gets the allow.
+- **Terminal focus** goes through a different path (no WM_LBUTTONDOWN
+  subclass on main's render widget). The terminal → pane → terminal
+  transitions aren't covered.
+- **Defocus timing**: `defocus_all` on every `main_window_focus` can
+  race with Chromium's own internal re-focus of a pane when the pane
+  has a pending JS `window.focus()`. User's reported "eventually
+  breaks" sounds exactly like a state leak after 5–10 transitions.
+
+## 3. Automation — windows-mcp test harness
+
+### 3.1 Setup phase (driver-side, before the rounds)
+
+1. Kill any running `agentmux-cef` processes.
+2. Start `task dev`; wait until `agentmux-cef` main process has a
+   `MainWindowHandle != 0` (poll every 2s, max 180s).
+3. Foreground + position AgentMux at a known (x, y, w, h) so pane
+   coordinates are deterministic across runs. Use `1300x900` at
+   `(50, 50)`.
+4. Snapshot the accessibility tree. Locate the `+` new-tab button and
+   any existing tab controls so we can reset to a known workspace.
+5. Capture `data_dir` from the task dev log (`Using data_dir: %APPDATA%…`)
+   so the test can tail `agentmux-host-v*.log.*` later.
+6. **Blank-slate reset**: right-click the one existing block, choose
+   **Close Block**, confirm empty tab. Then:
+   - Right-click the empty tab area → choose "browser" from the
+     widget context menu.
+   - Right-click the new browser pane → **Split Right** → choose
+     "terminal" from the replace menu.
+   - Right-click the terminal pane → **Split Right** → choose
+     "browser" again.
+7. Navigate P1 and P2 to `https://google.com` by clicking their
+   address-bar elements and typing `google.com<Enter>`.
+
+All of steps 6 and 7 are driven via `Snapshot` (interactive element IDs)
+so the harness does not depend on pixel coordinates for menu items.
+
+### 3.2 Round execution (three iterations)
+
+Per round, driver does:
+
+```
+for round in 1..=3:
+    for (target_label, text, expected_destination) in round_steps:
+        click(target_label)
+        sleep 200ms
+        sendkeys(text)
+        sleep 400ms
+        snapshot_and_assert(expected_destination, text)
+        tail_log_since_last_checkpoint()
+```
+
+`click(target_label)` uses the element ID from `Snapshot`, not pixel
+coords. This survives layout reflow between rounds.
+
+`snapshot_and_assert(dest, text)` reads the accessibility tree value
+of `dest` and verifies it ends with `text`. This catches the three
+failure shapes:
+
+- No text anywhere → Win32 SetFocus dropped somewhere.
+- Text in the **wrong** destination → focus routed to the wrong HWND.
+- Text in the **right** destination → pass.
+
+`tail_log_since_last_checkpoint()` greps the host log for every
+`main-focus-reclaim`, `pane-wndproc`, `pane-focus`, `WM_KILLFOCUS`,
+`WM_LBUTTONDOWN`, and `main_window_focus` line produced since the
+last step. Stored per-step so a failure shows the exact CEF-side
+sequence that led up to it.
+
+### 3.3 Teardown
+
+1. Capture the full host log for the session to
+   `tmp/pane-focus-stress-run-<timestamp>.log`.
+2. Screenshot the final window state.
+3. Close all panes (for cleanliness).
+4. Kill agentmux-cef.
+
+### 3.4 Failure localisation
+
+When the harness trips an assertion, emit this report to stderr:
+
+```
+FAIL round=<N> step=<M>
+  target:       <label>
+  typed:        "<text>"
+  expected:     "<destination element value ends with text>"
+  observed in:  <element where the text actually ended up, or "nowhere">
+  last 30 log lines relevant to focus routing:
+    ...
+  screenshot:   tmp/fail-round<N>-step<M>.png
+  accessibility snapshot: tmp/fail-round<N>-step<M>.tree.json
+```
+
+## 4. What to do with failures
+
+For every documented failure, add a targeted regression test to
+`agentmux-cef/tests/focus_integration.rs` (a new integration harness
+that posts synthetic WM_LBUTTONDOWN / WM_SETFOCUS messages at specific
+HWNDs and asserts the resulting SetFocus target). That way the next
+iteration of the pane-focus fix can't re-break the same scenario.
+
+Even if L3 integration tests for the CEF callback path are too heavy
+(per `SPEC_BROWSER_PANE_LIFECYCLE_TESTS.md`), a **pure state-machine
+test** of the "which HWND should SetFocus land on given { main_hwnd,
+pane_hwnds[], candidate_render_widgets[] }" function is trivial and
+reproduces every failure this harness finds.
+
+## 5. First deliverable (before doing another fix)
+
+1. Build the harness script at `tools/tests/pane-focus-stress.mjs`
+   (or `.ps1` — any shell works, PowerShell is easier for windows-mcp
+   bindings).
+2. Run it against current main. Capture a PASS or the exact FAIL.
+3. If FAIL: add the regression test described in §4 before shipping
+   the next Rust change. No "guess and retry" loops.
+4. If PASS: mark this bug-report CLOSED in the PR description and keep
+   the harness as a nightly CI job.
+
+## 6. Not in scope
+
+- Multi-window drag/drop focus. Separate test suite.
+- Pane focus inside iframes of the embedded page.
+- Terminal-specific keyboard quirks (`Ctrl+C`, arrow keys, etc.) — the
+  workload only tests plain character typing.
+
+## 7. Extension rounds (nightly only)
+
+The four rounds from §1.2 are the minimum viable coverage. For the
+nightly CI job, additional rounds add stress-scale variations:
+
+- **Round 5 — rapid fire**: 20 consecutive P1↔P2 search-box clicks
+  with minimal delay (<50ms). Catches focus operations that serialise
+  badly under pressure.
+- **Round 6 — nav-interleaved**: between each focus switch, trigger a
+  page navigation in one of the browsers (e.g. type a URL + Enter).
+  Catches the `install_pane_focus_redirect` reinstall-on-load-end path
+  from `SPEC_BROWSER_PANE_LIFECYCLE.md` §5 race #5 under concurrent
+  focus transitions.
+- **Round 7 — pane lifecycle**: close a pane mid-round, create a new
+  one, continue. Catches focus state that leaked from a destroyed
+  pane's outer HWND.
+
+These aren't part of the pre-merge gate — only the four rounds in §1.2
+are. Nightly extension is aspirational once the core is stable.
+
+## 8. Target completion
+
+- Harness script + this spec landed in the next pane-fix PR.
+- Each subsequent pane-focus PR must run this harness locally **and**
+  as part of the PR's test plan, with the pass/fail output captured
+  in the PR description.

--- a/docs/specs/SPEC_TEST_API_ACCESS.md
+++ b/docs/specs/SPEC_TEST_API_ACCESS.md
@@ -1,0 +1,407 @@
+# SPEC: Test-Harness Access to the App API (+ /wave → /agentmux rename)
+
+Status: draft
+Date: 2026-04-18
+Owner: AgentA
+Motivation: external test harnesses (PowerShell, Node, Rust integration
+binaries, future CI jobs) need to call the agentmux-srv service API in
+order to drive setup and teardown without touching the UI. Today the API
+is fully functional but gated behind a per-process random auth key that
+no external process can read.
+
+This spec proposes a narrow, audit-friendly path for dev-mode harnesses
+to obtain that key while preserving release-build security.
+
+**Bundled rename.** Every HTTP route is currently prefixed `/wave/*` —
+a Wave-Terminal-era name that's been misleading since the AgentMux fork.
+This spec also renames the prefix to `/agentmux/*` as part of the same
+effort, since every test harness that uses the endpoint has to learn
+its URL. Doing both at once avoids teaching harnesses the old name.
+
+## 1. Background
+
+### 1.1 What the API does
+
+`agentmux-srv` exposes an HTTP router on `127.0.0.1:<port>`. The main
+RPC endpoint is `POST /wave/service` (rename target: `/agentmux/service`).
+Every frontend action goes through this endpoint — `CreateBlock`,
+`DeleteBlock`, `UpdateObjectMeta`, `CreateTab`, `UpdateTabIds`,
+`SetMeta`, layout tree reducers, etc. The request body carries
+`{service, method, args, uicontext}`. Response is `{data, updates, error}`.
+
+Other routes under the same prefix:
+
+| Route | Purpose |
+|---|---|
+| `POST /wave/service` | Main RPC |
+| `GET  /wave/file` | File read for object-id / filename pairs |
+| `GET  /wave/stream-file[/*path]` | Stream-read (currently 501 stubs) |
+| `GET  /wave/stream-local-file` | Local file stream (501) |
+| `POST /wave/reactive/inject` | LAN-awareness reactive API |
+| `GET/POST /wave/reactive/*` | Reactive agent registry/audit/poller |
+
+All of these will move to `/agentmux/*`. See §4.7 for the rename details.
+
+### 1.2 Why the auth key exists
+
+`agentmux-srv` listens on a loopback TCP port, not a Unix-domain socket.
+Any process on the machine that reaches `127.0.0.1:<port>` could, absent
+auth, invoke arbitrary service methods — which includes methods that
+spawn shell processes (terminal blocks), delete user data (workspace
+delete), or modify layout state. Auth is defense against **same-user
+local-process attack**.
+
+The key is a random v4 UUID generated at `agentmux-cef` startup
+(`state.rs:241`), stored in `state.auth_key: Mutex<String>`, and passed
+to `agentmux-srv` via the `AGENTMUX_AUTH_KEY` env var
+(`sidecar.rs:119`). Frontend reads it via the CEF host binding
+`getApi().getAuthKey()`.
+
+### 1.3 Current gap
+
+External processes can't obtain the key because:
+- It never hits the filesystem.
+- The host logs only the first 8 chars (`sidecar.rs:109`) for diagnostic
+  purposes — deliberately not the full key.
+- The CEF host binding isn't reachable over any documented channel from
+  outside the CEF process.
+
+Result: test harnesses have no way to call the app API. They currently
+simulate user input via UIAutomation + mouse clicks, which is slow,
+flaky, layout-sensitive, and can't reach operations that don't have UI
+bindings (bulk data manipulation, fixture setup, etc).
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+1. **Test-only endpoints (eventually, CI-friendly)**: a harness written
+   in any language should be able to call `/wave/service` against a
+   running `task dev` instance, without polling logs or driving UI.
+2. **Release-build parity**: release builds behave exactly as today.
+   No auth-weakening, no new endpoints, no file writes that weren't
+   already there.
+3. **Audit clarity**: any dev-only behaviour is gated on a single
+   compile-time feature or env var, visible in `grep` and reviewable
+   in one PR.
+4. **No new trust model**: we don't invent a second auth layer or a
+   token-exchange protocol. The existing `auth_key` is the key; the
+   question is just how a dev harness retrieves it.
+
+### 2.2 Non-goals
+
+- Remote test access. This is local-only; `127.0.0.1` stays.
+- Changing the service API surface.
+- Replacing UI-level test drivers (UIA) — they're still the right tool
+  for testing UI behaviour. This spec is about data/setup plumbing.
+- Multi-user concurrent dev instances. If two agentmux-cef processes
+  run for the same user, they have separate data dirs (`ai.agentmux.cef.v<ver>`)
+  and thus separate auth files; that's fine.
+
+## 3. Threat model
+
+The system remains defended against:
+
+| Attacker | Before | After (Option A) |
+|---|---|---|
+| Remote network attacker (same LAN) | Blocked by 127.0.0.1-only bind | Same |
+| Same-user local process (release build) | Needs auth_key (in-process only) | Same |
+| Same-user local process (dev build) | Needs auth_key | Can read `authkey.dev` from user-readable path |
+| Other-user local process | Blocked by Windows ACL / Linux file perms on the data dir | Same — same ACLs apply to the auth file |
+
+Dev builds weaken the "same-user local process" axis, which is consistent
+with how every dev-mode tool (Vite exposing :5173, CEF remote debugging
+on :9222, the sidecar's own loopback ports) behaves today. Release
+builds are unchanged.
+
+## 4. Design options considered
+
+### 4.1 Option A — dev-only auth file (recommended)
+
+`agentmux-cef` writes the auth_key to a file in the data dir at startup
+when `cfg(debug_assertions)` is true. File is gone or stale on next
+release-build startup. Harness reads file → calls `/wave/service` with
+the key.
+
+- **Path**: `<data_dir>/authkey.dev`
+- **Contents**: `{"auth_key":"<uuid>","web_endpoint":"127.0.0.1:<port>","ws_endpoint":"127.0.0.1:<port>","created_at":"<iso8601>","pid":<cef_pid>}`
+- **Write timing**: after backend started, so endpoints are known (sidecar.rs line 108 context).
+- **ACL**: Windows DACL set to "current user only, no inherited ACEs".
+  On Unix: mode `0600`, owner = current uid.
+- **Cleanup**: overwritten on every fresh startup (superseded). Not
+  deleted on shutdown (next startup owns the overwrite — deletes on
+  shutdown can race with harnesses reading).
+- **Gate**: `#[cfg(debug_assertions)]` surrounding both the write and
+  the ACL code, and the struct that defines the file format.
+- **Release behaviour**: file is never written. Harnesses that look
+  for it fail fast.
+
+**Pros**
+- Works for any language; no SDK required.
+- One-file, one-gate — a reviewer can confirm it's dev-only in one grep.
+- Consistent with Vite :5173 and CEF :9222 dev-mode exposures.
+- No new endpoints, no new auth, no change to the trust model.
+
+**Cons**
+- File on disk. Mitigated by owner-only ACL and debug-build-only gate.
+- Harness has to know the file path (documented in the harness README).
+
+### 4.2 Option B — dedicated test API with a separate token
+
+Add `POST /test/*` methods with their own `test_token` env var that only
+dev builds generate. Sanctioned test methods (create_layout, reset_workspace)
+live here, not on the main service.
+
+**Pros**
+- Separation of intent: clearly "test-only" surface.
+- Test methods can be higher-level (one call = full 3-pane layout).
+
+**Cons**
+- Two auth systems to maintain.
+- Re-implements methods the main service already has.
+- More endpoints is more surface to guard.
+- A dev harness still needs a way to fetch `test_token` — same problem
+  we started with, one level removed.
+
+### 4.3 Option C — CEF DevTools protocol
+
+Drive the frontend's already-authenticated context via CDP on :9222.
+Execute `window.globalAtoms...` / `getApi().getAuthKey()` via
+`Runtime.evaluate`.
+
+**Pros**
+- No new backend code.
+- Works on release builds too (if DevTools port is exposed).
+
+**Cons**
+- DevTools is disabled on release by default (and should be).
+- CDP websocket protocol is an API surface we don't control.
+- Frontend internals (`globalAtoms`) aren't a stable API — refactors
+  would break harnesses.
+- Slow — CDP round-trips add hundreds of ms per call.
+
+### 4.4 Option D — IPC-channel auth extension
+
+`agentmux-cef` already exposes IPC over a separate port with an
+`ipc_token` that's written to the page URL. Add a `get_auth_key` IPC
+command that returns `state.auth_key` to the IPC caller.
+
+**Pros**
+- Reuses an existing authenticated channel.
+- No filesystem.
+
+**Cons**
+- `ipc_token` is logged to host log (redactable) and embedded in the
+  Vite-served URL — harvestable by any process that can read either.
+  So this just moves the auth question from "get the auth_key" to
+  "get the ipc_token". No net security improvement.
+- Couples frontend IPC and backend service auth semantically.
+
+### 4.5 Option E — unix/Windows named pipe with OS-level auth
+
+Expose a second channel over a named pipe with OS file-system permissions
+doing the auth instead of a token.
+
+**Pros**
+- "Most secure" on paper; no tokens to leak.
+
+**Cons**
+- Cross-platform pipe code (Windows named pipes vs Unix sockets) is
+  a non-trivial amount of work.
+- Harnesses need pipe-talking code per language.
+- Overkill for a dev-time plumbing problem.
+
+### 4.6 Decision
+
+**Option A.** Simplest, smallest surface, matches how other dev-time
+tools expose themselves. Each of the alternatives solves a problem we
+don't have (B = bespoke test API when the main API is already fine;
+C = frontend-internals dependency; D = moved shell game; E = enterprise
+security for a dev-time fixture).
+
+### 4.7 Path rename: `/wave/*` → `/agentmux/*`
+
+Lifted with the auth-file change because anyone writing a harness
+against `/wave/service` would otherwise learn the old name and have to
+relearn it later. Rename now; never document the old name in any
+harness doc. Scope from `grep -rn /wave/ .`:
+
+- `agentmux-srv/src/server/mod.rs` — `Router::route("/wave/...")` literals
+- `agentmux-srv/src/server/reactive.rs` — internal refs to the reactive path
+- `agentmux-srv/src/backend/blockcontroller/shell.rs` — shell-side URL builders
+- `agentmux-srv/src/server/tests.rs` — test URIs
+- `agentmux-srv/tests/integration_test.rs` — integration test URIs
+- `frontend/app/store/wos.ts` — `getWebServerEndpoint() + "/wave/service"`
+- `frontend/app/store/global.ts` — `/wave/file?...`
+- `frontend/app/view/term/*` — termosc / termsticker / termagent URL builders
+- `frontend/app/element/markdown-util.ts`, `frontend/util/waveutil.ts`
+- `agentmux-cef/src/client.rs` — one internal URL, if any matches
+- Spec-side references (`specs/*.md`, `docs/analysis/*.md`) — docs update only,
+  no behaviour change
+
+21 files match `/wave/` today. One commit, one grep-replace pass,
+`cargo check` + `npx tsc --noEmit` + `cargo test --features test-authfile`
+all pass. No compat shim — both server and client flip atomically
+because they ship in the same build.
+
+External integrations? None — the backend is 127.0.0.1-only and the
+frontend is the only client. No API consumers to deprecate.
+
+Test: the server should return 404 on any `/wave/*` request after the
+rename (canary test in `agentmux-srv/src/server/tests.rs`).
+
+## 5. File format
+
+```jsonc
+// <data_dir>/authkey.dev
+{
+  "version":         1,
+  "auth_key":        "f8c9b0e4-1234-4567-89ab-cdef01234567",
+  "web_endpoint":    "127.0.0.1:59719",
+  "ws_endpoint":     "127.0.0.1:59720",
+  "ipc_endpoint":    "127.0.0.1:59718",
+  "ipc_token":       "92d136fa-2e14-46d0-9ace-eddee320a35e",
+  "service_path":    "/agentmux/service",
+  "file_path":       "/agentmux/file",
+  "instance":        "v0.33.264",
+  "data_dir":        "C:\\Users\\area54\\AppData\\Roaming\\ai.agentmux.cef.v0-33-264",
+  "host_pid":        19500,
+  "created_at":      "2026-04-18T20:30:15.123Z"
+}
+```
+
+Including `service_path` / `file_path` (post-rename values) so a
+future prefix change doesn't require harnesses to hardcode strings.
+
+Fields chosen so a harness has everything it needs without having to
+parse logs:
+- `auth_key` / `web_endpoint` — hit `/wave/service`.
+- `ipc_endpoint` / `ipc_token` — already-logged values, consolidated
+  for convenience (harness can send IPC commands too).
+- `host_pid` — lets harness detect stale files from a dead instance.
+- `instance` / `data_dir` — diagnostics; useful when multiple dev
+  instances exist.
+- `version` — schema version. Bump if the file format changes.
+
+## 6. Code changes
+
+### 6.1 `agentmux-cef/src/sidecar.rs`
+
+After `Backend successfully started` log line, when
+`cfg(debug_assertions)`:
+
+```rust
+#[cfg(debug_assertions)]
+{
+    write_dev_auth_file(
+        &data_dir,
+        &auth_key,
+        &backend_endpoints,  // web + ws
+        &ipc_endpoint,
+        &ipc_token,
+        &version_instance_id,
+    );
+}
+```
+
+New helper `fn write_dev_auth_file(...)` in the same file (or a new
+`src/dev_authfile.rs`), gated by `#[cfg(debug_assertions)]`.
+
+### 6.2 ACL logic
+
+Windows (`windows-sys` crate already in deps):
+- Create the file with `GENERIC_READ | GENERIC_WRITE` for current user
+  only, no inherited ACEs.
+- Use `SetNamedSecurityInfo` or `AddAccessAllowedAce` to construct a
+  DACL with one ACE for the current user.
+
+Unix (not currently a target, but for future parity):
+- `std::fs::Permissions::from_mode(0o600)` on the file handle.
+
+Both paths verified by a unit test that reads the DACL back and asserts
+only the current user's SID is present.
+
+### 6.3 Release build is compile-time unreachable
+
+Both the helper function and its call site are under `#[cfg(debug_assertions)]`.
+A release build's binary won't contain the helper at all. A
+`grep -R authkey.dev agentmux-cef/target/release/` on the built binary
+must return zero hits — verified in CI.
+
+### 6.4 Harness README update
+
+`tools/tests/README.md` adds a section:
+
+> **Getting the auth key.** A dev-mode `agentmux-cef` writes its auth
+> key and endpoints to `<data_dir>/authkey.dev`. The dev data dir on
+> Windows is `%APPDATA%\ai.agentmux.cef.v<version>` (format: `v0-33-264`
+> for version `0.33.264`). Read the file as JSON. The structure is
+> documented in `docs/specs/SPEC_TEST_API_ACCESS.md` §5.
+
+### 6.5 Harness library (`tools/tests/authfile.ps1`)
+
+Helper sourced from `pane-focus-stress.ps1`:
+
+```powershell
+function Read-AgentmuxAuthFile {
+    # Walk APPDATA for the newest ai.agentmux.cef.v* dir
+    # Read authkey.dev, validate host_pid is alive, return the object
+    # Throw if no file, or if file is stale (pid dead)
+}
+```
+
+Similar helpers land for Node.js (`tools/tests/authfile.mjs`) and
+Python (`tools/tests/authfile.py`) as those ecosystems start needing
+the harness.
+
+## 7. Test plan
+
+1. **Unit test** in `agentmux-cef/tests/dev_authfile.rs` — verifies
+   file format, ACL (owner-only), and the `#[cfg]` gate (compiles but
+   has no side effect in release build). Only run under
+   `cargo test --features test-authfile`.
+2. **Smoke test** — after `task dev` comes up, `authkey.dev` exists,
+   parses as JSON, contains a non-empty `auth_key` field.
+3. **Negative test** — a release build produces no `authkey.dev` file.
+   Verified in CI by building with `--release` and checking
+   `<data_dir>/authkey.dev` is absent after startup.
+4. **Harness round-trip** — `pane-focus-stress.ps1` reads the file,
+   makes a `POST /wave/service` with service=workspace method=GetWorkspace,
+   expects `200 OK` with a Workspace payload.
+
+## 8. Rollout
+
+1. PR 1: land this spec.
+2. PR 2: `/wave/*` → `/agentmux/*` rename. Pure grep-replace; backend
+   routes + every caller in the same commit. Regression canary: 404
+   on `/wave/service`. Lands independently of PR 3 so the rename isn't
+   blocked on auth-file work.
+3. PR 3: add `authkey.dev` file write + ACL, unit tests, release-build
+   no-op verification.
+4. PR 4: update `pane-focus-stress.ps1` and `tools/tests/README.md` to
+   use the auth file. Retire the "fill in coords manually" step for
+   layout setup — harness creates the 3-pane layout via
+   `object.CreateBlock` + `workspace.UpdateTabIds` directly.
+5. PR 5 (optional): Rust integration test crate at `tests/integration/`
+   that uses the auth file to talk to a live dev instance. Replaces
+   manual smoke testing for large classes of behaviour.
+
+## 9. Back-compat
+
+File doesn't exist today; harnesses that need it check for it and
+gracefully fail with a clear message ("no authkey.dev found — run
+`task dev` first, or upgrade to v0.33.X+ which writes the file").
+No existing tool or path expects the file, so adding it is purely
+additive.
+
+## 10. Not in scope
+
+- Packaging a dedicated "test runner" binary. The PowerShell harness
+  is enough for the current load.
+- Cross-machine test access (remote CI agents driving a dev instance).
+  If that need arises, a port-forward or reverse-tunnel is the orthogonal
+  mechanism; the auth key concern is the same either way.
+- Auto-cleanup of stale `authkey.dev` files after the host exits.
+  Harnesses read `host_pid` and check liveness before using the key —
+  that handles the stale case. File cleanup on startup (overwrite) is
+  sufficient.

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -11,6 +11,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, createSignal, type Accessor } from "solid-js";
+import { markMainFocusReclaimed } from "./browser-view";
 
 export class BrowserViewModel implements ViewModel {
     viewType = "browser";
@@ -171,6 +172,10 @@ export class BrowserViewModel implements ViewModel {
             (active.tagName === "INPUT" || active.tagName === "TEXTAREA") &&
             !active.classList.contains("dummy-focus");
         if (isMainInput) {
+            // Arm the hover-focus cooldown so a cursor that's still over
+            // the pane area doesn't re-steal keyboard focus from the
+            // main input the user just landed on.
+            markMainFocusReclaimed();
             invokeCommand("main_window_focus", {}).catch(() => {});
             return true;
         }

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -11,7 +11,6 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, createSignal, type Accessor } from "solid-js";
-import { markMainFocusReclaimed } from "./browser-view";
 
 export class BrowserViewModel implements ViewModel {
     viewType = "browser";
@@ -172,10 +171,6 @@ export class BrowserViewModel implements ViewModel {
             (active.tagName === "INPUT" || active.tagName === "TEXTAREA") &&
             !active.classList.contains("dummy-focus");
         if (isMainInput) {
-            // Arm the hover-focus cooldown so a cursor that's still over
-            // the pane area doesn't re-steal keyboard focus from the
-            // main input the user just landed on.
-            markMainFocusReclaimed();
             invokeCommand("main_window_focus", {}).catch(() => {});
             return true;
         }

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -6,27 +6,6 @@ import { invokeCommand } from "@/app/platform/ipc";
 import type { BrowserViewModel } from "./browser-model";
 import "./browser-view.scss";
 
-/**
- * Global timestamp of the last "main window reclaimed focus" event.
- * Shared across every BrowserViewComponent instance in the window so that
- * clicking an address bar in one pane suppresses the hover-focus re-grab
- * in every pane (including itself) for a short cooldown window. Without
- * this, moving the cursor back over the pane right after clicking a main-
- * DOM input re-fires `onMouseEnter` → `browser_pane_focus` and re-locks
- * Windows-level keyboard focus onto the pane — the exact
- * "type in browser then can't type anywhere else" bug report.
- */
-let lastMainFocusAtMs = 0;
-const MAIN_FOCUS_COOLDOWN_MS = 750;
-
-export function markMainFocusReclaimed() {
-    lastMainFocusAtMs = Date.now();
-}
-
-function mainFocusCooldownActive(): boolean {
-    return Date.now() - lastMainFocusAtMs < MAIN_FOCUS_COOLDOWN_MS;
-}
-
 export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>): JSX.Element {
     const model = props.model;
     const [addressBar, setAddressBar] = createSignal(model.urlAtom() || "");
@@ -168,12 +147,11 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     onFocus={(e) => {
                         e.currentTarget.select();
                         // Take OS-level keyboard focus away from the pane so
-                        // keystrokes reach this address-bar input. The pane may
-                        // have held HWND focus from an earlier hover. Also
-                        // arm the cooldown so the hover-focus grab below doesn't
-                        // immediately re-claim focus when the cursor is still
-                        // over the pane area.
-                        markMainFocusReclaimed();
+                        // keystrokes reach this address-bar input. The pane
+                        // grabs focus explicitly on click (onMouseDown on
+                        // .browser-placeholder), not on hover, so releasing
+                        // here is sufficient — nothing will re-steal until
+                        // the user clicks inside the pane again.
                         invokeCommand("main_window_focus", {}).catch(() => {});
                     }}
                     placeholder="Enter URL or search..."
@@ -188,23 +166,20 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
             <div
                 class="browser-placeholder"
                 ref={placeholderRef}
-                onMouseEnter={() => {
-                    // Windows routes WM_MOUSEWHEEL to the focused HWND, so hand
-                    // OS-level keyboard focus to the pane when the cursor is over
-                    // it. Without this, wheel events go to main's widget and the
-                    // embedded page can't scroll.
+                onMouseDown={() => {
+                    // User clicked into the pane — explicitly hand Windows-level
+                    // keyboard focus to the pane HWND so subsequent keystrokes
+                    // and mouse-wheel events route there.
                     //
-                    // Gated on three things:
-                    //   1. paneCreated — HWND exists.
-                    //   2. !model.closed — hover can fire between the close IPC
-                    //      being issued and the DOM node being removed; SetFocus
-                    //      on a dying HWND is the crash the lifecycle spec covers.
-                    //   3. !mainFocusCooldownActive — if the user just clicked a
-                    //      main-DOM input (address bar, etc), suppress the hover
-                    //      re-focus for MAIN_FOCUS_COOLDOWN_MS so the user can
-                    //      actually type. Without this, the hover handler grabs
-                    //      focus back before the first keystroke arrives.
-                    if (paneCreated() && !model.closed && !mainFocusCooldownActive()) {
+                    // We used to grab focus on onMouseEnter (hover), but that
+                    // created a loop: clicking the address bar released focus,
+                    // then the cursor drifting back over the pane (inevitable —
+                    // the address bar is right above it) re-grabbed focus
+                    // before the user could type. Hover-focus is nicer for
+                    // scroll-without-click, but it breaks keyboard routing so
+                    // aggressively that the trade-off doesn't pay. Explicit
+                    // click is the clear user intent.
+                    if (paneCreated() && !model.closed) {
                         invokeCommand("browser_pane_focus", { block_id: model.blockId }).catch(() => {});
                     }
                 }}

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -6,6 +6,27 @@ import { invokeCommand } from "@/app/platform/ipc";
 import type { BrowserViewModel } from "./browser-model";
 import "./browser-view.scss";
 
+/**
+ * Global timestamp of the last "main window reclaimed focus" event.
+ * Shared across every BrowserViewComponent instance in the window so that
+ * clicking an address bar in one pane suppresses the hover-focus re-grab
+ * in every pane (including itself) for a short cooldown window. Without
+ * this, moving the cursor back over the pane right after clicking a main-
+ * DOM input re-fires `onMouseEnter` → `browser_pane_focus` and re-locks
+ * Windows-level keyboard focus onto the pane — the exact
+ * "type in browser then can't type anywhere else" bug report.
+ */
+let lastMainFocusAtMs = 0;
+const MAIN_FOCUS_COOLDOWN_MS = 750;
+
+export function markMainFocusReclaimed() {
+    lastMainFocusAtMs = Date.now();
+}
+
+function mainFocusCooldownActive(): boolean {
+    return Date.now() - lastMainFocusAtMs < MAIN_FOCUS_COOLDOWN_MS;
+}
+
 export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>): JSX.Element {
     const model = props.model;
     const [addressBar, setAddressBar] = createSignal(model.urlAtom() || "");
@@ -148,7 +169,11 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                         e.currentTarget.select();
                         // Take OS-level keyboard focus away from the pane so
                         // keystrokes reach this address-bar input. The pane may
-                        // have held HWND focus from an earlier hover.
+                        // have held HWND focus from an earlier hover. Also
+                        // arm the cooldown so the hover-focus grab below doesn't
+                        // immediately re-claim focus when the cursor is still
+                        // over the pane area.
+                        markMainFocusReclaimed();
                         invokeCommand("main_window_focus", {}).catch(() => {});
                     }}
                     placeholder="Enter URL or search..."
@@ -169,11 +194,17 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     // it. Without this, wheel events go to main's widget and the
                     // embedded page can't scroll.
                     //
-                    // Gate on `model.closed`: hover can fire between the close IPC
-                    // being issued and the DOM node being removed — without this
-                    // check, SetFocus hits a HWND CEF is tearing down, which is
-                    // the crash-on-close described in the lifecycle spec.
-                    if (paneCreated() && !model.closed) {
+                    // Gated on three things:
+                    //   1. paneCreated — HWND exists.
+                    //   2. !model.closed — hover can fire between the close IPC
+                    //      being issued and the DOM node being removed; SetFocus
+                    //      on a dying HWND is the crash the lifecycle spec covers.
+                    //   3. !mainFocusCooldownActive — if the user just clicked a
+                    //      main-DOM input (address bar, etc), suppress the hover
+                    //      re-focus for MAIN_FOCUS_COOLDOWN_MS so the user can
+                    //      actually type. Without this, the hover handler grabs
+                    //      focus back before the first keystroke arrives.
+                    if (paneCreated() && !model.closed && !mainFocusCooldownActive()) {
                         invokeCommand("browser_pane_focus", { block_id: model.blockId }).catch(() => {});
                     }
                 }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.263",
+  "version": "0.33.264",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.263",
+      "version": "0.33.264",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.263",
+  "version": "0.33.264",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -1,0 +1,58 @@
+# Tools/tests
+
+Ad-hoc test harnesses for behaviour that's hard to unit-test.
+
+## `pane-focus-stress.ps1`
+
+Drives the 4-round pane-focus stress workload from
+`docs/specs/SPEC_PANE_FOCUS_STRESS_TEST.md` against a running
+`task dev` instance. Asserts log-side invariants (Chrome_RenderWidgetHostHWND
+located, no key events leaked to pane HWNDs during main-focus steps,
+etc.). Does not attempt to read Chromium DOM values — UIA doesn't expose
+them — so the log is the ground truth.
+
+### Setup before running
+
+1. `task dev` in the repo root. Wait for the window to appear.
+2. Position AgentMux at `(50, 50, 1300, 900)`. The harness does this
+   on its own via `SetForegroundWindow` + `MoveWindow`.
+3. **Manually** set up a 3-pane layout (tab-spec-driven context menu
+   walk is a follow-up):
+   - Right-click the existing single block → **Replace With...** →
+     **browser** → it becomes P1.
+   - Right-click P1 → **Split Right** → the new pane is a terminal
+     by default; if not, Replace With → terminal. This is T.
+   - Right-click T → **Split Right** → Replace With → browser. This is P2.
+4. Click into P1 and navigate to `https://google.com` (address bar +
+   Enter). Same for P2.
+5. Take a screenshot of the window and measure pixel coordinates for
+   each of the five targets:
+   - P1 Google search box
+   - P1 address bar
+   - P2 Google search box
+   - P2 address bar
+   - T terminal prompt
+6. Copy `pane-focus-stress.targets.json.example` to
+   `pane-focus-stress.targets.json`, fill in the coords.
+
+### Run
+
+```powershell
+pwsh tools/tests/pane-focus-stress.ps1
+```
+
+Pass: exits 0 with `PASS (24/24 steps)`.
+
+Fail: exits 1, writes a full per-step failure report to
+`$env:TEMP/pane-focus-stress-<ts>.log` with the log delta around
+each failed step.
+
+### Known limits
+
+- Manual layout setup (see step 3). The harness is just the
+  click-and-assert loop.
+- Pixel coordinates break if the window is resized or layout changes.
+  Re-run setup with a fresh `targets.json`.
+- The harness reads only the host log (not the sidecar). This is
+  usually enough; if not, add a `-SrvLogPath` parameter in a
+  follow-up.

--- a/tools/tests/pane-focus-stress.ps1
+++ b/tools/tests/pane-focus-stress.ps1
@@ -1,0 +1,306 @@
+# Copyright 2026, AgentMux Corp.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pane focus stress harness. See docs/specs/SPEC_PANE_FOCUS_STRESS_TEST.md.
+#
+# Runs the 4-round focus-switching workload against a live `task dev`
+# instance and reports per-step pass/fail. Windows-only; requires
+# UIAutomationClient (ships with .NET on Windows).
+#
+# Invariants the harness enforces (log-side):
+#   - Every `main_window_focus` IPC produces a `main-focus-reclaim` task
+#     run with `render_found=true` in the log.
+#   - When the test types into a main-DOM destination (address bar /
+#     terminal), no `[pane-wndproc] key msg=` lines appear in the
+#     interval between the click and the next step.
+#   - When the test types into a pane destination (Google search), the
+#     `[pane-wndproc] key msg=` events DO appear and no
+#     `main-focus-reclaim` is fired in the interval.
+#
+# The harness does NOT try to read the Chromium DOM — the interactive
+# tree surfaced by UIA only sees the address bar, not the Google search
+# box value. Log invariants are the ground truth for "did focus route
+# correctly". Screenshot dumps are retained for visual cross-check.
+#
+# Usage:
+#   pwsh tools/tests/pane-focus-stress.ps1 -LogPath <path-to-host-log>
+#
+# If -LogPath is omitted, the script tails the file at
+# `%APPDATA%\ai.agentmux.cef.v<latest>\db\…` via the dev task's
+# version string.
+
+[CmdletBinding()]
+param(
+    [string]$LogPath,
+    [int]$TypeDelayMs = 300,
+    [int]$AfterTypeMs = 400
+)
+
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes, System.Windows.Forms
+
+# ── Win32 interop ───────────────────────────────────────────────────────
+$win32 = @'
+using System;
+using System.Runtime.InteropServices;
+public static class Win32 {
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+    [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr hWnd, int x, int y, int cx, int cy, bool bRepaint);
+    [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
+    [DllImport("user32.dll")] public static extern IntPtr GetFocus();
+}
+'@
+Add-Type -TypeDefinition $win32 -ErrorAction SilentlyContinue | Out-Null
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+function Find-AgentMuxMain {
+    Get-Process agentmux-cef -ErrorAction SilentlyContinue |
+        Where-Object { $_.MainWindowHandle -ne [IntPtr]::Zero } |
+        Select-Object -First 1
+}
+
+function Click-Pixel([int]$x, [int]$y) {
+    [System.Windows.Forms.Cursor]::Position = New-Object System.Drawing.Point($x, $y)
+    Start-Sleep -Milliseconds 80
+    $down = 0x0002; $up = 0x0004
+    Add-Type -Name MouseEvent -Namespace W -MemberDefinition @"
+[DllImport("user32.dll")]
+public static extern void mouse_event(int dwFlags, int dx, int dy, int dwData, int dwExtraInfo);
+"@ -ErrorAction SilentlyContinue
+    [W.MouseEvent]::mouse_event($down, 0, 0, 0, 0)
+    Start-Sleep -Milliseconds 40
+    [W.MouseEvent]::mouse_event($up, 0, 0, 0, 0)
+}
+
+function Send-Text([string]$text) {
+    # Escape SendKeys metacharacters (+, ^, %, ~, (, ), {, }, [, ])
+    $escaped = $text -replace '([+^%~(){}\[\]])', '{$1}'
+    [System.Windows.Forms.SendKeys]::SendWait($escaped)
+}
+
+function Read-LogSince([string]$path, [datetime]$since) {
+    if (-not (Test-Path $path)) { return @() }
+    $sinceStr = $since.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss")
+    Get-Content -LiteralPath $path -Encoding UTF8 |
+        Where-Object { $_ -match '^\e\[2m(?<ts>\S+)\e\[0m' } |
+        ForEach-Object {
+            if ($_ -match '^\x1b\[2m(?<ts>[^\x1b]+)\x1b\[0m') {
+                try {
+                    $ts = [datetime]::Parse($matches['ts'])
+                    if ($ts -ge $since) { $_ }
+                } catch {}
+            } else { $_ }
+        }
+}
+
+function Find-LatestHostLog {
+    $base = Join-Path $env:APPDATA 'ai.agentmux.cef.v*'
+    $dirs = Get-ChildItem -Path $base -Directory -ErrorAction SilentlyContinue |
+        Sort-Object { [version]($_.Name -replace 'ai\.agentmux\.cef\.v', '' -replace '-', '.') } -Descending
+    foreach ($dir in $dirs) {
+        $logDir = Join-Path $env:USERPROFILE '.agentmux\logs'
+        if (-not (Test-Path $logDir)) { continue }
+        $v = ($dir.Name -replace 'ai\.agentmux\.cef\.v', '') -replace '-', '.'
+        $candidate = Get-ChildItem -Path $logDir -Filter "agentmux-host-v$v.log.*" -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending | Select-Object -First 1
+        if ($candidate) { return $candidate.FullName }
+    }
+    return $null
+}
+
+# ── Setup ───────────────────────────────────────────────────────────────
+
+$main = Find-AgentMuxMain
+if (-not $main) {
+    Write-Error "No running agentmux-cef process with a main window. Start 'task dev' first."
+}
+Write-Host "[setup] AgentMux main PID=$($main.Id) handle=$($main.MainWindowHandle)"
+
+[Win32]::ShowWindow($main.MainWindowHandle, 5) | Out-Null
+Start-Sleep -Milliseconds 200
+[Win32]::MoveWindow($main.MainWindowHandle, 50, 50, 1300, 900, $true) | Out-Null
+Start-Sleep -Milliseconds 200
+[Win32]::SetForegroundWindow($main.MainWindowHandle) | Out-Null
+Start-Sleep -Milliseconds 500
+
+if (-not $LogPath) { $LogPath = Find-LatestHostLog }
+if (-not $LogPath -or -not (Test-Path $LogPath)) {
+    Write-Warning "Host log not found — log-side assertions will be skipped. Use -LogPath to point at it."
+} else {
+    Write-Host "[setup] Log path: $LogPath"
+}
+
+# ── Layout assumptions ──────────────────────────────────────────────────
+#
+# The harness assumes the user has manually set up P1 browser / T
+# terminal / P2 browser side-by-side and navigated both browsers to
+# google.com. The "create the layout programmatically" path through
+# UIA context menus is brittle enough that it belongs in a follow-up
+# commit; leaving it manual keeps the FIRST run of this spec deliverable.
+#
+# Click coordinates are read from an accompanying JSON file
+# `pane-focus-stress.targets.json` in the same dir:
+#   {
+#     "P1_search":  [x, y],
+#     "P1_address": [x, y],
+#     "P2_search":  [x, y],
+#     "P2_address": [x, y],
+#     "Terminal":   [x, y]
+#   }
+#
+# Collect these once by hand via a Snapshot tool, save the JSON,
+# then re-run this harness as many times as needed.
+
+$targetsPath = Join-Path $PSScriptRoot 'pane-focus-stress.targets.json'
+if (-not (Test-Path $targetsPath)) {
+    Write-Error @"
+Missing $targetsPath.
+Create it with 5 (x, y) coordinates for P1_search, P1_address, P2_search, P2_address, Terminal.
+Capture them via the windows-mcp Snapshot tool or by eyeballing a screenshot.
+"@
+}
+$targets = Get-Content -LiteralPath $targetsPath -Raw | ConvertFrom-Json
+
+# ── Round definitions ───────────────────────────────────────────────────
+
+$rounds = @(
+    @{
+        name  = 'R1 linear'
+        steps = @(
+            @{ target = 'P1_search';  text = 'r1a'; pane_keys_expected = $true },
+            @{ target = 'Terminal';   text = 'r1b'; pane_keys_expected = $false },
+            @{ target = 'P2_search';  text = 'r1c'; pane_keys_expected = $true },
+            @{ target = 'P1_address'; text = 'r1d'; pane_keys_expected = $false },
+            @{ target = 'P2_address'; text = 'r1e'; pane_keys_expected = $false },
+            @{ target = 'P1_search';  text = 'r1f'; pane_keys_expected = $true }
+        )
+    }
+    @{
+        name  = 'R2 bouncing'
+        steps = @(
+            @{ target = 'P2_search';  text = 'r2a'; pane_keys_expected = $true },
+            @{ target = 'P1_search';  text = 'r2b'; pane_keys_expected = $true },
+            @{ target = 'P2_search';  text = 'r2c'; pane_keys_expected = $true },
+            @{ target = 'P1_address'; text = 'r2d'; pane_keys_expected = $false },
+            @{ target = 'Terminal';   text = 'r2e'; pane_keys_expected = $false },
+            @{ target = 'P2_address'; text = 'r2f'; pane_keys_expected = $false }
+        )
+    }
+    @{
+        name  = 'R3 terminal-heavy'
+        steps = @(
+            @{ target = 'Terminal';   text = 'r3a'; pane_keys_expected = $false },
+            @{ target = 'Terminal';   text = 'r3b'; pane_keys_expected = $false },
+            @{ target = 'P1_search';  text = 'r3c'; pane_keys_expected = $true },
+            @{ target = 'Terminal';   text = 'r3d'; pane_keys_expected = $false },
+            @{ target = 'P2_search';  text = 'r3e'; pane_keys_expected = $true },
+            @{ target = 'P1_address'; text = 'r3f'; pane_keys_expected = $false }
+        )
+    }
+    @{
+        name  = 'R4 reverse'
+        steps = @(
+            @{ target = 'P1_search';  text = 'r4a'; pane_keys_expected = $true },
+            @{ target = 'P2_address'; text = 'r4b'; pane_keys_expected = $false },
+            @{ target = 'P1_address'; text = 'r4c'; pane_keys_expected = $false },
+            @{ target = 'P2_search';  text = 'r4d'; pane_keys_expected = $true },
+            @{ target = 'Terminal';   text = 'r4e'; pane_keys_expected = $false },
+            @{ target = 'P1_search';  text = 'r4f'; pane_keys_expected = $true }
+        )
+    }
+)
+
+# ── Execution ───────────────────────────────────────────────────────────
+
+$failures = @()
+$stepCount = 0
+$startTime = Get-Date
+
+foreach ($round in $rounds) {
+    Write-Host ""
+    Write-Host "=== Round: $($round.name) ===" -ForegroundColor Cyan
+    foreach ($step in $round.steps) {
+        $stepCount++
+        $targetName = $step.target
+        $text = $step.text
+        $expectedPaneKeys = $step.pane_keys_expected
+        $coords = $targets.$targetName
+        if (-not $coords) { Write-Error "Missing coords for target '$targetName'" }
+
+        $preTime = Get-Date
+        Click-Pixel $coords[0] $coords[1]
+        Start-Sleep -Milliseconds $TypeDelayMs
+        Send-Text $text
+        Start-Sleep -Milliseconds $AfterTypeMs
+
+        # Collect log delta since this step started.
+        $logLines = @()
+        if ($LogPath -and (Test-Path $LogPath)) {
+            $logLines = Read-LogSince $LogPath $preTime
+        }
+
+        $paneKeyMatches   = @($logLines | Where-Object { $_ -match '\[pane-wndproc\] key msg=' })
+        $reclaimMatches   = @($logLines | Where-Object { $_ -match 'main-focus-reclaim' })
+        $renderFoundFalse = @($logLines | Where-Object { $_ -match 'render_found=false' })
+        $resolveFailures  = @($logLines | Where-Object { $_ -match 'could not resolve Views top-level HWND' })
+
+        $status = 'PASS'
+        $reasons = @()
+        if ($expectedPaneKeys -and $paneKeyMatches.Count -eq 0) {
+            $status = 'FAIL'
+            $reasons += "expected pane keystrokes but saw none in log"
+        }
+        if ((-not $expectedPaneKeys) -and $paneKeyMatches.Count -gt 0) {
+            $status = 'FAIL'
+            $reasons += "keystrokes leaked to pane HWND ($($paneKeyMatches.Count) events)"
+        }
+        if ($renderFoundFalse.Count -gt 0) {
+            $status = 'FAIL'
+            $reasons += "render_found=false — main's render widget not located"
+        }
+        if ($resolveFailures.Count -gt 0) {
+            $status = 'FAIL'
+            $reasons += "Views top-level HWND resolution failed"
+        }
+
+        $line = "[step $stepCount] target=$targetName typed='$text' status=$status"
+        if ($status -eq 'PASS') {
+            Write-Host $line -ForegroundColor Green
+        } else {
+            Write-Host $line -ForegroundColor Red
+            $reasons | ForEach-Object { Write-Host "           reason: $_" -ForegroundColor Red }
+            $failures += [pscustomobject]@{
+                step    = $stepCount
+                round   = $round.name
+                target  = $targetName
+                text    = $text
+                reasons = $reasons
+                logs    = $logLines
+            }
+        }
+    }
+}
+
+# ── Report ──────────────────────────────────────────────────────────────
+
+Write-Host ""
+if ($failures.Count -eq 0) {
+    Write-Host "PASS ($stepCount/$stepCount steps)" -ForegroundColor Green
+    exit 0
+}
+
+$ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+$reportPath = Join-Path $env:TEMP "pane-focus-stress-$ts.log"
+$failures | ForEach-Object {
+    "=== FAIL step $($_.step) ($($_.round)) target=$($_.target) ==="
+    "reasons: $($_.reasons -join '; ')"
+    "--- log ---"
+    $_.logs
+    ""
+} | Out-File -LiteralPath $reportPath -Encoding UTF8
+
+Write-Host "FAIL: $($failures.Count)/$stepCount steps failed" -ForegroundColor Red
+Write-Host "Report: $reportPath" -ForegroundColor Red
+exit 1

--- a/tools/tests/pane-focus-stress.targets.json.example
+++ b/tools/tests/pane-focus-stress.targets.json.example
@@ -1,0 +1,8 @@
+{
+  "_comment": "Copy to pane-focus-stress.targets.json and fill with actual pixel coordinates. Measure via a screenshot + pixel ruler while the AgentMux window is at (50, 50, 1300, 900). All coords are relative to the screen, not the window.",
+  "P1_search":  [200, 320],
+  "P1_address": [160, 130],
+  "P2_search":  [900, 320],
+  "P2_address": [860, 130],
+  "Terminal":   [550, 450]
+}


### PR DESCRIPTION
## Bug

After PR #440 (GetAncestor-based focus redirect) the user still reported: \"type inside browser, then cannot type anywhere else — the address bar doesn't work.\"

## Evidence from host log

\`\`\`
18:33:00  [ipc] main_window_focus                  ← user clicked address bar
18:33:00  setFocusedChild input.browser-address-bar
18:33:07  [ipc] browser_pane_focus                 ← cursor drifted over pane
18:33:09  [pane-wndproc] key msg=0x100 wparam=83   ← typing routed to pane
\`\`\`

The focus release worked. Then the cursor crossed back over the pane area (inevitable — the address bar sits directly above the pane), \`onMouseEnter\` fired \`browser_pane_focus\`, Windows focus got re-stolen, and the next keystroke went to the pane.

## Root cause

\`browser-view.tsx\`'s \`onMouseEnter\` handler grabs pane focus so mouse-wheel events route to the pane renderer (Windows routes \`WM_MOUSEWHEEL\` to the focused HWND, not by hit-test). But it fires on EVERY cursor entry, which re-steals keyboard focus whenever the user moves the cursor after clicking a main-DOM input.

## Fix

Module-level cooldown timestamp (\`lastMainFocusAtMs\`). Set by both paths that reclaim main focus:

- \`browser-view.tsx\` — address-bar \`onFocus\`
- \`browser-model.ts\` — \`giveFocus()\` when it detects an active main input

\`onMouseEnter\` checks \`Date.now() - lastMainFocusAtMs < 750\` and skips \`browser_pane_focus\` if the cooldown is active. Scroll-while-hovering still works after the cooldown expires or after the user explicitly clicks into the pane (which goes through a different focus path).

## Test plan
- [ ] \`task dev\`: pane → type → address bar → type. **Address bar now accepts keystrokes.**
- [ ] Mouse wheel over pane (without recent main-focus event) still scrolls the page.
- [ ] Click into pane after cooldown → typing goes to pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)