### PR TITLE
refactor(http): rename /wave → /agentmux HTTP prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.264"
+version = "0.33.265"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.264"
+version = "0.33.265"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.264"
+version = "0.33.265"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.264"
+version = "0.33.265"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.264"
+version = "0.33.265"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -1221,7 +1221,7 @@ fn backend_close_window(web_endpoint: &str, auth_key: &str, window_id: &str) {
         "uicontext": null,
     }).to_string();
     let request = format!(
-        "POST /wave/service?service=window&method=CloseWindow&authkey={} HTTP/1.1\r\n\
+        "POST /agentmux/service?service=window&method=CloseWindow&authkey={} HTTP/1.1\r\n\
          Host: 127.0.0.1\r\n\
          Content-Type: application/json\r\n\
          Content-Length: {}\r\n\

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.264"
+version = "0.33.265"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.264"
+version = "0.33.265"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.264"
+version = "0.33.265"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -621,7 +621,7 @@ impl Controller for ShellController {
 
         // Auto-register with jekt if AGENTMUX_AGENT_ID was set in the block env.
         // This maps agent_id → block_id in the ReactiveHandler so jekt can deliver
-        // messages directly to this PTY without a separate /wave/reactive/register call.
+        // messages directly to this PTY without a separate /agentmux/reactive/register call.
         if let Some(ref agent_id) = agent_id_for_jekt {
             match crate::backend::reactive::get_global_handler()
                 .register_agent(agent_id, &self.block_id, Some(&self.tab_id))

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -79,25 +79,25 @@ pub fn build_router(state: AppState) -> Router {
 
     // No-auth routes (matching Go SkipAuth: true — localhost-only reactive endpoints)
     let reactive_routes = Router::new()
-        .route("/wave/reactive/inject", post(reactive::handle_reactive_inject))
-        .route("/wave/reactive/agents", get(reactive::handle_reactive_agents))
-        .route("/wave/reactive/agent", get(reactive::handle_reactive_agent))
-        .route("/wave/reactive/audit", get(reactive::handle_reactive_audit))
-        .route("/wave/reactive/register", post(reactive::handle_reactive_register))
+        .route("/agentmux/reactive/inject", post(reactive::handle_reactive_inject))
+        .route("/agentmux/reactive/agents", get(reactive::handle_reactive_agents))
+        .route("/agentmux/reactive/agent", get(reactive::handle_reactive_agent))
+        .route("/agentmux/reactive/audit", get(reactive::handle_reactive_audit))
+        .route("/agentmux/reactive/register", post(reactive::handle_reactive_register))
         .route(
-            "/wave/reactive/unregister",
+            "/agentmux/reactive/unregister",
             post(reactive::handle_reactive_unregister),
         )
         .route(
-            "/wave/reactive/poller/stats",
+            "/agentmux/reactive/poller/stats",
             get(reactive::handle_reactive_poller_stats),
         )
         .route(
-            "/wave/reactive/poller/config",
+            "/agentmux/reactive/poller/config",
             post(reactive::handle_reactive_poller_config),
         )
         .route(
-            "/wave/reactive/poller/status",
+            "/agentmux/reactive/poller/status",
             get(reactive::handle_reactive_poller_status),
         );
 
@@ -113,11 +113,11 @@ pub fn build_router(state: AppState) -> Router {
 
     let authed_routes = Router::new()
         .route("/ws", get(websocket::handle_ws))
-        .route("/wave/service", post(service::handle_service))
-        .route("/wave/file", get(files::handle_wave_file))
-        .route("/wave/stream-file", get(stub_501))
-        .route("/wave/stream-file/*path", get(stub_501))
-        .route("/wave/stream-local-file", get(stub_501))
+        .route("/agentmux/service", post(service::handle_service))
+        .route("/agentmux/file", get(files::handle_wave_file))
+        .route("/agentmux/stream-file", get(stub_501))
+        .route("/agentmux/stream-file/*path", get(stub_501))
+        .route("/agentmux/stream-local-file", get(stub_501))
         .route("/api/post-chat-message", get(stub_501).post(stub_501))
         .route("/docsite/*path", get(files::handle_docsite))
         .route("/schema/*path", get(files::handle_schema))

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -41,7 +41,7 @@ pub(super) async fn handle_reactive_inject(
         if let Some(entry) = agent_registry::lookup(&data_dir, &req.target_agent) {
             // Guard against self-forwarding loops.
             if entry.local_url != state.local_web_url {
-                let forward_url = format!("{}/wave/reactive/inject", entry.local_url);
+                let forward_url = format!("{}/agentmux/reactive/inject", entry.local_url);
                 tracing::debug!(
                     target = %req.target_agent,
                     url = %forward_url,

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -73,7 +73,7 @@ async fn health_returns_200() {
 async fn auth_rejects_bad_key() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/service")
+        .uri("/agentmux/service")
         .method("POST")
         .header("X-AuthKey", "wrong-key")
         .header("Content-Type", "application/json")
@@ -87,7 +87,7 @@ async fn auth_rejects_bad_key() {
 async fn auth_rejects_missing_key() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/service")
+        .uri("/agentmux/service")
         .method("POST")
         .header("Content-Type", "application/json")
         .body(Body::from(r#"{"service":"client","method":"GetClientData"}"#))
@@ -100,7 +100,7 @@ async fn auth_rejects_missing_key() {
 async fn auth_accepts_valid_header() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/service")
+        .uri("/agentmux/service")
         .method("POST")
         .header("X-AuthKey", "test-secret-key")
         .header("Content-Type", "application/json")
@@ -122,7 +122,7 @@ async fn auth_accepts_valid_header() {
 async fn auth_accepts_query_param() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/service?authkey=test-secret-key")
+        .uri("/agentmux/service?authkey=test-secret-key")
         .method("POST")
         .header("Content-Type", "application/json")
         .body(Body::from(
@@ -137,7 +137,7 @@ async fn auth_accepts_query_param() {
 async fn reactive_routes_skip_auth() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/reactive/agents")
+        .uri("/agentmux/reactive/agents")
         .body(Body::empty())
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
@@ -165,7 +165,7 @@ async fn cors_headers_present() {
 async fn service_get_client_data() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/service")
+        .uri("/agentmux/service")
         .method("POST")
         .header("X-AuthKey", "test-secret-key")
         .header("Content-Type", "application/json")
@@ -189,7 +189,7 @@ async fn service_get_client_data() {
 async fn service_list_workspaces() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/service")
+        .uri("/agentmux/service")
         .method("POST")
         .header("X-AuthKey", "test-secret-key")
         .header("Content-Type", "application/json")
@@ -212,7 +212,7 @@ async fn service_list_workspaces() {
 async fn service_unknown_method_returns_error() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/service")
+        .uri("/agentmux/service")
         .method("POST")
         .header("X-AuthKey", "test-secret-key")
         .header("Content-Type", "application/json")
@@ -236,7 +236,7 @@ async fn service_unknown_method_returns_error() {
 async fn reactive_agents_returns_empty_list() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/reactive/agents")
+        .uri("/agentmux/reactive/agents")
         .body(Body::empty())
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
@@ -253,7 +253,7 @@ async fn reactive_agents_returns_empty_list() {
 async fn reactive_poller_status() {
     let app = test_router();
     let req = Request::builder()
-        .uri("/wave/reactive/poller/status")
+        .uri("/agentmux/reactive/poller/status")
         .body(Body::empty())
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
@@ -271,7 +271,7 @@ async fn workspace_colors_and_icons() {
     let state = test_state();
     let app = build_router(state);
     let req = Request::builder()
-        .uri("/wave/service")
+        .uri("/agentmux/service")
         .method("POST")
         .header("X-AuthKey", "test-secret-key")
         .header("Content-Type", "application/json")

--- a/agentmux-srv/tests/integration_test.rs
+++ b/agentmux-srv/tests/integration_test.rs
@@ -65,7 +65,7 @@ fn auth_rejects_missing_key() {
 
     let client = reqwest::blocking::Client::new();
     let resp = client
-        .get(format!("http://{}/wave/service", web_addr))
+        .get(format!("http://{}/agentmux/service", web_addr))
         .send()
         .expect("request failed");
     assert_eq!(resp.status(), 401);
@@ -80,7 +80,7 @@ fn auth_accepts_valid_header() {
 
     let client = reqwest::blocking::Client::new();
     let resp = client
-        .post(format!("http://{}/wave/service", web_addr))
+        .post(format!("http://{}/agentmux/service", web_addr))
         .header("X-AuthKey", &auth_key)
         .header("Content-Type", "application/json")
         .body(r#"{"service":"client","method":"GetClientData"}"#)

--- a/docs/analysis/window-process-coupling.md
+++ b/docs/analysis/window-process-coupling.md
@@ -84,7 +84,7 @@ window.addEventListener("beforeunload", () => {
 **Design:**
 
 1. Frontend calls `registerBackendWindow(label, windowId)` IPC after `initWave()` completes, storing `window_label → backend_window_id` in `AppState.window_id_map`
-2. CEF Rust `on_before_close` hook: looks up the closing browser's label → looks up backend window ID → spawns thread → raw TCP call to `agentmux-srv /wave/service?method=CloseWindow`
+2. CEF Rust `on_before_close` hook: looks up the closing browser's label → looks up backend window ID → spawns thread → raw TCP call to `agentmux-srv /agentmux/service?method=CloseWindow`
 3. Also emits `"window-instances-changed"` to remaining windows (fixes the `windowCountAtom` stale count bug from Attempt 2)
 
 **Result:**
@@ -96,7 +96,7 @@ window.addEventListener("beforeunload", () => {
 
 ## Root Cause Analysis: v0.33.46 Window Close Failure
 
-The `on_before_close` Rust hook spawns a thread that calls `backend_close_window()`. This function makes a raw TCP connection to `agentmux-srv` and sends an HTTP POST to `/wave/service`.
+The `on_before_close` Rust hook spawns a thread that calls `backend_close_window()`. This function makes a raw TCP connection to `agentmux-srv` and sends an HTTP POST to `/agentmux/service`.
 
 Three possible failure points have been identified.
 

--- a/frontend/app/element/markdown-util.ts
+++ b/frontend/app/element/markdown-util.ts
@@ -165,7 +165,7 @@ export const resolveRemoteFile = async (filepath: string, resolveOpts: MarkdownR
         // console.log("markdown resolve", resolveOpts, filepath, "=>", baseDirUri, remoteUri);
         const usp = new URLSearchParams();
         usp.set("path", remoteUri);
-        return getWebServerEndpoint() + "/wave/stream-file?" + usp.toString();
+        return getWebServerEndpoint() + "/agentmux/stream-file?" + usp.toString();
     } catch (err) {
         console.warn("Failed to resolve remote file:", filepath, err);
         return null;

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -625,7 +625,7 @@ export async function fetchWaveFile(
         const authKey = getApi()?.getAuthKey?.();
         if (authKey) usp.set("authkey", authKey);
     }
-    const resp = await fetch(getWebServerEndpoint() + "/wave/file?" + usp.toString());
+    const resp = await fetch(getWebServerEndpoint() + "/agentmux/file?" + usp.toString());
     if (!resp.ok) {
         if (resp.status === 404) return { data: null, fileInfo: null };
         throw new Error("error getting wave file: " + resp.statusText);

--- a/frontend/app/store/wos.ts
+++ b/frontend/app/store/wos.ts
@@ -115,7 +115,7 @@ function callBackendService(service: string, method: string, args: any[], noUICo
         if (authKey) usp.set("authkey", authKey);
     }
 
-    const url = getWebServerEndpoint() + "/wave/service?" + usp.toString();
+    const url = getWebServerEndpoint() + "/agentmux/service?" + usp.toString();
     const fetchPromise = fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/frontend/app/view/term/termagent.ts
+++ b/frontend/app/view/term/termagent.ts
@@ -12,7 +12,7 @@ export const registeredAgentsByBlock = new Map<string, string>();
 
 export async function registerAgent(agentId: string, blockId: string, tabId?: string): Promise<void> {
     try {
-        const url = getWebServerEndpoint() + "/wave/reactive/register";
+        const url = getWebServerEndpoint() + "/agentmux/reactive/register";
         const response = await fetch(url, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -41,7 +41,7 @@ export async function registerAgent(agentId: string, blockId: string, tabId?: st
 
 export async function unregisterAgent(agentId: string): Promise<void> {
     try {
-        const url = getWebServerEndpoint() + "/wave/reactive/unregister";
+        const url = getWebServerEndpoint() + "/agentmux/reactive/unregister";
         const response = await fetch(url, {
             method: "POST",
             headers: { "Content-Type": "application/json" },

--- a/frontend/app/view/term/termosc.ts
+++ b/frontend/app/view/term/termosc.ts
@@ -289,7 +289,7 @@ export function handleOsc16162Command(data: string, blockId: string, loaded: boo
         case "X":
             fireAndForget(async () => {
                 try {
-                    const url = getWebServerEndpoint() + "/wave/reactive/poller/config";
+                    const url = getWebServerEndpoint() + "/agentmux/reactive/poller/config";
                     const response = await fetch(url, {
                         method: "POST",
                         headers: { "Content-Type": "application/json" },

--- a/frontend/app/view/term/termsticker.tsx
+++ b/frontend/app/view/term/termsticker.tsx
@@ -100,7 +100,7 @@ function TermSticker(props: { sticker: StickerType; config: StickerTermConfig })
     if (sticker.stickertype == "image") {
         if (sticker.imgsrc == null) return null;
         const streamingUrl =
-            getWebServerEndpoint() + "/wave/stream-local-file?path=" + encodeURIComponent(sticker.imgsrc);
+            getWebServerEndpoint() + "/agentmux/stream-local-file?path=" + encodeURIComponent(sticker.imgsrc);
         return (
             <div class="term-sticker term-sticker-image" style={style as any} onClick={clickHandler}>
                 <img src={streamingUrl} />

--- a/frontend/util/waveutil.ts
+++ b/frontend/util/waveutil.ts
@@ -8,7 +8,7 @@ import { generate as generateCSS, parse as parseCSS, walk as walkCSS } from "css
 function encodeFileURL(file: string) {
     const webEndpoint = getWebServerEndpoint();
     const fileUri = formatRemoteUri(file, "local");
-    const rtn = webEndpoint + `/wave/stream-file?path=${encodeURIComponent(fileUri)}&no404=1`;
+    const rtn = webEndpoint + `/agentmux/stream-file?path=${encodeURIComponent(fileUri)}&no404=1`;
     return rtn;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.264",
+  "version": "0.33.265",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.264",
+      "version": "0.33.265",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.264",
+  "version": "0.33.265",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/agentmux-local-url-injection.md
+++ b/specs/agentmux-local-url-injection.md
@@ -12,7 +12,7 @@
 
 The `agentbus-client` MCP server has two delivery paths:
 
-1. **Local** — `POST {AGENTMUX_LOCAL_URL}/wave/reactive/inject` → AgentMux writes directly to the PTY. Sub-millisecond, no cloud involved.
+1. **Local** — `POST {AGENTMUX_LOCAL_URL}/agentmux/reactive/inject` → AgentMux writes directly to the PTY. Sub-millisecond, no cloud involved.
 2. **Cloud polling** — polls `agentbus.asaf.cc/reactive/pending/{agentId}` every 5s, delivers via `console.error()` on the MCP server's stderr. Stderr from an MCP child process is not fed back as user input in Claude Code, so injections are silently lost.
 
 Path 1 is the correct path. Path 2 doesn't work for in-pane injection.

--- a/specs/jekt-auto-registration.md
+++ b/specs/jekt-auto-registration.md
@@ -12,7 +12,7 @@
 Jekt (terminal injection) currently requires a **manual registration call** before it works:
 
 ```bash
-POST /wave/reactive/register
+POST /agentmux/reactive/register
 { "agent_id": "AgentX", "block_id": "<block-id>" }
 ```
 
@@ -31,7 +31,7 @@ with `AGENTMUX_AGENT_ID` set, jekt should work immediately — no extra step.
 ```
 1. User/Forge sets cmd:env["AGENTMUX_AGENT_ID"] = "Agent1" on block
 2. Block spawns — AGENTMUX_AGENT_ID + AGENTMUX_BLOCKID are set in PTY env
-3. ← Manual step required: POST /wave/reactive/register {agent_id, block_id}
+3. ← Manual step required: POST /agentmux/reactive/register {agent_id, block_id}
 4. Jekt via POST /api/bus/inject → ReactiveHandler → blockcontroller::send_input → PTY ✓
 ```
 
@@ -131,7 +131,7 @@ Already exists on `ReactiveHandler`.
 - `shell.rs`: ~15 lines changed/added
 
 ### What does NOT change
-- `/wave/reactive/register` endpoint — still works for manual registration (backward compat,
+- `/agentmux/reactive/register` endpoint — still works for manual registration (backward compat,
   useful for non-shell blocks or external processes)
 - MessageBus registration — unchanged; agents can still call `bus:register` separately
 - Any frontend code
@@ -162,7 +162,7 @@ panes, etc. are unaffected.
 
 ```bash
 # 1. Open AgentMux, create a terminal pane with cmd:env["AGENTMUX_AGENT_ID"] = "test-agent"
-# 2. Immediately jekt it — no /wave/reactive/register call needed:
+# 2. Immediately jekt it — no /agentmux/reactive/register call needed:
 curl -X POST http://localhost:<port>/api/bus/inject \
   -H 'Content-Type: application/json' \
   -d '{"from": "agentx", "target": "test-agent", "message": "echo hello"}'
@@ -172,7 +172,7 @@ curl -X POST http://localhost:<port>/api/bus/inject \
 # Expected: {"status":"injected","via":"messagebus",...} (falls back, agent deregistered)
 
 # 4. Verify agents list:
-curl http://localhost:<port>/wave/reactive/agents
+curl http://localhost:<port>/agentmux/reactive/agents
 # Expected: [] after close, ["test-agent"] while running
 ```
 

--- a/specs/lan-awareness-and-embedded-jekt-api.md
+++ b/specs/lan-awareness-and-embedded-jekt-api.md
@@ -25,12 +25,12 @@ Agent (e.g., Claude Code)
   ├─ MCP tool: inject_terminal
   │   └─ @a5af/agentbus-client (Node.js stdio MCP server)
   │       │
-  │       ├─ Try 1: LOCAL — POST http://127.0.0.1:PORT/wave/reactive/inject
+  │       ├─ Try 1: LOCAL — POST http://127.0.0.1:PORT/agentmux/reactive/inject
   │       │   └─ ReactiveHandler → blockcontroller::send_input() → PTY write
   │       │   └─ Sub-millisecond, synchronous
   │       │
   │       ├─ Try 2: CROSS-INSTANCE — File registry lookup → HTTP forward
-  │       │   └─ {data_dir}/agents/{agent_id}.json → POST remote:PORT/wave/reactive/inject
+  │       │   └─ {data_dir}/agents/{agent_id}.json → POST remote:PORT/agentmux/reactive/inject
   │       │
   │       └─ Try 3: CLOUD — POST https://agentbus.asaf.cc/reactive/inject
   │           └─ Lambda + DynamoDB, 15s polling timeout
@@ -165,7 +165,7 @@ With LAN discovery, jekt delivery becomes a **4-tier cascade** with clear separa
 Jekt delivery priority:
   1. LOCAL PTY     — agent on this instance → direct PTY write (sub-ms)
   2. LOCAL MSGBUS  — agent has WS connection → push via MessageBus (ms)
-  3. LAN FORWARD   — agent on LAN peer → HTTP POST to peer's /wave/reactive/inject (low ms)
+  3. LAN FORWARD   — agent on LAN peer → HTTP POST to peer's /agentmux/reactive/inject (low ms)
   4. CLOUD RELAY   — agent unreachable locally/LAN → AgentBus cloud (agentbus.asaf.cc)
 ```
 
@@ -309,7 +309,7 @@ pub struct LanInstance {
 
 ### Phase 3: LAN-based Jekt Forwarding
 - When `inject_terminal` target not found locally, query LAN peers
-- Forward via HTTP to peer's `/wave/reactive/inject`
+- Forward via HTTP to peer's `/agentmux/reactive/inject`
 - Update `list_agents` to include agents from LAN peers
 - Update `broadcast` to fan out to LAN peers
 

--- a/specs/swarm-analysis.md
+++ b/specs/swarm-analysis.md
@@ -161,7 +161,7 @@ AgentMux already has the building blocks for subagent watching:
 |-----------|--------|-----------|
 | **File watcher** (`notify` crate) | Production | Watch `subagents/` directories for new JSONL files |
 | **Block/pane creation** (`wcore::create_block`) | Production | Create new panes for subagent activity |
-| **Agent registration** (`/wave/reactive/register`) | Production | Register subagents in the reactive system |
+| **Agent registration** (`/agentmux/reactive/register`) | Production | Register subagents in the reactive system |
 | **EventBus** | Production | Push subagent events to frontend in real-time |
 | **OSC 16162 protocol** | Production | Metadata extraction from terminal output |
 | **Forge widget** | Production | Agent creation/management (separate concern from Swarm) |


### PR DESCRIPTION
## Summary

Renames every HTTP route the backend exposes from \`/wave/*\` to \`/agentmux/*\`. Legacy Wave-Terminal-era prefix that's been misleading since the AgentMux fork.

| Before | After |
|---|---|
| \`POST /wave/service\` | \`POST /agentmux/service\` |
| \`GET /wave/file\` | \`GET /agentmux/file\` |
| \`GET /wave/stream-file[/*path]\` | \`GET /agentmux/stream-file[/*path]\` |
| \`GET /wave/stream-local-file\` | \`GET /agentmux/stream-local-file\` |
| \`*/wave/reactive/*\` | \`*/agentmux/reactive/*\` |

13 files, 38 + / 38 − . No compat shim — server and frontend ship in the same build, backend is 127.0.0.1-only, no external API consumers.

Spec: \`docs/specs/SPEC_TEST_API_ACCESS.md\` §4.7.

## Test plan
- [ ] \`cargo check\` in \`agentmux-srv\`: clean.
- [ ] \`npx tsc --noEmit\`: clean.
- [ ] \`task dev\`: app loads, tabs render, panes work (smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)