### PR TITLE
feat(test-harness): use authkey.dev for instance discovery + service smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.267"
+version = "0.33.268"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.267"
+version = "0.33.268"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.267"
+version = "0.33.268"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.267"
+version = "0.33.268"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.267"
+version = "0.33.268"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.267"
+version = "0.33.268"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.267"
+version = "0.33.268"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.267"
+version = "0.33.268"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.267",
+  "version": "0.33.268",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -2,37 +2,73 @@
 
 Ad-hoc test harnesses for behaviour that's hard to unit-test.
 
+All scripts here target a running **dev** agentmux-cef instance and
+discover it via `authkey.dev`, the file that debug builds write to
+their data dir at startup. See
+[`docs/specs/SPEC_TEST_API_ACCESS.md`](../../docs/specs/SPEC_TEST_API_ACCESS.md)
+§5–§6 for the file format and security model. Release builds do not
+write the file, so these scripts only work against `task dev`.
+
+## `authfile.ps1`
+
+Helper module sourced by the other scripts. Exports:
+
+- `Get-AgentMuxAuthFile` — finds the newest `authkey.dev` under
+  `%APPDATA%\ai.agentmux.cef.*`, validates the recorded `host_pid`
+  is alive, and returns the parsed JSON as a PSCustomObject.
+- `Invoke-AgentMuxService` — POSTs to `/agentmux/service` with the
+  auth key. Returns the response `data` field, throws on error.
+- `Get-AgentMuxHostLogPath` — resolves the host log file for the
+  instance described by an authfile object.
+
+```powershell
+. .\tools\tests\authfile.ps1
+$auth = Get-AgentMuxAuthFile
+$client = Invoke-AgentMuxService -Auth $auth -Service client -Method GetClientData
+```
+
+## `pane-focus-smoke.ps1`
+
+Minimum-viable harness sanity check: reads the auth file and calls
+`client.GetClientData`. Use this to confirm the harness↔backend path
+is wired correctly before debugging the longer stress test.
+
+```powershell
+pwsh tools/tests/pane-focus-smoke.ps1
+```
+
+Exit 0 = ready to run pane-focus-stress.ps1. Exit 1 = no dev
+instance, stale auth file, or auth/route mismatch.
+
 ## `pane-focus-stress.ps1`
 
 Drives the 4-round pane-focus stress workload from
-`docs/specs/SPEC_PANE_FOCUS_STRESS_TEST.md` against a running
-`task dev` instance. Asserts log-side invariants (Chrome_RenderWidgetHostHWND
-located, no key events leaked to pane HWNDs during main-focus steps,
-etc.). Does not attempt to read Chromium DOM values — UIA doesn't expose
+[`docs/specs/SPEC_PANE_FOCUS_STRESS_TEST.md`](../../docs/specs/SPEC_PANE_FOCUS_STRESS_TEST.md).
+Asserts log-side invariants (Chrome_RenderWidgetHostHWND located,
+no key events leaked to pane HWNDs during main-focus steps, etc.).
+Does not attempt to read Chromium DOM values — UIA doesn't expose
 them — so the log is the ground truth.
 
 ### Setup before running
 
 1. `task dev` in the repo root. Wait for the window to appear.
-2. Position AgentMux at `(50, 50, 1300, 900)`. The harness does this
-   on its own via `SetForegroundWindow` + `MoveWindow`.
-3. **Manually** set up a 3-pane layout (tab-spec-driven context menu
-   walk is a follow-up):
-   - Right-click the existing single block → **Replace With...** →
+2. **Manually** set up a 3-pane layout (programmatic layout
+   creation is tracked as a follow-up — see "Limits" below):
+   - Right-click the existing single block → **Replace With…** →
      **browser** → it becomes P1.
    - Right-click P1 → **Split Right** → the new pane is a terminal
      by default; if not, Replace With → terminal. This is T.
    - Right-click T → **Split Right** → Replace With → browser. This is P2.
-4. Click into P1 and navigate to `https://google.com` (address bar +
+3. Click into P1 and navigate to `https://google.com` (address bar +
    Enter). Same for P2.
-5. Take a screenshot of the window and measure pixel coordinates for
+4. Take a screenshot of the window and measure pixel coordinates for
    each of the five targets:
    - P1 Google search box
    - P1 address bar
    - P2 Google search box
    - P2 address bar
    - T terminal prompt
-6. Copy `pane-focus-stress.targets.json.example` to
+5. Copy `pane-focus-stress.targets.json.example` to
    `pane-focus-stress.targets.json`, fill in the coords.
 
 ### Run
@@ -41,18 +77,29 @@ them — so the log is the ground truth.
 pwsh tools/tests/pane-focus-stress.ps1
 ```
 
+The harness auto-locates the running dev instance, its log file, and
+its main window via `authkey.dev`. With `-SkipAuthFile` it falls back
+to image-name discovery, which can target the wrong process if
+multiple `agentmux-cef` instances are running.
+
 Pass: exits 0 with `PASS (24/24 steps)`.
 
 Fail: exits 1, writes a full per-step failure report to
 `$env:TEMP/pane-focus-stress-<ts>.log` with the log delta around
 each failed step.
 
-### Known limits
+### Limits
 
-- Manual layout setup (see step 3). The harness is just the
-  click-and-assert loop.
-- Pixel coordinates break if the window is resized or layout changes.
-  Re-run setup with a fresh `targets.json`.
-- The harness reads only the host log (not the sidecar). This is
-  usually enough; if not, add a `-SrvLogPath` parameter in a
-  follow-up.
+- **Manual layout setup.** Steps 2–5 above are still hand-driven. The
+  blocker is that block layout within a tab is reduced client-side
+  by `LayoutModel.treeReducer`; backend has no `layout.split` RPC
+  today. Two paths forward: write the layout actions into
+  `LayoutState.pendingbackendactions` directly (matches what the
+  `agent.open` handler does for one block), or add a backend
+  `layout.setup_three_pane` test fixture method gated on
+  `cfg(debug_assertions)`. Tracked as PR 4b.
+- **Pixel coordinates** break if the window is resized or the layout
+  changes. Re-run the coord-capture step with a fresh `targets.json`.
+- **Host-log only** (no sidecar log). If a failure looks like it lives
+  in `agentmux-srv`, add a `-SrvLogPath` parameter — kept out for now
+  to keep the harness narrow.

--- a/tools/tests/authfile.ps1
+++ b/tools/tests/authfile.ps1
@@ -1,0 +1,186 @@
+# Copyright 2026, AgentMux Corp.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Auth-file helper for test harnesses. Reads `<data_dir>/authkey.dev`
+# written by dev-mode agentmux-cef (see docs/specs/SPEC_TEST_API_ACCESS.md
+# §5–§6 and src/dev_authfile.rs).
+#
+# Why this exists: external harnesses need the per-process auth_key to
+# call POST /agentmux/service. The key is random per startup and
+# in-process only — debug builds expose it via the auth file as a
+# narrow test-fixture path. Release builds do not write the file.
+#
+# Source this from another script:
+#   . "$PSScriptRoot/authfile.ps1"
+#   $auth = Get-AgentMuxAuthFile
+#   $resp = Invoke-AgentMuxService -Auth $auth -Service client -Method GetClientData
+
+Set-StrictMode -Version Latest
+
+function Get-AgentMuxAuthFile {
+    <#
+    .SYNOPSIS
+    Locates and reads `authkey.dev` from a running dev agentmux-cef instance.
+
+    .DESCRIPTION
+    Walks the `%APPDATA%\ai.agentmux.cef.*` directories looking for any
+    `authkey.dev` file, picks the newest, validates that its `host_pid`
+    is alive, and returns the parsed JSON as a PSCustomObject.
+
+    Throws if no file is found or the recorded host_pid is dead — both
+    are signals that no dev instance is currently up.
+
+    .PARAMETER DataDir
+    Override the data dir search. Useful when targeting a portable
+    instance with a known data_dir.
+
+    .OUTPUTS
+    PSCustomObject with fields: version, auth_key, web_endpoint,
+    ws_endpoint, ipc_endpoint, ipc_token, service_path, file_path,
+    instance, data_dir, host_pid, created_at.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$DataDir
+    )
+
+    $candidates = @()
+    if ($DataDir) {
+        $p = Join-Path $DataDir 'authkey.dev'
+        if (Test-Path -LiteralPath $p) { $candidates += Get-Item -LiteralPath $p }
+    } else {
+        $base = Join-Path $env:APPDATA 'ai.agentmux.cef.*'
+        $candidates = Get-ChildItem -Path $base -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object { Join-Path $_.FullName 'authkey.dev' } |
+            Where-Object { Test-Path -LiteralPath $_ } |
+            Get-Item |
+            Sort-Object LastWriteTime -Descending
+    }
+
+    if (-not $candidates -or $candidates.Count -eq 0) {
+        throw @"
+No authkey.dev found under %APPDATA%\ai.agentmux.cef.*\.
+Start a dev instance first: ``task dev``. The file is written only by
+debug builds (see docs/specs/SPEC_TEST_API_ACCESS.md §5).
+"@
+    }
+
+    foreach ($file in $candidates) {
+        try {
+            $raw = Get-Content -LiteralPath $file.FullName -Raw -Encoding UTF8
+            $obj = $raw | ConvertFrom-Json
+        } catch {
+            Write-Verbose "Skipping unreadable $($file.FullName): $_"
+            continue
+        }
+
+        $pid_alive = $false
+        try {
+            $proc = Get-Process -Id $obj.host_pid -ErrorAction Stop
+            # Match on image name to guard against PID reuse across reboots.
+            if ($proc.ProcessName -like 'agentmux-cef*') { $pid_alive = $true }
+        } catch {
+            $pid_alive = $false
+        }
+
+        if ($pid_alive) {
+            Write-Verbose "Using authfile: $($file.FullName) (instance=$($obj.instance), pid=$($obj.host_pid))"
+            return $obj
+        } else {
+            Write-Verbose "Stale authfile (pid $($obj.host_pid) dead): $($file.FullName)"
+        }
+    }
+
+    throw @"
+Found authkey.dev file(s) but none belong to a live agentmux-cef process.
+Stale files from prior runs are safe to delete; a fresh ``task dev`` will
+overwrite them on next startup.
+"@
+}
+
+function Invoke-AgentMuxService {
+    <#
+    .SYNOPSIS
+    Calls a service method on the agentmux-srv RPC endpoint.
+
+    .DESCRIPTION
+    Wraps `POST /agentmux/service?service=<svc>&method=<m>&authkey=<key>`
+    with a JSON body of `{service, method, args, uicontext}`. Returns the
+    `data` field from the JSON response, or throws on transport / API error.
+
+    .PARAMETER Auth
+    The PSCustomObject returned by Get-AgentMuxAuthFile.
+
+    .PARAMETER Service
+    Service name (e.g. "client", "object", "workspace").
+
+    .PARAMETER Method
+    Method name on the service (e.g. "GetClientData", "CreateBlock").
+
+    .PARAMETER Args
+    Positional arguments as an array. Each element is JSON-serialized.
+    Pass @() for methods that take no arguments.
+
+    .PARAMETER TimeoutSec
+    HTTP timeout. Default 15s.
+
+    .EXAMPLE
+    $client = Invoke-AgentMuxService -Auth $auth -Service client -Method GetClientData -Args @()
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Auth,
+        [Parameter(Mandatory)] [string]$Service,
+        [Parameter(Mandatory)] [string]$Method,
+        [object[]]$Args = @(),
+        [int]$TimeoutSec = 15
+    )
+
+    $url = "http://{0}{1}?service={2}&method={3}&authkey={4}" -f `
+        $Auth.web_endpoint,
+        $Auth.service_path,
+        [uri]::EscapeDataString($Service),
+        [uri]::EscapeDataString($Method),
+        [uri]::EscapeDataString($Auth.auth_key)
+
+    $body = @{
+        service   = $Service
+        method    = $Method
+        args      = $Args
+        uicontext = $null
+    } | ConvertTo-Json -Depth 20 -Compress
+
+    $resp = Invoke-RestMethod -Method Post -Uri $url `
+        -ContentType 'application/json' `
+        -Body $body `
+        -TimeoutSec $TimeoutSec
+
+    if ($null -ne $resp.error -and $resp.error -ne '') {
+        throw "service $Service.$Method returned error: $($resp.error)"
+    }
+    return $resp.data
+}
+
+function Get-AgentMuxHostLogPath {
+    <#
+    .SYNOPSIS
+    Resolves the host log file path for the instance described by an authfile.
+
+    .DESCRIPTION
+    Logs land in `~/.agentmux/logs/agentmux-host-<instance>.log.<date>`.
+    Returns the newest matching file, or $null if none exist.
+
+    .PARAMETER Auth
+    The PSCustomObject returned by Get-AgentMuxAuthFile.
+    #>
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] $Auth)
+
+    $logDir = Join-Path $env:USERPROFILE '.agentmux\logs'
+    if (-not (Test-Path -LiteralPath $logDir)) { return $null }
+    $pattern = "agentmux-host-$($Auth.instance).log.*"
+    $f = Get-ChildItem -Path $logDir -Filter $pattern -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($f) { return $f.FullName }
+    return $null
+}

--- a/tools/tests/pane-focus-smoke.ps1
+++ b/tools/tests/pane-focus-smoke.ps1
@@ -1,0 +1,44 @@
+# Copyright 2026, AgentMux Corp.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Auth + service smoke test. Proves the harness->agentmux-srv path
+# works end-to-end against a running dev instance:
+#   1. Read authkey.dev (Get-AgentMuxAuthFile)
+#   2. POST /agentmux/service?service=client&method=GetClientData
+#   3. Assert the response carries a non-empty oid
+#
+# Use this to validate the test infrastructure before running the
+# longer pane-focus-stress.ps1, especially after agentmux-cef changes
+# that touch auth, sidecar startup, or the /agentmux route.
+#
+# Usage:
+#   pwsh tools/tests/pane-focus-smoke.ps1
+#
+# Exit 0 = harness can call the API. Exit 1 = wiring is broken; the
+# stress test won't work either.
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'authfile.ps1')
+
+$auth = Get-AgentMuxAuthFile
+Write-Host "[smoke] authfile resolved:"
+Write-Host "        instance     = $($auth.instance)"
+Write-Host "        host_pid     = $($auth.host_pid)"
+Write-Host "        web_endpoint = $($auth.web_endpoint)"
+Write-Host "        service_path = $($auth.service_path)"
+
+Write-Host "[smoke] calling client.GetClientData …"
+$client = Invoke-AgentMuxService -Auth $auth -Service client -Method GetClientData -Args @()
+
+if (-not $client) {
+    Write-Error "client.GetClientData returned null"
+}
+if (-not $client.oid -or $client.oid -eq '') {
+    Write-Error "client.GetClientData response missing oid: $($client | ConvertTo-Json -Depth 4)"
+}
+
+Write-Host "[smoke] PASS — client.oid=$($client.oid)" -ForegroundColor Green
+exit 0

--- a/tools/tests/pane-focus-stress.ps1
+++ b/tools/tests/pane-focus-stress.ps1
@@ -23,21 +23,26 @@
 # correctly". Screenshot dumps are retained for visual cross-check.
 #
 # Usage:
-#   pwsh tools/tests/pane-focus-stress.ps1 -LogPath <path-to-host-log>
+#   pwsh tools/tests/pane-focus-stress.ps1
 #
-# If -LogPath is omitted, the script tails the file at
-# `%APPDATA%\ai.agentmux.cef.v<latest>\db\…` via the dev task's
-# version string.
+# The harness auto-discovers the running dev instance via authkey.dev
+# (see SPEC_TEST_API_ACCESS.md and tools/tests/authfile.ps1). Override
+# with -LogPath if you want to point at a non-default log file, or
+# -SkipAuthFile to fall back to image-name-based discovery.
 
 [CmdletBinding()]
 param(
     [string]$LogPath,
+    [switch]$SkipAuthFile,
     [int]$TypeDelayMs = 300,
     [int]$AfterTypeMs = 400
 )
 
 $ErrorActionPreference = 'Stop'
 Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes, System.Windows.Forms
+
+# Pull in Get-AgentMuxAuthFile / Get-AgentMuxHostLogPath helpers.
+. (Join-Path $PSScriptRoot 'authfile.ps1')
 
 # ── Win32 interop ───────────────────────────────────────────────────────
 $win32 = @'
@@ -56,6 +61,17 @@ Add-Type -TypeDefinition $win32 -ErrorAction SilentlyContinue | Out-Null
 # ── Helpers ─────────────────────────────────────────────────────────────
 
 function Find-AgentMuxMain {
+    param([int]$PreferredPid = 0)
+    # If we know the dev instance's PID via authfile, pick that exact
+    # process — multiple agentmux-cef instances run side-by-side
+    # (portable + dev + multiple windows) and grabbing the first match
+    # routinely targets the wrong one.
+    if ($PreferredPid -gt 0) {
+        try {
+            $p = Get-Process -Id $PreferredPid -ErrorAction Stop
+            if ($p.MainWindowHandle -ne [IntPtr]::Zero) { return $p }
+        } catch {}
+    }
     Get-Process agentmux-cef -ErrorAction SilentlyContinue |
         Where-Object { $_.MainWindowHandle -ne [IntPtr]::Zero } |
         Select-Object -First 1
@@ -96,6 +112,10 @@ function Read-LogSince([string]$path, [datetime]$since) {
 }
 
 function Find-LatestHostLog {
+    # Legacy fallback used only when -SkipAuthFile is set. The
+    # version-suffix glob never matches dev mode (whose data dir is
+    # `ai.agentmux.cef.dev`) — Get-AgentMuxHostLogPath is the
+    # authoritative path resolver.
     $base = Join-Path $env:APPDATA 'ai.agentmux.cef.v*'
     $dirs = Get-ChildItem -Path $base -Directory -ErrorAction SilentlyContinue |
         Sort-Object { [version]($_.Name -replace 'ai\.agentmux\.cef\.v', '' -replace '-', '.') } -Descending
@@ -112,7 +132,24 @@ function Find-LatestHostLog {
 
 # ── Setup ───────────────────────────────────────────────────────────────
 
-$main = Find-AgentMuxMain
+$auth = $null
+$preferredPid = 0
+if (-not $SkipAuthFile) {
+    try {
+        $auth = Get-AgentMuxAuthFile
+        $preferredPid = $auth.host_pid
+        Write-Host "[setup] authkey.dev: instance=$($auth.instance) pid=$($auth.host_pid) endpoint=$($auth.web_endpoint)"
+        if (-not $LogPath) {
+            $candidate = Get-AgentMuxHostLogPath -Auth $auth
+            if ($candidate) { $LogPath = $candidate }
+        }
+    } catch {
+        Write-Warning "Auth file lookup failed: $_"
+        Write-Warning "Falling back to image-name discovery; layout / log targeting may pick the wrong instance if multiple agentmux-cef processes are running."
+    }
+}
+
+$main = Find-AgentMuxMain -PreferredPid $preferredPid
 if (-not $main) {
     Write-Error "No running agentmux-cef process with a main window. Start 'task dev' first."
 }
@@ -127,7 +164,7 @@ Start-Sleep -Milliseconds 500
 
 if (-not $LogPath) { $LogPath = Find-LatestHostLog }
 if (-not $LogPath -or -not (Test-Path $LogPath)) {
-    Write-Warning "Host log not found — log-side assertions will be skipped. Use -LogPath to point at it."
+    Write-Warning "Host log not found — log-side assertions will be skipped. Use -LogPath to point at it explicitly, or ensure a debug build wrote authkey.dev (-SkipAuthFile bypassed)."
 } else {
     Write-Host "[setup] Log path: $LogPath"
 }


### PR DESCRIPTION
## Summary

Wires the existing pane-focus harness up to `authkey.dev` (landed in #446) and adds a minimal smoke test that proves the harness↔backend path is intact before running anything more involved.

Implements PR 4 of [SPEC_TEST_API_ACCESS.md §8](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_TEST_API_ACCESS.md#8-rollout) — *partially*: the auth path is wired up, but programmatic 3-pane layout setup is explicitly deferred to a follow-up because the backend has no `layout.split` RPC today (block layout is reduced client-side by `LayoutModel.treeReducer`). The README documents this.

## Files

- **`tools/tests/authfile.ps1`** — sourceable PowerShell module:
  - `Get-AgentMuxAuthFile` — finds newest `authkey.dev` under `%APPDATA%\ai.agentmux.cef.*`, validates `host_pid` is alive (PID-reuse guarded by image-name match), returns parsed JSON.
  - `Invoke-AgentMuxService` — `POST /agentmux/service?service=…&method=…&authkey=…` with a `{service,method,args,uicontext}` JSON body. Returns `data` field, throws on `error`.
  - `Get-AgentMuxHostLogPath` — resolves `~/.agentmux/logs/agentmux-host-<instance>.log.*` for the discovered instance.

- **`tools/tests/pane-focus-smoke.ps1`** — calls `client.GetClientData` through the auth file and asserts a non-empty `oid`. Single-step validator: exit 0 means the harness wiring is good, exit 1 means stop and fix it before debugging the stress test.

- **`tools/tests/pane-focus-stress.ps1`** — sources the helper, picks the `agentmux-cef` process by `host_pid` (the previous first-match-by-image-name approach routinely targeted the wrong instance when portable + dev were running side-by-side — see CLAUDE.md "Multiple Instances Run in Parallel"), and pulls the log path from the helper. Adds `-SkipAuthFile` to keep the old fallback path available.

- **`tools/tests/README.md`** — documents the auth-file mechanism and is explicit about the layout-setup gap.

## Test plan

- [x] PowerShell parser check: all three scripts parse OK
- [ ] **Blocked on a working dev instance**: cannot run the smoke test end-to-end because the user's current `task dev` is in a broken state. Will run after the next clean dev startup. The wire format follows `frontend/app/store/wos.ts:118`'s exact request shape, so confidence is high — the smoke test is the safety net for any drift.
- [ ] **Blocked on PR 4b**: the stress test still requires the manual layout step; this PR does not change that.

## Follow-ups

- **PR 4b**: programmatic 3-pane layout. Two viable paths — (1) write `LayoutActionData` records into `LayoutState.pendingbackendactions` directly via `object.UpdateObject` (matches what `agent.open` does for one block); (2) add a `layout.setup_three_pane` test fixture method to `agentmux-srv/src/server/app_api.rs` gated on `cfg(debug_assertions)`. Will pick (2) — it gives the harness one idempotent call instead of three RPCs + a layout-tree reduction round-trip.
- **PR 5** (per spec §8): Rust integration test crate using the auth file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)