### PR TITLE
fix(dev-authfile): runtime AGENTMUX_DEV gate (task dev builds --release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.268"
+version = "0.33.269"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.268"
+version = "0.33.269"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.268"
+version = "0.33.269"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.268"
+version = "0.33.269"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.268"
+version = "0.33.269"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/dev_authfile.rs
+++ b/agentmux-cef/src/dev_authfile.rs
@@ -8,19 +8,20 @@
 //! harness in any language can call `POST /agentmux/service` against a
 //! running `task dev` instance.
 //!
-//! Gated on `cfg(debug_assertions)` at both the module declaration site
-//! (in `main.rs`) and via `#![cfg(debug_assertions)]` here. Release
-//! builds contain no symbols from this module — verifiable in CI by
-//! `grep -R authkey.dev target/release/`.
+//! Gated at the call site by a runtime `AGENTMUX_DEV=1` env-var check
+//! (see `main.rs`). The first revision of this module used
+//! `cfg(debug_assertions)`, but `task dev` builds with `--release`
+//! (Taskfile.yml `build:host:windows`), which made the gate a no-op
+//! exactly where we needed the file. The runtime env-var gate matches
+//! the same signal `sidecar.rs` uses to pick the dev data dir.
 //!
 //! On Windows the file is created with an owner-only DACL via
 //! `SetNamedSecurityInfoW`, with `PROTECTED_DACL_SECURITY_INFORMATION`
 //! to break parent-dir inheritance — defense against a hostile parent
-//! ACL change after file creation.
+//! ACL change after file creation. On Unix the file is chmod'd 0600
+//! after creation to override the default umask.
 //!
 //! Spec: `docs/specs/SPEC_TEST_API_ACCESS.md` §5–§6.
-
-#![cfg(debug_assertions)]
 
 use serde::Serialize;
 use std::path::Path;

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -25,7 +25,6 @@ mod app;
 mod browser_panes;
 mod client;
 mod commands;
-#[cfg(debug_assertions)]
 mod dev_authfile;
 mod events;
 mod ipc;
@@ -254,12 +253,18 @@ fn main() {
         std::process::exit(1);
     }
 
-    // Dev-only: write authkey.dev so external test harnesses can call the
-    // service API without polling logs or driving the UI. Release builds
-    // skip this entirely (debug_assertions is false). See
-    // docs/specs/SPEC_TEST_API_ACCESS.md §5.
-    #[cfg(debug_assertions)]
-    {
+    // Dev-only: write authkey.dev so external test harnesses can call
+    // the service API without polling logs or driving the UI. Gate is
+    // runtime, not cfg(debug_assertions), because `task dev` builds
+    // --release (Taskfile.yml `build:host:windows`) — a compile-time
+    // gate would silently no-op the file write in dev mode, defeating
+    // the purpose. Taskfile sets AGENTMUX_DEV=1 on the dev task; the
+    // user's installed/portable builds do not, so the file is only
+    // written when the operator has opted into dev mode for THIS run.
+    // See docs/specs/SPEC_TEST_API_ACCESS.md §3 (threat model) — the
+    // attacker class affected is "same-user local process", which we
+    // do not defend against.
+    if std::env::var("AGENTMUX_DEV").as_deref() == Ok("1") {
         let endpoints = app_state.backend_endpoints.lock().clone();
         let auth_key = app_state.auth_key.lock().clone();
         let ipc_token = app_state.ipc_token.clone();

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.268"
+version = "0.33.269"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.268"
+version = "0.33.269"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.268"
+version = "0.33.269"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_TEST_API_ACCESS.md
+++ b/docs/specs/SPEC_TEST_API_ACCESS.md
@@ -131,10 +131,17 @@ the key.
 - **Cleanup**: overwritten on every fresh startup (superseded). Not
   deleted on shutdown (next startup owns the overwrite — deletes on
   shutdown can race with harnesses reading).
-- **Gate**: `#[cfg(debug_assertions)]` surrounding both the write and
-  the ACL code, and the struct that defines the file format.
-- **Release behaviour**: file is never written. Harnesses that look
-  for it fail fast.
+- **Gate**: runtime check `std::env::var("AGENTMUX_DEV") == "1"`
+  surrounding the write call site. The first revision used
+  `#[cfg(debug_assertions)]`, but `task dev` builds with `--release`
+  (Taskfile.yml `build:host:windows`), which silently no-op'd the
+  write exactly where it was needed. The env-var gate reuses the
+  same signal `sidecar.rs` already uses to pick the dev data dir.
+- **Release behaviour**: file is not written unless the operator
+  explicitly sets `AGENTMUX_DEV=1` for that launch. Installed and
+  portable builds do not set the variable. The "same-user local
+  process" attacker class can set the variable on a launch they
+  control, but that attacker class is already out of scope (§3).
 
 **Pros**
 - Works for any language; no SDK required.
@@ -285,14 +292,12 @@ parse logs:
 
 ## 6. Code changes
 
-### 6.1 `agentmux-cef/src/sidecar.rs`
+### 6.1 `agentmux-cef/src/main.rs`
 
-After `Backend successfully started` log line, when
-`cfg(debug_assertions)`:
+After `backend_ready` is confirmed, when `AGENTMUX_DEV=1`:
 
 ```rust
-#[cfg(debug_assertions)]
-{
+if std::env::var("AGENTMUX_DEV").as_deref() == Ok("1") {
     write_dev_auth_file(
         &data_dir,
         &auth_key,
@@ -304,8 +309,11 @@ After `Backend successfully started` log line, when
 }
 ```
 
-New helper `fn write_dev_auth_file(...)` in the same file (or a new
-`src/dev_authfile.rs`), gated by `#[cfg(debug_assertions)]`.
+New helper `fn write_dev_auth_file(...)` in `src/dev_authfile.rs`,
+no `cfg` gate on the module — the runtime env-var gate at the call
+site is the only opt-in. Symbols ship in release binaries; the file
+is only created when the operator sets `AGENTMUX_DEV=1` for the
+launch (which `task dev` does via Taskfile.yml).
 
 ### 6.2 ACL logic
 
@@ -321,12 +329,15 @@ Unix (not currently a target, but for future parity):
 Both paths verified by a unit test that reads the DACL back and asserts
 only the current user's SID is present.
 
-### 6.3 Release build is compile-time unreachable
+### 6.3 Release build behaviour
 
-Both the helper function and its call site are under `#[cfg(debug_assertions)]`.
-A release build's binary won't contain the helper at all. A
-`grep -R authkey.dev agentmux-cef/target/release/` on the built binary
-must return zero hits — verified in CI.
+The helper symbols are present in release binaries (`grep authkey.dev`
+on a release build returns ~2 hits — the `FILE_NAME` const and the
+log message format string). The file is only created when the
+operator sets `AGENTMUX_DEV=1` for the launch. The threat model in
+§3 already accepts that the same-user local-process attacker can do
+this, so the runtime gate is defense-in-depth rather than a hard
+boundary.
 
 ### 6.4 Harness README update
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.268",
+  "version": "0.33.269",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR #446 shipped non-functional code. The `cfg(debug_assertions)` gate was silently no-op during `task dev` because [Taskfile.yml `build:host:windows`](https://github.com/agentmuxai/agentmux/blob/main/Taskfile.yml) uses `cargo build --release` — `debug_assertions` is false, so the entire write block was eliminated by the compiler. **The file was never written by the very mode it was meant to support**, and PR #447's smoke test had nothing to read.

This PR switches to a runtime check on `AGENTMUX_DEV=1`, which the Taskfile sets on the `dev` task and which `sidecar.rs` already uses to pick the dev data dir name. Same opt-in signal across the codebase.

## What changed

- `agentmux-cef/src/main.rs` — removed `#[cfg(debug_assertions)]` from both the `mod dev_authfile;` declaration and the call site. Replaced the cfg block with `if std::env::var("AGENTMUX_DEV").as_deref() == Ok("1") { … }`.
- `agentmux-cef/src/dev_authfile.rs` — removed `#![cfg(debug_assertions)]` from the top of the module so it compiles in release. Doc comment updated to explain the gate.
- `docs/specs/SPEC_TEST_API_ACCESS.md` — §5 (Gate field), §6.1 (call site code), §6.3 (release behaviour) updated to match. Old text claimed release binaries would have zero `authkey.dev` references; new text acknowledges ~2 (the const + log message format).

## Test plan

- [x] `cargo check -p agentmux-cef --release` passes
- [x] `cargo test -p agentmux-cef --features test-authfile dev_authfile` — 3 tests pass (format, overwrite, DACL)
- [x] Release build contains the helper: `grep -c authkey.dev target/release/agentmux-cef.exe` → `2` (was 0 under the old cfg gate)
- [ ] Manual: `task dev` produces `%APPDATA%\ai.agentmux.cef.dev\authkey.dev`, then `pwsh tools/tests/pane-focus-smoke.ps1` exits 0. **Will run once this lands and the user has a working dev instance.** The previous attempt crashed at `main.rs:338` (CEF init assert) — separate issue from this PR.

## Threat-model impact

Per [SPEC §3](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_TEST_API_ACCESS.md#3-threat-model), the affected attacker class is "same-user local process". Setting `AGENTMUX_DEV=1` is already a same-user-local-process action. That class is explicitly out of scope, so the runtime gate is defense-in-depth rather than a hard boundary. No change to remote-network or other-user-local defences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)