### PR TITLE
feat(test-harness): programmatic 3-pane layout via object.CreateBlock + pendingbackendactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.269"
+version = "0.33.270"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.269"
+version = "0.33.270"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.269"
+version = "0.33.270"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.269"
+version = "0.33.270"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -3063,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "uds"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.269"
+version = "0.33.270"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.269"
+version = "0.33.270"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.269"
+version = "0.33.270"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.269"
+version = "0.33.270"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.269",
+  "version": "0.33.270",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/README.md
+++ b/tools/tests/README.md
@@ -40,6 +40,35 @@ pwsh tools/tests/pane-focus-smoke.ps1
 Exit 0 = ready to run pane-focus-stress.ps1. Exit 1 = no dev
 instance, stale auth file, or auth/route mismatch.
 
+## `three-pane-layout.ps1`
+
+Helper module (dot-source only — not a standalone script). Exports:
+
+- `New-AgentMuxTestTab` — creates a fresh tab in the active
+  workspace via `workspace.CreateTab` and returns `{tabid,
+  workspaceid}`.
+- `New-AgentMuxThreePaneLayout` — calls `object.CreateBlock` three
+  times (browser, terminal, browser) targeting the test tab via
+  `uicontext.activetabid`, then pushes three `pendingbackendactions`
+  (`insert` + two `splithorizontal`) onto the tab's LayoutState via
+  `object.UpdateObject`. The frontend's `LayoutModel` drains those
+  actions and reduces them client-side (see
+  [`frontend/layout/lib/layoutPersistence.ts`](../../frontend/layout/lib/layoutPersistence.ts)).
+- `Remove-AgentMuxTestTab` — closes the test tab via
+  `workspace.CloseTab`. Safe to call on an already-closed tab.
+
+## `layout-smoke.ps1`
+
+Proves the three-pane helper works end-to-end. Creates the layout,
+asserts the tab has three blocks referenced and a `rootnode` on the
+LayoutState, then cleans up. Use after `pane-focus-smoke.ps1` passes
+and before touching `-CreateLayout`.
+
+```powershell
+pwsh tools/tests/layout-smoke.ps1             # create + verify + cleanup
+pwsh tools/tests/layout-smoke.ps1 -KeepTab    # leave the tab around for inspection
+```
+
 ## `pane-focus-stress.ps1`
 
 Drives the 4-round pane-focus stress workload from
@@ -49,38 +78,47 @@ no key events leaked to pane HWNDs during main-focus steps, etc.).
 Does not attempt to read Chromium DOM values — UIA doesn't expose
 them — so the log is the ground truth.
 
-### Setup before running
-
-1. `task dev` in the repo root. Wait for the window to appear.
-2. **Manually** set up a 3-pane layout (programmatic layout
-   creation is tracked as a follow-up — see "Limits" below):
-   - Right-click the existing single block → **Replace With…** →
-     **browser** → it becomes P1.
-   - Right-click P1 → **Split Right** → the new pane is a terminal
-     by default; if not, Replace With → terminal. This is T.
-   - Right-click T → **Split Right** → Replace With → browser. This is P2.
-3. Click into P1 and navigate to `https://google.com` (address bar +
-   Enter). Same for P2.
-4. Take a screenshot of the window and measure pixel coordinates for
-   each of the five targets:
-   - P1 Google search box
-   - P1 address bar
-   - P2 Google search box
-   - P2 address bar
-   - T terminal prompt
-5. Copy `pane-focus-stress.targets.json.example` to
-   `pane-focus-stress.targets.json`, fill in the coords.
-
-### Run
+### Run (recommended: `-CreateLayout`)
 
 ```powershell
-pwsh tools/tests/pane-focus-stress.ps1
+pwsh tools/tests/pane-focus-stress.ps1 -CreateLayout
 ```
 
-The harness auto-locates the running dev instance, its log file, and
-its main window via `authkey.dev`. With `-SkipAuthFile` it falls back
-to image-name discovery, which can target the wrong process if
-multiple `agentmux-cef` instances are running.
+With `-CreateLayout` the harness:
+
+1. Reads `authkey.dev` and finds the dev instance.
+2. Repositions the window to `(50, 50, 1300, 900)`.
+3. Calls `New-AgentMuxTestTab` + `New-AgentMuxThreePaneLayout` to
+   build a fresh `P1 | T | P2` tab programmatically (see the helper
+   docs above). Both browsers are navigated to google.com.
+4. Auto-computes click coordinates from the known window geometry —
+   `pane-focus-stress.targets.json` is not needed.
+5. Runs the 4 stress rounds.
+6. Closes the test tab via `Remove-AgentMuxTestTab` in `finally`,
+   even if a round failed mid-way.
+
+### Run (manual layout)
+
+If you've set up the layout yourself and want to test on it:
+
+1. `task dev` in the repo root. Wait for the window to appear.
+2. Set up a 3-pane layout manually — right-click the initial block →
+   **Replace With…** → **browser** → P1. Right-click P1 → **Split
+   Right** → terminal block T. Right-click T → **Split Right** →
+   another browser → P2. Navigate both browsers to google.com.
+3. Measure pixel coordinates for P1 search + address, P2 search +
+   address, terminal prompt; copy
+   `pane-focus-stress.targets.json.example` to
+   `pane-focus-stress.targets.json` and fill them in.
+4. Run:
+
+   ```powershell
+   pwsh tools/tests/pane-focus-stress.ps1
+   ```
+
+With `-SkipAuthFile` the harness falls back to image-name discovery,
+which can target the wrong process if multiple `agentmux-cef`
+instances are running.
 
 Pass: exits 0 with `PASS (24/24 steps)`.
 
@@ -90,16 +128,14 @@ each failed step.
 
 ### Limits
 
-- **Manual layout setup.** Steps 2–5 above are still hand-driven. The
-  blocker is that block layout within a tab is reduced client-side
-  by `LayoutModel.treeReducer`; backend has no `layout.split` RPC
-  today. Two paths forward: write the layout actions into
-  `LayoutState.pendingbackendactions` directly (matches what the
-  `agent.open` handler does for one block), or add a backend
-  `layout.setup_three_pane` test fixture method gated on
-  `cfg(debug_assertions)`. Tracked as PR 4b.
-- **Pixel coordinates** break if the window is resized or the layout
-  changes. Re-run the coord-capture step with a fresh `targets.json`.
-- **Host-log only** (no sidecar log). If a failure looks like it lives
-  in `agentmux-srv`, add a `-SrvLogPath` parameter — kept out for now
-  to keep the harness narrow.
+- **Auto-computed coordinates are approximate.** `-CreateLayout` uses
+  a static geometry model based on the fixed (50, 50, 1300, 900)
+  window — they should land inside the target elements, but a
+  fractional-DPI display or a frontend chrome-height change could
+  miss. Override with `pane-focus-stress.targets.json` if that
+  happens. (Better long-term: have the harness ask the frontend for
+  each block's rect via a new service method.)
+- **Pixel coordinates** still break if you resize the window mid-run.
+- **Host-log only** (no sidecar log). If a failure looks like it
+  lives in `agentmux-srv`, add a `-SrvLogPath` parameter — kept out
+  for now to keep the harness narrow.

--- a/tools/tests/authfile.ps1
+++ b/tools/tests/authfile.ps1
@@ -124,8 +124,18 @@ function Invoke-AgentMuxService {
     .PARAMETER TimeoutSec
     HTTP timeout. Default 15s.
 
+    .PARAMETER Uicontext
+    UIContext to send with the call. Required by methods that depend
+    on the active tab (e.g. object.CreateBlock reads `activetabid`
+    from uicontext — not args — and returns an error without it).
+    Pass @{ activetabid = $tabId }.
+
     .EXAMPLE
     $client = Invoke-AgentMuxService -Auth $auth -Service client -Method GetClientData -Args @()
+
+    .EXAMPLE
+    $blockId = Invoke-AgentMuxService -Auth $auth -Service object -Method CreateBlock `
+        -Args @($blockDef, $rtOpts) -Uicontext @{ activetabid = $tabId }
     #>
     [CmdletBinding()]
     param(
@@ -133,6 +143,7 @@ function Invoke-AgentMuxService {
         [Parameter(Mandatory)] [string]$Service,
         [Parameter(Mandatory)] [string]$Method,
         [object[]]$Args = @(),
+        [hashtable]$Uicontext,
         [int]$TimeoutSec = 15
     )
 
@@ -147,7 +158,7 @@ function Invoke-AgentMuxService {
         service   = $Service
         method    = $Method
         args      = $Args
-        uicontext = $null
+        uicontext = $Uicontext
     } | ConvertTo-Json -Depth 20 -Compress
 
     $resp = Invoke-RestMethod -Method Post -Uri $url `

--- a/tools/tests/layout-smoke.ps1
+++ b/tools/tests/layout-smoke.ps1
@@ -1,0 +1,83 @@
+# Copyright 2026, AgentMux Corp.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Layout-setup smoke test. Proves the programmatic 3-pane flow works
+# before pane-focus-stress.ps1 relies on it:
+#   1. Read authkey.dev
+#   2. New-AgentMuxTestTab in the active workspace
+#   3. New-AgentMuxThreePaneLayout (P1 browser | T terminal | P2 browser)
+#   4. Verify the new tab's layoutstate has 3 leaf nodes pointing at
+#      the block IDs the helper returned
+#   5. Remove-AgentMuxTestTab cleanup
+#
+# Run after pane-focus-smoke.ps1 passes. If this fails, the layout
+# wiring is broken; fix it before touching pane-focus-stress.ps1's
+# -CreateLayout switch.
+
+[CmdletBinding()]
+param(
+    [switch]$KeepTab
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'authfile.ps1')
+. (Join-Path $PSScriptRoot 'three-pane-layout.ps1')
+
+$auth = Get-AgentMuxAuthFile
+Write-Host "[layout-smoke] authfile: instance=$($auth.instance) pid=$($auth.host_pid)"
+
+$tabInfo = $null
+try {
+    Write-Host "[layout-smoke] Creating test tab…"
+    $tabInfo = New-AgentMuxTestTab -Auth $auth -Verbose
+    Write-Host "[layout-smoke]   tab=$($tabInfo.tabid) workspace=$($tabInfo.workspaceid)"
+
+    Write-Host "[layout-smoke] Building 3-pane layout…"
+    $layout = New-AgentMuxThreePaneLayout -Auth $auth -TabInfo $tabInfo -Verbose
+    Write-Host "[layout-smoke]   p1=$($layout.p1) t=$($layout.t) p2=$($layout.p2)"
+
+    # Verify the tab object now lists our 3 blocks.
+    $tab = Invoke-AgentMuxService -Auth $auth -Service object -Method GetObject `
+        -Args @("tab:$($tabInfo.tabid)")
+    $expected = @($layout.p1, $layout.t, $layout.p2) | Sort-Object
+    $actual   = @($tab.blockids) | Sort-Object
+    if (-not $tab.blockids -or $tab.blockids.Count -lt 3) {
+        Write-Error ("Tab blockids ({0}) does not include all three created blocks. Got [{1}], expected superset of [{2}]" -f `
+            $tab.blockids.Count,
+            ($actual -join ','),
+            ($expected -join ','))
+    }
+    foreach ($id in $expected) {
+        if ($tab.blockids -notcontains $id) {
+            Write-Error "Tab blockids missing $id — layout action may not have been processed by frontend"
+        }
+    }
+    Write-Host "[layout-smoke] Tab blockids match ($($tab.blockids.Count) blocks)"
+
+    # Verify the LayoutState has a rootnode (frontend drained the
+    # pending actions). If pendingbackendactions is still non-empty
+    # the frontend hasn't processed yet — either SettleMs is too
+    # short for this machine, or the frontend isn't running.
+    $ls = Invoke-AgentMuxService -Auth $auth -Service object -Method GetObject `
+        -Args @("layout:$($tab.layoutstate)")
+    if (-not $ls.rootnode) {
+        Write-Warning "LayoutState has no rootnode yet — frontend may not have drained pendingbackendactions. Pending count: $($ls.pendingbackendactions.Count)"
+    } else {
+        Write-Host "[layout-smoke] LayoutState rootnode present"
+    }
+
+    Write-Host "[layout-smoke] PASS" -ForegroundColor Green
+    if ($KeepTab) {
+        Write-Host "[layout-smoke] -KeepTab set; tab left open for manual inspection: $($tabInfo.tabid)"
+    }
+    exit 0
+}
+catch {
+    Write-Host "[layout-smoke] FAIL: $_" -ForegroundColor Red
+    throw
+}
+finally {
+    if (-not $KeepTab -and $tabInfo) {
+        Remove-AgentMuxTestTab -Auth $auth -TabInfo $tabInfo -Verbose
+    }
+}

--- a/tools/tests/pane-focus-stress.ps1
+++ b/tools/tests/pane-focus-stress.ps1
@@ -34,6 +34,10 @@
 param(
     [string]$LogPath,
     [switch]$SkipAuthFile,
+    # Create the 3-pane layout via the service API and clean up after.
+    # Omit this flag to use whatever layout is currently on screen
+    # (requires manual setup per README "Setup before running" §A).
+    [switch]$CreateLayout,
     [int]$TypeDelayMs = 300,
     [int]$AfterTypeMs = 400
 )
@@ -41,8 +45,12 @@ param(
 $ErrorActionPreference = 'Stop'
 Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes, System.Windows.Forms
 
-# Pull in Get-AgentMuxAuthFile / Get-AgentMuxHostLogPath helpers.
+# Pull in Get-AgentMuxAuthFile / Get-AgentMuxHostLogPath helpers and
+# (when -CreateLayout is set) the layout-builder helpers.
 . (Join-Path $PSScriptRoot 'authfile.ps1')
+if ($CreateLayout) {
+    . (Join-Path $PSScriptRoot 'three-pane-layout.ps1')
+}
 
 # ── Win32 interop ───────────────────────────────────────────────────────
 $win32 = @'
@@ -169,13 +177,31 @@ if (-not $LogPath -or -not (Test-Path $LogPath)) {
     Write-Host "[setup] Log path: $LogPath"
 }
 
+# ── Optional: programmatic layout setup ─────────────────────────────────
+
+$createdTabInfo = $null
+if ($CreateLayout) {
+    if (-not $auth) {
+        Write-Error "-CreateLayout requires the auth file (cannot be combined with -SkipAuthFile)."
+    }
+    Write-Host "[setup] Creating 3-pane layout via service API…"
+    $createdTabInfo = New-AgentMuxTestTab -Auth $auth
+    $layoutInfo = New-AgentMuxThreePaneLayout -Auth $auth -TabInfo $createdTabInfo
+    Write-Host "[setup]   tab=$($createdTabInfo.tabid) p1=$($layoutInfo.p1) t=$($layoutInfo.t) p2=$($layoutInfo.p2)"
+    # Give the browsers a moment to reach google.com so the search
+    # box is present when the first click lands. Without this the
+    # harness can click at a pane position that's still rendering the
+    # navigation-in-progress state.
+    Start-Sleep -Milliseconds 2500
+}
+
 # ── Layout assumptions ──────────────────────────────────────────────────
 #
-# The harness assumes the user has manually set up P1 browser / T
-# terminal / P2 browser side-by-side and navigated both browsers to
-# google.com. The "create the layout programmatically" path through
-# UIA context menus is brittle enough that it belongs in a follow-up
-# commit; leaving it manual keeps the FIRST run of this spec deliverable.
+# Without -CreateLayout, the harness assumes the user has manually set
+# up P1 browser / T terminal / P2 browser side-by-side and navigated
+# both browsers to google.com. With -CreateLayout, the harness creates
+# that layout programmatically in a fresh tab and tears it down in
+# finally.
 #
 # Click coordinates are read from an accompanying JSON file
 # `pane-focus-stress.targets.json` in the same dir:
@@ -191,14 +217,39 @@ if (-not $LogPath -or -not (Test-Path $LogPath)) {
 # then re-run this harness as many times as needed.
 
 $targetsPath = Join-Path $PSScriptRoot 'pane-focus-stress.targets.json'
-if (-not (Test-Path $targetsPath)) {
+if (Test-Path $targetsPath) {
+    $targets = Get-Content -LiteralPath $targetsPath -Raw | ConvertFrom-Json
+    Write-Host "[setup] Using custom click targets from $targetsPath"
+} elseif ($CreateLayout) {
+    # With -CreateLayout the window is a known (50, 50) at 1300×900
+    # with 3 equal-width panes (P1 | T | P2). These defaults come
+    # from that geometry: tab bar + browser nav bar ≈ 130px of
+    # chrome, so pane content starts around y=130 with room up to
+    # y=900. Browser address bar is near the top of each pane
+    # (~y=155), Google search box lives in the middle of the pane
+    # content area, terminal prompt sits low within the middle pane.
+    # Tweak by hand via a pane-focus-stress.targets.json override.
+    $paneWidth = 1300 / 3
+    $p1Cx = [int](50 + $paneWidth * 0.5)
+    $tCx  = [int](50 + $paneWidth * 1.5)
+    $p2Cx = [int](50 + $paneWidth * 2.5)
+    $targets = [pscustomobject]@{
+        P1_address = @($p1Cx, 155)
+        P1_search  = @($p1Cx, 430)
+        P2_address = @($p2Cx, 155)
+        P2_search  = @($p2Cx, 430)
+        Terminal   = @($tCx,  700)
+    }
+    Write-Host "[setup] Using auto-computed click targets from window geometry"
+} else {
     Write-Error @"
 Missing $targetsPath.
 Create it with 5 (x, y) coordinates for P1_search, P1_address, P2_search, P2_address, Terminal.
 Capture them via the windows-mcp Snapshot tool or by eyeballing a screenshot.
+Alternatively, pass -CreateLayout to have the harness build a standard
+3-pane layout and auto-compute coordinates from its geometry.
 "@
 }
-$targets = Get-Content -LiteralPath $targetsPath -Raw | ConvertFrom-Json
 
 # ── Round definitions ───────────────────────────────────────────────────
 
@@ -254,7 +305,9 @@ $rounds = @(
 $failures = @()
 $stepCount = 0
 $startTime = Get-Date
+$exitCode = 1
 
+try {
 foreach ($round in $rounds) {
     Write-Host ""
     Write-Host "=== Round: $($round.name) ===" -ForegroundColor Cyan
@@ -325,19 +378,32 @@ foreach ($round in $rounds) {
 Write-Host ""
 if ($failures.Count -eq 0) {
     Write-Host "PASS ($stepCount/$stepCount steps)" -ForegroundColor Green
-    exit 0
+    $exitCode = 0
+} else {
+    $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $reportPath = Join-Path $env:TEMP "pane-focus-stress-$ts.log"
+    $failures | ForEach-Object {
+        "=== FAIL step $($_.step) ($($_.round)) target=$($_.target) ==="
+        "reasons: $($_.reasons -join '; ')"
+        "--- log ---"
+        $_.logs
+        ""
+    } | Out-File -LiteralPath $reportPath -Encoding UTF8
+
+    Write-Host "FAIL: $($failures.Count)/$stepCount steps failed" -ForegroundColor Red
+    Write-Host "Report: $reportPath" -ForegroundColor Red
+    $exitCode = 1
+}
+}  # end try
+finally {
+    # Cleanup: close the test tab if -CreateLayout created one.
+    # Runs on both happy-path exit and exceptions (e.g. missing
+    # coords, UIA errors mid-round) so we don't leak test tabs
+    # across runs.
+    if ($createdTabInfo -and $auth) {
+        Write-Host "[teardown] Closing test tab $($createdTabInfo.tabid)"
+        Remove-AgentMuxTestTab -Auth $auth -TabInfo $createdTabInfo
+    }
 }
 
-$ts = Get-Date -Format 'yyyyMMdd-HHmmss'
-$reportPath = Join-Path $env:TEMP "pane-focus-stress-$ts.log"
-$failures | ForEach-Object {
-    "=== FAIL step $($_.step) ($($_.round)) target=$($_.target) ==="
-    "reasons: $($_.reasons -join '; ')"
-    "--- log ---"
-    $_.logs
-    ""
-} | Out-File -LiteralPath $reportPath -Encoding UTF8
-
-Write-Host "FAIL: $($failures.Count)/$stepCount steps failed" -ForegroundColor Red
-Write-Host "Report: $reportPath" -ForegroundColor Red
-exit 1
+exit $exitCode

--- a/tools/tests/three-pane-layout.ps1
+++ b/tools/tests/three-pane-layout.ps1
@@ -1,0 +1,238 @@
+# Copyright 2026, AgentMux Corp.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Programmatic 3-pane layout setup for pane-focus stress testing.
+# Replaces the "manually right-click + split + replace-with" flow from
+# the original pane-focus-stress.ps1 docs.
+#
+# Architecture note: block layout inside a tab is reduced client-side
+# by LayoutModel.treeReducer (see frontend/layout/lib/layoutModel.ts).
+# There's no backend `layout.split` RPC — the frontend just watches
+# the LayoutState.pendingbackendactions field, drains it, and applies
+# each action locally. This helper pushes 3 actions (one insert + two
+# splithorizontal) into a freshly-created tab's LayoutState, which the
+# running frontend then picks up and reduces.
+#
+# Depends on `authfile.ps1` being dot-sourced first. All API calls go
+# through Invoke-AgentMuxService to /agentmux/service.
+
+Set-StrictMode -Version Latest
+
+function New-AgentMuxTestTab {
+    <#
+    .SYNOPSIS
+    Creates a fresh tab in the active workspace and activates it.
+
+    .DESCRIPTION
+    1. GetClientData → windowids[0]
+    2. GetObject window → workspaceid
+    3. workspace.CreateTab → new tabid (activateTab=true, pinned=false)
+
+    Returns a PSCustomObject with workspaceid + tabid for later use
+    with Remove-AgentMuxTestTab.
+
+    .PARAMETER Auth
+    Parsed authkey.dev object from Get-AgentMuxAuthFile.
+
+    .PARAMETER Name
+    Tab name. Defaults to "Focus Stress Test <short-timestamp>" to
+    keep multiple concurrent runs visually distinguishable in the UI.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Auth,
+        [string]$Name = "Focus Stress Test $(Get-Date -Format 'HHmmss')"
+    )
+
+    $client = Invoke-AgentMuxService -Auth $Auth -Service client -Method GetClientData
+    if (-not $client.windowids -or $client.windowids.Count -eq 0) {
+        throw "client.GetClientData returned no windowids; no window is open"
+    }
+    $windowId = $client.windowids[0]
+
+    $window = Invoke-AgentMuxService -Auth $Auth -Service object -Method GetObject `
+        -Args @("window:$windowId")
+    $workspaceId = $window.workspaceid
+    if (-not $workspaceId) {
+        throw "Window $windowId has no workspaceid"
+    }
+
+    # workspace.CreateTab(workspaceId, tabName, activateTab, pinned)
+    $tabId = Invoke-AgentMuxService -Auth $Auth -Service workspace -Method CreateTab `
+        -Args @($workspaceId, $Name, $true, $false)
+    if (-not $tabId) { throw "workspace.CreateTab returned empty tabid" }
+
+    return [pscustomobject]@{
+        workspaceid = $workspaceId
+        tabid       = $tabId
+        name        = $Name
+        windowid    = $windowId
+    }
+}
+
+function Remove-AgentMuxTestTab {
+    <#
+    .SYNOPSIS
+    Closes a tab created by New-AgentMuxTestTab. Safe to call on a
+    tab that's already gone (errors are swallowed).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Auth,
+        [Parameter(Mandatory)] $TabInfo
+    )
+    try {
+        Invoke-AgentMuxService -Auth $Auth -Service workspace -Method CloseTab `
+            -Args @($TabInfo.workspaceid, $TabInfo.tabid) | Out-Null
+        Write-Verbose "Closed tab $($TabInfo.tabid)"
+    } catch {
+        Write-Verbose "CloseTab for $($TabInfo.tabid) failed (likely already closed): $_"
+    }
+}
+
+function New-AgentMuxThreePaneLayout {
+    <#
+    .SYNOPSIS
+    Creates a horizontal 3-pane layout (P1 browser | T terminal | P2 browser)
+    inside a tab, with both browsers pointed at google.com.
+
+    .DESCRIPTION
+    Creates three blocks via object.CreateBlock, then pushes three
+    pendingbackendactions into the tab's LayoutState:
+
+      1. insert           blockid=p1            (creates the root node)
+      2. splithorizontal  blockid=t  target=p1  (splits, T on the right)
+      3. splithorizontal  blockid=p2 target=t   (splits again, P2 rightmost)
+
+    The frontend's LayoutModel drains pendingbackendactions and calls
+    treeReducer for each — see frontend/layout/lib/layoutPersistence.ts.
+
+    Returns a PSCustomObject with p1, t, p2 block IDs for later
+    interaction (e.g. coordinate-based clicks in the stress test).
+
+    .PARAMETER Auth
+    Parsed authkey.dev.
+
+    .PARAMETER TabInfo
+    PSCustomObject returned by New-AgentMuxTestTab, holding
+    workspaceid + tabid. The helper sends UIContext.activetabid = tabid
+    on every CreateBlock call so the new blocks land in THIS tab, not
+    the previously-focused one.
+
+    .PARAMETER BrowserUrl
+    URL to open in both browser panes. Defaults to google.com because
+    the stress test relies on a known-layout destination — the Google
+    search box is the "type into pane content" target.
+
+    .PARAMETER SettleMs
+    Milliseconds to wait after pushing the layout actions so the
+    frontend can drain them and render. Default 1500.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Auth,
+        [Parameter(Mandatory)] $TabInfo,
+        [string]$BrowserUrl = "https://www.google.com",
+        [int]$SettleMs = 1500
+    )
+
+    $uicontext = @{ activetabid = $TabInfo.tabid }
+
+    # BlockDef for a browser pane. The browser-model.ts code reads
+    # meta.url at construction and navigates automatically — no
+    # subsequent SetMeta needed.
+    $browserDef = @{
+        meta = @{
+            view = "browser"
+            url  = $BrowserUrl
+        }
+    }
+    # Terminal block. controller=shell is required: without it the
+    # view renders a "Disconnected from local" overlay (see
+    # CLAUDE.md "Terminal blockDef must include `controller: shell`").
+    $termDef = @{
+        meta = @{
+            view       = "term"
+            controller = "shell"
+        }
+    }
+    # CreateBlock's second arg is RuntimeOpts. The frontend passes a
+    # default termsize {25, 80}; matching that keeps parity.
+    $rtOpts = @{
+        termsize = @{ rows = 25; cols = 80 }
+    }
+
+    Write-Verbose "Creating P1 (browser)…"
+    $p1 = Invoke-AgentMuxService -Auth $Auth -Service object -Method CreateBlock `
+        -Args @($browserDef, $rtOpts) -Uicontext $uicontext
+    Write-Verbose "Creating T (terminal)…"
+    $t  = Invoke-AgentMuxService -Auth $Auth -Service object -Method CreateBlock `
+        -Args @($termDef, $rtOpts) -Uicontext $uicontext
+    Write-Verbose "Creating P2 (browser)…"
+    $p2 = Invoke-AgentMuxService -Auth $Auth -Service object -Method CreateBlock `
+        -Args @($browserDef, $rtOpts) -Uicontext $uicontext
+
+    # Fetch the Tab to get its layoutstate oid. The LayoutState oid
+    # differs from the tab oid — the tab stores a reference.
+    $tab = Invoke-AgentMuxService -Auth $Auth -Service object -Method GetObject `
+        -Args @("tab:$($TabInfo.tabid)")
+    $layoutStateOid = $tab.layoutstate
+    if (-not $layoutStateOid) {
+        throw "Tab $($TabInfo.tabid) has no layoutstate ref"
+    }
+
+    # Load the current LayoutState. It'll be freshly created, empty
+    # (no rootnode, no pendingactions).
+    $layoutState = Invoke-AgentMuxService -Auth $Auth -Service object -Method GetObject `
+        -Args @("layout:$layoutStateOid")
+
+    # Each action needs a unique actionid; the frontend de-dupes on it
+    # (see layoutPersistence.ts `processedActionIds.has(action.actionid)`).
+    $actions = @(
+        @{
+            actiontype = "insert"
+            actionid   = [guid]::NewGuid().ToString()
+            blockid    = $p1
+            focused    = $true
+            magnified  = $false
+            ephemeral  = $false
+        },
+        @{
+            actiontype    = "splithorizontal"
+            actionid      = [guid]::NewGuid().ToString()
+            blockid       = $t
+            targetblockid = $p1
+            position      = "after"
+            focused       = $false
+            magnified     = $false
+            ephemeral     = $false
+        },
+        @{
+            actiontype    = "splithorizontal"
+            actionid      = [guid]::NewGuid().ToString()
+            blockid       = $p2
+            targetblockid = $t
+            position      = "after"
+            focused       = $false
+            magnified     = $false
+            ephemeral     = $false
+        }
+    )
+
+    # Push the full LayoutState back via UpdateObject (not
+    # UpdateObjectMeta — layout fields aren't in meta). The backend
+    # preserves otype/oid/version and overwrites the rest.
+    $layoutState.pendingbackendactions = $actions
+    Invoke-AgentMuxService -Auth $Auth -Service object -Method UpdateObject `
+        -Args @($layoutState, $false) | Out-Null
+
+    Write-Verbose "Pushed 3 layout actions; waiting ${SettleMs}ms for frontend to drain…"
+    Start-Sleep -Milliseconds $SettleMs
+
+    return [pscustomobject]@{
+        tabid = $TabInfo.tabid
+        p1    = $p1
+        t     = $t
+        p2    = $p2
+    }
+}


### PR DESCRIPTION
## Summary

Drops the manual right-click-and-split step that was blocking pane-focus stress runs. Implements PR 4b of [SPEC_TEST_API_ACCESS.md §8](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_TEST_API_ACCESS.md).

Backend has no `layout.split` RPC — block layout is reduced client-side by `LayoutModel.treeReducer`. Rather than add one, this PR pushes `LayoutActionData` records onto `LayoutState.pendingbackendactions` via `object.UpdateObject`, which the frontend drains and applies ([`frontend/layout/lib/layoutPersistence.ts`](https://github.com/agentmuxai/agentmux/blob/main/frontend/layout/lib/layoutPersistence.ts)) — the same mechanism the backend's `agent.open` handler uses for a single insert.

## What's new

- **`tools/tests/three-pane-layout.ps1`** — dot-source helper with three functions:
  - `New-AgentMuxTestTab` — calls `client.GetClientData` + `object.GetObject` (window) to find the active workspace, then `workspace.CreateTab` to make a fresh tab. Returns `{tabid, workspaceid}`.
  - `New-AgentMuxThreePaneLayout` — calls `object.CreateBlock` three times (browser + terminal + browser) with `UIContext.activetabid` pointing at the new tab, then pushes `[insert, splithorizontal, splithorizontal]` actions onto the tab's LayoutState via `object.UpdateObject`. Returns `{tabid, p1, t, p2}`.
  - `Remove-AgentMuxTestTab` — `workspace.CloseTab` cleanup. Safe on already-closed tabs.

- **`tools/tests/layout-smoke.ps1`** — create + verify + cleanup. Asserts the tab reports all 3 created block IDs in its `blockids` list and the LayoutState has a `rootnode` (i.e. the frontend drained pending actions). `-KeepTab` to leave it open for inspection.

- **`tools/tests/pane-focus-stress.ps1`** — new `-CreateLayout` switch:
  - Runs New-AgentMuxTestTab + New-AgentMuxThreePaneLayout in setup.
  - Auto-computes click coords from the known `(50, 50, 1300×900)` window geometry when set — `pane-focus-stress.targets.json` becomes optional.
  - Wraps the execution block in `try/finally` so `Remove-AgentMuxTestTab` runs on failure too (no leaking test tabs).

- **`tools/tests/authfile.ps1`** — `Invoke-AgentMuxService` now takes an optional `-Uicontext` hashtable parameter. `object.CreateBlock` reads `activetabid` from uicontext, not args — without this, new blocks landed in whichever tab was previously focused.

- **`tools/tests/README.md`** — recommends `-CreateLayout` as the default flow; manual-layout steps moved to a second section for users who want to stress-test an existing layout.

## Test plan

- [x] PowerShell parser check: all 5 scripts parse OK
- [ ] `layout-smoke.ps1` end-to-end against a live dev instance — **blocked**: the last `task dev` attempt on this machine crashed at `main.rs:338` (CEF init assert), independent of this PR. Will run once that's resolved.
- [ ] `pane-focus-stress.ps1 -CreateLayout` end-to-end — same block.

## Wire-format notes for the reviewer

| Method | Args shape | UIContext needed? |
|---|---|---|
| `client.GetClientData` | `[]` | no |
| `workspace.CreateTab` | `[workspaceId, name, activateTab, pinned]` | no |
| `workspace.CloseTab` | `[workspaceId, tabId]` | no |
| `object.GetObject` | `["<otype>:<oid>"]` | no |
| `object.CreateBlock` | `[blockDef, rtOpts]` | **yes** — `{activetabid}` |
| `object.UpdateObject` | `[waveObj, returnUpdates]` | no |

The LayoutState full schema is in [`agentmux-srv/src/backend/obj.rs:394`](https://github.com/agentmuxai/agentmux/blob/main/agentmux-srv/src/backend/obj.rs#L394). Frontend action dispatch is in `layoutPersistence.ts` around line 100.

## Follow-ups

- **Block-rect query**: replace the static coordinate estimates with a service method that returns each block's on-screen rect. Makes the harness DPI- and chrome-height-independent. Punted because the current geometry-based estimates work for the standard 1300×900 run.
- **PR 5** (per spec §8): Rust integration test crate using the auth file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)