### PR TITLE
fix(test-harness): strict-mode safety + Taskfile AGENTMUX_DEV propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.270"
+version = "0.33.271"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.270"
+version = "0.33.271"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.270"
+version = "0.33.271"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.270"
+version = "0.33.271"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -494,7 +494,12 @@ tasks:
                   exit 1
                 fi
                 echo "Vite ready."
-                cd "$DEV_DIR" && LD_LIBRARY_PATH=. ./agentmux-cef{{exeExt}} --url=http://localhost:5173
+                # Inline AGENTMUX_DEV=1 on the launch: go-task's top-level
+                # env: block (on the `dev` task) doesn't propagate into
+                # cmd: shell subprocesses invoked via `task:` on Windows,
+                # so agentmux-cef would start without the flag and skip
+                # the authkey.dev write (docs/specs/SPEC_TEST_API_ACCESS.md §6).
+                cd "$DEV_DIR" && LD_LIBRARY_PATH=. AGENTMUX_DEV=1 ./agentmux-cef{{exeExt}} --url=http://localhost:5173
 
     run:
         desc: Run the host (must be built and bundled first).

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.270"
+version = "0.33.271"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.270"
+version = "0.33.271"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.270"
+version = "0.33.271"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.270"
+version = "0.33.271"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.270",
+  "version": "0.33.271",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/authfile.ps1
+++ b/tools/tests/authfile.ps1
@@ -50,14 +50,17 @@ function Get-AgentMuxAuthFile {
         if (Test-Path -LiteralPath $p) { $candidates += Get-Item -LiteralPath $p }
     } else {
         $base = Join-Path $env:APPDATA 'ai.agentmux.cef.*'
-        $candidates = Get-ChildItem -Path $base -Directory -ErrorAction SilentlyContinue |
+        # Wrap with @(...) so a single match doesn't collapse into a
+        # bare object — `.Count` and `foreach` both need an array under
+        # Set-StrictMode -Version Latest, which this module enables.
+        $candidates = @(Get-ChildItem -Path $base -Directory -ErrorAction SilentlyContinue |
             ForEach-Object { Join-Path $_.FullName 'authkey.dev' } |
             Where-Object { Test-Path -LiteralPath $_ } |
             Get-Item |
-            Sort-Object LastWriteTime -Descending
+            Sort-Object LastWriteTime -Descending)
     }
 
-    if (-not $candidates -or $candidates.Count -eq 0) {
+    if ($candidates.Count -eq 0) {
         throw @"
 No authkey.dev found under %APPDATA%\ai.agentmux.cef.*\.
 Start a dev instance first: ``task dev``. The file is written only by
@@ -166,10 +169,16 @@ function Invoke-AgentMuxService {
         -Body $body `
         -TimeoutSec $TimeoutSec
 
-    if ($null -ne $resp.error -and $resp.error -ne '') {
-        throw "service $Service.$Method returned error: $($resp.error)"
+    # Under Set-StrictMode -Version Latest, $resp.error throws when
+    # the JSON has no `error` field — the server omits it entirely
+    # on success. PSObject.Properties lookup is strict-safe.
+    $errProp = $resp.PSObject.Properties['error']
+    if ($errProp -and $errProp.Value) {
+        throw "service $Service.$Method returned error: $($errProp.Value)"
     }
-    return $resp.data
+    $dataProp = $resp.PSObject.Properties['data']
+    if ($dataProp) { return $dataProp.Value }
+    return $null
 }
 
 function Get-AgentMuxHostLogPath {

--- a/tools/tests/layout-smoke.ps1
+++ b/tools/tests/layout-smoke.ps1
@@ -58,10 +58,17 @@ try {
     # pending actions). If pendingbackendactions is still non-empty
     # the frontend hasn't processed yet — either SettleMs is too
     # short for this machine, or the frontend isn't running.
+    # Property access is PSObject.Properties-based because strict
+    # mode throws on missing properties and the serialized LayoutState
+    # omits rootnode/pending when unset.
     $ls = Invoke-AgentMuxService -Auth $auth -Service object -Method GetObject `
         -Args @("layout:$($tab.layoutstate)")
-    if (-not $ls.rootnode) {
-        Write-Warning "LayoutState has no rootnode yet — frontend may not have drained pendingbackendactions. Pending count: $($ls.pendingbackendactions.Count)"
+    $rootnode = $ls.PSObject.Properties['rootnode']
+    $pending  = $ls.PSObject.Properties['pendingbackendactions']
+    if (-not $rootnode -or -not $rootnode.Value) {
+        $pendingCount = 0
+        if ($pending -and $pending.Value) { $pendingCount = @($pending.Value).Count }
+        Write-Warning "LayoutState has no rootnode yet - frontend may not have drained pendingbackendactions. Pending count: $pendingCount"
     } else {
         Write-Host "[layout-smoke] LayoutState rootnode present"
     }

--- a/tools/tests/three-pane-layout.ps1
+++ b/tools/tests/three-pane-layout.ps1
@@ -222,9 +222,24 @@ function New-AgentMuxThreePaneLayout {
     # Push the full LayoutState back via UpdateObject (not
     # UpdateObjectMeta — layout fields aren't in meta). The backend
     # preserves otype/oid/version and overwrites the rest.
-    $layoutState.pendingbackendactions = $actions
+    #
+    # Rebuild as a hashtable rather than mutating $layoutState: under
+    # Set-StrictMode -Version Latest, assigning to a property that
+    # isn't already present on the PSCustomObject throws. `pendingbackendactions`
+    # is omitted from the serialized JSON when None, so a fresh
+    # LayoutState never has that property in the parsed response.
+    $updatePayload = @{
+        otype                 = "layout"
+        oid                   = $layoutStateOid
+        version               = $layoutState.version
+        pendingbackendactions = $actions
+    }
+    foreach ($propName in @("rootnode", "magnifiednodeid", "focusednodeid", "leaforder", "meta")) {
+        $prop = $layoutState.PSObject.Properties[$propName]
+        if ($prop) { $updatePayload[$propName] = $prop.Value }
+    }
     Invoke-AgentMuxService -Auth $Auth -Service object -Method UpdateObject `
-        -Args @($layoutState, $false) | Out-Null
+        -Args @($updatePayload, $false) | Out-Null
 
     Write-Verbose "Pushed 3 layout actions; waiting ${SettleMs}ms for frontend to drain…"
     Start-Sleep -Milliseconds $SettleMs


### PR DESCRIPTION
## Summary

Four distinct bugs kept the harness from running end-to-end against a live dev instance. Found by actually running it on a working `task dev` for the first time.

## The bugs

1. **`authfile.ps1` Get-AgentMuxAuthFile** did `$candidates.Count` on a pipeline result. When only one `authkey.dev` exists, the pipeline collapses to a bare `Get-Item` object — no `.Count` property. Under `Set-StrictMode -Version Latest` (which this module enables) that throws. Fix: wrap the pipeline in `@(...)` so it's always an array.

2. **`authfile.ps1` Invoke-AgentMuxService** read `$resp.error` directly. The Rust server omits `error` from the JSON on success (serde `skip_if_none`), so strict mode threw on *every* successful call. Fix: use `PSObject.Properties['error']` lookup.

3. **`three-pane-layout.ps1` New-AgentMuxThreePaneLayout** did `$layoutState.pendingbackendactions = $actions`. A fresh LayoutState has no `pendingbackendactions` field in the response (`Option<Vec<...>>`, `None` when empty), so strict mode threw on property set. Fix: rebuild the payload as a hashtable preserving existing fields.

4. **Taskfile `dev` task** sets `env: AGENTMUX_DEV: "1"` at the task level, but go-task on Windows doesn't propagate that into `cmd:` shell subprocesses invoked through `task:`. Verified by comparing runs:
   - `task dev` → no authkey.dev written
   - `AGENTMUX_DEV=1 task dev` → authkey.dev written correctly
   Fix: inline `AGENTMUX_DEV=1` on the actual launch command in `dev:serve`.

## End-to-end validation

Against a live v0.33.270 dev instance:

```
$ pwsh tools/tests/pane-focus-smoke.ps1
[smoke] PASS - client.oid=8d21ac6a-f921-44a3-81e5-847b20d8afe8

$ pwsh tools/tests/layout-smoke.ps1
[layout-smoke] Tab blockids match (3 blocks)
[layout-smoke] PASS

$ pwsh tools/tests/pane-focus-stress.ps1 -CreateLayout
... runs all 24 steps, cleans up the tab
```

## Follow-up (known orthogonal issue)

The stress test reports 11/24 step failures on search-box clicks. The frontend isn't draining `pendingbackendactions` onto the new tab within the 1500ms settle window (or the new tab isn't being made visually active despite `activateTab=true` on `CreateTab`), so clicks land on the previously-active layout. I called this out in the commit message; it'll be a separate investigation PR. This PR just makes the harness infrastructure run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)