### PR TITLE
feat(test-harness): broadcast service-API updates + sequential layout actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.271"
+version = "0.33.272"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.271"
+version = "0.33.272"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +42,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.271"
+version = "0.33.272"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.271"
+version = "0.33.272"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.271"
+version = "0.33.272"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.271"
+version = "0.33.272"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.271"
+version = "0.33.272"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.271"
+version = "0.33.272"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -27,6 +27,30 @@ pub(super) async fn handle_service(
         call.method,
         elapsed.as_secs_f64() * 1000.0,
     );
+
+    // Broadcast every WaveObjUpdate the handler returned so other
+    // clients (additional windows, test harnesses, etc.) learn about
+    // changes they didn't initiate. The calling HTTP client also gets
+    // `updates` in the response body — this broadcast is for
+    // everybody else on the event bus. Before this, only a handful
+    // of handlers (agent.open, blockcontroller events) broadcast
+    // manually, so an external harness's CreateTab / UpdateObject
+    // were invisible to the frontend.
+    if let Some(updates) = &result.updates {
+        for update in updates {
+            if let Ok(data) = serde_json::to_value(update) {
+                let oref = format!("{}:{}", update.otype, update.oid);
+                state.event_bus.broadcast_event(
+                    &crate::backend::eventbus::WSEventType {
+                        eventtype: "waveobj:update".to_string(),
+                        oref,
+                        data: Some(data),
+                    },
+                );
+            }
+        }
+    }
+
     Json(result)
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.271",
+  "version": "0.33.272",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.271",
+      "version": "0.33.272",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.265",
+  "version": "0.33.271",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.265",
+      "version": "0.33.271",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.271",
+  "version": "0.33.272",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/three-pane-layout.ps1
+++ b/tools/tests/three-pane-layout.ps1
@@ -62,6 +62,15 @@ function New-AgentMuxTestTab {
         -Args @($workspaceId, $Name, $true, $false)
     if (-not $tabId) { throw "workspace.CreateTab returned empty tabid" }
 
+    # Explicit SetActiveTab after CreateTab. CreateTab(activate=true)
+    # flips workspace.activetabid on the backend, but in practice the
+    # frontend's tab switch doesn't always fire on that path alone —
+    # the stress harness saw clicks landing on the prior tab's layout.
+    # SetActiveTab runs heal_layout + broadcasts a workspace update
+    # that the frontend's activeTabId() atom reliably reacts to.
+    Invoke-AgentMuxService -Auth $Auth -Service workspace -Method SetActiveTab `
+        -Args @($workspaceId, $tabId) | Out-Null
+
     return [pscustomobject]@{
         workspaceid = $workspaceId
         tabid       = $tabId
@@ -133,7 +142,7 @@ function New-AgentMuxThreePaneLayout {
         [Parameter(Mandatory)] $Auth,
         [Parameter(Mandatory)] $TabInfo,
         [string]$BrowserUrl = "https://www.google.com",
-        [int]$SettleMs = 1500
+        [int]$SettleMs = 3500
     )
 
     $uicontext = @{ activetabid = $TabInfo.tabid }
@@ -186,9 +195,18 @@ function New-AgentMuxThreePaneLayout {
     $layoutState = Invoke-AgentMuxService -Auth $Auth -Service object -Method GetObject `
         -Args @("layout:$layoutStateOid")
 
-    # Each action needs a unique actionid; the frontend de-dupes on it
-    # (see layoutPersistence.ts `processedActionIds.has(action.actionid)`).
-    $actions = @(
+    # Push layout actions ONE AT A TIME, letting the frontend drain
+    # between each. Pushing all three in one batch doesn't work: the
+    # frontend's processPendingBackendActions loops the actions but
+    # calls getNodeByBlockId against `model.leafs` (a memoized signal)
+    # — that signal is only refreshed by updateTree() at the END of
+    # the loop, so action 2's splithorizontal can't find the target
+    # block that action 1 just inserted. The loop silently no-ops on
+    # the misses. Per-action push forces updateTree + persistToBackend
+    # to run between each, so the next push sees the freshly-materialized
+    # target. See frontend/layout/lib/layoutPersistence.ts and
+    # layoutNodeModels.ts `getNodeByBlockId`.
+    $plan = @(
         @{
             actiontype = "insert"
             actionid   = [guid]::NewGuid().ToString()
@@ -219,30 +237,37 @@ function New-AgentMuxThreePaneLayout {
         }
     )
 
-    # Push the full LayoutState back via UpdateObject (not
-    # UpdateObjectMeta — layout fields aren't in meta). The backend
-    # preserves otype/oid/version and overwrites the rest.
-    #
-    # Rebuild as a hashtable rather than mutating $layoutState: under
-    # Set-StrictMode -Version Latest, assigning to a property that
-    # isn't already present on the PSCustomObject throws. `pendingbackendactions`
-    # is omitted from the serialized JSON when None, so a fresh
-    # LayoutState never has that property in the parsed response.
-    $updatePayload = @{
-        otype                 = "layout"
-        oid                   = $layoutStateOid
-        version               = $layoutState.version
-        pendingbackendactions = $actions
-    }
-    foreach ($propName in @("rootnode", "magnifiednodeid", "focusednodeid", "leaforder", "meta")) {
-        $prop = $layoutState.PSObject.Properties[$propName]
-        if ($prop) { $updatePayload[$propName] = $prop.Value }
-    }
-    Invoke-AgentMuxService -Auth $Auth -Service object -Method UpdateObject `
-        -Args @($updatePayload, $false) | Out-Null
+    # Budget the settle time across 3 pushes. Default 3500ms → ~1200ms
+    # per push, which is generous for a locally-running dev instance.
+    $perStepSettle = [int]($SettleMs / $plan.Count)
 
-    Write-Verbose "Pushed 3 layout actions; waiting ${SettleMs}ms for frontend to drain…"
-    Start-Sleep -Milliseconds $SettleMs
+    for ($i = 0; $i -lt $plan.Count; $i++) {
+        Write-Verbose "Layout action $($i + 1)/$($plan.Count): $($plan[$i].actiontype) $($plan[$i].blockid)"
+
+        # Re-fetch the LayoutState each iteration — the frontend wrote
+        # back rootnode/version from the previous action via
+        # persistToBackend, and UpdateObject takes the whole object.
+        $currentLs = Invoke-AgentMuxService -Auth $Auth -Service object -Method GetObject `
+            -Args @("layout:$layoutStateOid")
+
+        # Rebuild as a hashtable: under Set-StrictMode assigning to a
+        # property the PSCustomObject doesn't have throws.
+        $payload = @{
+            otype                 = "layout"
+            oid                   = $layoutStateOid
+            version               = $currentLs.version
+            pendingbackendactions = @($plan[$i])
+        }
+        foreach ($propName in @("rootnode", "magnifiednodeid", "focusednodeid", "leaforder", "meta")) {
+            $prop = $currentLs.PSObject.Properties[$propName]
+            if ($prop) { $payload[$propName] = $prop.Value }
+        }
+
+        Invoke-AgentMuxService -Auth $Auth -Service object -Method UpdateObject `
+            -Args @($payload, $false) | Out-Null
+
+        Start-Sleep -Milliseconds $perStepSettle
+    }
 
     return [pscustomobject]@{
         tabid = $TabInfo.tabid


### PR DESCRIPTION
## Summary

Two focused fixes that together make the programmatic 3-pane layout actually render on screen. Before this PR the harness's `workspace.CreateTab` + `object.CreateBlock` + `object.UpdateObject` sequence completed cleanly (Tab.blockids had 3 entries), but only P1 ever made it into the LayoutState rootnode. Root cause was in two independent places.

## Fix 1 — centralized service-API broadcast (`agentmux-srv/src/server/service.rs`)

Before: the HTTP `handle_service` returned `updates` only in the response body. The frontend (a separate process, listening over WebSocket) never saw changes that originated from another HTTP client. A handful of handlers — `agent.open`, `blockcontroller` events — called `event_bus.broadcast_event` manually; the rest didn't. Result: when the harness created a tab or pushed a LayoutState update, the CEF frontend was oblivious.

After: a single loop at the end of `handle_service` broadcasts every `WaveObjUpdate` the handler returned:

```rust
if let Some(updates) = &result.updates {
    for update in updates {
        state.event_bus.broadcast_event(&WSEventType {
            eventtype: "waveobj:update".to_string(),
            oref: format!("{}:{}", update.otype, update.oid),
            data: Some(serde_json::to_value(update)?),
        });
    }
}
```

Frontend self-broadcasts are safe — `updateWaveObject` in `wos.ts` already skips updates whose `version <= current`, so the originating client sees no double-apply.

## Fix 2 — sequential layout actions (`tools/tests/three-pane-layout.ps1`)

Before: the helper pushed all three layout actions (`insert P1`, `splithorizontal T target=P1`, `splithorizontal P2 target=T`) in a single `UpdateObject` call. Frontend's `processPendingBackendActions` loops them, but `getNodeByBlockId` looks at `model.leafs` — a memoized signal that `updateTree()` only refreshes at the END of the loop. So actions 2 and 3 silently no-op (`console.error` fires but returns): the loop runs, only action 1 lands in the tree.

After: push actions one at a time, re-fetching the LayoutState between each so the next push carries the new `rootnode` + `version`. `SettleMs` budget is divided across the 3 pushes.

Adding `updateTree()` between actions in the frontend is the "correct" fix, but it's a bigger surface change and this per-action push is the smaller, more-surgical harness-side equivalent. The frontend batch-processing can be revisited separately if it matters for production code paths.

## Validation

Against a live `task dev` with the fixes:

```
$ pwsh tools/tests/layout-smoke.ps1
[layout-smoke] Tab blockids match (3 blocks)
[layout-smoke] LayoutState rootnode present
[layout-smoke] PASS
```

Screenshot after the layout-smoke confirms **P1 browser (google.com) | T terminal (pwsh prompt) | P2 browser (google.com)** rendered side by side in the test tab.

`pane-focus-stress.ps1 -CreateLayout` now runs all 24 steps. 13 pass (address bar + terminal clicks), 11 fail — all on `P1_search`/`P2_search` clicks. The coord estimate `y=430` for the Google search box was picked blind; it misses the actual search input (slightly higher on screen). That's a straight coord refinement, tracked as a follow-up since it doesn't belong in the layout-rendering path.

## Next follow-ups (separate PRs)

1. Refine search-box y coordinate. Either lower the static default or use `Snapshot`/UIAutomation to find the search input dynamically.
2. Consider fixing the frontend's `processPendingBackendActions` to refresh the leafs cache between actions, so multi-action pushes work.
3. Rust integration test crate using the auth file (per SPEC §8 optional step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)