### PR TITLE
feat(browser-dom-api): CDP-backed /agentmux/browser/query endpoint (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,18 +10,21 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.273"
+version = "0.33.274"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
  "cef",
  "chrono",
  "dirs",
+ "futures-util",
  "json_comments",
  "parking_lot",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite",
  "tower-http",
  "tracing",
  "tracing-appender",
@@ -34,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.273"
+version = "0.33.274"
 dependencies = [
  "tokio",
  "tracing",
@@ -42,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.273"
+version = "0.33.274"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -50,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.273"
+version = "0.33.274"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -938,6 +941,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.273"
+version = "0.33.274"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"
@@ -39,6 +39,10 @@ tower-http = { version = "0.6", features = ["cors", "fs"] }
 tokio = { version = "1", features = ["full"] }
 whoami = "1"
 json_comments = "0.2"
+# Browser DOM API (SPEC_BROWSER_DOM_API.md): CDP WebSocket client + /json probe
+tokio-tungstenite = "0.24"
+futures-util = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/agentmux-cef/src/browser_api/cdp.rs
+++ b/agentmux-cef/src/browser_api/cdp.rs
@@ -1,0 +1,107 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal Chrome DevTools Protocol (CDP) WebSocket client.
+//!
+//! One session = one WebSocket to `ws://127.0.0.1:<debug_port>/devtools/page/<target>`.
+//! Per-request construction in Phase 1 (see PLAN §Phase 5 for pooling).
+//!
+//! CDP protocol: every client request is `{id, method, params}`; every
+//! server reply with matching `id` is `{id, result}` or `{id, error}`.
+//! Events (no id) are ignored here — we don't subscribe to any in
+//! Phase 1 since every method we use is request/response.
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::net::TcpStream;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::protocol::Message,
+    MaybeTlsStream, WebSocketStream,
+};
+
+pub type CdpError = String;
+
+pub struct CdpSession {
+    ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
+    next_id: u64,
+}
+
+impl CdpSession {
+    /// Open a CDP session against `ws://127.0.0.1:<port>/devtools/page/<target>`.
+    pub async fn connect(ws_url: &str) -> Result<Self, CdpError> {
+        let (ws, _resp) = connect_async(ws_url)
+            .await
+            .map_err(|e| format!("CDP connect {ws_url}: {e}"))?;
+        Ok(Self { ws, next_id: 1 })
+    }
+
+    /// Send `{id, method, params}` and wait for the reply with the
+    /// same id. Events (no id) and unrelated replies are silently
+    /// discarded — v1 doesn't multiplex.
+    pub async fn call(
+        &mut self,
+        method: &str,
+        params: Value,
+    ) -> Result<Value, CdpError> {
+        let id = self.next_id;
+        self.next_id += 1;
+
+        let req = json!({ "id": id, "method": method, "params": params });
+        let msg = Message::Text(req.to_string().into());
+        self.ws
+            .send(msg)
+            .await
+            .map_err(|e| format!("CDP send {method}: {e}"))?;
+
+        // Wait up to 10s for the matching reply. CDP replies are
+        // usually <100 ms on localhost; the generous bound is a
+        // safety net for pages stalled on JS execution.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(format!("CDP timeout waiting for reply to {method}"));
+            }
+            let next = tokio::time::timeout(remaining, self.ws.next()).await;
+            let frame = match next {
+                Ok(Some(Ok(f))) => f,
+                Ok(Some(Err(e))) => return Err(format!("CDP ws error: {e}")),
+                Ok(None) => return Err("CDP ws closed".to_string()),
+                Err(_) => return Err(format!("CDP timeout waiting for reply to {method}")),
+            };
+            let text = match frame {
+                Message::Text(t) => t,
+                Message::Binary(_) | Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => continue,
+                Message::Close(_) => return Err("CDP ws closed by peer".to_string()),
+            };
+
+            let msg: Value = serde_json::from_str(&text)
+                .map_err(|e| format!("CDP parse: {e}"))?;
+            // Events have no top-level "id". Skip them.
+            let Some(msg_id) = msg.get("id").and_then(|v| v.as_u64()) else {
+                continue;
+            };
+            if msg_id != id {
+                // Interleaved reply to a previous call — unexpected in
+                // v1 since we don't pipeline, but skip it to be safe.
+                continue;
+            }
+            if let Some(err) = msg.get("error") {
+                return Err(format!(
+                    "CDP {method} error: {}",
+                    err.get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown"),
+                ));
+            }
+            return Ok(msg.get("result").cloned().unwrap_or(Value::Null));
+        }
+    }
+
+    pub async fn close(mut self) {
+        let _ = self.ws.close(None).await;
+    }
+}

--- a/agentmux-cef/src/browser_api/mod.rs
+++ b/agentmux-cef/src/browser_api/mod.rs
@@ -1,0 +1,60 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Browser-pane DOM API (`/agentmux/browser/*`).
+//!
+//! External clients (test harnesses, automation scripts) use these
+//! endpoints to query and mutate the DOM inside a running browser
+//! pane without depending on screen-pixel geometry. Implemented as a
+//! thin proxy over CEF's Chrome DevTools Protocol (CDP) server on
+//! `remote_debugging_port` (9223 dev / 9222 release).
+//!
+//! Phase 1 implements only `browser.query` — a CSS-selector lookup
+//! that returns matching elements with their tag, text, attrs, and
+//! bounding rect. Subsequent phases layer on `focus_info`, `eval`,
+//! `screenshot`, and the write methods (`click_element`,
+//! `dispatch_key`, …). See `docs/specs/SPEC_BROWSER_DOM_API.md` and
+//! `docs/specs/PLAN_BROWSER_DOM_API.md`.
+//!
+//! All routes require `Authorization: Bearer <ipc_token>` — same
+//! scheme as the existing `/ipc` route in `crate::ipc`.
+
+use std::sync::Arc;
+
+use axum::routing::post;
+use axum::Router;
+
+use crate::state::AppState;
+
+pub mod cdp;
+pub mod resolver;
+pub mod routes;
+pub mod types;
+
+/// Register `/agentmux/browser/*` routes on the given axum Router.
+/// Called from `ipc::start_ipc_server` alongside the existing
+/// `/ipc` + `/health` routes.
+pub fn register_routes(router: Router<Arc<AppState>>) -> Router<Arc<AppState>> {
+    router.route("/agentmux/browser/query", post(routes::query))
+}
+
+/// Shared state for the browser API — primarily the CDP target
+/// cache (block_id → target_id). Lives inside `AppState` and is
+/// lazily populated on first resolve per block.
+pub struct BrowserApiState {
+    pub target_cache: resolver::TargetCache,
+}
+
+impl BrowserApiState {
+    pub fn new() -> Self {
+        Self {
+            target_cache: resolver::TargetCache::new(),
+        }
+    }
+}
+
+impl Default for BrowserApiState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/agentmux-cef/src/browser_api/resolver.rs
+++ b/agentmux-cef/src/browser_api/resolver.rs
@@ -1,0 +1,149 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resolve `block_id` → CDP target id.
+//!
+//! CEF's `/json` endpoint exposes every active page target but does
+//! NOT expose the underlying `cef::Browser::identifier()`, so we can't
+//! match by CEF id directly. Phase 1 strategy:
+//!
+//! 1. Ask the pane manager for the pane's current URL.
+//! 2. Probe `GET http://127.0.0.1:<debug>/json`.
+//! 3. Find the entry whose `url` matches the pane's URL AND whose
+//!    `id` isn't already owned by some other cached block.
+//! 4. Cache `(block_id → target_id)` for subsequent calls.
+//!
+//! Known limit: two panes navigated to the same URL can't be
+//! distinguished this way. Phase-1 consumers (dom-smoke, stress
+//! harness) use distinct URLs to avoid the collision. A later phase
+//! can swap in a snapshot-at-create strategy for bulletproof
+//! one-to-one mapping (see `SPEC_BROWSER_DOM_API.md` §5.5).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde::Deserialize;
+
+use crate::state::AppState;
+
+pub type ResolveError = String;
+
+#[derive(Default)]
+pub struct TargetCache {
+    // block_id → target_id
+    entries: Mutex<HashMap<String, String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonTarget {
+    id: String,
+    url: String,
+    #[serde(default, rename = "type")]
+    kind: String,
+}
+
+impl TargetCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn resolve(
+        &self,
+        state: &Arc<AppState>,
+        block_id: &str,
+    ) -> Result<String, ResolveError> {
+        // Fast path: cache hit.
+        if let Some(cached) = self.entries.lock().get(block_id).cloned() {
+            return Ok(cached);
+        }
+
+        // Determine the pane's current URL on the CEF UI side. The
+        // browser_panes manager exposes this via main_frame().url()
+        // when the pane is Live.
+        let pane_url = state
+            .browser_panes
+            .pane_url(state, block_id)
+            .ok_or_else(|| {
+                format!("UNKNOWN_BLOCK_ID: no live browser pane for block_id={block_id}")
+            })?;
+
+        // Probe /json.
+        let debug_port = *state.debug_port.lock();
+        if debug_port == 0 {
+            return Err("CEF debug port not yet configured".to_string());
+        }
+        let json_url = format!("http://127.0.0.1:{debug_port}/json");
+        let resp = reqwest::get(&json_url)
+            .await
+            .map_err(|e| format!("GET {json_url}: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!("{json_url} returned {}", resp.status()));
+        }
+        let targets: Vec<JsonTarget> = resp
+            .json()
+            .await
+            .map_err(|e| format!("parse /json: {e}"))?;
+
+        // Filter:
+        // - type=="page" (skip worker, iframe, etc.)
+        // - url matches the pane's url (exact or trailing-slash-tolerant)
+        // - id not already in our cache (avoids claiming another block's target)
+        let already_cached: Vec<String> = self
+            .entries
+            .lock()
+            .values()
+            .cloned()
+            .collect();
+
+        let pane_url_norm = normalize_url(&pane_url);
+        let candidate = targets
+            .iter()
+            .filter(|t| t.kind == "page" || t.kind.is_empty())
+            .filter(|t| !already_cached.contains(&t.id))
+            .find(|t| normalize_url(&t.url) == pane_url_norm);
+
+        let target_id = match candidate {
+            Some(t) => t.id.clone(),
+            None => {
+                return Err(format!(
+                    "UNKNOWN_BLOCK_ID: no unclaimed CDP target matches url={pane_url} \
+                     for block_id={block_id} (found {} targets)",
+                    targets.len()
+                ))
+            }
+        };
+
+        self.entries
+            .lock()
+            .insert(block_id.to_string(), target_id.clone());
+        Ok(target_id)
+    }
+
+    /// Invalidate a block's cached target — called when a pane closes
+    /// or navigates. On next resolve we'll re-probe.
+    pub fn forget(&self, block_id: &str) {
+        self.entries.lock().remove(block_id);
+    }
+}
+
+fn normalize_url(u: &str) -> String {
+    // `https://www.google.com` vs `https://www.google.com/` are the
+    // same target; CEF /json includes the trailing slash, the pane's
+    // meta.url in our tests usually doesn't.
+    let trimmed = u.trim_end_matches('/').to_string();
+    trimmed.to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_url;
+
+    #[test]
+    fn normalize_strips_trailing_slash_and_lowercases() {
+        assert_eq!(
+            normalize_url("https://www.google.com/"),
+            normalize_url("https://WWW.GOOGLE.COM"),
+        );
+    }
+}

--- a/agentmux-cef/src/browser_api/routes.rs
+++ b/agentmux-cef/src/browser_api/routes.rs
@@ -1,0 +1,133 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Axum route handlers for `/agentmux/browser/*`.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::Json;
+use serde_json::json;
+
+use super::cdp::CdpSession;
+use super::types::{ApiResponse, Element, QueryData, QueryReq};
+use crate::state::AppState;
+
+/// `POST /agentmux/browser/query` — find DOM elements matching a CSS
+/// selector in the specified pane. See `SPEC_BROWSER_DOM_API.md`
+/// §5.2 for response shape.
+pub async fn query(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<QueryReq>,
+) -> (StatusCode, Json<ApiResponse<QueryData>>) {
+    if !authorized(&headers, &state.ipc_token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiResponse::err("unauthorized: missing or invalid bearer token")),
+        );
+    }
+
+    // Resolve block_id → CDP target id.
+    let target = match state
+        .browser_api
+        .target_cache
+        .resolve(&state, &req.block_id)
+        .await
+    {
+        Ok(t) => t,
+        Err(e) => return ok_body(ApiResponse::err(e)),
+    };
+
+    // Open the CDP WebSocket for that target.
+    let debug_port = *state.debug_port.lock();
+    let ws_url = format!("ws://127.0.0.1:{debug_port}/devtools/page/{target}");
+    let mut cdp = match CdpSession::connect(&ws_url).await {
+        Ok(s) => s,
+        Err(e) => {
+            // Target might be stale (pane closed underneath us).
+            state.browser_api.target_cache.forget(&req.block_id);
+            return ok_body(ApiResponse::err(format!("CDP connect: {e}")));
+        }
+    };
+
+    // Inject the helper (idempotent — it guards on `window.__amq_query`).
+    let helper = include_str!("scripts/query.js");
+    if let Err(e) = cdp
+        .call(
+            "Runtime.evaluate",
+            json!({
+                "expression": helper,
+                "returnByValue": false,
+            }),
+        )
+        .await
+    {
+        let _ = cdp.close().await;
+        return ok_body(ApiResponse::err(format!("CDP inject helper: {e}")));
+    }
+
+    // Call the helper. Serializing the selector through serde_json
+    // handles quote-escaping safely.
+    let selector_js = serde_json::to_string(&req.selector)
+        .unwrap_or_else(|_| "\"\"".to_string());
+    let call_expr = format!(
+        "__amq_query({sel}, {lim})",
+        sel = selector_js,
+        lim = req.limit.unwrap_or(0),
+    );
+    let eval_result = match cdp
+        .call(
+            "Runtime.evaluate",
+            json!({
+                "expression": call_expr,
+                "returnByValue": true,
+                "awaitPromise": false,
+            }),
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = cdp.close().await;
+            return ok_body(ApiResponse::err(format!("CDP call __amq_query: {e}")));
+        }
+    };
+
+    let _ = cdp.close().await;
+
+    // CDP Runtime.evaluate reply shape (with returnByValue):
+    //   { result: { type, value } } or { result: { type, value: { error } } }
+    let value = eval_result
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+
+    // Check for script-level error surfaced by the helper.
+    if let Some(err) = value.get("error").and_then(|v| v.as_str()) {
+        return ok_body(ApiResponse::err(format!("DOM query error: {err}")));
+    }
+
+    // Normal case: { matches: [...] }
+    let matches: Vec<Element> = value
+        .get("matches")
+        .and_then(|m| serde_json::from_value(m.clone()).ok())
+        .unwrap_or_default();
+
+    ok_body(ApiResponse::ok(QueryData { matches }))
+}
+
+fn authorized(headers: &HeaderMap, expected: &str) -> bool {
+    headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(|token| token == expected)
+        .unwrap_or(false)
+}
+
+fn ok_body<T>(body: ApiResponse<T>) -> (StatusCode, Json<ApiResponse<T>>) {
+    (StatusCode::OK, Json(body))
+}

--- a/agentmux-cef/src/browser_api/scripts/query.js
+++ b/agentmux-cef/src/browser_api/scripts/query.js
@@ -1,0 +1,64 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// DOM query helper injected into a browser-pane context via CDP
+// `Runtime.evaluate`. Called by /agentmux/browser/query.
+//
+// Idempotent: re-injected on every request, but the IIFE checks
+// for an existing definition before replacing, so visible state on
+// window is stable across calls.
+
+(() => {
+  if (window.__amq_query) return;
+
+  // Compute a :nth-of-type path from <body> to `el` — stable enough
+  // to use as a follow-up targeting handle, as long as the DOM
+  // hasn't been restructured in between.
+  window.__amq_path = (el) => {
+    if (!el || el.nodeType !== 1) return '';
+    if (el === document.body) return 'body';
+    const segs = [];
+    let node = el;
+    while (node && node.nodeType === 1 && node !== document.body) {
+      const tag = node.tagName.toLowerCase();
+      const parent = node.parentNode;
+      if (!parent) { segs.unshift(tag); break; }
+      // nth-of-type among siblings of same tag
+      let idx = 1;
+      for (const sib of parent.children) {
+        if (sib === node) break;
+        if (sib.tagName === node.tagName) idx += 1;
+      }
+      segs.unshift(`${tag}:nth-of-type(${idx})`);
+      node = parent;
+    }
+    segs.unshift('body');
+    return segs.join(' > ');
+  };
+
+  window.__amq_query = (selector, limit) => {
+    let nodes;
+    try {
+      nodes = document.querySelectorAll(selector);
+    } catch (e) {
+      return { error: String(e) };
+    }
+    const out = [];
+    const n = limit > 0 ? Math.min(limit, nodes.length) : nodes.length;
+    for (let i = 0; i < n; i++) {
+      const el = nodes[i];
+      const r = el.getBoundingClientRect();
+      const attrs = {};
+      for (const a of el.attributes) attrs[a.name] = a.value;
+      out.push({
+        selector: window.__amq_path(el),
+        tag: el.tagName.toLowerCase(),
+        text: (el.textContent || '').slice(0, 500),
+        attrs,
+        rect: { x: r.x, y: r.y, width: r.width, height: r.height },
+        focused: el === document.activeElement,
+      });
+    }
+    return { matches: out };
+  };
+})();

--- a/agentmux-cef/src/browser_api/types.rs
+++ b/agentmux-cef/src/browser_api/types.rs
@@ -1,0 +1,66 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Request/response types for the browser DOM API.
+
+use serde::{Deserialize, Serialize};
+
+// ── Generic response envelope ───────────────────────────────────────────
+
+/// Every `/agentmux/browser/*` response is one of these two shapes.
+/// Matches `SPEC_BROWSER_DOM_API.md` §5.1.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum ApiResponse<T> {
+    Ok { ok: bool, data: T },
+    Err { ok: bool, error: String },
+}
+
+impl<T> ApiResponse<T> {
+    pub fn ok(data: T) -> Self {
+        ApiResponse::Ok { ok: true, data }
+    }
+    pub fn err(msg: impl Into<String>) -> Self {
+        ApiResponse::Err {
+            ok: false,
+            error: msg.into(),
+        }
+    }
+}
+
+// ── browser.query ───────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct QueryReq {
+    pub block_id: String,
+    pub selector: String,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct QueryData {
+    pub matches: Vec<Element>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Element {
+    /// Unique CSS path the backend-injected helper computed for this node.
+    /// Stable enough to target the same element in a follow-up call,
+    /// provided the DOM hasn't been restructured in between.
+    pub selector: String,
+    pub tag: String,
+    /// First ~500 chars of textContent — full text would balloon responses.
+    pub text: String,
+    pub attrs: serde_json::Map<String, serde_json::Value>,
+    pub rect: Rect,
+    pub focused: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Rect {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -149,6 +149,17 @@ impl BrowserPaneManager {
         state.browsers.lock().get(&label).cloned()
     }
 
+    /// Return the current URL of the pane's main frame, if the pane
+    /// is Live. Used by the browser DOM API resolver
+    /// (`crate::browser_api::resolver`) to match CEF `/json` targets
+    /// against block ids without a first-class `browserId` field on
+    /// the CEF side.
+    pub fn pane_url(&self, state: &Arc<AppState>, block_id: &str) -> Option<String> {
+        let browser = self.live_browser(state, block_id)?;
+        let frame = browser.main_frame()?;
+        Some(CefString::from(&frame.url()).to_string())
+    }
+
     pub fn create(
         &self,
         state: &Arc<AppState>,

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -82,7 +82,11 @@ pub async fn start_ipc_server(state: Arc<AppState>) -> u16 {
 
     let mut app = Router::new()
         .route("/ipc", post(handle_ipc))
-        .route("/health", get(health))
+        .route("/health", get(health));
+    // Browser DOM API routes (`/agentmux/browser/*`). Token auth is
+    // enforced inside each handler — same bearer scheme as /ipc.
+    app = crate::browser_api::register_routes(app);
+    let mut app = app
         .layer(CorsLayer::permissive())
         .with_state(state);
 

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -22,6 +22,7 @@
 )]
 
 mod app;
+mod browser_api;
 mod browser_panes;
 mod client;
 mod commands;
@@ -319,10 +320,12 @@ fn main() {
     let cache_dir = CefString::from(data_dir.to_str().unwrap_or(""));
 
     // Configure CEF settings.
+    let debug_port: u16 = if is_dev { 9223 } else { 9222 };
+    *app_state.debug_port.lock() = debug_port;
     let settings = Settings {
         no_sandbox: 1,
         background_color: 0xFF000000,
-        remote_debugging_port: if is_dev { 9223 } else { 9222 },
+        remote_debugging_port: debug_port as i32,
         root_cache_path: cache_dir,
         resources_dir_path: resources_dir,
         locales_dir_path: locales_dir,

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -229,6 +229,17 @@ pub struct AppState {
     /// Embedded browser panes (native CefBrowserView per pane).
     pub browser_panes: crate::browser_panes::BrowserPaneManager,
 
+    /// Browser DOM API state — CDP target cache + future connection
+    /// pool. See `crate::browser_api`.
+    pub browser_api: crate::browser_api::BrowserApiState,
+
+    /// CEF remote debugging port (9223 dev / 9222 release). Populated
+    /// by `main.rs` from the same `is_dev` branch that sets
+    /// `Settings.remote_debugging_port`. Used by the browser DOM API
+    /// (`/agentmux/browser/*`) to open CDP WebSocket connections to
+    /// pane targets. See `docs/specs/SPEC_BROWSER_DOM_API.md` §6.
+    pub debug_port: Mutex<u16>,
+
     /// Windows Job Object handle -- keeps backend alive until frontend exits
     #[cfg(target_os = "windows")]
     pub job_handle: Mutex<Option<JobHandle>>,
@@ -260,6 +271,8 @@ impl Default for AppState {
             version_config_dir: Mutex::new(None),
             active_drag: Mutex::new(None),
             browser_panes: crate::browser_panes::BrowserPaneManager::new(),
+            browser_api: crate::browser_api::BrowserApiState::new(),
+            debug_port: Mutex::new(0),
             #[cfg(target_os = "windows")]
             job_handle: Mutex::new(None),
         }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.273"
+version = "0.33.274"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.273"
+version = "0.33.274"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.273"
+version = "0.33.274"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/PLAN_BROWSER_DOM_API.md
+++ b/docs/specs/PLAN_BROWSER_DOM_API.md
@@ -1,0 +1,423 @@
+# PLAN: Browser-pane DOM API implementation
+
+Companion to `docs/specs/SPEC_BROWSER_DOM_API.md`. The spec says
+**what** to build; this plan says **how**, in the order an
+implementor should actually tackle it.
+
+Each phase maps to one PR. Every phase is independently testable and
+leaves the repo in a working state.
+
+---
+
+## Phase 0 — prerequisites (done in spec PR)
+
+- ✅ Spec committed at `docs/specs/SPEC_BROWSER_DOM_API.md`.
+- ✅ Spec auth header corrected to `Authorization: Bearer <ipc_token>`
+  (matches `agentmux-cef/src/ipc.rs:131-136`).
+- ✅ Confirmed dep chain already carries `tokio-tungstenite` + `reqwest`
+  via `agentmux-srv`'s tree (so no new top-level deps needed — just
+  add them to `agentmux-cef/Cargo.toml`).
+- ✅ Confirmed `remote_debugging_port` = 9223 dev / 9222 release in
+  `agentmux-cef/src/main.rs:325`.
+- ✅ Confirmed CEF exposes `/json` target list on that port.
+
+## Phase 1 — CDP client + target resolver + first read endpoint
+
+**PR shape**: minimum-viable DOM API. One read method,
+`browser.query`, going through a brand-new plumbing stack. All later
+methods layer onto this same infrastructure.
+
+**Validation gate**: `dom-smoke.ps1` can open a 3-pane layout, call
+`browser.query` for `input[name='q']` in P1, assert the response
+carries a non-empty `matches` array with a plausible `rect`.
+
+### Files to add
+
+```
+agentmux-cef/src/browser_api/
+├── mod.rs           (~60 lines — module root, route registrar)
+├── cdp.rs           (~180 lines — WebSocket client + message pump)
+├── resolver.rs      (~120 lines — block_id → CDP target id)
+├── routes.rs        (~150 lines — axum handlers for this phase)
+├── types.rs         (~80 lines — request/response structs)
+└── scripts/
+    └── query.js    (~40 lines — DOM query helper)
+```
+
+### Files to change
+
+| File | Change |
+|---|---|
+| `agentmux-cef/src/main.rs` | `mod browser_api;` |
+| `agentmux-cef/src/ipc.rs` | Extract auth middleware into a reusable extractor (`BearerAuth`), then register `/agentmux/browser/*` routes via `browser_api::register_routes(router, state)`. |
+| `agentmux-cef/src/browser_panes.rs` | Add `browser_identifier_for(block_id: &str) -> Option<i32>` returning the CEF `Browser.identifier()` for the pane. This is all `resolver.rs` needs from the pane manager. |
+| `agentmux-cef/Cargo.toml` | Add `tokio-tungstenite = "0.24"` (or whichever the workspace uses — align with `agentmux-srv`). `futures-util` for WS stream helpers. |
+
+### Key types
+
+```rust
+// agentmux-cef/src/browser_api/types.rs
+#[derive(serde::Deserialize)]
+pub struct QueryReq {
+    pub block_id: String,
+    pub selector: String,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[derive(serde::Serialize)]
+pub struct Element {
+    pub selector: String,   // unique path the backend computed
+    pub tag: String,
+    pub text: String,
+    pub attrs: serde_json::Map<String, serde_json::Value>,
+    pub rect: Rect,
+    pub focused: bool,
+}
+
+#[derive(serde::Serialize)]
+pub struct Rect { pub x: f64, pub y: f64, pub width: f64, pub height: f64 }
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApiResponse<T> {
+    Ok { data: T },
+    Err { error: String },
+}
+```
+
+### CDP client sketch (cdp.rs)
+
+```rust
+pub struct CdpSession {
+    sink: SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>,
+    stream: SplitStream<...>,
+    next_id: std::sync::atomic::AtomicU64,
+}
+
+impl CdpSession {
+    pub async fn connect(debugger_url: &str) -> Result<Self, CdpError>;
+    pub async fn call(&mut self, method: &str, params: Value)
+        -> Result<Value, CdpError>;   // blocks until reply with matching id
+    pub async fn close(self);
+}
+```
+
+One WS per API request in this phase. Fine for localhost (~10 ms per
+round-trip). Pooling is Phase 5 — only implement it if measurement
+shows it matters.
+
+### Resolver sketch (resolver.rs)
+
+```rust
+pub struct TargetCache {
+    // (block_id, cef_browser_id) → cdp_target_id
+    entries: parking_lot::Mutex<HashMap<(String, i32), String>>,
+}
+
+impl TargetCache {
+    pub async fn resolve(
+        &self,
+        pane_mgr: &BrowserPaneManager,
+        debug_port: u16,
+        block_id: &str,
+    ) -> Result<String, ResolveError>;
+}
+```
+
+`resolve()`:
+1. `let id = pane_mgr.browser_identifier_for(block_id).ok_or(UnknownBlock)?;`
+2. Check cache for `(block_id, id)`. Hit → return.
+3. Miss: `GET http://127.0.0.1:{debug_port}/json` via `reqwest`,
+   parse array of targets, find the one whose `browserId`
+   (or equivalent — verify during implementation) matches `id`.
+4. Insert into cache, return target id.
+
+Invalidation: on pane close, call `TargetCache::drop_block(block_id)`.
+Wire into `BrowserPaneManager::close` after it empties `state.browsers`.
+
+### Route handler sketch (routes.rs)
+
+```rust
+pub async fn query(
+    BearerAuth(_token): BearerAuth,
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<QueryReq>,
+) -> Json<ApiResponse<QueryData>> {
+    let target = match state.browser_api
+        .target_cache
+        .resolve(&state.browser_panes, state.debug_port, &req.block_id)
+        .await
+    {
+        Ok(t) => t,
+        Err(e) => return Json(ApiResponse::err(e.to_string())),
+    };
+
+    let ws_url = format!(
+        "ws://127.0.0.1:{}/devtools/page/{}",
+        state.debug_port, target
+    );
+
+    let mut cdp = match CdpSession::connect(&ws_url).await {
+        Ok(s) => s, Err(e) => return err_resp(e),
+    };
+
+    // Inject query helper (idempotent — our script guards with
+    // `if (!window.__amq_query) { ... }`).
+    let helper = include_str!("scripts/query.js");
+    let _ = cdp.call("Runtime.evaluate", json!({
+        "expression": helper,
+        "returnByValue": false,
+    })).await;
+
+    let call_expr = format!(
+        "__amq_query({}, {})",
+        serde_json::to_string(&req.selector).unwrap(),
+        req.limit.unwrap_or(0),
+    );
+    let result = match cdp.call("Runtime.evaluate", json!({
+        "expression": call_expr,
+        "returnByValue": true,
+    })).await {
+        Ok(v) => v,
+        Err(e) => return err_resp(e),
+    };
+
+    let _ = cdp.close().await;
+
+    let matches = serde_json::from_value(result["result"]["value"].clone())
+        .unwrap_or_default();
+    Json(ApiResponse::ok(QueryData { matches }))
+}
+```
+
+### `query.js` sketch
+
+```js
+(() => {
+  if (window.__amq_query) return;
+  window.__amq_query = (selector, limit) => {
+    const nodes = document.querySelectorAll(selector);
+    const out = [];
+    const n = limit > 0 ? Math.min(limit, nodes.length) : nodes.length;
+    for (let i = 0; i < n; i++) {
+      const el = nodes[i];
+      const r = el.getBoundingClientRect();
+      const attrs = {};
+      for (const a of el.attributes) attrs[a.name] = a.value;
+      out.push({
+        selector: __amq_path(el),     // derived unique path
+        tag: el.tagName.toLowerCase(),
+        text: (el.textContent || '').slice(0, 500),
+        attrs,
+        rect: { x: r.x, y: r.y, width: r.width, height: r.height },
+        focused: el === document.activeElement,
+      });
+    }
+    return out;
+  };
+  window.__amq_path = /* nth-of-type chain up to body */;
+})();
+```
+
+### Tests
+
+1. **Unit** (`agentmux-cef/tests/cdp_roundtrip.rs`): start a minimal
+   in-process CDP-mimicking WS server, connect with `CdpSession`,
+   send a `Runtime.evaluate`-like call, verify reply threading
+   (response `id` matches request `id`). Gated behind
+   `--features test-cdp` so it doesn't run by default.
+
+2. **Integration** (`tools/tests/dom-smoke.ps1`):
+   ```powershell
+   # setup: assume task dev is up + layout-smoke creates the layout
+   $auth = Get-AgentMuxAuthFile
+   $layout = New-AgentMuxThreePaneLayout -Auth $auth ...
+   $matches = Invoke-AgentMuxBrowserApi -Auth $auth -Method query `
+       -Body @{ block_id = $layout.p1; selector = "input[name='q']" }
+   if ($matches.matches.Count -lt 1) { Write-Error "no match" }
+   ```
+
+3. **Regression**: existing tests all still pass. Specifically
+   `pane-focus-smoke.ps1` and `layout-smoke.ps1`.
+
+### Estimated effort
+
+~1-2 days hands-on. WS machinery is the bulk of it; resolver + route
+are straightforward once the client works. PR commit count ~3-5.
+
+---
+
+## Phase 2 — remaining read endpoints
+
+**PR shape**: now that the plumbing is proven, add the three
+remaining read methods with minimal new infrastructure.
+
+- `focus_info` — `Runtime.evaluate` on
+  `document.activeElement` then re-use the `Element` serializer.
+- `eval` — thin wrapper around `Runtime.evaluate` with
+  `returnByValue: true` + optional `awaitPromise`. Return either the
+  JSON value or the exception details.
+- `screenshot` — `Page.captureScreenshot` with `format: "png"`,
+  `fromSurface: true` (includes the rendered view including overlays
+  the main frame would see). Returns base64.
+
+### New files
+
+- `agentmux-cef/src/browser_api/scripts/focus_info.js` — shares
+  `__amq_path` helper from `query.js`. Extract the path helper into
+  its own file and `include_str!` it into both.
+
+### Change to existing files
+
+- `agentmux-cef/src/browser_api/routes.rs` — three new handlers.
+- `agentmux-cef/src/browser_api/types.rs` — request/response types
+  for the new methods.
+- `agentmux-cef/src/browser_api/mod.rs` — register new routes.
+
+### Tests
+
+- Extend `dom-smoke.ps1` with three new assertions: `focus_info`
+  returns null before any click, returns P1's search input after
+  `browser.focus_element` (Phase 3), `eval` of `1+1` returns 2,
+  `screenshot` returns a byte string starting with PNG magic
+  `\x89PNG`.
+
+### Estimated effort
+
+~half a day.
+
+---
+
+## Phase 3 — write endpoints
+
+**PR shape**: the mutation surface. All four methods use existing
+CDP domains; no new client infrastructure.
+
+| Method | CDP translation |
+|---|---|
+| `click_element` | `DOM.querySelector` → `DOM.getBoxModel` → `Input.dispatchMouseEvent` × 2 (down/up) at the box centroid |
+| `focus_element` | `Runtime.evaluate` on `document.querySelector(sel).focus()` |
+| `dispatch_key` | `Input.dispatchKeyEvent` (one per key) — or `Input.insertText` for the `text:` path |
+| `navigate` | Direct call to existing `browser_panes.navigate()` (bypass CDP — we already have this path) |
+
+### Subtle bits
+
+- `click_element` needs a real mouse event (not DOM `.click()`) so
+  that `:focus-visible`, pointer-related listeners, and pane
+  keyboard-focus routing all behave like a user. That's why we go
+  via `Input.dispatchMouseEvent`, not `el.click()`.
+- `dispatch_key` with `text:` → prefer `Input.insertText` when
+  possible (atomic, doesn't need synthetic key codes). Fall back to
+  per-char `dispatchKeyEvent` for single keys like `Enter`.
+- `focus_element` is intentionally distinct from `click_element` —
+  tests that want "give keyboard focus without synthesizing a mouse
+  gesture" get a separate method.
+
+### Tests
+
+- Extend `dom-smoke.ps1`: click the search box, type "hello",
+  read back its `value` via `eval("...")`.
+- **Hook into existing tests** — the hand-off goal from the user:
+  rewrite `tools/tests/pane-focus-stress.ps1` to swap pixel
+  `mouse_event` + `SendKeys` for `browser.focus_element` +
+  `browser.dispatch_key`. Terminal pane clicks stay pixel-based
+  (terminal isn't a browser), so keep `Click-Pixel` as a fallback
+  for the `Terminal` target. Coord-auto-compute can be deleted for
+  the browser targets.
+- Log-side invariants (`[pane-wndproc] key msg=…`, no reclaim during
+  pane steps) stay, but the test no longer depends on pixel geometry
+  for browser targets. All 24 stress steps should pass.
+
+### Estimated effort
+
+~1 day including harness rewrite.
+
+---
+
+## Phase 4 — harness rewrite + 24/24 pass
+
+This phase is where the DOM API earns its keep. A single PR that:
+
+1. Adds PowerShell wrapper helpers in `tools/tests/authfile.ps1`:
+   ```powershell
+   function Invoke-AgentMuxBrowserApi {
+       param($Auth, [string]$Method, [hashtable]$Body)
+       # POSTs to $Auth.ipc_endpoint + "/agentmux/browser/" + $Method
+       # with Authorization: Bearer $Auth.ipc_token
+   }
+   ```
+2. Rewrites `pane-focus-stress.ps1`:
+   - Replace `Click-Pixel $p1.search; Send-Text 'foo'` with
+     `Invoke-AgentMuxBrowserApi -Method focus_element ... ; -Method dispatch_key ...`.
+   - Keep the log-side assertion (pane keystrokes must appear) — it's
+     verifying a different invariant (Win32 keyboard routing) from
+     what the API does (DOM state).
+   - For address-bar targets, the address bar is frontend DOM, not a
+     pane's DOM — those stay pixel-based or, if we want end-to-end
+     DOM, add a parallel `browser.main_dom.query` against the main
+     window's CDP target. Simpler: leave address-bar clicks as-is.
+3. Updates `tools/tests/README.md` to document the DOM API path.
+
+**Success criterion for this phase**: `pwsh pane-focus-stress.ps1
+-CreateLayout` returns `PASS (24/24)` consistently. If it doesn't,
+the `[pane-wndproc]` invariant OR the DOM API has a real bug to
+fix — either way, actionable.
+
+### Estimated effort
+
+Half a day once Phase 3 lands.
+
+---
+
+## Phase 5 (optional) — connection pool
+
+Only do this if measurement from Phase 4 shows CDP latency is a real
+problem. Expected: harness run time goes from ~15 s (per-request WS)
+to ~3 s (pooled). If it stays under 30 s either way, skip — the
+complexity isn't worth it.
+
+Design: `browser_api::pool::CdpPool` keyed by `block_id`. Opens on
+first request, kept alive with a 60 s idle timeout, torn down on
+pane close.
+
+---
+
+## Risk register
+
+| Risk | Mitigation |
+|---|---|
+| CEF `/json` target schema doesn't expose `browserId` the way we expect | Phase 1 prototype resolver against a live dev instance before committing — curl `/json` and inspect. If `browserId` isn't present, fall back to matching `url` + `title`, or add a CEF-side identifier injection. |
+| `Runtime.evaluate` injects `__amq_query` into every page the caller touches | Acceptable per spec §7. If a real problem arises, move to isolated context (`uniqueContextId` / `Runtime.executionContextCreated`). Phase 6 if needed. |
+| WebSocket per request is too slow | Measure in Phase 4. Phase 5 exists for this. |
+| Cross-origin iframes | Out of scope v1 (spec §2.2). Surfaces only the main frame. Add `frame_id` param when a consumer needs it. |
+| Pane recreates CDP target mid-session (navigation can do this in some configs) | `resolver.rs` invalidates its cache on resolve failure, retries once. If that still fails, surface `UNKNOWN_BLOCK_ID`. |
+| `tokio-tungstenite` version skew across workspace crates | Align to whatever `agentmux-srv` already uses. Check `Cargo.lock` before picking a version pin. |
+
+---
+
+## Dependencies
+
+```
+Phase 1  ──▶  Phase 2  ──▶  Phase 3  ──▶  Phase 4  ──▶  (Phase 5)
+                                  │
+                                  └─▶  Phase 3 is where the harness
+                                       rewrite becomes valuable.
+```
+
+Phase 1 is the only phase with actual engineering risk — everything
+after is "write another handler that calls a different CDP method".
+Front-load it.
+
+## Delivery checklist per phase
+
+- [ ] Unit tests pass: `cargo test -p agentmux-cef --features test-cdp`
+- [ ] No new warnings in `cargo check -p agentmux-cef`
+- [ ] `dom-smoke.ps1` passes end-to-end against a live dev instance
+- [ ] `layout-smoke.ps1` still passes (regression)
+- [ ] `pane-focus-smoke.ps1` still passes (regression)
+- [ ] Version bumped (`bump patch`), lockfile synced
+- [ ] PR opened with explicit test-plan checkboxes + reagent LGTM
+- [ ] Docs updated: `tools/tests/README.md` gains a section as new
+      endpoints come online; `SPEC_BROWSER_DOM_API.md` edited only
+      if a design decision changes mid-implementation

--- a/docs/specs/SPEC_BROWSER_DOM_API.md
+++ b/docs/specs/SPEC_BROWSER_DOM_API.md
@@ -1,0 +1,434 @@
+# SPEC: Browser-pane DOM API (`/agentmux/browser/*`)
+
+Status: draft
+Date: 2026-04-19
+Owner: AgentA
+Motivation: pixel-coordinate clicks against browser panes are a flaky
+test channel. Search box not at the expected `y`? 11/24 stress-test
+failures. High-DPI monitor? All coords shift. Page re-layout after
+an ad loads? Miss. We want a robust way for an external client (test
+harness, automation script, future agent-driven workflow) to query
+and mutate the DOM inside a running browser pane, without screen
+geometry ever entering the picture.
+
+## 1. Motivation
+
+### 1.1 What the pane-focus stress test actually needs
+
+The stress test asserts "after clicking P1's search box and typing
+'foo', was focus correctly routed to the pane". Today it uses:
+
+- Win32 mouse `mouse_event` clicks at a computed `(x, y)`
+- SendKeys to deliver text
+- Log grep for `[pane-wndproc] key msg=...` as proof-of-life
+
+The pixel click is the weak link. Goal: replace it with something
+that says "give focus to the `<input name='q'>` element in the pane
+belonging to block P1", and that reports back "document.activeElement
+in pane P1 is now `<input name='q'>`". No coordinates needed.
+
+### 1.2 Other consumers
+
+- **Agent-driven browsing**: future agents could drive web-form
+  interactions programmatically instead of spinning up a separate
+  headless browser.
+- **Screenshot-assisted testing**: capture the pane's rendered
+  content, diff against a golden image.
+- **Page-load assertions**: wait for `document.readyState === 'complete'`,
+  assert a title, check a meta tag.
+
+Every case benefits from having a DOM-level RPC into the pane's
+content context — neither pixel geometry nor Win32 keyboard routing
+belong in the test surface.
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+1. **HTTP-addressable DOM**: an external client can POST a selector
+   and receive JSON describing matching elements — their tag, text,
+   attrs, bounding rect, focus state.
+2. **Input delivery**: the same client can click or type into a
+   selected element without involving Win32 or the cursor.
+3. **Arbitrary JS evaluation**: for cases the above don't cover,
+   run a string of JS in the pane's renderer and get the serialized
+   result back.
+4. **Per-pane isolation**: every call is scoped to a specific
+   `block_id`; one pane can't read another's DOM.
+5. **Auth-gated**: same `auth_key` / `ipc_token` story as the rest
+   of the API.
+
+### 2.2 Non-goals
+
+- Cross-origin cookie or storage manipulation (out of scope; CDP
+  supports it but we don't expose it).
+- Remote access. Loopback-only, same as `/agentmux/service`.
+- UI recording / event replay. Out of scope.
+- Subprocess / worker / iframe targeting beyond the top frame. The
+  initial API exposes only the pane's main frame; add iframe
+  targeting as a follow-up if needed.
+
+## 3. Background
+
+### 3.1 What a pane is
+
+Each browser pane (`view: "browser"` block) is a full CEF `Browser`
+instance hosted as a native Win32 child HWND inside the main window.
+Managed by `agentmux-cef/src/browser_panes.rs` (`BrowserPaneManager`)
+and tracked in `state.browsers` keyed by pane label.
+
+### 3.2 What CEF already exposes
+
+CEF ships a Chrome DevTools Protocol server on
+`remote_debugging_port` — port 9223 in dev (`AGENTMUX_DEV=1` +
+`main.rs:325`), 9222 otherwise. Every CEF `Browser` shows up in
+`GET http://127.0.0.1:<port>/json` as a CDP target, each with its own
+`webSocketDebuggerUrl` and a unique `id`.
+
+CDP is well-documented, stable across Chromium versions, and exposes
+all the primitives we need (`Runtime.evaluate`, `DOM.querySelector`,
+`Input.dispatchKeyEvent`, `Page.captureScreenshot`, …).
+
+### 3.3 What we DON'T have
+
+- No CEF-side mapping from `block_id` → CDP target. Today the only
+  correspondence between our block IDs and CEF browser IDs is
+  in-process inside `BrowserPaneManager.inner.panes`.
+- No client-facing endpoint that can issue CDP commands. Frontend
+  never had to do this because it owns the DOM already.
+- Nothing that marshals CDP JSON → our API's JSON shape.
+
+## 4. Design options
+
+### 4.1 Option A — CDP proxy (recommended)
+
+Add HTTP endpoints under `/agentmux/browser/*` on the CEF IPC server.
+Each handler:
+
+1. Resolves `block_id` → CDP target id (via a new
+   `BrowserPaneManager.cdp_target_for(block_id)`).
+2. Opens a WebSocket to `ws://127.0.0.1:<debug>/devtools/page/<target>`.
+3. Sends a CDP command, awaits the reply.
+4. Translates the CDP response into our API shape, returns as JSON.
+
+**Pros**: CDP is already there, CEF-maintained, battle-tested. No JS
+injection, no renderer-side glue code. Arbitrary DOM access comes
+for free (`Runtime.evaluate`).
+
+**Cons**: Opening a WS per request is slower than a long-lived
+connection (maybe ~10 ms round-trip on localhost). Easy to upgrade
+to pooled WS later — start simple.
+
+### 4.2 Option B — CefMessageRouter with injected JS
+
+Install a `CefMessageRouter` and pre-load a script in every pane that
+exposes `window.__agentmux_api(...)` backed by native handlers.
+Harness would `execute_javascript` through CEF to invoke it.
+
+**Pros**: Same-process, sub-ms overhead.
+
+**Cons**: Requires injecting JS into every loaded page — including
+google.com, third-party docs, etc. That's a real attack surface for
+content that shouldn't see our API. Also: we'd have to marshal every
+return value manually; V8 → Rust type bridging is error-prone.
+
+### 4.3 Option C — `execute_javascript` + blockfile round-trip
+
+Use CEF's one-way `execute_javascript` to run code, have that code
+POST results back to `/agentmux/file` (an existing endpoint).
+
+**Pros**: No CDP dependency.
+
+**Cons**: Per-call: inject JS that contains a unique token, run it,
+poll `/agentmux/file`. Orders of magnitude slower and more complex
+than CDP. Also still requires JS injection into user-facing pages.
+
+### 4.4 Decision
+
+**Option A.** CDP proxy. Single-purpose, reuses CEF infrastructure,
+doesn't pollute the DOM of visited pages, and returns structured
+results synchronously.
+
+## 5. API surface
+
+### 5.1 Endpoint
+
+Lives on the **CEF IPC server** (`ipc_endpoint` in `authkey.dev`),
+not `agentmux-srv`. Reason: browser panes are managed by the CEF
+host process; putting the routes there avoids an extra IPC hop.
+
+```
+POST http://<ipc_endpoint>/agentmux/browser/<method>
+Header: Authorization: Bearer <ipc_token>
+Content-Type: application/json
+Body: { "block_id": "...", <method-specific fields> }
+```
+
+The `Authorization: Bearer` scheme is the same one already used by
+the existing `/ipc` route (`agentmux-cef/src/ipc.rs:131-136`), so
+the new routes reuse the existing token-validation middleware
+without a new auth surface.
+
+Response on success: `{"ok": true, "data": <method-specific>}`.
+Response on failure: `{"ok": false, "error": "<message>"}`.
+
+### 5.2 Read methods
+
+| Method | Body | Response `data` |
+|---|---|---|
+| `query` | `{selector: string, limit?: number}` | `{matches: Element[]}` |
+| `focus_info` | `{}` | `{focused: Element \| null}` |
+| `eval` | `{script: string, await_promise?: bool}` | `{result: any, type: string}` |
+| `screenshot` | `{}` | `{png_base64: string}` |
+
+`Element` shape:
+
+```json
+{
+  "selector": "input[name='q']",
+  "tag": "input",
+  "text": "",
+  "attrs": {"name": "q", "aria-label": "Search"},
+  "rect": {"x": 220, "y": 308, "width": 600, "height": 44},
+  "focused": true
+}
+```
+
+The `selector` returned for each match is a **derived unique path**
+(backend computes it from the node position, tag, attrs), usable in
+a subsequent call to target that exact node. We do NOT echo back the
+caller's selector — we give them a concrete handle.
+
+### 5.3 Write methods
+
+| Method | Body | Response |
+|---|---|---|
+| `click_element` | `{selector: string}` | `{ok: true}` |
+| `dispatch_key` | `{selector?: string, text?: string, key?: string}` | `{ok: true}` |
+| `focus_element` | `{selector: string}` | `{ok: true}` |
+| `navigate` | `{url: string}` | `{ok: true}` |
+
+`dispatch_key` behaviour:
+
+- If `text` is set: dispatch that text as a sequence of `keydown` +
+  `char` + `keyup` events against the element (focuses it first if
+  `selector` given, otherwise against the current active element).
+- If `key` is set: dispatch one keystroke (CDP `Input.dispatchKeyEvent`
+  with the canonical key name).
+
+### 5.4 Auth
+
+Every request carries `Authorization: Bearer <ipc_token>`. Missing /
+wrong → 401. Same mechanism as the existing `/ipc` route, so one
+middleware / extractor covers both.
+
+### 5.5 Scope: panes, windows, instances
+
+`block_id` is **globally unique within an `agentmux-cef` process**.
+`BrowserPaneManager` is a single struct owned by `AppState`, so its
+pane map spans every window in the process — tear-off windows share
+one manager and one `remote_debugging_port`. The resolver therefore
+doesn't need a `window_id` param: `block_id` alone is sufficient
+across the full process, regardless of which window owns the pane.
+
+Across AgentMux instances (portable A, portable B, `task dev` C),
+every process has its own data dir, `authkey.dev`, IPC port, and
+debug port. A harness picks the instance via `Get-AgentMuxAuthFile`
+(newest live by default, `-DataDir` override for explicit selection)
+and calls that instance's `ipc_endpoint`. The DOM API has no
+cross-instance story — and doesn't need one, since each instance is
+fully isolated by design.
+
+**Resolver invariant**: `cdp_target_for(block_id)` asserts
+single-match. If the `/json` probe surfaces zero or more than one
+target pointing at our CEF `Browser.identifier()`, treat it as an
+internal error (`UNKNOWN_BLOCK_ID`). The one-to-one mapping is the
+contract; defending against a drifted mapping means failing fast
+rather than picking arbitrarily.
+
+### 5.6 Error conditions
+
+- Pane closed or never existed → `{"ok": false, "error": "UNKNOWN_BLOCK_ID"}`
+- Selector matched nothing → `{"ok": true, "data": {"matches": []}}` (not an error)
+- CDP round-trip failed → `{"ok": false, "error": "CDP: <reason>"}`
+- JS eval threw → `{"ok": false, "error": "EvalError: <message>"}` with
+  stack included in `data.exception` if configured.
+
+## 6. Implementation
+
+### 6.1 `BrowserPaneManager` changes
+
+Add:
+
+```rust
+/// Resolve a pane's CDP target — the page-id CEF publishes on its
+/// remote debugging port. Returns None when the pane isn't Live.
+pub fn cdp_target_for(&self, block_id: &str) -> Option<String>;
+```
+
+CEF exposes a browser's identifier via `browser.identifier()` (an
+`i32`). Chrome DevTools Protocol target ids are strings. CEF's `/json`
+endpoint lists both, so we can build a map at create time or resolve
+lazily on first query.
+
+Lazy resolution is simpler for v1: on each `cdp_target_for` call,
+fetch `/json`, find the entry whose `url` matches this pane's current
+URL and whose `browser_id` matches our stored identifier. Cache per
+(block_id, browser_id) pair.
+
+### 6.2 HTTP route in `agentmux-cef/src/ipc.rs`
+
+The IPC server already uses `axum`. Add a new scope:
+
+```rust
+.route("/agentmux/browser/query", post(browser::query))
+.route("/agentmux/browser/focus_info", post(browser::focus_info))
+.route("/agentmux/browser/eval", post(browser::eval))
+.route("/agentmux/browser/screenshot", post(browser::screenshot))
+.route("/agentmux/browser/click_element", post(browser::click_element))
+.route("/agentmux/browser/dispatch_key", post(browser::dispatch_key))
+.route("/agentmux/browser/focus_element", post(browser::focus_element))
+.route("/agentmux/browser/navigate", post(browser::navigate))
+```
+
+A new `agentmux-cef/src/browser_api/mod.rs` houses the handlers.
+
+### 6.3 CDP client
+
+Thin wrapper in `agentmux-cef/src/browser_api/cdp.rs`:
+
+```rust
+pub struct CdpSession {
+    ws: WebSocket,
+    next_id: AtomicU64,
+}
+impl CdpSession {
+    pub async fn connect(target_url: &str) -> Result<Self, CdpError>;
+    pub async fn call(&mut self, method: &str, params: serde_json::Value)
+        -> Result<serde_json::Value, CdpError>;
+}
+```
+
+One WS per request initially. If request latency is a problem, add
+a pool keyed by `block_id`.
+
+Dependency: `tokio-tungstenite` for WS (already in Cargo.lock via
+`axum`'s deps — confirm).
+
+### 6.4 Handler sketch: `browser.query`
+
+```rust
+async fn query(State(state): State<AppState>, Json(req): Json<QueryReq>)
+    -> Json<Response<QueryData>>
+{
+    let target = match state.browser_panes.cdp_target_for(&req.block_id) {
+        Some(t) => t,
+        None => return err("UNKNOWN_BLOCK_ID"),
+    };
+    let ws_url = format!("ws://127.0.0.1:{}/devtools/page/{}",
+        debug_port(), target);
+    let mut cdp = CdpSession::connect(&ws_url).await?;
+
+    // Runtime.evaluate with a helper that returns our serialized shape.
+    let js = include_str!("query.js");  // defines window.__amq_query
+    let _ = cdp.call("Runtime.evaluate", json!({
+        "expression": js,
+    })).await?;
+
+    let result = cdp.call("Runtime.evaluate", json!({
+        "expression": format!("__amq_query({:?}, {})",
+            req.selector, req.limit.unwrap_or(0)),
+        "returnByValue": true,
+    })).await?;
+
+    Json(Response::ok(QueryData { matches: extract(result) }))
+}
+```
+
+`query.js` is a small helper that takes `(selector, limit)` and
+returns `{matches: [...]}` with the `Element` shape defined in §5.2.
+Kept out of the user page's global scope by defining it on `window`
+via an IIFE + gated by our token.
+
+### 6.5 Block-id → CDP target resolution
+
+On first query for a block_id:
+
+1. Grab the `Browser.identifier()` from `state.browsers[label]`.
+2. `GET http://127.0.0.1:<debug>/json` — returns an array of targets.
+3. Match each target's `browserId` to our identifier (CEF embeds it).
+4. Cache the result in `browser_api::target_cache` keyed by
+   `(block_id, identifier)`.
+5. On pane close (`browser_panes.close`), invalidate the cache entry.
+
+If the match fails (pane closed underneath us, or Chromium recreated
+the frame), return `UNKNOWN_BLOCK_ID` and let the caller retry.
+
+## 7. Security
+
+Same posture as the rest of the IPC API:
+
+| Attacker | Defended? |
+|---|---|
+| Remote network | Yes — loopback-only bind. |
+| Other local user | Yes — Windows ACL on data dir + `authkey.dev`. |
+| Same-user process without ipc_token | Yes — token required on every request. |
+| Same-user process with ipc_token | No (out of scope; they already have the key). |
+
+**Content isolation**: `eval` runs in the pane's renderer, which may
+be loaded from an untrusted origin. The helper script `query.js` is
+injected into every page that gets queried; it defines a function
+on `window` under a distinctive name (`__amq_*`). Pages can see it.
+For a paranoid mode, v2 could use `Runtime.evaluate` with
+`uniqueContextId` or `executionContextId = isolated` so the helper
+lives in a separate JS world never visible to page script. Default
+for v1 is the page's own world (simpler, slightly less isolated).
+
+## 8. Test plan
+
+- Unit: CDP client round-trip against a fake CDP server.
+- Integration: new `tools/tests/dom-smoke.ps1` that opens a test
+  layout, calls `browser.query` for `input[name='q']` in both
+  browser panes, asserts both match and have non-empty `rect`.
+- Harness rewrite: `pane-focus-stress.ps1` swaps pixel clicks for
+  `browser.click_element`/`browser.focus_element` +
+  `browser.dispatch_key`. The log-side invariants stay (still assert
+  `[pane-wndproc] key msg=` events arrive), but the input side is
+  DOM-driven.
+- Regression: the existing CEF remote-debugging feature still works
+  (dev ports 9223/9222 remain open; our API just layers on top).
+
+## 9. Rollout
+
+1. **PR 1**: this spec.
+2. **PR 2**: `BrowserPaneManager.cdp_target_for` + `/json` resolver +
+   one read endpoint (`browser.query`) + unit tests + smoke test.
+3. **PR 3**: remaining read endpoints (`focus_info`, `eval`,
+   `screenshot`).
+4. **PR 4**: write endpoints (`click_element`, `focus_element`,
+   `dispatch_key`, `navigate`). Port the stress test harness over.
+5. **PR 5** (optional): persistent CDP connections, measured against
+   per-request-WS baseline only if latency actually matters.
+
+## 10. Open questions
+
+- **Isolated execution context**: default to the page's world or to
+  an isolated world? V1 picks page-world; revisit if it causes
+  problems with CSP-strict sites.
+- **WebSocket vs HTTP/2 streams**: CDP is WS-native. If axum adds
+  HTTP/2 streaming and we'd rather avoid WS deps, a shim is possible
+  — but premature.
+- **Frame targeting**: iframes and cross-origin subframes each get
+  their own target id. V1 exposes only the main frame. Spec out an
+  iframe-targeting extension when there's a real consumer.
+
+## 11. Not in scope
+
+- `Network.*` CDP domain (request/response interception).
+- `Debugger.*` domain.
+- `Profiler.*`.
+- Workers / service workers.
+- Cross-process tracing.
+
+Each of these is a much bigger surface and adding them isn't needed
+for the stress-test use case. Hold until a concrete need appears.

--- a/package-lock.json
+++ b/package-lock.json
@@ -380,7 +380,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -588,7 +587,6 @@
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -985,7 +983,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1034,7 +1031,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1046,6 +1042,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1062,6 +1059,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1078,6 +1076,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1094,6 +1093,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1110,6 +1110,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,6 +1127,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1142,6 +1144,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1158,6 +1161,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1174,6 +1178,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1190,6 +1195,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1206,6 +1212,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1222,6 +1229,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1238,6 +1246,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1254,6 +1263,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1270,6 +1280,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1286,6 +1297,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1302,6 +1314,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1318,6 +1331,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1334,6 +1348,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1350,6 +1365,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1366,6 +1382,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1382,6 +1399,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,6 +1416,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1414,6 +1433,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1430,6 +1450,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1446,6 +1467,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1928,6 +1950,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1967,6 +1990,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1987,6 +2011,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2007,6 +2032,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2027,6 +2053,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2047,6 +2074,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2067,6 +2095,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2087,6 +2116,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2107,6 +2137,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2127,6 +2158,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2147,6 +2179,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2167,6 +2200,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2187,6 +2221,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2207,6 +2242,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2421,6 +2457,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2434,6 +2471,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2447,6 +2485,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2460,6 +2499,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2473,6 +2513,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2486,6 +2527,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2499,6 +2541,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2512,6 +2555,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2525,6 +2569,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2538,6 +2583,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2551,6 +2597,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2564,6 +2611,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2577,6 +2625,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2590,6 +2639,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2603,6 +2653,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2616,6 +2667,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2629,6 +2681,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2642,6 +2695,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2655,6 +2709,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2668,6 +2723,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2681,6 +2737,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2694,6 +2751,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2707,6 +2765,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2720,6 +2779,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2733,6 +2793,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2990,7 +3051,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3290,8 +3350,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@table-nav/core/-/core-0.0.9.tgz",
       "integrity": "sha512-9LhTDDeGpjgvwKa96EeLejzXqgq9bThvF3ngdcOGjlWtxwrej4rWs4xSX5EVEEUIeA4TU2Vwe7UifrHRLgU4dw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@table-nav/react": {
       "version": "0.0.9",
@@ -4164,9 +4223,8 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4192,8 +4250,8 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4202,9 +4260,8 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4326,7 +4383,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4788,7 +4844,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5054,7 +5109,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5204,7 +5258,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -5230,7 +5283,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5485,7 +5538,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5895,7 +5947,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6106,7 +6157,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6248,7 +6299,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6315,7 +6366,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6607,6 +6657,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6700,6 +6751,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6745,7 +6797,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7328,7 +7380,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7462,7 +7514,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7482,7 +7534,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7653,7 +7705,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7910,7 +7962,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7943,6 +7995,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7963,6 +8016,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7983,6 +8037,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8003,6 +8058,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8023,6 +8079,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8043,6 +8100,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8063,6 +8121,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8083,6 +8142,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8103,6 +8163,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8123,6 +8184,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8143,6 +8205,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8702,7 +8765,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9339,8 +9401,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -9393,6 +9454,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9442,6 +9504,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9509,8 +9572,7 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.14.0.tgz",
       "integrity": "sha512-RjV0pqc79kYhQLC3vTcLRb5GLpI1n6qh0Oua3g+bGH4EgNOJHVBGP7u0zZtxoAa0dkHlAqTTSYRb9MMmxNLjig==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/overlayscrollbars-react": {
       "version": "0.5.6",
@@ -9721,6 +9783,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9775,6 +9838,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9815,7 +9879,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9930,7 +9993,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9979,7 +10041,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10055,7 +10116,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10394,7 +10455,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10460,8 +10521,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10562,9 +10623,8 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10616,7 +10676,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10735,7 +10794,6 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -11077,8 +11135,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11212,6 +11269,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11427,7 +11485,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11447,6 +11505,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11476,7 +11535,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11519,7 +11577,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -11527,7 +11585,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -11749,8 +11806,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11916,6 +11973,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11932,6 +11990,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11948,6 +12007,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11964,6 +12024,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11980,6 +12041,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11996,6 +12058,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12012,6 +12075,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12028,6 +12092,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12044,6 +12109,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12060,6 +12126,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12076,6 +12143,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12092,6 +12160,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12108,6 +12177,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12124,6 +12194,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12140,6 +12211,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12156,6 +12228,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12172,6 +12245,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12188,6 +12262,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12204,6 +12279,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12220,6 +12296,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12236,6 +12313,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12252,6 +12330,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12268,6 +12347,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12284,6 +12364,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12300,6 +12381,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12316,6 +12398,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12329,6 +12412,7 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12370,6 +12454,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12405,7 +12490,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -12787,7 +12871,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -12826,7 +12909,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.273",
+  "version": "0.33.274",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/authfile.ps1
+++ b/tools/tests/authfile.ps1
@@ -204,3 +204,57 @@ function Get-AgentMuxHostLogPath {
     if ($f) { return $f.FullName }
     return $null
 }
+
+function Invoke-AgentMuxBrowserApi {
+    <#
+    .SYNOPSIS
+    Calls a method on the browser DOM API (`/agentmux/browser/*`).
+
+    .DESCRIPTION
+    Wraps `POST http://<ipc_endpoint>/agentmux/browser/<method>` with
+    the `Authorization: Bearer <ipc_token>` header. The endpoint is
+    served by the agentmux-cef IPC server — NOT agentmux-srv — because
+    browser panes are managed by the host process. See
+    `docs/specs/SPEC_BROWSER_DOM_API.md`.
+
+    .PARAMETER Auth
+    Parsed authkey.dev. Supplies ipc_endpoint + ipc_token.
+
+    .PARAMETER Method
+    Method name (e.g. "query", "focus_info"). Appended to the URL path.
+
+    .PARAMETER Body
+    Request payload as a hashtable. Serialized as JSON.
+
+    .PARAMETER TimeoutSec
+    HTTP timeout. Default 15s.
+
+    .EXAMPLE
+    $resp = Invoke-AgentMuxBrowserApi -Auth $auth -Method query `
+        -Body @{ block_id = $p1; selector = "input[name='q']" }
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Auth,
+        [Parameter(Mandatory)] [string]$Method,
+        [Parameter(Mandatory)] [hashtable]$Body,
+        [int]$TimeoutSec = 15
+    )
+    $url = "http://{0}/agentmux/browser/{1}" -f $Auth.ipc_endpoint, $Method
+    $jsonBody = $Body | ConvertTo-Json -Depth 10 -Compress
+    $resp = Invoke-RestMethod -Method Post -Uri $url `
+        -Headers @{ Authorization = "Bearer $($Auth.ipc_token)" } `
+        -ContentType 'application/json' `
+        -Body $jsonBody `
+        -TimeoutSec $TimeoutSec
+
+    $okProp = $resp.PSObject.Properties['ok']
+    if (-not $okProp -or -not $okProp.Value) {
+        $errProp = $resp.PSObject.Properties['error']
+        $msg = if ($errProp) { $errProp.Value } else { "unknown" }
+        throw "browser.$Method failed: $msg"
+    }
+    $dataProp = $resp.PSObject.Properties['data']
+    if ($dataProp) { return $dataProp.Value }
+    return $null
+}

--- a/tools/tests/dom-smoke.ps1
+++ b/tools/tests/dom-smoke.ps1
@@ -1,0 +1,121 @@
+# Copyright 2026, AgentMux Corp.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Browser DOM API smoke test. Proves /agentmux/browser/query works
+# end-to-end against a running dev instance:
+#   1. Create a test tab with TWO browser panes at DISTINCT URLs
+#      (the Phase-1 resolver disambiguates by URL — same URL in both
+#      panes would be ambiguous).
+#   2. Call browser.query for P1 → assert it finds the expected
+#      element on that URL.
+#   3. Same for P2 — verifies per-pane isolation.
+#   4. Cleanup: close the test tab.
+#
+# Run after layout-smoke.ps1 passes. If this fails, the DOM API
+# plumbing has a real bug.
+#
+# Usage:
+#   pwsh tools/tests/dom-smoke.ps1
+
+[CmdletBinding()]
+param(
+    [switch]$KeepTab
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'authfile.ps1')
+. (Join-Path $PSScriptRoot 'three-pane-layout.ps1')
+
+$auth = Get-AgentMuxAuthFile
+Write-Host "[dom-smoke] authfile: instance=$($auth.instance) pid=$($auth.host_pid)"
+
+$tabInfo = $null
+try {
+    Write-Host "[dom-smoke] Creating test tab with two browser panes at distinct URLs"
+    $tabInfo = New-AgentMuxTestTab -Auth $auth -Name "DOM Smoke"
+
+    # Re-implement a minimal 2-browser layout inline so we can control
+    # the URLs per pane. (The shared helper sends both to google.com
+    # which would trip the URL-match resolver.)
+    $client = Invoke-AgentMuxService -Auth $auth -Service client -Method GetClientData
+    $uicontext = @{ activetabid = $tabInfo.tabid }
+    $rtOpts = @{ termsize = @{ rows = 25; cols = 80 } }
+
+    $p1Def = @{ meta = @{ view = "browser"; url = "https://example.com/" } }
+    $p2Def = @{ meta = @{ view = "browser"; url = "https://www.google.com/" } }
+
+    $p1 = Invoke-AgentMuxService -Auth $auth -Service object -Method CreateBlock `
+        -Args @($p1Def, $rtOpts) -Uicontext $uicontext
+    $p2 = Invoke-AgentMuxService -Auth $auth -Service object -Method CreateBlock `
+        -Args @($p2Def, $rtOpts) -Uicontext $uicontext
+
+    # Push layout actions one-at-a-time (see three-pane-layout.ps1 for why).
+    $tab = Invoke-AgentMuxService -Auth $auth -Service object -Method GetObject `
+        -Args @("tab:$($tabInfo.tabid)")
+    $lsOid = $tab.layoutstate
+
+    $actions = @(
+        @{ actiontype = "insert"; actionid = (New-Guid).ToString();
+           blockid = $p1; focused = $true; magnified = $false; ephemeral = $false },
+        @{ actiontype = "splithorizontal"; actionid = (New-Guid).ToString();
+           blockid = $p2; targetblockid = $p1; position = "after";
+           focused = $false; magnified = $false; ephemeral = $false }
+    )
+    foreach ($act in $actions) {
+        $ls = Invoke-AgentMuxService -Auth $auth -Service object -Method GetObject `
+            -Args @("layout:$lsOid")
+        $payload = @{
+            otype = "layout"; oid = $lsOid
+            version = $ls.version
+            pendingbackendactions = @($act)
+        }
+        foreach ($p in @("rootnode","magnifiednodeid","focusednodeid","leaforder","meta")) {
+            $prop = $ls.PSObject.Properties[$p]
+            if ($prop) { $payload[$p] = $prop.Value }
+        }
+        Invoke-AgentMuxService -Auth $auth -Service object -Method UpdateObject `
+            -Args @($payload, $false) | Out-Null
+        Start-Sleep -Milliseconds 1000
+    }
+
+    # Let the browsers load the pages. example.com is tiny (<100ms);
+    # google.com has more assets. 3s is a comfortable ceiling.
+    Write-Host "[dom-smoke] Waiting 3s for browsers to load target pages"
+    Start-Sleep -Milliseconds 3000
+
+    Write-Host "[dom-smoke] browser.query for h1 in P1 (example.com)"
+    $p1Resp = Invoke-AgentMuxBrowserApi -Auth $auth -Method query `
+        -Body @{ block_id = $p1; selector = "h1" }
+    if (-not $p1Resp.matches -or $p1Resp.matches.Count -lt 1) {
+        Write-Error "P1 query returned no <h1> — got $($p1Resp | ConvertTo-Json -Depth 3)"
+    }
+    $p1H1 = $p1Resp.matches[0]
+    if ($p1H1.text -notmatch "Example Domain") {
+        Write-Error "P1 <h1> text didn't mention 'Example Domain': '$($p1H1.text)'"
+    }
+    Write-Host "[dom-smoke]   P1 h1: '$($p1H1.text)' rect=($($p1H1.rect.x),$($p1H1.rect.y),$($p1H1.rect.width)x$($p1H1.rect.height))"
+
+    Write-Host "[dom-smoke] browser.query for input[name='q'] in P2 (google.com)"
+    $p2Resp = Invoke-AgentMuxBrowserApi -Auth $auth -Method query `
+        -Body @{ block_id = $p2; selector = "input[name='q'], textarea[name='q']" }
+    if (-not $p2Resp.matches -or $p2Resp.matches.Count -lt 1) {
+        Write-Error "P2 query returned no Google search field"
+    }
+    $p2Search = $p2Resp.matches[0]
+    Write-Host "[dom-smoke]   P2 search: tag=$($p2Search.tag) rect=($($p2Search.rect.x),$($p2Search.rect.y),$($p2Search.rect.width)x$($p2Search.rect.height))"
+
+    Write-Host "[dom-smoke] PASS" -ForegroundColor Green
+    if ($KeepTab) {
+        Write-Host "[dom-smoke] -KeepTab set; tab left open: $($tabInfo.tabid)"
+    }
+    exit 0
+}
+catch {
+    Write-Host "[dom-smoke] FAIL: $_" -ForegroundColor Red
+    throw
+}
+finally {
+    if (-not $KeepTab -and $tabInfo) {
+        Remove-AgentMuxTestTab -Auth $auth -TabInfo $tabInfo
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of [SPEC_BROWSER_DOM_API.md](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_BROWSER_DOM_API.md) — external clients can now query the DOM inside a browser pane via HTTP. **No dependency on screen pixel coordinates**, which were the root cause of 11/24 spurious failures in `pane-focus-stress.ps1 -CreateLayout`.

```
POST http://<ipc_endpoint>/agentmux/browser/query
Authorization: Bearer <ipc_token>
Content-Type: application/json
{ "block_id": "...", "selector": "input[name='q']", "limit": 5 }

→ { "ok": true,
    "data": { "matches": [
      { "selector": "body > ...", "tag": "textarea", "text": "",
        "attrs": {"name": "q", "aria-label": "Search"},
        "rect": {"x": 71, "y": 377, "width": 113, "height": 50},
        "focused": false } ] } }
```

## Design

- **CDP proxy**, not V8 injection. The host opens a WebSocket to CEF's existing `remote_debugging_port` (9223 dev / 9222 release), runs `Runtime.evaluate` with a small injected helper, returns the serialized result. No new attack surface on user pages beyond one `window.__amq_*` function.
- **Block-id → CDP target resolution by URL match**. CEF's `/json` endpoint doesn't expose a `browserId` field, so Phase 1 identifies panes by their current URL. Limitation: two panes at the same URL get ambiguously resolved; the smoke test works around this by using distinct URLs. A snapshot-at-create design is noted in the spec/plan as a future hardening.
- **Auth reuses `Authorization: Bearer <ipc_token>`**, the same scheme as `/ipc`. No new credential surface.

## What's new

```
agentmux-cef/src/browser_api/
├── mod.rs             — module root + register_routes
├── cdp.rs             — tokio-tungstenite WS client (call/method/await reply)
├── resolver.rs        — block_id → CDP target cache + /json probe
├── routes.rs          — axum POST handler for browser.query
├── types.rs           — request/response structs (QueryReq, QueryData, Element, Rect, ApiResponse)
└── scripts/query.js   — DOM query helper (injected via Runtime.evaluate)

docs/specs/
├── SPEC_BROWSER_DOM_API.md  — what, why, auth, error shape, threat model
└── PLAN_BROWSER_DOM_API.md  — phased rollout + risk register

tools/tests/
├── authfile.ps1       — new `Invoke-AgentMuxBrowserApi` helper
└── dom-smoke.ps1      — end-to-end integration test (new)
```

Dependencies: `tokio-tungstenite 0.24` + `futures-util` + `reqwest` added to `agentmux-cef/Cargo.toml`. All were already in the workspace tree via `agentmux-srv`.

Supporting changes:

- `BrowserPaneManager.pane_url()` — returns the pane's current URL (main frame). Needed because `/json` exposes URL but not CEF browser identifier.
- `AppState.debug_port: Mutex<u16>` + `AppState.browser_api: BrowserApiState`. `main.rs` populates the port from the same `is_dev` branch that drives `Settings.remote_debugging_port`.

## Test plan

- [x] **DOM smoke** against a live dev instance — PASS:
  ```
  [dom-smoke] browser.query for h1 in P1 (example.com)
  [dom-smoke]   P1 h1: 'Example Domain' rect=(62,145,186x64)
  [dom-smoke] browser.query for input[name='q'] in P2 (google.com)
  [dom-smoke]   P2 search: tag=textarea rect=(71,377,113x50)
  [dom-smoke] PASS
  ```
- [x] **Regression**: `pane-focus-smoke.ps1` still PASS, `layout-smoke.ps1` still PASS.
- [x] **Auth check**: omitting `Authorization` returns 401.
- [x] `cargo check -p agentmux-cef` — clean (pre-existing warnings only).
- [ ] Unit tests for CDP client round-trip against a mock WS server — deferred to Phase 2 per plan.

Observed side benefit: Google's search field is a `<textarea>`, not `<input>`. Hardcoded `input[name='q']` selectors in any future test would miss; the DOM API path surfaces the real tag.

## Follow-ups (from the plan)

- **Phase 2**: `focus_info`, `eval`, `screenshot` reads.
- **Phase 3**: write methods — `click_element`, `focus_element`, `dispatch_key`, `navigate`.
- **Phase 4**: rewrite `pane-focus-stress.ps1` to use DOM-API input delivery; target 24/24 pass.
- **Phase 5 (optional)**: CDP connection pool if per-request WS overhead shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)