### PR TITLE
feat(browser-dom-api): focus_info + eval + screenshot (Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.274"
+version = "0.33.275"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.274"
+version = "0.33.275"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.274"
+version = "0.33.275"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.274"
+version = "0.33.275"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.274"
+version = "0.33.275"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_api/mod.rs
+++ b/agentmux-cef/src/browser_api/mod.rs
@@ -35,7 +35,11 @@ pub mod types;
 /// Called from `ipc::start_ipc_server` alongside the existing
 /// `/ipc` + `/health` routes.
 pub fn register_routes(router: Router<Arc<AppState>>) -> Router<Arc<AppState>> {
-    router.route("/agentmux/browser/query", post(routes::query))
+    router
+        .route("/agentmux/browser/query", post(routes::query))
+        .route("/agentmux/browser/focus_info", post(routes::focus_info))
+        .route("/agentmux/browser/eval", post(routes::eval))
+        .route("/agentmux/browser/screenshot", post(routes::screenshot))
 }
 
 /// Shared state for the browser API — primarily the CDP target

--- a/agentmux-cef/src/browser_api/routes.rs
+++ b/agentmux-cef/src/browser_api/routes.rs
@@ -11,7 +11,10 @@ use axum::Json;
 use serde_json::json;
 
 use super::cdp::CdpSession;
-use super::types::{ApiResponse, Element, QueryData, QueryReq};
+use super::types::{
+    ApiResponse, Element, EvalData, EvalReq, FocusInfoData, FocusInfoReq, QueryData, QueryReq,
+    ScreenshotData, ScreenshotReq,
+};
 use crate::state::AppState;
 
 /// `POST /agentmux/browser/query` — find DOM elements matching a CSS
@@ -117,6 +120,221 @@ pub async fn query(
         .unwrap_or_default();
 
     ok_body(ApiResponse::ok(QueryData { matches }))
+}
+
+/// `POST /agentmux/browser/focus_info` — report the current
+/// `document.activeElement` of the pane as an `Element`. See §5.2.
+pub async fn focus_info(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<FocusInfoReq>,
+) -> (StatusCode, Json<ApiResponse<FocusInfoData>>) {
+    if !authorized(&headers, &state.ipc_token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiResponse::err("unauthorized: missing or invalid bearer token")),
+        );
+    }
+
+    let mut cdp = match open_cdp_for_block(&state, &req.block_id).await {
+        Ok(c) => c,
+        Err(e) => return ok_body(ApiResponse::err(e)),
+    };
+
+    // Inject helpers (idempotent).
+    let helper = include_str!("scripts/query.js");
+    if let Err(e) = cdp
+        .call(
+            "Runtime.evaluate",
+            json!({ "expression": helper, "returnByValue": false }),
+        )
+        .await
+    {
+        let _ = cdp.close().await;
+        return ok_body(ApiResponse::err(format!("CDP inject helper: {e}")));
+    }
+
+    let eval_result = match cdp
+        .call(
+            "Runtime.evaluate",
+            json!({
+                "expression": "__amq_focus_info()",
+                "returnByValue": true,
+            }),
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = cdp.close().await;
+            return ok_body(ApiResponse::err(format!("CDP call __amq_focus_info: {e}")));
+        }
+    };
+
+    let _ = cdp.close().await;
+
+    let value = eval_result
+        .get("result")
+        .and_then(|r| r.get("value"))
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+
+    // value is either null or an Element object.
+    let focused: Option<Element> = if value.is_null() {
+        None
+    } else {
+        match serde_json::from_value(value) {
+            Ok(e) => Some(e),
+            Err(e) => return ok_body(ApiResponse::err(format!("parse element: {e}"))),
+        }
+    };
+    ok_body(ApiResponse::ok(FocusInfoData { focused }))
+}
+
+/// `POST /agentmux/browser/eval` — run arbitrary JS in the pane's
+/// renderer, return the serialized value.
+///
+/// Thin wrapper over CDP `Runtime.evaluate`. The script runs in the
+/// pane's JS world (not an isolated context); treat it as arbitrary
+/// code execution in whatever origin the pane currently loads.
+pub async fn eval(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<EvalReq>,
+) -> (StatusCode, Json<ApiResponse<EvalData>>) {
+    if !authorized(&headers, &state.ipc_token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiResponse::err("unauthorized: missing or invalid bearer token")),
+        );
+    }
+
+    let mut cdp = match open_cdp_for_block(&state, &req.block_id).await {
+        Ok(c) => c,
+        Err(e) => return ok_body(ApiResponse::err(e)),
+    };
+
+    let eval_result = match cdp
+        .call(
+            "Runtime.evaluate",
+            json!({
+                "expression": req.script,
+                "returnByValue": true,
+                "awaitPromise": req.await_promise,
+            }),
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = cdp.close().await;
+            return ok_body(ApiResponse::err(format!("CDP eval: {e}")));
+        }
+    };
+
+    let _ = cdp.close().await;
+
+    // CDP shape: { result: { type, value } } on success,
+    //            { exceptionDetails: { ... } } on throw.
+    if let Some(exc) = eval_result.get("exceptionDetails") {
+        let msg = exc
+            .get("exception")
+            .and_then(|e| e.get("description"))
+            .and_then(|d| d.as_str())
+            .or_else(|| exc.get("text").and_then(|t| t.as_str()))
+            .unwrap_or("unknown exception")
+            .to_string();
+        return ok_body(ApiResponse::ok(EvalData {
+            result: serde_json::Value::Null,
+            type_: "undefined".to_string(),
+            exception: Some(msg),
+        }));
+    }
+
+    let result = eval_result.get("result").cloned().unwrap_or_default();
+    let type_ = result
+        .get("type")
+        .and_then(|t| t.as_str())
+        .unwrap_or("undefined")
+        .to_string();
+    let value = result.get("value").cloned().unwrap_or(serde_json::Value::Null);
+
+    ok_body(ApiResponse::ok(EvalData {
+        result: value,
+        type_,
+        exception: None,
+    }))
+}
+
+/// `POST /agentmux/browser/screenshot` — capture a PNG of the pane's
+/// rendered viewport. Uses CDP `Page.captureScreenshot`.
+pub async fn screenshot(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<ScreenshotReq>,
+) -> (StatusCode, Json<ApiResponse<ScreenshotData>>) {
+    if !authorized(&headers, &state.ipc_token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiResponse::err("unauthorized: missing or invalid bearer token")),
+        );
+    }
+
+    let mut cdp = match open_cdp_for_block(&state, &req.block_id).await {
+        Ok(c) => c,
+        Err(e) => return ok_body(ApiResponse::err(e)),
+    };
+
+    let cap = match cdp
+        .call(
+            "Page.captureScreenshot",
+            json!({
+                "format": "png",
+                "fromSurface": true,
+            }),
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = cdp.close().await;
+            return ok_body(ApiResponse::err(format!("CDP Page.captureScreenshot: {e}")));
+        }
+    };
+
+    let _ = cdp.close().await;
+
+    let data = match cap.get("data").and_then(|d| d.as_str()) {
+        Some(s) => s.to_string(),
+        None => {
+            return ok_body(ApiResponse::err(
+                "Page.captureScreenshot returned no `data` field".to_string(),
+            ))
+        }
+    };
+
+    ok_body(ApiResponse::ok(ScreenshotData { png_base64: data }))
+}
+
+// ── shared helpers ──────────────────────────────────────────────────────
+
+async fn open_cdp_for_block(
+    state: &Arc<AppState>,
+    block_id: &str,
+) -> Result<CdpSession, String> {
+    let target = state
+        .browser_api
+        .target_cache
+        .resolve(state, block_id)
+        .await?;
+    let debug_port = *state.debug_port.lock();
+    let ws_url = format!("ws://127.0.0.1:{debug_port}/devtools/page/{target}");
+    CdpSession::connect(&ws_url).await.map_err(|e| {
+        // On connect failure the cached target may be stale; drop it
+        // so the next call re-probes.
+        state.browser_api.target_cache.forget(block_id);
+        format!("CDP connect: {e}")
+    })
 }
 
 fn authorized(headers: &HeaderMap, expected: &str) -> bool {

--- a/agentmux-cef/src/browser_api/scripts/query.js
+++ b/agentmux-cef/src/browser_api/scripts/query.js
@@ -36,6 +36,25 @@
     return segs.join(' > ');
   };
 
+  // Snapshot whatever has focus right now as our Element shape.
+  // Returns null when nothing meaningful is focused (document.body
+  // is the default resting state; there's no input focus to report).
+  window.__amq_focus_info = () => {
+    const el = document.activeElement;
+    if (!el || el === document.body) return null;
+    const r = el.getBoundingClientRect();
+    const attrs = {};
+    for (const a of el.attributes) attrs[a.name] = a.value;
+    return {
+      selector: window.__amq_path(el),
+      tag: el.tagName.toLowerCase(),
+      text: (el.textContent || '').slice(0, 500),
+      attrs,
+      rect: { x: r.x, y: r.y, width: r.width, height: r.height },
+      focused: true,
+    };
+  };
+
   window.__amq_query = (selector, limit) => {
     let nodes;
     try {

--- a/agentmux-cef/src/browser_api/types.rs
+++ b/agentmux-cef/src/browser_api/types.rs
@@ -64,3 +64,60 @@ pub struct Rect {
     pub width: f64,
     pub height: f64,
 }
+
+// ── browser.focus_info ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct FocusInfoReq {
+    pub block_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FocusInfoData {
+    /// null when `document.activeElement` is null or the `<body>`
+    /// (the default resting state with no focused control).
+    pub focused: Option<Element>,
+}
+
+// ── browser.eval ────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct EvalReq {
+    pub block_id: String,
+    pub script: String,
+    /// If true and the script returns a Promise, wait for it to
+    /// resolve before returning. Maps to CDP `Runtime.evaluate`
+    /// `awaitPromise`.
+    #[serde(default)]
+    pub await_promise: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EvalData {
+    /// The serialized JS return value, whatever shape the script
+    /// produced. `null` if the script returned `undefined` or threw.
+    pub result: serde_json::Value,
+    /// CDP's type tag: "object" | "string" | "number" | "boolean" |
+    /// "undefined" | "function" | "symbol" | "bigint". Kept so
+    /// callers can distinguish `null`-the-value from `null`-the-failure.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Populated when the script threw. The message + stack, when
+    /// available. `result` is null in this case.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exception: Option<String>,
+}
+
+// ── browser.screenshot ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct ScreenshotReq {
+    pub block_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScreenshotData {
+    /// Base64-encoded PNG bytes — same format CDP's
+    /// `Page.captureScreenshot` returns.
+    pub png_base64: String,
+}

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.274"
+version = "0.33.275"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.274"
+version = "0.33.275"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.274"
+version = "0.33.275"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.274",
+  "version": "0.33.275",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.274",
+      "version": "0.33.275",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.273",
+  "version": "0.33.274",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.273",
+      "version": "0.33.274",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.274",
+  "version": "0.33.275",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/dom-smoke.ps1
+++ b/tools/tests/dom-smoke.ps1
@@ -104,6 +104,74 @@ try {
     $p2Search = $p2Resp.matches[0]
     Write-Host "[dom-smoke]   P2 search: tag=$($p2Search.tag) rect=($($p2Search.rect.x),$($p2Search.rect.y),$($p2Search.rect.width)x$($p2Search.rect.height))"
 
+    # ── Phase 2 assertions ────────────────────────────────────────────
+
+    Write-Host "[dom-smoke] browser.eval 1+1 in P1"
+    $evalResp = Invoke-AgentMuxBrowserApi -Auth $auth -Method eval `
+        -Body @{ block_id = $p1; script = "1 + 1" }
+    $excProp = $evalResp.PSObject.Properties['exception']
+    if ($excProp -and $excProp.Value) {
+        Write-Error "eval 1+1 unexpectedly threw: $($excProp.Value)"
+    }
+    if ($evalResp.result -ne 2) {
+        Write-Error "eval 1+1 returned $($evalResp.result), expected 2"
+    }
+    Write-Host "[dom-smoke]   eval 1+1 = $($evalResp.result) (type=$($evalResp.type))"
+
+    Write-Host "[dom-smoke] browser.eval with a throwing script (negative test)"
+    $throwResp = Invoke-AgentMuxBrowserApi -Auth $auth -Method eval `
+        -Body @{ block_id = $p1; script = "throw new Error('expected')" }
+    $throwExc = $throwResp.PSObject.Properties['exception']
+    if (-not $throwExc -or -not $throwExc.Value) {
+        Write-Error "throwing eval didn't surface an exception"
+    }
+    if ($throwExc.Value -notmatch 'expected') {
+        Write-Error "exception text didn't include 'expected': '$($throwExc.Value)'"
+    }
+    Write-Host "[dom-smoke]   exception captured: $($throwExc.Value.Substring(0, [Math]::Min($throwExc.Value.Length, 80)))"
+
+    Write-Host "[dom-smoke] browser.focus_info on P1 (expect null or body — nothing user-focused)"
+    $focusResp = Invoke-AgentMuxBrowserApi -Auth $auth -Method focus_info `
+        -Body @{ block_id = $p1 }
+    $focusedProp = $focusResp.PSObject.Properties['focused']
+    if ($focusedProp -and $null -ne $focusedProp.Value) {
+        Write-Host "[dom-smoke]   P1 focused: $($focusedProp.Value.tag) (acceptable — page may have auto-focused something)"
+    } else {
+        Write-Host "[dom-smoke]   P1 focused: null (default resting state)"
+    }
+
+    Write-Host "[dom-smoke] browser.focus_info on P2 after programmatic focus"
+    # Focus the search field via eval, then assert focus_info sees it.
+    Invoke-AgentMuxBrowserApi -Auth $auth -Method eval `
+        -Body @{ block_id = $p2; script = "document.querySelector('textarea[name=\""q\""], input[name=\""q\""]').focus()" } | Out-Null
+    Start-Sleep -Milliseconds 200
+    $focusResp2 = Invoke-AgentMuxBrowserApi -Auth $auth -Method focus_info `
+        -Body @{ block_id = $p2 }
+    $focused2 = $focusResp2.PSObject.Properties['focused']
+    if (-not $focused2 -or $null -eq $focused2.Value) {
+        Write-Error "focus_info didn't report any focused element after programmatic focus"
+    }
+    $focusedTag = $focused2.Value.tag
+    if ($focusedTag -notin @('textarea','input')) {
+        Write-Error "focused element tag was '$focusedTag', expected textarea or input"
+    }
+    Write-Host "[dom-smoke]   P2 focused after focus(): $focusedTag (attrs.name=$($focused2.Value.attrs.name))"
+
+    Write-Host "[dom-smoke] browser.screenshot P1"
+    $shotResp = Invoke-AgentMuxBrowserApi -Auth $auth -Method screenshot `
+        -Body @{ block_id = $p1 }
+    if (-not $shotResp.png_base64) {
+        Write-Error "screenshot returned empty png_base64"
+    }
+    $pngBytes = [Convert]::FromBase64String($shotResp.png_base64)
+    # PNG magic: 89 50 4E 47 0D 0A 1A 0A
+    if ($pngBytes.Length -lt 8 -or
+        $pngBytes[0] -ne 0x89 -or $pngBytes[1] -ne 0x50 -or
+        $pngBytes[2] -ne 0x4E -or $pngBytes[3] -ne 0x47) {
+        Write-Error "screenshot bytes don't start with PNG magic (got $($pngBytes[0..3] | ForEach-Object { '0x{0:X2}' -f $_ } | Join-String -Separator ' '))"
+    }
+    Write-Host "[dom-smoke]   screenshot OK, $($pngBytes.Length) bytes of PNG"
+
     Write-Host "[dom-smoke] PASS" -ForegroundColor Green
     if ($KeepTab) {
         Write-Host "[dom-smoke] -KeepTab set; tab left open: $($tabInfo.tabid)"


### PR DESCRIPTION
## Summary

Phase 2 of the browser DOM API — three more read endpoints layered on Phase 1's CDP infrastructure ([#453](https://github.com/agentmuxai/agentmux/pull/453)). No new plumbing; handlers reuse the existing `CdpSession` + `TargetCache`.

| Endpoint | Returns |
|---|---|
| `POST /agentmux/browser/focus_info` | `{focused: Element \| null}` — current `document.activeElement`, or null when nothing is user-focused (body resting state → null) |
| `POST /agentmux/browser/eval` | `{result, type, exception?}` — arbitrary JS via CDP `Runtime.evaluate`; throws surface as `exception` string |
| `POST /agentmux/browser/screenshot` | `{png_base64}` — CDP `Page.captureScreenshot` with `fromSurface: true` |

## Design notes

- **`eval` exception shape**: `{result: null, type: "undefined", exception: "Error: msg\n  at <anonymous>:..."}` — callers can always distinguish null-the-value from null-the-failure by checking `exception`.
- **`eval` `await_promise`**: optional flag that maps to CDP's same-named param. If your script returns a Promise, the call blocks until it resolves.
- **`focus_info` body-as-null**: `document.activeElement === document.body` is the default resting state in Chromium. Reporting it as a focused Element would be noise; treated as null.
- **`screenshot` fromSurface**: captures the composited frame (what the user sees) not just the DOM. Includes overlays, animations mid-frame, etc.
- **Shared helper**: `open_cdp_for_block()` factors out the auth+resolve+connect dance. Auth check stays per-handler because `ApiResponse<T>` has T-specific variants.

## Test plan

- [x] Extended `tools/tests/dom-smoke.ps1` with 7 assertions covering all four read methods. Against a live dev instance:
  ```
  [dom-smoke] eval 1+1 = 2 (type=number)
  [dom-smoke] exception captured: Error: expected at <anonymous>:1:7
  [dom-smoke] P1 focused: null (default resting state)
  [dom-smoke] P2 focused after focus(): textarea (attrs.name=q)
  [dom-smoke] screenshot OK, 9490 bytes of PNG
  [dom-smoke] PASS
  ```
- [x] `focus_info` round-trip: eval programmatic `.focus()` → assert `focus_info` sees the newly-focused element — this is the pattern the stress test will use in Phase 4.
- [x] PNG magic byte check on screenshot output (`\x89PNG`).
- [x] `cargo check -p agentmux-cef` clean (pre-existing warnings only).
- [x] Regression: `pane-focus-smoke.ps1`, `layout-smoke.ps1` still pass.

## Next

- **Phase 3**: write endpoints — `click_element`, `focus_element`, `dispatch_key`, `navigate`. After those land, Phase 4 rewrites `pane-focus-stress.ps1` to use DOM-level input delivery (target: 24/24 pass).
- **Phase 5** (optional): CDP connection pool if per-request WS overhead shows up in Phase 4 measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)