### PR TITLE
fix(stress-harness): coords from actual window rect + pane-HWND-derived y

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.278"
+version = "0.33.279"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.278"
+version = "0.33.279"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.278"
+version = "0.33.279"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.278"
+version = "0.33.279"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.278"
+version = "0.33.279"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.278"
+version = "0.33.279"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.278"
+version = "0.33.279"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.278"
+version = "0.33.279"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retros/2026-04-19-browser-dom-api.md
+++ b/docs/retros/2026-04-19-browser-dom-api.md
@@ -66,3 +66,53 @@ None of these needed 24/24 on the stress test to be valuable. They're the real w
 ## Bottom line
 
 Shipped the DOM API (four PRs, all merged). Exposed a real Win32 focus-routing bug that's been hidden for ≥2 weeks by a blind log parser. Did *not* hit the 24/24 target, but the target was based on a false reading anyway. Next pickup is (3) + (4) in the action table above.
+
+---
+
+## Post-reboot addendum (same day)
+
+After reboot, toolchain compiled clean in 2m09s — transient state, as expected. Dug into the focus-reclaim failure and found **two separate issues** layered on top of each other:
+
+### Issue 1 — harness hardcoded a 1300×900 window on a 900×1600 portrait monitor
+
+`MoveWindow` silently clamps to the primary screen. Requesting 1300 wide got 800–920 actual depending on chrome. The "auto-computed coords" divided by 3 assuming 1300, so `$tCx = 700` landed *inside P2's actual HWND* (x=666–968) instead of the terminal gap (x=355–666). Every "terminal" click was a pane click; every "P2 search" click was off-screen.
+
+**Fix**: read `GetWindowRect` back after `MoveWindow`, derive all coords from the actual rect. Plus enumerate child HWNDs at runtime to find the real pane top (chrome height varies by theme/DPI). Committed in the same branch as this retro addendum.
+
+### Issue 2 — terminal clicks never call `main_window_focus`
+
+Grep for `main_window_focus` across the frontend returns **exactly two callers**: `browser-model.ts:174` (`giveFocus()` when main DOM already has focus) and `browser-view.tsx:155` (address bar `onFocus`). **Nothing else ever requests focus reclaim.**
+
+The stress-test premise — "clicking the terminal after a pane should route subsequent keys to main" — is based on a misunderstanding of how focus transfer works. A mouse click in Windows doesn't automatically transfer Win32 focus to the clicked HWND's top-level; focus transfer requires an explicit `SetFocus` call, which in this codebase only fires from `MainFocusReclaimTask`, which only fires from the `main_window_focus` IPC, which only the address bar invokes.
+
+Clicking the terminal:
+- Updates DOM focus to the xterm canvas (main-window DOM state)
+- Does NOT invoke `main_window_focus` IPC
+- Does NOT transfer Win32 focus to the main window's render widget
+- So SendKeys keeps routing to whichever pane last had the focus handed to it
+
+This wasn't a regression. The test's "expected no pane keys on terminal step" invariant has never been true. It was a phantom pass hidden by the broken log filter (Issue #2 in the main retro above).
+
+**Options forward**:
+- A. Add `main_window_focus` IPC to the terminal view's focus handler (treats terminal like address bar — gives it "main chrome owns keyboard" semantics). Probably what a user expects.
+- B. Change the test to only assert "no leak" after actual main-chrome focus transitions (i.e. the address bar steps).
+- C. Broader fix: on any non-pane DOM element gaining focus, fire `main_window_focus`. Centralizes the focus-reclaim policy.
+
+(A) is minimal and fixes the immediate user-visible case (type in browser → type in terminal → expect terminal to receive keys). (C) is structurally cleaner but widens the blast radius.
+
+### Action items update
+
+| # | Item | Status |
+|---|---|---|
+| 1 | Toolchain crash → reboot | ✅ Fixed by reboot (as predicted ~70%) |
+| 2 | Harness self-check (false-assert detection) | still open |
+| 3 | Pane HWND covers nav bar? | ❌ Not the cause. Actual cause: window clamping + auto-coord math |
+| 4 | Rerun stress test after (3) | done — still 24/24 fail, but *now* we understand why (Issue 2 above) |
+| 5 | Phase 4b: don't use focus_element in stress test | partially applied; still relevant |
+| 6 | Add no-LTO dev guide to CLAUDE.md | not needed — LTO wasn't the issue |
+| **7** | **Add `main_window_focus` IPC to terminal view's focus handler** — treats terminal like address bar | new, open |
+| **8** | **Rework stress-test invariants** — "no pane keys on terminal step" requires terminal to *explicitly* transfer Win32 focus; either make that happen (#7) or remove the invariant | new, open |
+
+### What to try next
+
+Start with (#7) — 3-line change in the terminal view's focus handler, fires the same IPC the address bar does. If that makes terminal steps pass, the harness is validated and we can work down from 24/24-fail to whatever the real number is.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.278",
+  "version": "0.33.279",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.278",
+      "version": "0.33.279",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.278",
+  "version": "0.33.279",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/pane-focus-stress.ps1
+++ b/tools/tests/pane-focus-stress.ps1
@@ -56,12 +56,19 @@ if ($CreateLayout) {
 $win32 = @'
 using System;
 using System.Runtime.InteropServices;
+public struct RECT { public int left, top, right, bottom; }
 public static class Win32 {
     [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
     [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
     [DllImport("user32.dll")] public static extern bool MoveWindow(IntPtr hWnd, int x, int y, int cx, int cy, bool bRepaint);
     [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
     [DllImport("user32.dll")] public static extern IntPtr GetFocus();
+}
+// A second class so callers that already do [Win32Rect]::GetWindowRect work;
+// keeping it separate avoids Add-Type compile conflicts when the script is
+// re-sourced in the same PS session.
+public static class Win32Rect {
+    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr hWnd, out RECT r);
 }
 '@
 Add-Type -TypeDefinition $win32 -ErrorAction SilentlyContinue | Out-Null
@@ -133,6 +140,53 @@ function Read-LogSince([string]$path, [datetime]$since) {
         }
 }
 
+function Get-AgentMuxPaneTop {
+    <#
+    .SYNOPSIS
+    Enumerate main window's child HWNDs and return the TOP of the
+    first pane HWND — the pane content area's screen-Y. Used by the
+    stress test to compute "above the pane" y-coords for address-bar
+    clicks (which must land on main window DOM, not the pane).
+
+    Returns $WindowY + 107 as a fallback if enumeration finds nothing.
+    #>
+    param(
+        [Parameter(Mandatory)] [IntPtr]$MainHwnd,
+        [Parameter(Mandatory)] [int]$WindowY
+    )
+    try {
+        Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+public static class PaneEnum {
+    [DllImport("user32.dll")] public static extern bool GetWindowRect(IntPtr h, out PaneRect r);
+    [DllImport("user32.dll")] public static extern bool EnumChildWindows(IntPtr h, EnumProc cb, IntPtr p);
+    public delegate bool EnumProc(IntPtr h, IntPtr p);
+}
+public struct PaneRect { public int left, top, right, bottom; }
+'@ -ErrorAction SilentlyContinue | Out-Null
+    } catch {}
+
+    $tops = New-Object System.Collections.ArrayList
+    $cb = [PaneEnum+EnumProc] {
+        param([IntPtr]$h, [IntPtr]$p)
+        $r = New-Object PaneRect
+        [PaneEnum]::GetWindowRect($h, [ref]$r) | Out-Null
+        # Pane HWNDs are narrower than the full main window (3 panes
+        # side by side) and tall. Filter by "width < window_width/2
+        # and height > 100" to skip the main-chrome HWND.
+        if (($r.right - $r.left) -gt 50 -and ($r.right - $r.left) -lt 500 -and ($r.bottom - $r.top) -gt 300) {
+            $null = $tops.Add($r.top)
+        }
+        return $true
+    }
+    [PaneEnum]::EnumChildWindows($MainHwnd, $cb, [IntPtr]::Zero) | Out-Null
+    if ($tops.Count -gt 0) {
+        return ($tops | Sort-Object | Select-Object -First 1)
+    }
+    return ($WindowY + 107)  # fallback to the pre-measurement constant
+}
+
 function Find-LatestHostLog {
     # Legacy fallback used only when -SkipAuthFile is set. The
     # version-suffix glob never matches dev mode (whose data dir is
@@ -179,10 +233,30 @@ Write-Host "[setup] AgentMux main PID=$($main.Id) handle=$($main.MainWindowHandl
 
 [Win32]::ShowWindow($main.MainWindowHandle, 5) | Out-Null
 Start-Sleep -Milliseconds 200
-[Win32]::MoveWindow($main.MainWindowHandle, 50, 50, 1300, 900, $true) | Out-Null
+# Size the window to fit the primary display. Earlier versions hard-coded
+# 1300×900 which got silently clamped on narrower monitors (e.g. 900×1600
+# portrait), pushing pane coords out of alignment and making clicks land
+# on the wrong HWNDs. Size the window to primary screen minus 2× the
+# window origin; then read back the ACTUAL rect for coord math below.
+$screen = [System.Windows.Forms.Screen]::PrimaryScreen.WorkingArea
+$origin = 50
+$reqW = [Math]::Min(1300, $screen.Width - 2 * $origin)
+$reqH = [Math]::Min(900,  $screen.Height - 2 * $origin)
+[Win32]::MoveWindow($main.MainWindowHandle, $origin, $origin, $reqW, $reqH, $true) | Out-Null
 Start-Sleep -Milliseconds 200
 [Win32]::SetForegroundWindow($main.MainWindowHandle) | Out-Null
 Start-Sleep -Milliseconds 500
+
+# Read back the actual window rect — Windows may clamp our request
+# below the primary screen's dimensions. All coord math below is based
+# on this, NOT the requested size.
+$winRect = New-Object RECT
+[Win32Rect]::GetWindowRect($main.MainWindowHandle, [ref]$winRect) | Out-Null
+$winX = $winRect.left
+$winY = $winRect.top
+$winW = $winRect.right - $winRect.left
+$winH = $winRect.bottom - $winRect.top
+Write-Host "[setup] Window actual rect=($winX, $winY, ${winW}x${winH}) (requested ${reqW}x${reqH})"
 
 if (-not $LogPath) { $LogPath = Find-LatestHostLog }
 if (-not $LogPath -or -not (Test-Path $LogPath)) {
@@ -236,26 +310,48 @@ if (Test-Path $targetsPath) {
     $targets = Get-Content -LiteralPath $targetsPath -Raw | ConvertFrom-Json
     Write-Host "[setup] Using custom click targets from $targetsPath"
 } elseif ($CreateLayout) {
-    # With -CreateLayout the window is a known (50, 50) at 1300×900
-    # with 3 equal-width panes (P1 | T | P2). These defaults come
-    # from that geometry: tab bar + browser nav bar ≈ 130px of
-    # chrome, so pane content starts around y=130 with room up to
-    # y=900. Browser address bar is near the top of each pane
-    # (~y=155), Google search box lives in the middle of the pane
-    # content area, terminal prompt sits low within the middle pane.
-    # Tweak by hand via a pane-focus-stress.targets.json override.
-    $paneWidth = 1300 / 3
-    $p1Cx = [int](50 + $paneWidth * 0.5)
-    $tCx  = [int](50 + $paneWidth * 1.5)
-    $p2Cx = [int](50 + $paneWidth * 2.5)
+    # With -CreateLayout, compute click targets from the ACTUAL window
+    # rect we measured above — NOT a hardcoded 1300×900. That assumption
+    # breaks on any display narrower than ~1500 px (Windows clamps the
+    # window and the 3-pane math sends clicks into the wrong HWNDs —
+    # confirmed on a 900×1600 portrait display where `$tCx` landed
+    # inside P2's actual HWND instead of the terminal).
+    #
+    # Layout model for the window content:
+    #   - top chrome (title + tab bar): ~60 px
+    #   - pane header + browser nav bar: ~40 px each in P1/P2
+    #   - content below that fills the rest
+    # Panes: 3 equal horizontal columns. Centers at 1/6, 3/6, 5/6 of window width.
+    # Read back ACTUAL pane HWND positions. The "chrome above pane"
+    # offset depends on theme/DPI/window-decoration settings, so we
+    # can't just pick a magic y. Strategy:
+    #   - address bar is in main window's DOM, ABOVE the pane HWND
+    #   - pick a y that's halfway between the window top and the
+    #     first pane HWND top — that reliably lands in the nav bar.
+    $paneTop = Get-AgentMuxPaneTop -MainHwnd $main.MainWindowHandle -WindowY $winY
+    $paneWidth = $winW / 3
+    $p1Cx = [int]($winX + $paneWidth * 0.5)
+    $tCx  = [int]($winX + $paneWidth * 1.5)
+    $p2Cx = [int]($winX + $paneWidth * 2.5)
+    # Nav bar lives roughly in the bottom 2/3 of the chrome above the
+    # pane HWND; pick 2/3 down from window top to pane top.
+    $addressY = [int]($winY + (($paneTop - $winY) * 0.66))
+    # Search box is roughly mid-height of the browser content area.
+    # Pane runs from $paneTop to near window bottom.
+    $paneBottom = $winY + $winH - 20  # account for status bar
+    $searchY  = [int]($paneTop + ($paneBottom - $paneTop) * 0.35)
+    $termY    = [int]($paneTop + ($paneBottom - $paneTop) * 0.55)
     $targets = [pscustomobject]@{
-        P1_address = @($p1Cx, 155)
-        P1_search  = @($p1Cx, 430)
-        P2_address = @($p2Cx, 155)
-        P2_search  = @($p2Cx, 430)
-        Terminal   = @($tCx,  700)
+        P1_address = @($p1Cx, $addressY)
+        P1_search  = @($p1Cx, $searchY)
+        P2_address = @($p2Cx, $addressY)
+        P2_search  = @($p2Cx, $searchY)
+        Terminal   = @($tCx,  $termY)
     }
-    Write-Host "[setup] Using auto-computed click targets from window geometry"
+    Write-Host "[setup] Auto-computed targets:"
+    Write-Host "         paneTop=$paneTop paneBottom=$paneBottom"
+    Write-Host "         x: P1=$p1Cx T=$tCx P2=$p2Cx"
+    Write-Host "         y: addressY=$addressY searchY=$searchY termY=$termY"
 } else {
     Write-Error @"
 Missing $targetsPath.


### PR DESCRIPTION
## Summary

The stress-test harness had two layered bugs that together produced the 24/24 failure pattern. This PR addresses the first; the second is captured in the retro and tracked as action items #7/#8 for a follow-up PR.

## Fix: auto-computed click coords now track actual window geometry

Previously the `-CreateLayout` path hardcoded coord math around a 1300×900 window. On a portrait 900×1600 display with DPR=1, Windows silently clamps `MoveWindow(1300)` to 800–920 actual. The `$tCx = 50 + (1300/3)*1.5 = 700` coord then landed *inside P2's actual pane HWND* (x=666–968) instead of the terminal gap. Every "Terminal" click hit P2; every "P2 search" click landed off-screen.

This PR:

1. Sizes the window using `min(1300, screen_width - 2*origin)` — never asks for more than the display can give.
2. Calls `GetWindowRect` after `MoveWindow` to read the actual clamped rect. All downstream coord math uses `$winW`/`$winH` from the real rect.
3. Enumerates child HWNDs at runtime via `EnumChildWindows` and filters to the pane HWND stack (narrow + tall) to derive `paneTop`. Chrome height varies by theme/DPI; hardcoding "pane content starts at y=157" was fragile.
4. Recomputes `addressY` as 2/3 up from `paneTop` into the chrome above (lands in nav bar regardless of its exact pixel height), and `searchY`/`termY` as percentages of pane content.

Before this PR, `auto-computed targets: P1=266 T=700 P2=1133` — with actual window 800 wide, T=700 was inside P2. After: `P1=183 T=450 P2=717` — all inside their correct HWNDs on an 800-wide window.

## What still fails — tracked, not in this PR

24/24 still fail. With the coord math fixed the failures reveal a **separate genuine issue**: only the browser address bar's DOM `onFocus` handler invokes the `main_window_focus` IPC. Clicking the terminal doesn't transfer Win32 keyboard focus away from the previously-focused pane, so `SendKeys` keeps routing to the pane.

Three options for the follow-up:

| Option | Behaviour change |
|---|---|
| **A** | Add `main_window_focus` IPC call to terminal view's focus handler (3-line change) |
| **B** | Relax the stress test's "no pane keys on terminal step" invariant |
| **C** | Fire `main_window_focus` on any non-pane DOM element gaining focus (broader policy) |

See the retro's "Post-reboot addendum" for the full analysis and action items #7 / #8.

## Files changed

- `tools/tests/pane-focus-stress.ps1` — `Get-AgentMuxPaneTop` helper + reworked coord math using actual rect.
- `docs/retros/2026-04-19-browser-dom-api.md` — post-reboot addendum documenting both bugs and the follow-up options.
- `Cargo.toml`, `Cargo.lock`, `*/Cargo.toml`, `package.json`, `package-lock.json`, `VERSION_HISTORY.md` — version bump to 0.33.279.

No Rust code changes. No frontend code changes. Harness-only + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)