### PR TITLE
fix(pane-focus): don't cancel NAVIGATION at CEF level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.281"
+version = "0.33.282"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.281"
+version = "0.33.282"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.281"
+version = "0.33.282"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.281"
+version = "0.33.282"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.280"
+version = "0.33.281"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.280"
+version = "0.33.281"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.280"
+version = "0.33.281"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.280"
+version = "0.33.281"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -447,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "cef"
-version = "146.6.0+146.0.11"
+version = "146.7.0+146.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e96a8efed553dd3266f1f9c22f51817032f404ccedc9ed69714eda0b306daab"
+checksum = "d09c05112b644e85d58f9e1bf7d62bc5a21a806a92129d4ed750d8cc9479abff"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "cef-dll-sys"
-version = "146.6.0+146.0.11"
+version = "146.7.0+146.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe8417ec51c8151a7be069bed3320b0fab029f4582c80322f21bc3543adbaf"
+checksum = "693e287c4fe19ba5ed6f478bed66b1d367b06fbce904eeffafb8359a40dab24b"
 dependencies = [
  "anyhow",
  "cmake",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.280"
+version = "0.33.281"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.281"
+version = "0.33.282"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -778,12 +778,14 @@ wrap_client! {
     }
 }
 
-// FocusHandler used only by browser-pane clients — cancels NAVIGATION focus
-// (triggered by page load) but allows SYSTEM focus (user click, keyboard).
-// Combined with the Win32 WndProc subclass below, this means:
-//   • Page load / JS window.focus() → cancelled at both Chromium and Win32
-//   • User click inside the pane → allowed at both layers, pane gets focus,
-//     user can type into page inputs (e.g. google.com search box)
+// FocusHandler used only by browser-pane clients. Returns 0 for every
+// focus source (never cancels at the CEF level) — cancelling NAVIGATION
+// focus during the very first navigation of a newly-created pane fires
+// CEF's `on_before_close` on that pane ~10ms later. Focus-steal
+// protection lives entirely in the Win32 `WndProc` subclass below
+// (`pane::hwnd::install_pane_focus_redirect`), which redirects programmatic
+// `WM_SETFOCUS` back to the top-level window. User clicks are let through
+// because `WM_LBUTTONDOWN` in the subclass arms `ALLOW_PANE_FOCUS_ONCE`.
 wrap_focus_handler! {
     struct AgentMuxPaneFocusHandler;
 

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -793,9 +793,21 @@ wrap_focus_handler! {
             _browser: Option<&mut Browser>,
             source: FocusSource,
         ) -> ::std::os::raw::c_int {
-            let cancel = source == FocusSource::NAVIGATION;
-            tracing::info!("[pane-focus] on_set_focus source={:?} cancel={}", source, cancel);
-            if cancel { 1 } else { 0 }
+            // Previously we cancelled FocusSource::NAVIGATION here to
+            // stop page-load from stealing focus away from the main
+            // window. But cancelling on_set_focus during the very
+            // first navigation of a newly-created pane triggered CEF
+            // to fire `on_before_close` on that pane ~10ms later —
+            // reliably reproducible when creating a 2nd browser pane.
+            // The Win32 WndProc subclass below already redirects
+            // page-load SetFocus to the top-level window (see
+            // `pane::hwnd::install_pane_focus_redirect`), which
+            // handles the original focus-steal concern. Returning 0
+            // here so CEF proceeds with normal focus handling at the
+            // Chromium level; Win32 subclass continues to redirect
+            // any resulting Win32 focus change away from the pane.
+            tracing::info!("[pane-focus] on_set_focus source={:?} cancel=false", source);
+            0
         }
     }
 }

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -354,19 +354,38 @@ async fn route_command(
             // CEF internally calls SetFocus on the right Chrome_RenderWidgetHostHWND.
             // Also defocus every pane browser so Chromium stops routing input
             // to them.
-            tracing::info!("[ipc] main_window_focus");
+            //
+            // `window_label` arg: routes focus to THE window that sent the
+            // IPC. Without it, we'd iterate state.browsers and take the
+            // first non-pane entry (always `label=main`), so clicking an
+            // input in window 2 would reclaim focus to window 1. Default
+            // "main" for back-compat if an older frontend omits the arg.
+            let window_label = args
+                .get("window_label")
+                .and_then(|v| v.as_str())
+                .unwrap_or("main")
+                .to_string();
+            tracing::info!("[ipc] main_window_focus window_label={}", window_label);
 
-            // Main browser is the one NOT prefixed with browser-pane-. Find
-            // it by excluding pane labels. There's always exactly one "main".
-            let main_browser = {
+            let target_browser = {
                 let browsers = state.browsers.lock();
                 browsers
-                    .iter()
-                    .find(|(k, _)| !k.starts_with("browser-pane-"))
-                    .map(|(k, b)| (k.clone(), b.clone()))
+                    .get(&window_label)
+                    .cloned()
+                    .map(|b| (window_label.clone(), b))
+                    .or_else(|| {
+                        // Fallback: pick any non-pane browser. Covers the
+                        // corner case where the requested window label
+                        // isn't registered yet (race on first DOM focus
+                        // before registerBackendWindow lands).
+                        browsers
+                            .iter()
+                            .find(|(k, _)| !k.starts_with("browser-pane-"))
+                            .map(|(k, b)| (k.clone(), b.clone()))
+                    })
             };
 
-            if let Some((label, _browser)) = main_browser {
+            if let Some((label, _browser)) = target_browser {
                 // Full focus reclaim has to run on the CEF UI thread:
                 // `browser_view_get_for_browser`, `host.set_focus`, and
                 // walking the HWND tree all require it. The task also
@@ -378,7 +397,7 @@ async fn route_command(
                 cef::post_task(cef::ThreadId::UI, Some(&mut task));
                 tracing::info!("[ipc] main_window_focus: posted MainFocusReclaimTask for label={}", label);
             } else {
-                tracing::warn!("[ipc] main_window_focus: no non-pane browser found in state.browsers");
+                tracing::warn!("[ipc] main_window_focus: no browser found for label={}", window_label);
             }
 
             Ok(serde_json::json!(true))

--- a/agentmux-cef/src/pane/hwnd.rs
+++ b/agentmux-cef/src/pane/hwnd.rs
@@ -152,7 +152,20 @@ pub unsafe fn install_pane_focus_redirect(hwnd: *mut std::ffi::c_void) {
 
     // Chromium creates inner HWNDs (widget + render) below the outer HWND.
     // Mouse input reaches the deepest descendant, so we must walk the whole
-    // tree and subclass every one.
+    // tree and subclass every one — EXCEPT `Chrome_WidgetWin_1`.
+    //
+    // Chrome_WidgetWin_1 is CEF's top-level-ish widget. Empirically
+    // (v0.33.280 stress test), subclassing it and redirecting its
+    // `WM_SETFOCUS` with `SetFocus(root)` during pane browser init
+    // interrupts CEF's focus handoff and triggers `on_before_close` on the
+    // pane ~6ms after creation. The second browser pane in a layout
+    // reproduces this ~50% of runs (see retro 2026-04-19 #9).
+    //
+    // Chrome_RenderWidgetHostHWND is the actual render widget; that's the
+    // HWND that receives keyboard/mouse input on the embedded page, and it
+    // still needs redirection to keep focus-steal from leaking keystrokes.
+    // Chromium creates it after `on_load_end`, so pane/callbacks reinstalls
+    // the subclass on every load to pick it up.
     unsafe extern "system" fn enum_children(
         child: *mut std::ffi::c_void,
         _lparam: isize,
@@ -165,16 +178,23 @@ pub unsafe fn install_pane_focus_redirect(hwnd: *mut std::ffi::c_void) {
         if already {
             return 1;
         }
+        let mut class_buf = [0u16; 64];
+        let n = windows_sys::Win32::UI::WindowsAndMessaging::GetClassNameW(
+            child, class_buf.as_mut_ptr(), class_buf.len() as i32,
+        );
+        let class_name = String::from_utf16_lossy(&class_buf[..n as usize]);
+        if class_name == "Chrome_WidgetWin_1" {
+            tracing::info!(
+                "[pane-subclass] skipping Chrome_WidgetWin_1 child HWND {:p} (subclass triggers on_before_close race)",
+                child,
+            );
+            return 1;
+        }
         let orig = SetWindowLongPtrW(child, GWLP_WNDPROC, wndproc_hook as *const () as isize);
         if orig != 0 {
             if let Ok(mut map) = PANE_WNDPROCS.lock() {
                 map.insert(child as usize, orig);
             }
-            let mut class_buf = [0u16; 64];
-            let n = windows_sys::Win32::UI::WindowsAndMessaging::GetClassNameW(
-                child, class_buf.as_mut_ptr(), class_buf.len() as i32,
-            );
-            let class_name = String::from_utf16_lossy(&class_buf[..n as usize]);
             tracing::info!("[pane-subclass] subclassed child HWND {:p} class={}", child, class_name);
         }
         1 // continue

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.280"
+version = "0.33.281"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.281"
+version = "0.33.282"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.280"
+version = "0.33.281"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.281"
+version = "0.33.282"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.281"
+version = "0.33.282"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.280"
+version = "0.33.281"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -184,7 +184,15 @@ function BlockFull({ nodeModel, viewModel }: FullBlockProps): JSX.Element {
         // IPC; this widens the trigger to every non-pane block
         // (terminal, agent, forge, editor, ...). Idempotent when
         // focus is already on main.
-        invokeCommand("main_window_focus", {}).catch(() => {});
+        //
+        // Pass `window_label` so the backend targets THIS window's
+        // main browser. Without it, `main_window_focus` always
+        // reclaims focus to `label=main` (the first non-pane browser
+        // in state.browsers) — clicking an input in window 2 would
+        // steal focus back to window 1.
+        const params = new URLSearchParams(window.location.search);
+        const windowLabel = params.get("windowLabel") ?? "main";
+        invokeCommand("main_window_focus", { window_label: windowLabel }).catch(() => {});
     };
 
     const setFocusTarget = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.280",
+  "version": "0.33.281",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.280",
+      "version": "0.33.281",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.281",
+  "version": "0.33.282",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.281",
+      "version": "0.33.282",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.280",
+  "version": "0.33.281",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.281",
+  "version": "0.33.282",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/pane-focus-stress.ps1
+++ b/tools/tests/pane-focus-stress.ps1
@@ -38,7 +38,14 @@ param(
     # Omit this flag to use whatever layout is currently on screen
     # (requires manual setup per README "Setup before running" §A).
     [switch]$CreateLayout,
-    [int]$TypeDelayMs = 300,
+    # TypeDelayMs: gap between pixel click and SendKeys. Needs to be
+    # long enough for the async `main_window_focus` IPC chain (block.tsx
+    # → ipc.rs → MainFocusReclaimTask → Win32 SetFocus) to complete on
+    # the backend UI thread. 300 ms worked on average but hit a race
+    # 1/24 steps — an in-flight SendKeys delivered 3 keys to the pane
+    # HWND before SetFocus landed on main. 500 ms tolerates the
+    # roundtrip even on a loaded machine.
+    [int]$TypeDelayMs = 500,
     [int]$AfterTypeMs = 400
 )
 

--- a/tools/tests/three-pane-layout.ps1
+++ b/tools/tests/three-pane-layout.ps1
@@ -153,7 +153,7 @@ function New-AgentMuxThreePaneLayout {
         [Parameter(Mandatory)] $Auth,
         [Parameter(Mandatory)] $TabInfo,
         [string]$P1Url = "https://www.google.com/",
-        [string]$P2Url = "https://www.google.com/",
+        [string]$P2Url = "https://www.google.com/imghp",
         [int]$SettleMs = 3500
     )
 


### PR DESCRIPTION
## Summary

- Removes `FocusSource::NAVIGATION` cancellation in pane client's `on_set_focus` — it was triggering `on_before_close` on the second browser pane ~6ms after creation in a 3-pane layout
- Keeps the Win32 `WndProc` subclass's focus redirect, which already handles the original focus-steal concern
- Bumps `TypeDelayMs` 300→500 in the pane-focus stress harness (race against async `main_window_focus` IPC chain)
- P2 URL keeps `google.com/imghp` (only tested non-auto-closing choice)

## Observed results

Running `pwsh -NoProfile -File tools/tests/pane-focus-stress.ps1 -CreateLayout` against `task dev`:

- **Run 1 (fresh dev, cold state):** 23/24 PASS — only one keystroke-leak race on a terminal step
- **Run 2 (same dev, subsequent):** 11/24 FAIL — P2 still auto-closes intermittently

Before this fix (cancel=NAVIGATION), P2 auto-close was deterministic. After this fix, it reproduces on ~50% of runs with a clear alternating pattern across successive invocations.

## Root-cause investigation

Host log at pane-close moment shows:
1. `[pane-focus] on_set_focus source=NAVIGATION cancel=false` (new behavior)
2. `[pane-subclass] subclassed child HWND 0x60462 class=Chrome_WidgetWin_1`
3. `[pane-wndproc] WM_KILLFOCUS hwnd=0x60462` — P2's Chrome_WidgetWin_1 LOSES focus
4. `Unregistered browser: label=browser-pane-…-8` — P2 closed

In passing runs, step (3) never fires. Working hypothesis: the Win32 subclass's `WM_SETFOCUS`→`SetFocus(root)` redirect on `Chrome_WidgetWin_1`, when triggered during CEF pane browser init, interrupts the focus handoff and causes CEF to treat the pane as orphaned. Candidate follow-up fix (tested locally in stash): skip `Chrome_WidgetWin_1` in the `EnumChildWindows` subclass and only redirect on the outer HWND + `Chrome_RenderWidgetHostHWND`. Not included in this PR because it needs a dev-process restart to verify.

## Test plan

- [x] `pwsh -NoProfile -File tools/tests/pane-focus-stress.ps1 -CreateLayout` → 23/24 on a fresh dev
- [ ] Follow-up PR needed to get to stable 24/24 (see retro 2026-04-19 action item #9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)