### PR TITLE
revert(pane-subclass): restore Chrome_WidgetWin_1 subclass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.282"
+version = "0.33.283"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.282"
+version = "0.33.283"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.282"
+version = "0.33.283"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.282"
+version = "0.33.283"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.282"
+version = "0.33.283"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/pane/hwnd.rs
+++ b/agentmux-cef/src/pane/hwnd.rs
@@ -152,20 +152,7 @@ pub unsafe fn install_pane_focus_redirect(hwnd: *mut std::ffi::c_void) {
 
     // Chromium creates inner HWNDs (widget + render) below the outer HWND.
     // Mouse input reaches the deepest descendant, so we must walk the whole
-    // tree and subclass every one — EXCEPT `Chrome_WidgetWin_1`.
-    //
-    // Chrome_WidgetWin_1 is CEF's top-level-ish widget. Empirically
-    // (v0.33.280 stress test), subclassing it and redirecting its
-    // `WM_SETFOCUS` with `SetFocus(root)` during pane browser init
-    // interrupts CEF's focus handoff and triggers `on_before_close` on the
-    // pane ~6ms after creation. The second browser pane in a layout
-    // reproduces this ~50% of runs (see retro 2026-04-19 #9).
-    //
-    // Chrome_RenderWidgetHostHWND is the actual render widget; that's the
-    // HWND that receives keyboard/mouse input on the embedded page, and it
-    // still needs redirection to keep focus-steal from leaking keystrokes.
-    // Chromium creates it after `on_load_end`, so pane/callbacks reinstalls
-    // the subclass on every load to pick it up.
+    // tree and subclass every one.
     unsafe extern "system" fn enum_children(
         child: *mut std::ffi::c_void,
         _lparam: isize,
@@ -178,23 +165,16 @@ pub unsafe fn install_pane_focus_redirect(hwnd: *mut std::ffi::c_void) {
         if already {
             return 1;
         }
-        let mut class_buf = [0u16; 64];
-        let n = windows_sys::Win32::UI::WindowsAndMessaging::GetClassNameW(
-            child, class_buf.as_mut_ptr(), class_buf.len() as i32,
-        );
-        let class_name = String::from_utf16_lossy(&class_buf[..n as usize]);
-        if class_name == "Chrome_WidgetWin_1" {
-            tracing::info!(
-                "[pane-subclass] skipping Chrome_WidgetWin_1 child HWND {:p} (subclass triggers on_before_close race)",
-                child,
-            );
-            return 1;
-        }
         let orig = SetWindowLongPtrW(child, GWLP_WNDPROC, wndproc_hook as *const () as isize);
         if orig != 0 {
             if let Ok(mut map) = PANE_WNDPROCS.lock() {
                 map.insert(child as usize, orig);
             }
+            let mut class_buf = [0u16; 64];
+            let n = windows_sys::Win32::UI::WindowsAndMessaging::GetClassNameW(
+                child, class_buf.as_mut_ptr(), class_buf.len() as i32,
+            );
+            let class_name = String::from_utf16_lossy(&class_buf[..n as usize]);
             tracing::info!("[pane-subclass] subclassed child HWND {:p} class={}", child, class_name);
         }
         1 // continue

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.282"
+version = "0.33.283"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.282"
+version = "0.33.283"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.282"
+version = "0.33.283"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.282",
+  "version": "0.33.283",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.282",
+      "version": "0.33.283",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.282",
+  "version": "0.33.283",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Follow-up to #460. Reverts the experimental \`Chrome_WidgetWin_1\` skip in \`pane::hwnd::install_pane_focus_redirect\` because it broke pane focus entirely.

## Test results on v0.33.282

| Target | Result |
|--------|--------|
| \`P1_address\`, \`P2_address\` (DOM inputs in main HWND) | PASS |
| \`Terminal\` | PASS |
| \`P1_search\`, \`P2_search\` (inputs inside pane HWND) | **FAIL — \"expected pane keystrokes but saw none in log\"** |

\`WM_LBUTTONDOWN\` fired on the pane HWND (arming \`ALLOW_PANE_FOCUS_ONCE\`) but no \`WM_SETFOCUS\` allowed log, no \`WM_KEYDOWN\`/\`WM_CHAR\` follow-up. Chromium's click-to-focus path needs \`Chrome_WidgetWin_1\` in the subclass tree to land focus on the renderer.

## Net effect

Back to the ~50% P2 auto-close rate from #460 — still an improvement over the ~100% pre-#460 state, just not the stable 24/24 the skip was meant to deliver.

## Next approach

Post the \`WM_SETFOCUS → SetFocus(root)\` redirect asynchronously via \`PostMessage\` (or schedule a UI-thread task) so CEF's focus handoff completes before we claw focus back. The synchronous redirect mid-WndProc is what triggers \`on_before_close\` during pane init; deferring by one message-pump cycle should dodge the race without skipping the subclass.

## Test plan

- [x] \`pwsh -NoProfile -File tools/tests/pane-focus-stress.ps1 -CreateLayout\` returns to ~23/24 baseline after this revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)