### PR TITLE
fix(cli): handle .cmd wrappers pointing to .exe (not just .js)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.284"
+version = "0.33.285"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.284"
+version = "0.33.285"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.284"
+version = "0.33.285"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.284"
+version = "0.33.285"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.283"
+version = "0.33.284"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.283"
+version = "0.33.284"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.283"
+version = "0.33.284"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.283"
+version = "0.33.284"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.284 | 2026-04-19 | 159.7 MiB | 333.1 MiB | |
 | 0.33.245 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |
 | 0.33.240 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |
 | 0.33.234 | 2026-04-17 | 158.6 MiB | 330.8 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.284"
+version = "0.33.285"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.283"
+version = "0.33.284"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.283"
+version = "0.33.284"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.284"
+version = "0.33.285"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/cli.rs
+++ b/agentmux-common/src/cli.rs
@@ -1,34 +1,56 @@
+/// Resolved target of a Windows `.cmd` npm shim.
+#[cfg(windows)]
+enum ResolvedShim {
+    /// Shim invokes a Node.js script; run via `node <path>`.
+    NodeScript(String),
+    /// Shim invokes a native executable directly; run via `<path>`.
+    /// Seen on @anthropic-ai/claude-code v2+, which ships a prebuilt
+    /// `claude.exe` instead of a JS entry point.
+    Executable(String),
+}
+
 /// Create a Command for a CLI binary.
 ///
 /// On Windows, npm-generated `.cmd` batch wrappers cannot be reliably spawned
 /// via `cmd.exe /C` when stdio is piped — arguments get dropped, output is lost,
 /// and the underlying CLI never executes. Instead, we parse the `.cmd` file to
-/// extract the Node.js entry script path and invoke `node <script>` directly.
+/// extract the real entry point and invoke it directly (either `node <script>`
+/// for JS shims or the target `.exe` directly for native-binary shims).
 pub fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
     #[cfg(windows)]
     if cli_path.ends_with(".cmd") || cli_path.ends_with(".bat") {
-        if let Some(entry_script) = parse_cmd_wrapper(cli_path) {
-            tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
-            let mut c = tokio::process::Command::new("node");
-            c.arg(&entry_script);
-            return c;
+        match parse_cmd_wrapper(cli_path) {
+            Some(ResolvedShim::NodeScript(entry_script)) => {
+                tracing::debug!(cmd = %cli_path, script = %entry_script, "resolved .cmd → node");
+                let mut c = tokio::process::Command::new("node");
+                c.arg(&entry_script);
+                return c;
+            }
+            Some(ResolvedShim::Executable(exe_path)) => {
+                tracing::debug!(cmd = %cli_path, exe = %exe_path, "resolved .cmd → native .exe");
+                return tokio::process::Command::new(&exe_path);
+            }
+            None => {
+                tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
+                let mut c = tokio::process::Command::new("cmd.exe");
+                c.args(["/C", cli_path]);
+                return c;
+            }
         }
-        tracing::warn!(cmd = %cli_path, "could not parse .cmd wrapper, falling back to cmd.exe /C");
-        let mut c = tokio::process::Command::new("cmd.exe");
-        c.args(["/C", cli_path]);
-        return c;
     }
     tokio::process::Command::new(cli_path)
 }
 
-/// Parse an npm-generated `.cmd` wrapper to extract the Node.js entry script path.
+/// Parse an npm-generated `.cmd` wrapper to extract the real entry point.
 ///
-/// npm `.cmd` wrappers contain a line like:
-///   `"%_prog%"  "%dp0%\..\@anthropic-ai\claude-code\cli.js" %*`
-/// where `%dp0%` is the directory containing the `.cmd` file itself.
-/// We extract the relative path after `%dp0%\` and resolve it to an absolute path.
+/// npm `.cmd` wrappers contain a line like one of:
+///   `"%_prog%"  "%dp0%\..\@anthropic-ai\claude-code\cli.js" %*`   (JS shim)
+///   `"%dp0%\..\@anthropic-ai\claude-code\bin\claude.exe"   %*`    (native .exe shim)
+/// where `%dp0%` is the directory containing the `.cmd` file itself. We extract
+/// the relative path after `%dp0%\`, resolve it to an absolute path, and tag it
+/// as either a Node script (`.js/.mjs/.cjs`) or a native executable (`.exe`).
 #[cfg(windows)]
-fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
+fn parse_cmd_wrapper(cmd_path: &str) -> Option<ResolvedShim> {
     let content = std::fs::read_to_string(cmd_path).ok()?;
     let cmd_dir = std::path::Path::new(cmd_path).parent()?;
 
@@ -43,19 +65,31 @@ fn parse_cmd_wrapper(cmd_path: &str) -> Option<String> {
                 .or_else(|| after_dp0.find(" %*"))
                 .unwrap_or(after_dp0.len());
             let relative_path = &after_dp0[..end];
-            if relative_path.ends_with(".js") || relative_path.ends_with(".mjs") || relative_path.ends_with(".cjs") {
-                let resolved = cmd_dir.join(relative_path);
-                if let Ok(canonical) = resolved.canonicalize() {
-                    let mut path_str = canonical.to_string_lossy().to_string();
-                    // Windows canonicalize() returns \\?\C:\... (UNC extended path)
-                    // which Node.js cannot handle — strip the prefix.
-                    if path_str.starts_with(r"\\?\") {
-                        path_str = path_str[4..].to_string();
-                    }
-                    return Some(path_str);
-                }
-                return Some(resolved.to_string_lossy().to_string());
+            let is_node_script = relative_path.ends_with(".js")
+                || relative_path.ends_with(".mjs")
+                || relative_path.ends_with(".cjs");
+            let is_exe = relative_path.ends_with(".exe");
+            if !is_node_script && !is_exe {
+                continue;
             }
+            let resolved = cmd_dir.join(relative_path);
+            let path_str = match resolved.canonicalize() {
+                Ok(canonical) => {
+                    let mut s = canonical.to_string_lossy().to_string();
+                    // Windows canonicalize() returns \\?\C:\... (UNC extended path)
+                    // which Node.js (and some native binaries) can't handle — strip.
+                    if s.starts_with(r"\\?\") {
+                        s = s[4..].to_string();
+                    }
+                    s
+                }
+                Err(_) => resolved.to_string_lossy().to_string(),
+            };
+            return Some(if is_node_script {
+                ResolvedShim::NodeScript(path_str)
+            } else {
+                ResolvedShim::Executable(path_str)
+            });
         }
     }
     None

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.283"
+version = "0.33.284"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.284"
+version = "0.33.285"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.283"
+version = "0.33.284"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.284"
+version = "0.33.285"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.283",
+  "version": "0.33.284",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.283",
+      "version": "0.33.284",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.284",
+  "version": "0.33.285",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.284",
+      "version": "0.33.285",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.284",
+  "version": "0.33.285",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.283",
+  "version": "0.33.284",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

`@anthropic-ai/claude-code` v2+ ships a prebuilt `claude.exe` and its npm `.cmd` wrapper invokes that `.exe` directly:

```
"%dp0%\..\@anthropic-ai\claude-code\bin\claude.exe"   %*
```

The old parser only accepted `.js/.mjs/.cjs`, fell through to the `"could not parse .cmd wrapper"` warning, and used `cmd.exe /C` — which silently drops stdio when piped, so the CLI never actually runs.

## User-visible symptom

Launch an agent pane → complete Claude OAuth in the browser → pane gets stuck on *"waiting for login to complete..."* forever. Host log shows `CheckCliAuth` firing every 2 s (from `launch-flow.ts` polling) with the parse-warning on every call. Every poll returns `authenticated=false` even though credentials are on disk.

## Fix

- `parse_cmd_wrapper` now returns a `ResolvedShim` enum (`NodeScript(path)` or `Executable(path)`).
- `make_cli_cmd` spawns either `node <script>` or `<exe>` accordingly.
- Fallback to `cmd.exe /C` is still present for shims we can't recognise.

## Test plan

- [ ] Build portable, launch agent pane, complete OAuth, confirm auth state flips to authenticated.
- [ ] Verify no `"could not parse .cmd wrapper"` warnings in host log for claude.cmd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)