### PR TITLE
docs(app-api): add user-facing App API guide + related specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Knowledge workers running AI agents across long-horizon tasks are blind while it
 
 AgentMux is an open-source desktop application that surfaces what agents are doing in real time: tool calls, reasoning steps, source citations, output streams, and conflicts between agents. The human role is observer and supervisor, not driver.
 
-Cross-platform (Windows, macOS, Linux). 100% Rust backend (Tokio + Axum). Chromium-based desktop UI. Apache 2.0.
+Cross-platform (Windows, macOS, Linux). 100% Rust backend (Tokio + Axum). CEF host (bundled Chromium). Apache 2.0.
 
 - **Live agent monitoring** — Watch every tool call and decision step as it happens. Catch an agent undoing correct work mid-task and redirect it before the damage compounds.
 - **Multi-agent orchestration** — Run parallel agents and see all of them at once. Spot conflicts before synthesis. Redirect any agent without killing the others.
@@ -42,7 +42,7 @@ Cross-platform (Windows, macOS, Linux). 100% Rust backend (Tokio + Axum). Chromi
 | Tool | Version | Purpose |
 |------|---------|---------|
 | **Node.js** | 22 LTS | Frontend build |
-| **Rust** | 1.77+ | Backend + Host |
+| **Rust** | 1.77+ | Backend + CEF host |
 | **[Task](https://taskfile.dev/)** | Latest | Build orchestration |
 | **CMake** | 3.20+ | CEF native build (cef-dll-sys) |
 | **Ninja** | 1.10+ | CEF native build (cef-dll-sys) |
@@ -56,14 +56,14 @@ Platform-specific:
 
 ```bash
 npm install        # install frontend dependencies
-task dev           # Vite hot reload
+task dev           # CEF host + Vite hot reload
 ```
 
 ### Production Build
 
 ```bash
-task package              # Windows portable ZIP
-task package:linux        # Linux portable (planned)
+task cef:package:portable        # Windows portable ZIP
+task cef:package:portable:linux  # Linux portable (planned)
 ```
 
 ## Widgets
@@ -103,6 +103,22 @@ Nothing on disk moves — working directories, GitHub CLI config dirs, and env v
 
 Click the 👤 button on any agent card to assign external accounts (GitHub PAT, AWS profile, Anthropic API key, etc.) to that agent. Accounts are stored per-agent and survive renames. You can swap, add, or unassign accounts at any time without restarting the agent.
 
+## App API
+
+AgentMux exposes a local WebSocket RPC surface so external tools and agents can drive the host — open agent panes, send messages, read output, and more. It binds to loopback only and is auth-gated per instance.
+
+```javascript
+// ws://127.0.0.1:{WS_PORT}/ws?authkey={AUTH_KEY}
+ws.send(JSON.stringify({
+  wscommand: "rpc",
+  message: { command: "agent.list", reqid: "demo-1", data: {} },
+}));
+```
+
+- **Getting started:** [`docs/api/getting-started.md`](./docs/api/getting-started.md) — connect, discover credentials, make your first call.
+- **Command reference:** [`docs/specs/app-api-extension.md`](./docs/specs/app-api-extension.md).
+- **Implementation status:** [`docs/specs/app-api-status.md`](./docs/specs/app-api-status.md).
+
 ## Architecture
 
 ```
@@ -131,16 +147,16 @@ Click the 👤 button on any agent card to assign external accounts (GitHub PAT,
 - **Backend:** Rust (Tokio + Axum + SQLite + portable-pty)
 - **Terminal:** xterm.js
 
-> **Note:** The Tauri host was removed. All code is Chromium-based.
+> **Note:** The Tauri host (`src-tauri/`) is deprecated and no longer maintained. All development uses the CEF host. Tauri code remains in the repo for reference but should not be used.
 
 ## Build Commands
 
 | Command | Description |
 |---------|-------------|
-| `task dev` | Development mode (Vite hot reload) |
-| `task package` | Windows portable ZIP with launcher |
-| `task build:host` | Build the host binary |
-| `task bundle` | Bundle runtime DLLs |
+| `task dev` | Development mode (CEF host + Vite hot reload) |
+| `task cef:build` | Build the CEF host binary |
+| `task cef:bundle` | Bundle CEF runtime DLLs |
+| `task cef:package:portable` | Windows portable ZIP with launcher |
 | `task build:backend` | Build agentmux-srv |
 | `task build:frontend` | Build frontend only |
 | `task test` | Run tests (vitest) |
@@ -172,7 +188,7 @@ Releases are built by [`agentmuxai/agentmux-builder`](https://github.com/agentmu
 
 1. The builder's workflow checks out this repo at the given ref
 2. Builds run in parallel on `ubuntu-latest`, `macos-latest`, and `windows-latest`
-3. Each job builds the Rust backend binary (agentmux-srv), then builds the host
+3. Each job builds the Rust backend binary (agentmux-srv), then builds the CEF host
 4. macOS builds are code-signed and notarized via Apple Developer credentials
 5. Windows builds include both an NSIS installer and a portable ZIP
 6. A final `create-release` job collects all artifacts and creates a GitHub Release on this repo
@@ -206,7 +222,7 @@ git push origin main
 git tag v0.X.Y && git push origin v0.X.Y
 
 # 3. Trigger the builder (builds all platforms, creates GitHub Release)
-gh workflow run build.yml -R agentmuxai/agentmux-builder -f ref=v0.X.Y
+gh workflow run tauri-build.yml -R agentmuxai/agentmux-builder -f ref=v0.X.Y
 
 # 4. Wait for build to complete (~15-20 min)
 gh run list -R agentmuxai/agentmux-builder --limit 1

--- a/README.md
+++ b/README.md
@@ -150,8 +150,6 @@ ws.send(JSON.stringify({
 - **Backend:** Rust (Tokio + Axum + SQLite + portable-pty)
 - **Terminal:** xterm.js
 
-> **Note:** The Tauri host (`src-tauri/`) is deprecated and no longer maintained. All development uses the CEF host. Tauri code remains in the repo for reference but should not be used.
-
 ## Build Commands
 
 | Command | Description |
@@ -199,9 +197,7 @@ Releases are built by [`agentmuxai/agentmux-builder`](https://github.com/agentmu
 ### Triggering a release
 
 ```bash
-# Manual workflow dispatch (pass a tag, branch, or SHA).
-# The workflow file is still named tauri-build.yml for historical reasons,
-# even though the CEF host replaced Tauri.
+# Manual workflow dispatch (pass a tag, branch, or SHA)
 gh workflow run tauri-build.yml -R agentmuxai/agentmux-builder -f ref=v0.33.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Cross-platform (Windows, macOS, Linux). 100% Rust backend (Tokio + Axum). CEF ho
 - **Live agent monitoring** — Watch every tool call and decision step as it happens. Catch an agent undoing correct work mid-task and redirect it before the damage compounds.
 - **Multi-agent orchestration** — Run parallel agents and see all of them at once. Spot conflicts before synthesis. Redirect any agent without killing the others.
 - **Guardrail observability** — See which constraints are active and firing. Tune your agent system from live signal, not post-mortem guesswork.
-- **Built-in Claude integration** — Agent sessions are first-class citizens alongside terminals, editor, and system metrics.
+- **Multi-provider agent support** — Claude Code, Codex CLI, and Gemini CLI as first-class providers, alongside terminals, editor, browser, and system metrics.
 - **Forge widget** — Agent picker wired to live Forge data for orchestration workflows.
+- **App API** — Local WebSocket RPC so external tools and agents can open panes, send messages, and read output. See [`docs/api/getting-started.md`](./docs/api/getting-started.md).
 - **Drag and drop** — Rearrange panes by dragging headers, reorder tabs, drag panes and tabs across windows.
 - **Per-pane zoom** — Independent zoom level per pane, plus global chrome zoom.
 - **Real PTY support** — Authentic terminal emulation via xterm.js and portable-pty.
@@ -62,8 +63,10 @@ task dev           # CEF host + Vite hot reload
 ### Production Build
 
 ```bash
-task cef:package:portable        # Windows portable ZIP
-task cef:package:portable:linux  # Linux portable (planned)
+task package           # Portable ZIP for the host platform
+task package:macos     # macOS DMG
+task package:linux     # Linux AppImage / deb
+task package:msix      # Windows MSIX installer
 ```
 
 ## Widgets
@@ -124,7 +127,7 @@ ws.send(JSON.stringify({
 ```
                     ┌─────────────────────────────────┐
                     │           Frontend               │
-                    │   SolidJS + xterm.js + Jotai     │
+                    │   SolidJS + xterm.js             │
                     └──────────────────┬───────────────┘
                                        │
                     ┌──────────────────▼───────────────┐
@@ -142,7 +145,7 @@ ws.send(JSON.stringify({
 ```
 
 **Stack:**
-- **Frontend:** SolidJS + TypeScript + Vite + Jotai
+- **Frontend:** SolidJS + TypeScript + Vite (state via SolidJS signals)
 - **Desktop:** CEF 146 via cef-rs — bundles its own Chromium (~148 MB ZIP, ~150 ms startup)
 - **Backend:** Rust (Tokio + Axum + SQLite + portable-pty)
 - **Terminal:** xterm.js
@@ -154,9 +157,9 @@ ws.send(JSON.stringify({
 | Command | Description |
 |---------|-------------|
 | `task dev` | Development mode (CEF host + Vite hot reload) |
-| `task cef:build` | Build the CEF host binary |
-| `task cef:bundle` | Bundle CEF runtime DLLs |
-| `task cef:package:portable` | Windows portable ZIP with launcher |
+| `task build:host` | Build the CEF host binary |
+| `task bundle` | Bundle CEF runtime DLLs |
+| `task package` | Package a portable build for the host platform |
 | `task build:backend` | Build agentmux-srv |
 | `task build:frontend` | Build frontend only |
 | `task test` | Run tests (vitest) |
@@ -196,8 +199,10 @@ Releases are built by [`agentmuxai/agentmux-builder`](https://github.com/agentmu
 ### Triggering a release
 
 ```bash
-# Manual workflow dispatch (pass a tag, branch, or SHA)
-gh workflow run build.yml -R agentmuxai/agentmux-builder -f ref=v0.33.0
+# Manual workflow dispatch (pass a tag, branch, or SHA).
+# The workflow file is still named tauri-build.yml for historical reasons,
+# even though the CEF host replaced Tauri.
+gh workflow run tauri-build.yml -R agentmuxai/agentmux-builder -f ref=v0.33.0
 ```
 
 ### Release artifacts

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Project documentation organized by type.
 | Directory | Purpose |
 |-----------|---------|
 | `analysis/` | Technical analysis, audits, benchmarks, root cause investigations |
+| `api/` | User-facing API guides (start with `api/getting-started.md`) |
 | `investigations/` | Active bug investigations with reproduction steps |
 | `reports/` | Session reports, handoff notes, bug fix summaries |
 | `research/` | Research into technologies, approaches, and design options |

--- a/docs/api/getting-started.md
+++ b/docs/api/getting-started.md
@@ -1,0 +1,142 @@
+# Getting Started with the AgentMux App API
+
+The App API lets external tools and agents control a running AgentMux
+host — open agent panes, send messages, read output, and (soon) open
+file/view panes. It speaks WSH RPC over a local WebSocket.
+
+This guide shows how to connect and make your first call.
+
+## At a glance
+
+- Transport: WebSocket on `127.0.0.1:{WS_PORT}/ws`
+- Auth: `authkey` query param or `X-AuthKey` header
+- Envelope: WSH RPC JSON
+- Scope: local only, loopback bind, auth-gated
+
+Full command reference: [`docs/specs/app-api-extension.md`](../specs/app-api-extension.md).
+Current implementation status: [`docs/specs/app-api-status.md`](../specs/app-api-status.md).
+
+## Discover connection info
+
+AgentMux doesn't publish WS_PORT or AUTH_KEY as fixed values — both
+are per-instance. There are two ways to find them.
+
+### Method 1 — parse the host log (works from any shell)
+
+```bash
+LOG=$(ls -t ~/.agentmux/logs/agentmux-host-v*.log.* | head -1)
+
+IPC_TOKEN=$(grep "ipc_token=" "$LOG" | tail -1 \
+  | sed 's/.*ipc_token=\([^&"]*\).*/\1/')
+IPC_PORT=$(grep "IPC HTTP server started" "$LOG" | tail -1 \
+  | sed 's/.*127.0.0.1:\([0-9]*\).*/\1/')
+
+AUTH_KEY=$(curl -s \
+  -H "Authorization: Bearer $IPC_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd":"get_auth_key","args":{}}' \
+  "http://127.0.0.1:$IPC_PORT/ipc" | jq -r .data)
+
+WS_PORT=$(curl -s \
+  -H "Authorization: Bearer $IPC_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"cmd":"get_backend_endpoints","args":{}}' \
+  "http://127.0.0.1:$IPC_PORT/ipc" | jq -r '.data.ws | split(":") | last')
+
+echo "ws://127.0.0.1:$WS_PORT/ws?authkey=$AUTH_KEY"
+```
+
+The IPC token is the bearer token CEF injects into the page URL. Any
+process able to read the AgentMux log can use it to ask the host for
+the backend auth key and WebSocket port.
+
+### Method 2 — from inside an agent pane
+
+Agents launched by AgentMux inherit env vars that identify the
+instance. You can read them with the same method above (the log path
+is stable), or — once shipped — use the planned `agentmux` CLI
+wrapper.
+
+## Send your first command
+
+With `WS_PORT` and `AUTH_KEY` in hand, send a WSH RPC envelope:
+
+```json
+{
+  "wscommand": "rpc",
+  "message": {
+    "command": "agent.list",
+    "reqid": "demo-1",
+    "data": {}
+  }
+}
+```
+
+Minimal Node example:
+
+```javascript
+import WebSocket from "ws";
+
+const ws = new WebSocket(`ws://127.0.0.1:${WS_PORT}/ws?authkey=${AUTH_KEY}`);
+
+ws.on("open", () => {
+  ws.send(JSON.stringify({
+    wscommand: "rpc",
+    message: { command: "agent.list", reqid: "demo-1", data: {} },
+  }));
+});
+
+ws.on("message", (buf) => console.log(buf.toString()));
+```
+
+You should see a response listing every agent pane currently open.
+
+## Common commands
+
+| Command | What it does |
+|---------|--------------|
+| `agent.list` | List open agent panes (good first call to verify the connection) |
+| `agent.open` | Open a pane running a registered agent |
+| `agent.send` | Send a user message to a running agent |
+| `agent.status` | Report an agent's state and session ID |
+| `agent.output` | Read accumulated output lines |
+| `agent.stop` | Stop an agent's controller process |
+
+Request/response shapes for each are in
+[`docs/specs/app-api-extension.md`](../specs/app-api-extension.md).
+
+## Security model
+
+- The WebSocket listens on loopback only.
+- Every request requires the backend auth key.
+- The auth key is rotated per AgentMux process — restarting the host
+  invalidates outstanding clients.
+- There is no remote/network surface.
+
+If you're writing an integration that runs on the same machine as
+AgentMux, this is the path. If you need cross-machine access, wait
+for the planned HTTP REST gateway
+([`docs/specs/app-api-extension.md`](../specs/app-api-extension.md)
+Tier 3).
+
+## Troubleshooting
+
+- **`connection refused`** — AgentMux isn't running, or the log's
+  WS_PORT is stale (the host restarted). Re-run the discovery step.
+- **`401 unauthorized`** — the auth key rotated (host restart), or
+  you pasted the IPC token instead of the backend auth key. These
+  are different values.
+- **`unknown command`** — check the command name against
+  `app-api-status.md`. Tier 1 is implemented; Tier 2+ may not be yet.
+- **`CLI_NOT_AVAILABLE` on `agent.open`** — the target provider's CLI
+  isn't installed at the expected path. Install it first; see
+  `app-api-status.md` for the exact npm command.
+
+## What's next
+
+- Tier 2 (`pane.open` and friends) — draft in
+  [`docs/specs/app-api-pane-open.md`](../specs/app-api-pane-open.md).
+- Tier 3 HTTP REST gateway and Tier 4 MCP exposure are planned; see
+  the extension spec.
+- A shell wrapper (`agentmux` CLI) that hides the discovery dance is
+  being discussed.

--- a/docs/specs/SPEC-explicit-runtime-summary.md
+++ b/docs/specs/SPEC-explicit-runtime-summary.md
@@ -1,0 +1,110 @@
+# SPEC: Explicit Runtime Summary in Agent Control Bar
+
+Status: Draft
+Owner: TBD
+Date: 2026-04-20
+
+## Problem
+
+The agent control bar, collapsed, currently shows a summary like:
+
+    Mode: Bypass · Model: Default · Effort: Default
+
+When the user hasn't picked a model or effort, `AgentRuntimeConfig.model`
+and `AgentRuntimeConfig.effort` are `null`. `buildRuntimeArgs` skips the
+`--model` and `--effort` flags in that case, so the Claude Code CLI picks
+its own default. AgentMux doesn't know what that default is, so the UI
+shows the literal word "Default".
+
+The user wants the collapsed summary to always show the **explicit**
+model and effort the agent is running with — never the placeholder
+"Default".
+
+## Goals
+
+1. Collapsed summary always shows three fields: `Mode`, `Model`, `Effort`.
+2. Each field shows the concrete value in use (e.g. `Sonnet`, `Medium`),
+   not the word "Default".
+3. The displayed value matches what the CLI actually runs with.
+
+## Non-goals
+
+- Changing the set of available models or effort levels.
+- Reworking the expanded dropdown's select controls.
+- Per-provider default resolution (scoped to Claude Code provider only
+  for now).
+
+## Approach
+
+Two viable options. Pick one.
+
+### Option A — Pin explicit defaults in `DEFAULT_RUNTIME_CONFIG`
+
+Change `DEFAULT_RUNTIME_CONFIG` in `frontend/app/view/agent/types.ts`
+from `{ model: null, effort: null }` to explicit values, e.g.
+`{ model: "sonnet", effort: "medium" }`.
+
+- `buildRuntimeArgs` will then always emit `--model sonnet --effort
+  medium`, and the UI summary renders the same explicit labels.
+- Deterministic: the CLI no longer silently picks.
+- Drawback: removes the "let the CLI decide" escape hatch. If Claude
+  Code changes its internal default, AgentMux won't follow unless we
+  bump this constant.
+
+### Option B — Display-only defaults
+
+Keep `DEFAULT_RUNTIME_CONFIG` as `null` for model/effort. In
+`AgentControlBar.compactSummary`, substitute the hardcoded display
+fallback (e.g. `"Sonnet"`, `"Medium"`) when the field is null.
+
+- CLI behavior unchanged; "Default" means "CLI picks".
+- UI drifts if Claude Code's default changes silently.
+
+### Recommendation
+
+**Option A.** Explicit beats implicit for runtime config the user is
+about to send to a subprocess. If we later want a "let CLI decide"
+option, we can add a distinct `"auto"` sentinel that the UI can
+render as such.
+
+## Concrete changes (Option A)
+
+1. `frontend/app/view/agent/types.ts`
+   - `DEFAULT_RUNTIME_CONFIG.model`: `null` → `"sonnet"`
+   - `DEFAULT_RUNTIME_CONFIG.effort`: `null` → `"medium"`
+
+2. `frontend/app/view/agent/components/AgentControlBar.tsx`
+   - `compactSummary`: drop the `r.model ? … : "Default"` fallback — it
+     will never hit null now. Render labels straight from
+     `MODEL_LABELS` / `EFFORT_LABELS`.
+   - `isNonDefault`: re-check that "non-default" indicator still works
+     when defaults are no longer null.
+
+3. `frontend/app/view/agent/buildRuntimeArgs.ts`
+   - No code change needed; the existing `if (config.model)` branch
+     fires automatically.
+
+4. Tests / smoke
+   - New session: summary reads `Mode: Bypass · Model: Sonnet · Effort:
+     Medium`. Confirm `--model sonnet --effort medium` appear in
+     launched CLI args.
+   - Existing sessions with `model: null` in block metadata: confirm
+     `getRuntimeConfig` falls back to the new defaults, so the summary
+     updates on next open.
+
+## Open questions
+
+- Effort default: `medium` or leave unset for now? Claude Code's own
+  default for `--effort` isn't documented here — confirm before
+  picking.
+- Should "Default" remain in the expanded dropdown as a distinct
+  selectable option meaning "let CLI decide"? Under Option A, that
+  option currently maps to `null`; keeping it means preserving the
+  opt-out.
+
+## Affected files
+
+- `frontend/app/view/agent/types.ts`
+- `frontend/app/view/agent/components/AgentControlBar.tsx`
+- `frontend/app/view/agent/buildRuntimeArgs.ts` (read-only)
+- `frontend/app/view/agent/commands/global/runtime.ts` (review "Default" entry)

--- a/docs/specs/app-api-pane-open.md
+++ b/docs/specs/app-api-pane-open.md
@@ -1,0 +1,174 @@
+# App API — `pane.open` Spec
+
+Status: Proposed
+Date: 2026-04-20
+Depends on: `app-api-extension.md`, `app-api-status.md`
+
+## Motivation
+
+Agents running inside an agent pane can already call the App API over
+WebSocket RPC to open/send/stop other agents (`agent.open`,
+`agent.send`, etc.). What they **can't** do today is ask the host to
+open an arbitrary view — for example, to show a spec file they just
+wrote in a preview pane next to their own pane.
+
+Today this requires the user to manually open the pane. If the agent
+could request it, typical "write a doc, then show it" and "open this
+log while I work" flows become one-shot.
+
+## Goals
+
+1. An agent can request a new pane containing a specific view (preview,
+   codeeditor, term, web, sysinfo, help).
+2. For file-backed views (preview, codeeditor), the agent supplies a
+   path and the pane opens with that file loaded.
+3. Placement is controllable: same tab (split beside current pane), new
+   tab, or a named tab.
+4. The call is idempotent where sensible — opening the same file
+   focuses the existing pane instead of creating a duplicate.
+5. The call honors AgentMux's existing block permissions and path
+   sandboxing (no exposing files outside the user's allowed roots).
+
+## Non-goals
+
+- Creating new view types.
+- Controlling pane geometry precisely (width/height in pixels).
+- Window-level operations (new window, move to window). Covered
+  elsewhere.
+- Closing or re-arranging existing panes beyond focusing an
+  already-open match.
+
+## Design principles (carried from app-api-extension.md)
+
+- High-level intent, not low-level mechanics. Agent says "show me this
+  file in a preview pane," not "CreateBlock with view=preview, SetMeta
+  file=…, …".
+- Stable contract over internal metadata keys.
+- Idempotent for file-backed opens.
+- Transport-agnostic: same command over CEF IPC, WebSocket RPC, HTTP
+  REST.
+
+## Command: `pane.open`
+
+### Request
+
+```typescript
+{
+  // What to show
+  view: "preview" | "codeeditor" | "term" | "web" | "sysinfo" | "help";
+
+  // View-specific arguments (mutually exclusive by view)
+  file?: string;      // absolute or workspace-relative path; required for preview/codeeditor
+  url?: string;       // required for web
+  cwd?: string;       // optional for term (defaults to current pane's cwd)
+
+  // Placement
+  placement?: {
+    tab?: "current" | "new" | string;   // default "current"; string = tab name
+    split?: "right" | "below" | "tab";  // default "right" when tab=current
+    focus?: boolean;                    // default true
+  };
+
+  // Behavior
+  idempotent?: boolean;  // default true for file/url views, false for term
+  title?: string;        // optional explicit pane title
+}
+```
+
+### Response
+
+```typescript
+{
+  blockId: string;       // created or reused pane
+  tabId: string;
+  created: boolean;      // false if we focused an existing match
+}
+```
+
+### Errors
+
+- `INVALID_VIEW` — unknown view.
+- `MISSING_ARG` — view requires `file`/`url`/etc. and it wasn't
+  provided.
+- `PATH_DENIED` — path falls outside allowed roots.
+- `FILE_NOT_FOUND` — file doesn't exist when view=preview/codeeditor
+  and `allowMissing` is not set.
+- `TAB_NOT_FOUND` — `placement.tab` was a name that doesn't exist and
+  `createTab` wasn't requested.
+
+### Idempotency rules
+
+When `idempotent` is true (default for file/url views):
+- For `preview` / `codeeditor`: if a pane in the target tab already
+  has the same view and the same resolved absolute file path, focus
+  it and return `created: false`.
+- For `web`: same-origin + same path match → focus.
+- `term` / `sysinfo` / `help`: no dedup; always create.
+
+### Path resolution
+
+- Absolute paths are used as-is, then validated against allowed roots.
+- Relative paths resolve against the calling pane's `cmd:cwd` (for
+  agent panes) or the workspace root.
+- Paths containing `..` that escape allowed roots are rejected with
+  `PATH_DENIED`.
+
+### Sandboxing
+
+The existing filesystem access controls that apply to the `preview`
+and `codeeditor` views (user-allowed roots) apply here. This command
+does not widen access — it only surfaces a file the user could open
+manually.
+
+## Tier assignment
+
+Tier 2 in the existing app-api-extension.md taxonomy (UI
+orchestration, high-value but not on the critical path of agent
+lifecycle).
+
+## Implementation sketch
+
+1. Add `PaneOpenRequest` / `PaneOpenResponse` to
+   `agentmux-srv/src/backend/rpc_types.rs`.
+2. Add a handler in `agentmux-srv/src/server/app_api.rs` that:
+   - validates the request (view + required fields),
+   - resolves the path / URL,
+   - searches the current tab's blocks for an existing match when
+     idempotent,
+   - otherwise orchestrates `CreateBlock` → `SetMeta` with the view's
+     expected metadata keys,
+   - applies placement via the existing split/tab layout APIs.
+3. Expose the same handler over CEF IPC for in-process callers, and
+   (Tier 3) over the HTTP REST surface when it lands.
+4. Update `docs/specs/app-api-status.md` with implementation status.
+
+## Discoverability for agents
+
+Update the agent startup/system prompt generation to mention
+`pane.open` alongside `agent.send` / `agent.open`, with a one-line
+example. Without discoverability, no agent will know to call it.
+
+## Open questions
+
+- Should we ship a thin shell wrapper (`agentmux pane open <file>`)
+  so shell-based agents can call this without writing a WebSocket
+  client? Aligns with the "CLI tool" gap noted in `app-api-status.md`.
+- Placement grammar: do we need `split: "left" | "above"` for
+  completeness, or is "right / below / new tab" sufficient for agent
+  use cases?
+- Should `pane.open` accept multiple files and open them as a group
+  (common when writing a spec + opening the affected source files)?
+- Permission model: do we want a per-agent capability check before
+  honoring `pane.open`, or is the existing App API authkey sufficient?
+
+## Affected files
+
+- `agentmux-srv/src/server/app_api.rs`
+- `agentmux-srv/src/backend/rpc_types.rs`
+- `agentmux-srv/src/backend/blocks.rs` (or wherever block creation
+  lives) — confirm CreateBlock + layout helpers are callable from the
+  App API handler
+- `frontend/app/store/wshrpc` CEF IPC surface (if we also expose this
+  in-process)
+- `docs/specs/app-api-extension.md` — cross-reference
+- `docs/specs/app-api-status.md` — add status row


### PR DESCRIPTION
## Summary

- Add `docs/api/getting-started.md` — user-facing guide for connecting to the App API (WebSocket, auth key discovery, first call, common commands, troubleshooting).
- Surface the App API from `README.md` with a short section between *Agents* and *Architecture*, linking to the guide and the existing specs.
- Index the new `docs/api/` directory in `docs/README.md`.
- Add two related specs:
  - `docs/specs/SPEC-explicit-runtime-summary.md` — collapsed Agent Control Bar should show explicit Mode/Model/Effort instead of the word "Default".
  - `docs/specs/app-api-pane-open.md` — Tier 2 `pane.open` command so agents can request a file/view pane. Follow-up to `app-api-extension.md`.

## Motivation

The App API (`agent.open`, `agent.send`, etc. in `agentmux-srv/src/server/app_api.rs`) is fully implemented but only documented in internal design specs. External agents and integrators have no obvious entry point — connection info (auth key + WS_PORT discovery) is buried in a status doc as a bash snippet.

## Test plan

- [ ] Read-through `docs/api/getting-started.md` for accuracy of the auth discovery steps (log path, IPC endpoint, backend auth key extraction).
- [ ] Verify README links resolve: `./docs/api/getting-started.md`, `./docs/specs/app-api-extension.md`, `./docs/specs/app-api-status.md`.
- [ ] Verify `docs/README.md` table renders with the new `api/` row.
- [ ] (Optional) Try the Node example in the guide against a running instance to confirm it connects and gets a response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)