### PR TITLE
refactor(agent): rename pinnedToolNodes → pinnedNodes (hover-unification phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.285"
+version = "0.33.286"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.285"
+version = "0.33.286"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.285"
+version = "0.33.286"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.285"
+version = "0.33.286"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.285"
+version = "0.33.286"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.285"
+version = "0.33.286"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.285"
+version = "0.33.286"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.285"
+version = "0.33.286"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -176,13 +176,13 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
     // docs/specs/tool-collapse.md.
     const toggleToolPin = (nodeId: string) => {
         setDocumentState((prev) => {
-            const pinned = new Set(prev.pinnedToolNodes);
+            const pinned = new Set(prev.pinnedNodes);
             if (pinned.has(nodeId)) {
                 pinned.delete(nodeId);
             } else {
                 pinned.add(nodeId);
             }
-            return { ...prev, pinnedToolNodes: pinned };
+            return { ...prev, pinnedNodes: pinned };
         });
     };
 
@@ -427,7 +427,7 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                 node={node}
                                 collapsed={documentState().collapsedNodes.has(node.id)}
                                 onToggle={() => toggleCollapse(node.id)}
-                                toolPinned={documentState().pinnedToolNodes.has(node.id)}
+                                toolPinned={documentState().pinnedNodes.has(node.id)}
                                 onToggleToolPin={() => toggleToolPin(node.id)}
                                 onSubagentClick={onSubagentClick}
                             />

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -44,7 +44,7 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         documentAtom: createSignal<DocumentNode[]>([]),
         documentStateAtom: createSignal<DocumentState>({
             collapsedNodes: new Set<string>(),
-            pinnedToolNodes: new Set<string>(),
+            pinnedNodes: new Set<string>(),
             scrollPosition: 0,
             selectedNode: null,
             filter: {

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -304,11 +304,12 @@ export interface Bookmark {
 export interface DocumentState {
     collapsedNodes: Set<string>; // Node IDs that are collapsed (agent messages)
     /**
-     * Tool nodes the user has clicked to PIN open. A tool node renders
-     * expanded when pinned OR hovered OR status is running/failed.
-     * Default is collapsed — see docs/specs/tool-collapse.md.
+     * Nodes the user has clicked to PIN expanded. For tool nodes this opens
+     * the portal overlay with tool-specific content; for other kinds this is
+     * used by future expansion surfaces. Default is collapsed — see
+     * docs/specs/tool-collapse.md.
      */
-    pinnedToolNodes: Set<string>;
+    pinnedNodes: Set<string>;
     scrollPosition: number;
     selectedNode: string | null; // For keyboard navigation
     filter: FilterState;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "agentmux",
-  "version": "0.33.285",
+  "version": "0.33.286",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.285",
+  "version": "0.33.286",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Renames `pinnedToolNodes` → `pinnedNodes` in `DocumentState` (types.ts, state.ts, AgentDocumentView.tsx)
- Pure compiler-guaranteed refactor — 5 references, no behavior change, TypeScript clean
- Widens the field's semantic scope from tool-only to any node kind, unblocking phases 2-8 of the hover-unification plan

## Context

Part of the hover-unification refactor (`docs/specs/hover-unification-implementation-plan.md`). AgentX completed this rename; AgentY is picking up from here.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Open agent pane, click to pin a tool — stays pinned
- [ ] `grep pinnedToolNodes frontend/` returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)