### PR TITLE
feat(agent-runtime): show explicit Mode/Model/Effort in collapsed control bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.286"
+version = "0.33.287"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.286"
+version = "0.33.287"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.286"
+version = "0.33.287"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.286"
+version = "0.33.287"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.286"
+version = "0.33.287"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.286"
+version = "0.33.287"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.286"
+version = "0.33.287"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.286"
+version = "0.33.287"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -72,15 +72,8 @@ export function buildRuntimeArgs(
     const permFlags = PERMISSION_FLAGS[config.permissionMode] ?? PERMISSION_FLAGS.bypass;
     args.push(...permFlags);
 
-    // Apply model if set
-    if (config.model) {
-        args.push("--model", config.model);
-    }
-
-    // Apply effort if set
-    if (config.effort) {
-        args.push("--effort", config.effort);
-    }
+    args.push("--model", config.model);
+    args.push("--effort", config.effort);
 
     return args;
 }

--- a/frontend/app/view/agent/commands/global/runtime.ts
+++ b/frontend/app/view/agent/commands/global/runtime.ts
@@ -68,7 +68,6 @@ function modelChoices(ctx: SlashCommandContext): SlashChoice[] {
         { ...make("opus", "Opus", "Claude Opus — highest quality", "opus"), aliases: ["claude-opus"] },
         { ...make("sonnet", "Sonnet", "Claude Sonnet — balanced", "sonnet"), aliases: ["claude-sonnet"] },
         { ...make("haiku", "Haiku", "Claude Haiku — fastest", "haiku"), aliases: ["claude-haiku"] },
-        make("default", "Default", "Provider default", null),
     ];
 }
 
@@ -79,11 +78,9 @@ export const modelCommand: SlashCommand = {
     arg: { kind: "enum", required: true, choices: modelChoices },
     availability: "any-agent",
     handler: async (ctx, arg): Promise<SlashResult> => {
-        const model: ModelChoice = arg === "default" ? null : (arg as ModelChoice);
-        const result = await updateRuntime(ctx, { model });
+        const result = await updateRuntime(ctx, { model: arg as ModelChoice });
         if (result.ok === false) return runtimeError(result.error);
-        const label = result.updated.model ?? "default";
-        return { kind: "ok", message: `model set to ${label} (applies to next turn)` };
+        return { kind: "ok", message: `model set to ${result.updated.model} (applies to next turn)` };
     },
 };
 
@@ -109,7 +106,6 @@ function effortChoices(ctx: SlashCommandContext): SlashChoice[] {
         make("medium", "Medium", "Balanced reasoning effort", "medium", ["med"]),
         make("high", "High", "High reasoning effort", "high"),
         make("max", "Max", "Maximum reasoning effort", "max"),
-        make("default", "Default", "Provider default", null),
     ];
 }
 
@@ -120,11 +116,9 @@ export const effortCommand: SlashCommand = {
     arg: { kind: "enum", required: true, choices: effortChoices },
     availability: "any-agent",
     handler: async (ctx, arg): Promise<SlashResult> => {
-        const effort: EffortLevel = arg === "default" ? null : (arg as EffortLevel);
-        const result = await updateRuntime(ctx, { effort });
+        const result = await updateRuntime(ctx, { effort: arg as EffortLevel });
         if (result.ok === false) return runtimeError(result.error);
-        const label = result.updated.effort ?? "default";
-        return { kind: "ok", message: `effort set to ${label} (applies to next turn)` };
+        return { kind: "ok", message: `effort set to ${result.updated.effort} (applies to next turn)` };
     },
 };
 
@@ -239,8 +233,8 @@ export const runtimeCommand: SlashCommand = {
         const r = getRuntimeConfig(ctx.block()?.meta);
         const parts = [
             `permission: ${r.permissionMode}`,
-            `model: ${r.model ?? "default"}`,
-            `effort: ${r.effort ?? "default"}`,
+            `model: ${r.model}`,
+            `effort: ${r.effort}`,
         ];
         return { kind: "ok", message: `runtime config — ${parts.join(" · ")}` };
     },

--- a/frontend/app/view/agent/components/AgentControlBar.tsx
+++ b/frontend/app/view/agent/components/AgentControlBar.tsx
@@ -87,10 +87,11 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
 
     const compactSummary = (): string => {
         const r = runtime();
-        const parts: string[] = [PERMISSION_LABELS[r.permissionMode]];
-        if (r.model) parts.push(MODEL_LABELS[r.model] || r.model);
-        if (r.effort) parts.push(`Effort: ${EFFORT_LABELS[r.effort] || r.effort}`);
-        return parts.join(" · ");
+        return [
+            PERMISSION_LABELS[r.permissionMode],
+            MODEL_LABELS[r.model] || r.model,
+            `Effort: ${EFFORT_LABELS[r.effort] || r.effort}`,
+        ].join(" · ");
     };
 
     // ── Session management helpers ──────────────────────────────────────────────
@@ -284,10 +285,9 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
                         <label class="agent-control-label">Model</label>
                         <select
                             class="agent-control-select"
-                            value={runtime().model ?? ""}
-                            onChange={(e) => updateRuntime({ model: (e.target.value || null) as ModelChoice })}
+                            value={runtime().model}
+                            onChange={(e) => updateRuntime({ model: e.target.value as ModelChoice })}
                         >
-                            <option value="">Default</option>
                             <option value="opus">Opus</option>
                             <option value="sonnet">Sonnet</option>
                             <option value="haiku">Haiku</option>
@@ -297,10 +297,9 @@ export const AgentControlBar = ({ blockId, blockAtom, providerId }: AgentControl
                         <label class="agent-control-label">Effort</label>
                         <select
                             class="agent-control-select"
-                            value={runtime().effort ?? ""}
-                            onChange={(e) => updateRuntime({ effort: (e.target.value || null) as EffortLevel })}
+                            value={runtime().effort}
+                            onChange={(e) => updateRuntime({ effort: e.target.value as EffortLevel })}
                         >
-                            <option value="">Default</option>
                             <option value="low">Low</option>
                             <option value="medium">Medium</option>
                             <option value="high">High</option>

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -345,8 +345,8 @@ export type LogFn = (tag: string, text: string, level?: "info" | "error" | "warn
  * Applied as CLI flags on each turn (between --resume spawns).
  */
 export type PermissionMode = "bypass" | "auto" | "acceptEdits" | "plan" | "default";
-export type ModelChoice = null | "opus" | "sonnet" | "haiku";
-export type EffortLevel = null | "low" | "medium" | "high" | "max";
+export type ModelChoice = "opus" | "sonnet" | "haiku";
+export type EffortLevel = "low" | "medium" | "high" | "max";
 
 export interface AgentRuntimeConfig {
     permissionMode: PermissionMode;
@@ -356,8 +356,8 @@ export interface AgentRuntimeConfig {
 
 export const DEFAULT_RUNTIME_CONFIG: AgentRuntimeConfig = {
     permissionMode: "bypass",
-    model: null,
-    effort: null,
+    model: "sonnet",
+    effort: "medium",
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.286",
+  "version": "0.33.287",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Implements Option A from `docs/specs/SPEC-explicit-runtime-summary.md` (merged in #463).

The collapsed Agent Control Bar now always shows all three runtime values — `Mode · Model · Effort: <Value>` — instead of hiding Model and Effort when they're at their defaults. To make that work cleanly, defaults are now explicit values rather than \"let the CLI decide\".

## Changes

- **`types.ts`** — `ModelChoice` and `EffortLevel` drop `null` from their unions. `DEFAULT_RUNTIME_CONFIG.model` → `\"sonnet\"`, `DEFAULT_RUNTIME_CONFIG.effort` → `\"medium\"`.
- **`AgentControlBar.tsx`** — `compactSummary` always renders all three; the Model and Effort selects no longer have a \"Default\" option that would round-trip to a concrete value.
- **`commands/global/runtime.ts`** — `/model` and `/effort` slash commands drop their `default` choice; `/runtime` drops its `?? \"default\"` fallbacks.
- **`buildRuntimeArgs.ts`** — `--model` and `--effort` are now always appended to the CLI invocation (was conditional).

## Migration

Existing sessions with `model: null` or `effort: null` stored in block metadata resolve to the new defaults automatically via the existing `??` fallback in `getRuntimeConfig`.

## Test plan

- [x] `npx vitest run frontend/app/view/agent/` → 110 passed.
- [x] `tsc --noEmit` clean in touched files (pre-existing codemirror errors unrelated).
- [ ] Open a new agent pane — collapsed bar reads \"Bypass · Sonnet · Effort: Medium\".
- [ ] Open the dropdown — Model and Effort selects no longer show \"Default\"; current values are highlighted.
- [ ] Run a turn — verify `--model sonnet --effort medium` land in the spawned CLI args.
- [ ] Restore an older session that was saved with `model: null` — verify it resolves to Sonnet on next open and works unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)