### PR TITLE
feat(app-api): implement pane.open for programmatic pane creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.287"
+version = "0.33.288"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.287"
+version = "0.33.288"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.287"
+version = "0.33.288"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.287"
+version = "0.33.288"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.287"
+version = "0.33.288"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.287"
+version = "0.33.288"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.287"
+version = "0.33.288"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.287"
+version = "0.33.288"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -296,6 +296,9 @@ pub const COMMAND_AGENT_LIST: &str = "agent.list";
 pub const COMMAND_AGENT_OUTPUT: &str = "agent.output";
 pub const COMMAND_AGENT_STREAM: &str = "agent.stream";
 
+// App API Tier 2 — pane lifecycle commands
+pub const COMMAND_PANE_OPEN: &str = "pane.open";
+
 // App API Tier 1 — blockfile pagination commands
 pub const COMMAND_BLOCKFILE_LINE_COUNT: &str = "blockfile:line_count";
 pub const COMMAND_BLOCKFILE_READ_RANGE: &str = "blockfile:read_range";
@@ -619,6 +622,37 @@ pub struct AgentOpenResult {
     pub provider: String,
     pub controller_type: String,
     pub status: String,
+    pub created: bool,
+}
+
+/// Request for pane.open — create a new pane showing the given view.
+///
+/// Supported views: `editor`, `term`, `browser`, `sysinfo`, `help`.
+/// `file` is required for `editor`; `url` is required for `browser`.
+/// Placement: if `split_direction` ("right" / "left" / "down" / "up")
+/// and `split_reference_block_id` are provided, the new pane splits
+/// relative to that block. Otherwise it is inserted at the tab root.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CommandPaneOpenData {
+    pub view: String,
+    pub file: Option<String>,
+    pub url: Option<String>,
+    pub cwd: Option<String>,
+    pub title: Option<String>,
+    pub tab_id: Option<String>,
+    pub split_direction: Option<String>,
+    pub split_reference_block_id: Option<String>,
+    pub focus: Option<bool>,
+}
+
+/// Response from pane.open.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct PaneOpenResult {
+    pub block_id: String,
+    pub tab_id: String,
+    pub view: String,
     pub created: bool,
 }
 

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -27,6 +27,7 @@ pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     register_agent_status(engine, state);
     register_agent_list(engine, state);
     register_agent_output(engine, state);
+    register_pane_open(engine, state);
     register_blockfile_line_count(engine, state);
     register_blockfile_read_range(engine, state);
     register_session_digest(engine, state);
@@ -589,6 +590,190 @@ fn register_agent_output(engine: &Arc<WshRpcEngine>, state: &AppState) {
             })
         }),
     );
+}
+
+// ---------------------------------------------------------------------------
+// pane.open
+// ---------------------------------------------------------------------------
+
+fn register_pane_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let wstore = state.wstore.clone();
+    let event_bus = state.event_bus.clone();
+
+    engine.register_handler(
+        COMMAND_PANE_OPEN,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let event_bus = event_bus.clone();
+            Box::pin(async move {
+                let cmd: CommandPaneOpenData = serde_json::from_value(data)
+                    .map_err(|e| format!("pane.open: {e}"))?;
+
+                tracing::info!(view = %cmd.view, "pane.open");
+
+                // Build meta for the requested view, validating required args
+                let meta = build_pane_meta(&cmd)?;
+
+                // Resolve tab
+                let tab_id = resolve_tab_id(&wstore, cmd.tab_id.as_deref())?;
+
+                // Create block
+                let block = crate::backend::wcore::create_block(&wstore, &tab_id, meta)
+                    .map_err(|e| format!("pane.open: create_block: {e}"))?;
+                let block_id = block.oid.clone();
+
+                // Enqueue layout action — split if requested, else append
+                let (actiontype, targetblockid, position) = resolve_placement(
+                    cmd.split_direction.as_deref(),
+                    cmd.split_reference_block_id.as_deref(),
+                );
+                let focused = cmd.focus.unwrap_or(true);
+
+                {
+                    let tab: Tab = wstore.must_get(&tab_id)
+                        .map_err(|e| format!("pane.open: reload tab: {e}"))?;
+                    if let Ok(mut layout) = wstore.must_get::<obj::LayoutState>(&tab.layoutstate) {
+                        let mut actions = layout.pendingbackendactions.take().unwrap_or_default();
+                        actions.push(obj::LayoutActionData {
+                            actiontype,
+                            actionid: uuid::Uuid::new_v4().to_string(),
+                            blockid: block_id.clone(),
+                            nodesize: None,
+                            indexarr: None,
+                            focused,
+                            magnified: false,
+                            ephemeral: false,
+                            targetblockid,
+                            position,
+                        });
+                        layout.pendingbackendactions = Some(actions);
+                        let _ = wstore.update(&mut layout);
+                    }
+                }
+
+                tracing::info!(
+                    block_id = %block_id,
+                    view = %cmd.view,
+                    "pane.open: block created + layout updated"
+                );
+
+                // Broadcast block + tab + layout updates
+                {
+                    let mut updates = Vec::new();
+                    if let Ok(updated_block) = wstore.must_get::<Block>(&block_id) {
+                        updates.push(obj::WaveObjUpdate {
+                            updatetype: "update".into(),
+                            otype: "block".into(),
+                            oid: block_id.clone(),
+                            obj: Some(obj::wave_obj_to_value(&updated_block)),
+                        });
+                    }
+                    if let Ok(updated_tab) = wstore.must_get::<Tab>(&tab_id) {
+                        updates.push(obj::WaveObjUpdate {
+                            updatetype: "update".into(),
+                            otype: "tab".into(),
+                            oid: tab_id.clone(),
+                            obj: Some(obj::wave_obj_to_value(&updated_tab)),
+                        });
+                        if let Ok(updated_layout) = wstore.must_get::<obj::LayoutState>(&updated_tab.layoutstate) {
+                            updates.push(obj::WaveObjUpdate {
+                                updatetype: "update".into(),
+                                otype: "layout".into(),
+                                oid: updated_tab.layoutstate.clone(),
+                                obj: Some(obj::wave_obj_to_value(&updated_layout)),
+                            });
+                        }
+                    }
+                    for update in &updates {
+                        let oref = format!("{}:{}", update.otype, update.oid);
+                        if let Ok(data) = serde_json::to_value(update) {
+                            event_bus.broadcast_event(
+                                &crate::backend::eventbus::WSEventType {
+                                    eventtype: "waveobj:update".to_string(),
+                                    oref,
+                                    data: Some(data),
+                                },
+                            );
+                        }
+                    }
+                }
+
+                Ok(Some(serde_json::to_value(&PaneOpenResult {
+                    block_id,
+                    tab_id,
+                    view: cmd.view,
+                    created: true,
+                }).unwrap()))
+            })
+        }),
+    );
+}
+
+/// Build the metadata map for a pane.open request, validating required args.
+fn build_pane_meta(cmd: &CommandPaneOpenData) -> Result<MetaMapType, String> {
+    let mut meta = MetaMapType::new();
+
+    match cmd.view.as_str() {
+        "editor" => {
+            let file = cmd.file.as_deref().filter(|s| !s.is_empty())
+                .ok_or_else(|| "MISSING_ARG: view=editor requires 'file'".to_string())?;
+            meta.insert("view".to_string(), json!("editor"));
+            meta.insert("file".to_string(), json!(file));
+        }
+        "term" => {
+            meta.insert("view".to_string(), json!("term"));
+            meta.insert("controller".to_string(), json!("shell"));
+            if let Some(cwd) = cmd.cwd.as_deref().filter(|s| !s.is_empty()) {
+                meta.insert("cmd:cwd".to_string(), json!(cwd));
+            }
+        }
+        "browser" => {
+            let url = cmd.url.as_deref().filter(|s| !s.is_empty())
+                .ok_or_else(|| "MISSING_ARG: view=browser requires 'url'".to_string())?;
+            meta.insert("view".to_string(), json!("browser"));
+            meta.insert("url".to_string(), json!(url));
+        }
+        "sysinfo" => {
+            meta.insert("view".to_string(), json!("sysinfo"));
+        }
+        "help" => {
+            meta.insert("view".to_string(), json!("help"));
+        }
+        other => {
+            return Err(format!(
+                "INVALID_VIEW: unsupported view '{other}' (expected editor/term/browser/sysinfo/help)"
+            ));
+        }
+    }
+
+    if let Some(title) = cmd.title.as_deref().filter(|s| !s.is_empty()) {
+        meta.insert("frame:title".to_string(), json!(title));
+    }
+
+    Ok(meta)
+}
+
+/// Translate `split_direction` + `split_reference_block_id` into the backend
+/// layout action triple. Returns `(actiontype, targetblockid, position)`.
+/// Falls back to a plain `insert` if direction/reference are missing.
+fn resolve_placement(
+    direction: Option<&str>,
+    reference: Option<&str>,
+) -> (String, String, String) {
+    let reference = match reference.filter(|s| !s.is_empty()) {
+        Some(r) => r,
+        None => return ("insert".to_string(), String::new(), String::new()),
+    };
+
+    let (actiontype, position) = match direction {
+        Some("right") => (crate::backend::wcore::LAYOUT_ACTION_SPLIT_HORIZONTAL, "after"),
+        Some("left") => (crate::backend::wcore::LAYOUT_ACTION_SPLIT_HORIZONTAL, "before"),
+        Some("down") | Some("below") => (crate::backend::wcore::LAYOUT_ACTION_SPLIT_VERTICAL, "after"),
+        Some("up") | Some("above") => (crate::backend::wcore::LAYOUT_ACTION_SPLIT_VERTICAL, "before"),
+        _ => return ("insert".to_string(), String::new(), String::new()),
+    };
+
+    (actiontype.to_string(), reference.to_string(), position.to_string())
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/specs/app-api-status.md
+++ b/docs/specs/app-api-status.md
@@ -20,6 +20,7 @@ All Tier 1 commands register on the WSH RPC engine and respond correctly:
 | `agent.status` | Working | Returns agent state, session ID, exit code |
 | `agent.list` | Working | Lists all agent panes across tabs |
 | `agent.output` | Implemented | Reads broker event history (needs persist > 0 for blockfile events) |
+| `pane.open` | Implemented | Creates a block for view `editor`/`term`/`browser`/`sysinfo`/`help`, optionally split-placed against a reference block. MVP: no idempotency, no new-tab placement, no path sandboxing — see `app-api-pane-open.md`. |
 
 ### WebSocket Protocol
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.287",
+  "version": "0.33.288",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Implements the `pane.open` Tier 2 command per `docs/specs/app-api-pane-open.md` (merged in #463). Lets external tools and agents open a non-agent pane in the host via the App API — an editor (file), term (shell), browser (url), sysinfo, or help pane — optionally split-placed against a reference block.

Motivation: agents writing files (e.g. a spec) can now ask the host to show that file to the user next to the agent pane, instead of telling the user to open it manually.

## Changes

- **`backend/rpc_types.rs`** — add `COMMAND_PANE_OPEN` constant, `CommandPaneOpenData`, `PaneOpenResult`.
- **`server/app_api.rs`** — add `register_pane_open` handler plus two small helpers:
  - `build_pane_meta` validates `view`, requires `file` for editor and `url` for browser, and writes the view-specific metadata (`view`, `file`, `url`, `cmd:cwd`, `frame:title`).
  - `resolve_placement` translates `split_direction` (`right`/`left`/`down`/`up` with aliases) into the backend layout action triple (`splithorizontal`/`splitvertical` + `after`/`before`), falling back to plain `insert`.
- Handler mirrors the `agent.open` pattern: `create_block` → push `LayoutActionData` onto `LayoutState.pendingbackendactions` → broadcast three `waveobj:update` events (block/tab/layout). That's the same mechanism used by cross-window DnD and `agent.open` since 0.33.83 (see `app-api-status.md`).
- **`docs/specs/app-api-status.md`** — status row added.
- **Version bump** 0.33.287 → 0.33.288.

## MVP scope (deferred to follow-ups)

- Views: `editor`, `term`, `browser`, `sysinfo`, `help`. The spec mentioned `preview` / `codeeditor` but those aren't registered `BlockRegistry` entries — `editor` + `browser` cover their use cases.
- **No idempotency** — always creates a new block. Open spec question: focus-if-already-open for file views.
- **No new-tab placement** — `tab_id` must be current or explicit.
- **No path sandboxing at this layer** — relies on the view's own file-access gating. The spec's open question about extracting a shared `validate_path_under_roots` helper is deferred.

## Test plan

- [x] `cargo check -p agentmux-srv` clean (10 pre-existing warnings, none from new code).
- [ ] Via WebSocket: `pane.open { view: \"editor\", file: \"<path>\" }` opens an editor pane.
- [ ] With `split_direction: \"right\"` + `split_reference_block_id`, the pane splits right of the reference.
- [ ] `pane.open { view: \"term\", cwd: \"<path>\" }` opens a shell terminal in the given cwd.
- [ ] `pane.open { view: \"sysinfo\" }` opens the sysinfo widget.
- [ ] Invalid view → returns `INVALID_VIEW: ...` error.
- [ ] `view: \"editor\"` without `file` → `MISSING_ARG: view=editor requires 'file'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)