### PR TITLE
feat(agent): merge bookmark button into NodeHoverStrip (hover-unification phase 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.289"
+version = "0.33.290"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.289"
+version = "0.33.290"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.289"
+version = "0.33.290"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.289"
+version = "0.33.290"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.289"
+version = "0.33.290"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.289"
+version = "0.33.290"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.289"
+version = "0.33.290"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.289"
+version = "0.33.290"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -85,6 +85,37 @@
             color: var(--secondary-text-color);
             font-variant-numeric: tabular-nums;
         }
+
+        .node-strip-btn {
+            pointer-events: auto;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1px 4px;
+            background: transparent;
+            border: none;
+            border-radius: 3px;
+            color: var(--secondary-text-color);
+            cursor: pointer;
+            font-size: 11px;
+            line-height: 1.2;
+
+            &:hover:not(:disabled) {
+                background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
+                color: var(--main-text-color);
+            }
+
+            &--active {
+                color: var(--warning-color, #eab308);
+            }
+
+            &:disabled,
+            &--disabled {
+                opacity: 0.35;
+                cursor: not-allowed;
+                pointer-events: none;
+            }
+        }
     }
 
     // === Status Log (terminal-style) ===
@@ -2814,48 +2845,6 @@
     .agent-node-bookmarked {
         border-left: 2px solid var(--warning-color, #eab308) !important;
         padding-left: 2px;
-        position: relative;
-    }
-
-    // Small bookmark button shown on hover in the top-right corner of each node wrapper.
-    .agent-bookmark-btn {
-        position: absolute;
-        top: 2px;
-        right: 2px;
-        width: 18px;
-        height: 18px;
-        padding: 0;
-        background: none;
-        border: none;
-        border-radius: 3px;
-        font-size: 11px;
-        line-height: 18px;
-        text-align: center;
-        cursor: pointer;
-        color: var(--secondary-text-color);
-        opacity: 0;
-        transition: opacity 0.12s, color 0.12s, background 0.12s;
-        z-index: 2;
-        user-select: none;
-
-        &--active {
-            color: var(--warning-color, #eab308);
-            opacity: 0.9;
-        }
-
-        &:hover {
-            background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
-            color: var(--warning-color, #eab308);
-        }
-    }
-
-    // Show the bookmark button when the parent wrapper is hovered.
-    .agent-document-node-wrapper:hover .agent-bookmark-btn {
-        opacity: 0.7;
-    }
-
-    // Node wrapper must be position:relative so the absolute bookmark btn works.
-    .agent-document-node-wrapper {
         position: relative;
     }
 

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -412,17 +412,6 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                             data-node-id={node.id}
                             onContextMenu={handleContextMenu}
                         >
-                            {/* Bookmark indicator button — shown on hover */}
-                            <Show when={onBookmark != null}>
-                                <button
-                                    class="agent-bookmark-btn"
-                                    classList={{ "agent-bookmark-btn--active": isBookmarked() }}
-                                    onClick={(e) => { e.stopPropagation(); onBookmark!(node); }}
-                                    title={isBookmarked() ? "Remove bookmark" : "Bookmark this message"}
-                                >
-                                    {isBookmarked() ? "\uD83D\uDD16" : "\uD83D\uDD16"}
-                                </button>
-                            </Show>
                             <DocumentNodeRenderer
                                 node={node}
                                 collapsed={documentState().collapsedNodes.has(node.id)}
@@ -431,7 +420,12 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                 onToggleToolPin={() => toggleToolPin(node.id)}
                                 onSubagentClick={onSubagentClick}
                             />
-                            <NodeHoverStrip timestamp={(node as any).timestamp} nodeId={node.id} />
+                            <NodeHoverStrip
+                                timestamp={(node as any).timestamp}
+                                nodeId={node.id}
+                                isBookmarked={isBookmarked()}
+                                onBookmark={onBookmark != null ? () => onBookmark(node) : undefined}
+                            />
                         </div>
                     );
                 }}

--- a/frontend/app/view/agent/components/NodeHoverStrip.tsx
+++ b/frontend/app/view/agent/components/NodeHoverStrip.tsx
@@ -50,17 +50,19 @@ const StripButton = (props: StripButtonProps): JSX.Element => {
 };
 
 export const NodeHoverStrip = (props: NodeHoverStripProps): JSX.Element => (
-    <Show when={props.timestamp != null}>
+    <Show when={props.timestamp != null || props.onBookmark != null}>
         <div
             class="node-strip"
             data-node-strip-for={props.nodeId}
         >
-            <time
-                class="node-strip-time"
-                dateTime={new Date(props.timestamp!).toISOString()}
-            >
-                {formatLocalized(props.timestamp!)}
-            </time>
+            <Show when={props.timestamp != null}>
+                <time
+                    class="node-strip-time"
+                    dateTime={new Date(props.timestamp!).toISOString()}
+                >
+                    {formatLocalized(props.timestamp!)}
+                </time>
+            </Show>
             <Show when={props.onBookmark}>
                 <StripButton
                     icon="🔖"

--- a/frontend/app/view/agent/components/NodeHoverStrip.tsx
+++ b/frontend/app/view/agent/components/NodeHoverStrip.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * NodeHoverStrip — row-level hover strip with timestamp and (later) action
- * buttons. Visibility is pure CSS (.agent-document-node-wrapper:hover and
- * :focus-within). No JS signals for show/hide.
+ * NodeHoverStrip — row-level hover strip with timestamp and action buttons.
+ * Visibility is pure CSS (.agent-document-node-wrapper:hover and :focus-within).
+ * No JS signals for show/hide.
  *
  * SolidJS reactivity: props are never destructured. See AgentDocumentView.tsx
  * (comment above DocumentNodeRenderer) for the reactivity rule and rationale.
@@ -15,7 +15,39 @@ import { Show, type JSX } from "solid-js";
 interface NodeHoverStripProps {
     timestamp?: number; // Unix ms
     nodeId: string;
+    isBookmarked?: boolean;
+    onBookmark?: () => void;
 }
+
+interface StripButtonProps {
+    icon: string;
+    label: string;
+    active?: boolean;
+    onClick?: () => void;
+}
+
+const StripButton = (props: StripButtonProps): JSX.Element => {
+    const disabled = () => props.onClick == null;
+    return (
+        <button
+            type="button"
+            class="node-strip-btn"
+            classList={{
+                "node-strip-btn--active": props.active === true,
+                "node-strip-btn--disabled": disabled(),
+            }}
+            disabled={disabled()}
+            onClick={(e) => {
+                e.stopPropagation();
+                props.onClick?.();
+            }}
+            title={props.label}
+            aria-label={props.label}
+        >
+            {props.icon}
+        </button>
+    );
+};
 
 export const NodeHoverStrip = (props: NodeHoverStripProps): JSX.Element => (
     <Show when={props.timestamp != null}>
@@ -29,6 +61,14 @@ export const NodeHoverStrip = (props: NodeHoverStripProps): JSX.Element => (
             >
                 {formatLocalized(props.timestamp!)}
             </time>
+            <Show when={props.onBookmark}>
+                <StripButton
+                    icon="🔖"
+                    label={props.isBookmarked ? "Remove bookmark" : "Bookmark"}
+                    active={props.isBookmarked === true}
+                    onClick={props.onBookmark}
+                />
+            </Show>
         </div>
     </Show>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.289",
+  "version": "0.33.290",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.289",
+      "version": "0.33.290",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.289",
+  "version": "0.33.290",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Adds `StripButton` primitive to `NodeHoverStrip` — an accessible emoji button rendered inside the hover strip
- `NodeHoverStrip` gains `isBookmarked` and `onBookmark` props; the 🔖 button renders when `onBookmark` is provided
- `AgentDocumentView` wires the new props and removes the old standalone `.agent-bookmark-btn` absolute-positioned button
- Deletes `.agent-bookmark-btn` / `.agent-bookmark-btn--active` CSS; adds `.node-strip-btn` with `pointer-events: auto` (the strip container stays `pointer-events: none`, so only buttons are interactive)
- Right-click context menu for bookmarking is unchanged

## Part of hover-unification

Stacks on #466 (phase 2, merged). Phases 4+ will add Expand, New Pane, and keyboard support.

## Test plan

- [ ] Hover a node row → 🔖 button appears in the hover strip (right of timestamp)
- [ ] Click 🔖 → node bookmarked, button turns yellow (`--active`)
- [ ] Click again → bookmark removed
- [ ] Right-click row → context menu still shows Bookmark/Remove bookmark
- [ ] Rows with no `onBookmark` wired → no button rendered (e.g. system messages)
- [ ] No `.agent-bookmark-btn` references remain in compiled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)