### PR TITLE
feat(agent): remove ToolBlock hover-expand, wire Expand button in strip (hover-unification phase 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.290"
+version = "0.33.291"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.290"
+version = "0.33.291"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.290"
+version = "0.33.291"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.290"
+version = "0.33.291"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.290"
+version = "0.33.291"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.290"
+version = "0.33.291"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.290"
+version = "0.33.291"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.290"
+version = "0.33.291"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -383,6 +383,9 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
             <For each={document()}>
                 {(node) => {
                     const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
+                    const canExpand = () => node.type === "tool";
+                    const isExpanded = () => node.type === "tool" && documentState().pinnedNodes.has(node.id);
+                    const onExpand = node.type === "tool" ? () => toggleToolPin(node.id) : undefined;
 
                     const handleContextMenu = (e: MouseEvent) => {
                         if (!onBookmark) return;
@@ -425,6 +428,9 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                 nodeId={node.id}
                                 isBookmarked={isBookmarked()}
                                 onBookmark={onBookmark != null ? () => onBookmark(node) : undefined}
+                                canExpand={canExpand()}
+                                isExpanded={isExpanded()}
+                                onExpand={onExpand}
                             />
                         </div>
                     );

--- a/frontend/app/view/agent/components/NodeHoverStrip.tsx
+++ b/frontend/app/view/agent/components/NodeHoverStrip.tsx
@@ -17,6 +17,9 @@ interface NodeHoverStripProps {
     nodeId: string;
     isBookmarked?: boolean;
     onBookmark?: () => void;
+    canExpand?: boolean;
+    isExpanded?: boolean;
+    onExpand?: () => void;
 }
 
 interface StripButtonProps {
@@ -62,6 +65,14 @@ export const NodeHoverStrip = (props: NodeHoverStripProps): JSX.Element => (
                 >
                     {formatLocalized(props.timestamp!)}
                 </time>
+            </Show>
+            <Show when={props.canExpand}>
+                <StripButton
+                    icon={props.isExpanded ? "⊟" : "⊞"}
+                    label={props.isExpanded ? "Collapse" : "Expand"}
+                    active={props.isExpanded === true}
+                    onClick={props.onExpand}
+                />
             </Show>
             <Show when={props.onBookmark}>
                 <StripButton

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -12,11 +12,8 @@
  *     Applies to ALL statuses — running, success, and failed.
  *     Running tools show a ⏳ spinner in the summary; failed tools show ✗.
  *     No content body is rendered in the document flow.
- *   - Hover: expands via the portal overlay on mouseenter, collapses
- *     on mouseleave. The portal escapes the `content-visibility: auto`
- *     paint containment on .agent-document-node-wrapper (see PR #367).
- *   - Click: pins the expanded state. A pinned-open block stays open even
- *     after the mouse leaves. Clicking again unpins.
+ *   - Click summary or strip Expand button: pins the expanded state. The portal
+ *     overlay renders the tool content. Clicking again unpins / collapses.
  *
  * Prior behavior removed in SPEC_AGENT_PANE_FOLLOWUPS items #4 + #5:
  *   running and failed states used to force-expand inline, taking 2+ lines
@@ -32,8 +29,8 @@
  *   without triggering a parent re-render of the component. This bit us
  *   in an earlier version of this file: `pinned` was destructured, and
  *   pin toggles — which mutate `documentState` but not the document
- *   array — never reached the component, so clicking to pin visibly
- *   worked while hovered but collapsed again on mouseleave.
+ *   array — never reached the component, so the pin state appeared to
+ *   reset on the next render cycle.
  */
 
 import clsx from "clsx";
@@ -95,12 +92,10 @@ function findScrollParent(el: HTMLElement): HTMLElement | null {
 const OVERLAY_MAX_HEIGHT_PX = 400;
 
 export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
-    const [hovered, setHovered] = createSignal(false);
-    // Position of the collapsed row in viewport coordinates, recomputed on
-    // mouseenter. The overlay is rendered via a <Portal> to document.body to
-    // escape the paint containment imposed by .agent-document-node-wrapper's
-    // `content-visibility: auto` — otherwise the absolute-positioned overlay
-    // gets clipped at the wrapper's edge and the hover expansion is invisible.
+    // Position of the collapsed row in viewport coordinates, recomputed when
+    // pinned flips true. The overlay is rendered via a <Portal> to document.body
+    // to escape the paint containment imposed by .agent-document-node-wrapper's
+    // `content-visibility: auto` — otherwise the overlay gets clipped.
     const [overlayRect, setOverlayRect] = createSignal<{
         left: number;
         right: number;
@@ -112,22 +107,8 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
 
     let blockRef: HTMLDivElement | undefined;
 
-    // Collapsed-by-default for every status. Running, success, and failed
-    // all get the same one-line treatment (SPEC_AGENT_PANE_FOLLOWUPS items
-    // #4 and #5). Hover reveals the body via the portal overlay; click
-    // pins it open. Progress + error content are still accessible — just
-    // not always-on visually.
-    //
-    // The running state shows a spinner in the collapsed summary; the
-    // failed state shows a red ✗. Both indicate what's happening without
-    // consuming vertical space from the pane.
-    const expanded = () => props.pinned || hovered();
-
-    // All transient / pinned expansion now goes through the portal overlay.
-    // Nothing renders inline in the document flow anymore — so we don't
-    // need a separate `overlayMode` predicate; every expansion IS overlay
-    // mode. Kept as an accessor for parity with the existing SCSS hooks.
-    const overlayMode = () => hovered() || props.pinned;
+    const expanded = () => props.pinned;
+    const overlayMode = () => props.pinned;
 
     const statusIcon = (): string => STATUS_ICON[props.node.status] || "•";
 
@@ -149,32 +130,11 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         });
     };
 
-    // Hover-leave is deferred by a microtask so that mouseleave on the
-    // summary block followed by mouseenter on the portal overlay doesn't
-    // cause a visible collapse. The portal is rendered to document.body,
-    // not as a DOM descendant of the block — a direct onMouseLeave →
-    // setHovered(false) would momentarily hide the overlay as the cursor
-    // transits the one-pixel gap between the summary row and the portal.
-    let leavePending = 0;
-    const handleMouseEnter = () => {
-        if (leavePending) {
-            clearTimeout(leavePending);
-            leavePending = 0;
+    // Measure position when pin flips true so the portal has coordinates on first render.
+    createEffect(() => {
+        if (props.pinned && blockRef) {
+            measure();
         }
-        measure();
-        setHovered(true);
-    };
-
-    const handleMouseLeave = () => {
-        if (leavePending) clearTimeout(leavePending);
-        leavePending = window.setTimeout(() => {
-            leavePending = 0;
-            setHovered(false);
-        }, 0);
-    };
-
-    onCleanup(() => {
-        if (leavePending) clearTimeout(leavePending);
     });
 
     // Reposition the portal overlay on scroll so a PINNED overlay stays
@@ -292,7 +252,7 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     };
 
     // Overlay style — only meaningful when overlayMode() is true. Computed
-    // from overlayRect() which is set during handleMouseEnter / handleScroll.
+    // from overlayRect() which is set during measure() / handleScroll.
     //
     // Zoom correction: the portal renders to document.body, outside the
     // .agent-view zoom context. getBoundingClientRect() returns viewport
@@ -341,8 +301,6 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                 success: props.node.status === "success",
                 failed: props.node.status === "failed",
             })}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
         >
             <div class="agent-tool-summary" onClick={props.onTogglePin}>
                 <span class="agent-tool-status-icon">{statusIcon()}</span>
@@ -382,14 +340,6 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                         })}
                         style={overlayStyle()}
                         onClick={(e) => e.stopPropagation()}
-                        // Use handleMouseEnter (not an inline setHovered(true))
-                        // so the pending leavePending timeout from the block's
-                        // mouseleave is cleared. Otherwise the timeout fires
-                        // on the next tick after the portal's mouseenter
-                        // has set hovered=true, flipping it back to false
-                        // and collapsing the overlay mid-transit.
-                        onMouseEnter={handleMouseEnter}
-                        onMouseLeave={handleMouseLeave}
                     >
                         {renderToolContent()}
                     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.290",
+  "version": "0.33.291",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.290",
+      "version": "0.33.291",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.290",
+  "version": "0.33.291",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- **ToolBlock**: delete `hovered` signal, `leavePending`, `handleMouseEnter`/`handleMouseLeave`, and the first `onCleanup`. `expanded()` and `overlayMode()` now derive from `props.pinned` only. A new `createEffect` calls `measure()` when the pin flips true so the portal overlay has coordinates on first render.
- **NodeHoverStrip**: add `canExpand`/`isExpanded`/`onExpand` props; render ⊞/⊟ Expand button between the timestamp and the bookmark button (tool rows only in this phase).
- **AgentDocumentView**: compute `canExpand`/`isExpanded`/`onExpand` per node inside the `<For>` callback and pass them to `<NodeHoverStrip>`.

## Behavior change

Tool rows no longer auto-expand on hover. The overlay opens only when the user pins the block — via the summary row click or the new Expand button in the hover strip.

## Test plan

- [ ] Hover a tool row → strip appears with ⊞ Expand button. **No overlay opens on hover.**
- [ ] Click ⊞ in the strip → portal overlay renders the tool content; button shows ⊟ (active).
- [ ] Click ⊟ → overlay hides.
- [ ] Click the tool summary row directly → still pins/unpins (kept behavior).
- [ ] Hover a non-tool row → strip appears, Expand button not visible.
- [ ] Scroll while pinned → overlay tracks the row.
- [ ] Grep ToolBlock for `hovered`/`leavePending`/`handleMouseEnter`/`handleMouseLeave` → zero results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)