### PR TITLE
feat(agent): widen strip Expand to all collapsible node kinds (hover-unification phase 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.291"
+version = "0.33.292"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.291"
+version = "0.33.292"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.291"
+version = "0.33.292"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.291"
+version = "0.33.292"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.291"
+version = "0.33.292"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.291"
+version = "0.33.292"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.291"
+version = "0.33.292"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.291"
+version = "0.33.292"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -157,8 +157,7 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
 
     if (scrollToBottomRef) scrollToBottomRef(jumpToBottom);
 
-    // Toggle collapsed state for a node (agent messages only — tool blocks
-    // manage their own expand/collapse via hover + pin).
+    // Toggle collapsed state for collapsible nodes (agent messages, sections, user messages).
     const toggleCollapse = (nodeId: string) => {
         setDocumentState((prev) => {
             const collapsed = new Set(prev.collapsedNodes);
@@ -171,17 +170,12 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
         });
     };
 
-    // Toggle the "pinned open" state for a tool node. Tool blocks render
-    // collapsed by default — hover expands, click pins. See
-    // docs/specs/tool-collapse.md.
-    const toggleToolPin = (nodeId: string) => {
+    // Toggle the "pinned open" state for a tool node.
+    const togglePin = (nodeId: string) => {
         setDocumentState((prev) => {
             const pinned = new Set(prev.pinnedNodes);
-            if (pinned.has(nodeId)) {
-                pinned.delete(nodeId);
-            } else {
-                pinned.add(nodeId);
-            }
+            if (pinned.has(nodeId)) pinned.delete(nodeId);
+            else pinned.add(nodeId);
             return { ...prev, pinnedNodes: pinned };
         });
     };
@@ -383,9 +377,25 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
             <For each={document()}>
                 {(node) => {
                     const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
-                    const canExpand = () => node.type === "tool";
-                    const isExpanded = () => node.type === "tool" && documentState().pinnedNodes.has(node.id);
-                    const onExpand = node.type === "tool" ? () => toggleToolPin(node.id) : undefined;
+                    const canExpand = () => {
+                        switch (node.type) {
+                            case "tool":
+                            case "agent_message":
+                            case "user_message":
+                            case "section":
+                                return true;
+                            default:
+                                return false;
+                        }
+                    };
+                    const isExpanded = () => {
+                        if (node.type === "tool") return documentState().pinnedNodes.has(node.id);
+                        return !documentState().collapsedNodes.has(node.id);
+                    };
+                    const onExpand = () => {
+                        if (node.type === "tool") togglePin(node.id);
+                        else toggleCollapse(node.id);
+                    };
 
                     const handleContextMenu = (e: MouseEvent) => {
                         if (!onBookmark) return;
@@ -420,7 +430,7 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                 collapsed={documentState().collapsedNodes.has(node.id)}
                                 onToggle={() => toggleCollapse(node.id)}
                                 toolPinned={documentState().pinnedNodes.has(node.id)}
-                                onToggleToolPin={() => toggleToolPin(node.id)}
+                                onToggleToolPin={() => togglePin(node.id)}
                                 onSubagentClick={onSubagentClick}
                             />
                             <NodeHoverStrip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.291",
+  "version": "0.33.292",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.291",
+      "version": "0.33.292",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.291",
+  "version": "0.33.292",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- **Rename** `toggleToolPin` → `togglePin` (the function name no longer needs to be tool-scoped).
- **`canExpand`** now returns `true` for `tool`, `agent_message`, `user_message`, and `section` rows. `markdown` and `subagent_link` remain `false` (no collapse affordance).
- **`isExpanded`**: for `tool` → `pinnedNodes.has(id)`; for all other expandable types → `!collapsedNodes.has(id)` (expanded by default, since nothing is collapsed at start).
- **`onExpand`**: for `tool` → `togglePin`; for others → `toggleCollapse` (existing helper, same set that `AgentMessageBlock` already reads).

## Test plan

- [ ] Hover a tool row → ⊞/⊟ Expand button works as in phase 4.
- [ ] Hover an agent-message row → ⊟ Expand visible (initially expanded). Click → collapses `AgentMessageBlock`. Click ⊞ → expands again.
- [ ] Hover a user-message row → ⊟ Expand visible. Click → toggles `collapsedNodes` (visual effect depends on renderer).
- [ ] Hover a section row → same.
- [ ] Hover a markdown or subagent-link row → Expand button not visible.
- [ ] `grep -n toggleToolPin frontend/app/view/agent/components/AgentDocumentView.tsx` → zero results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)