### PR TITLE
feat(agent): stub New pane / New window / New agent buttons in strip (hover-unification phase 6-7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.292"
+version = "0.33.293"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.292"
+version = "0.33.293"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.292"
+version = "0.33.293"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.292"
+version = "0.33.293"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.292"
+version = "0.33.293"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.292"
+version = "0.33.293"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.292"
+version = "0.33.293"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.292"
+version = "0.33.293"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -396,6 +396,14 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                         if (node.type === "tool") togglePin(node.id);
                         else toggleCollapse(node.id);
                     };
+                    // Phase 6: "new pane" for tool rows — deferred until a scratch view exists.
+                    const onOpenInNewPane = node.type === "tool"
+                        ? () => console.warn("[hover-strip] open in new pane — not yet implemented")
+                        : undefined;
+                    const onOpenInNewWindow = () =>
+                        console.warn("[hover-strip] open in new window — not yet implemented");
+                    const onNewAgentFromHere = () =>
+                        console.warn("[hover-strip] new agent from here — not yet implemented");
 
                     const handleContextMenu = (e: MouseEvent) => {
                         if (!onBookmark) return;
@@ -441,6 +449,9 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                 canExpand={canExpand()}
                                 isExpanded={isExpanded()}
                                 onExpand={onExpand}
+                                onOpenInNewPane={onOpenInNewPane}
+                                onOpenInNewWindow={onOpenInNewWindow}
+                                onNewAgentFromHere={onNewAgentFromHere}
                             />
                         </div>
                     );

--- a/frontend/app/view/agent/components/NodeHoverStrip.tsx
+++ b/frontend/app/view/agent/components/NodeHoverStrip.tsx
@@ -20,6 +20,9 @@ interface NodeHoverStripProps {
     canExpand?: boolean;
     isExpanded?: boolean;
     onExpand?: () => void;
+    onOpenInNewPane?: () => void;   // undefined → button hidden (non-tool rows)
+    onOpenInNewWindow?: () => void; // stub — logs console.warn until CEF bridge ships
+    onNewAgentFromHere?: () => void; // stub — requires backend RPC in v2
 }
 
 interface StripButtonProps {
@@ -53,7 +56,14 @@ const StripButton = (props: StripButtonProps): JSX.Element => {
 };
 
 export const NodeHoverStrip = (props: NodeHoverStripProps): JSX.Element => (
-    <Show when={props.timestamp != null || props.onBookmark != null}>
+    <Show when={
+        props.timestamp != null ||
+        props.canExpand ||
+        props.onBookmark != null ||
+        props.onOpenInNewPane != null ||
+        props.onOpenInNewWindow != null ||
+        props.onNewAgentFromHere != null
+    }>
         <div
             class="node-strip"
             data-node-strip-for={props.nodeId}
@@ -80,6 +90,27 @@ export const NodeHoverStrip = (props: NodeHoverStripProps): JSX.Element => (
                     label={props.isBookmarked ? "Remove bookmark" : "Bookmark"}
                     active={props.isBookmarked === true}
                     onClick={props.onBookmark}
+                />
+            </Show>
+            <Show when={props.onOpenInNewPane}>
+                <StripButton
+                    icon="⧉"
+                    label="Open in new pane"
+                    onClick={props.onOpenInNewPane}
+                />
+            </Show>
+            <Show when={props.onOpenInNewWindow}>
+                <StripButton
+                    icon="⊡"
+                    label="Open in new window"
+                    onClick={props.onOpenInNewWindow}
+                />
+            </Show>
+            <Show when={props.onNewAgentFromHere}>
+                <StripButton
+                    icon="✦"
+                    label="New agent from here"
+                    onClick={props.onNewAgentFromHere}
                 />
             </Show>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.292",
+  "version": "0.33.293",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.292",
+      "version": "0.33.293",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.292",
+  "version": "0.33.293",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Combines spec phases 6 and 7 — both add buttons that are stubs until backend support ships.

- **NodeHoverStrip**: three new optional props + buttons:
  - `onOpenInNewPane` → ⧉ "Open in new pane" (hidden on non-tool rows)
  - `onOpenInNewWindow` → ⊡ "Open in new window" (always shown)
  - `onNewAgentFromHere` → ✦ "New agent from here" (always shown)
  - Outer `<Show>` guard widened to include the new props so the strip always renders when any button is present.
- **AgentDocumentView**: stub handlers wired per node:
  - `onOpenInNewPane`: tool rows only — deferred until a scratch/tool view exists (no view target yet)
  - `onOpenInNewWindow`: all rows — `console.warn` stub
  - `onNewAgentFromHere`: all rows — `console.warn` stub (requires `agent.clone_from_row` RPC in v2)

## Test plan

- [ ] Hover any row → strip shows ⊡ and ✦ buttons; clicking either logs a console.warn.
- [ ] Hover a tool row → additionally shows ⧉ button; clicking logs console.warn.
- [ ] Hover a non-tool row → ⧉ not visible.
- [ ] Bookmark (🔖) and Expand (⊞/⊟) buttons still work as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)