### PR TITLE
feat(agent): keyboard focus + shortcuts for hover strip (hover-unification phase 8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.293"
+version = "0.33.294"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.293"
+version = "0.33.294"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.293"
+version = "0.33.294"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.293"
+version = "0.33.294"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.293"
+version = "0.33.294"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.293"
+version = "0.33.294"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.293"
+version = "0.33.294"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.293"
+version = "0.33.294"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -81,6 +81,11 @@
             opacity: 1;
         }
 
+        &:focus {
+            outline: 1px solid var(--accent-color, #3b82f6);
+            outline-offset: -1px;
+        }
+
         .node-strip-time {
             color: var(--secondary-text-color);
             font-variant-numeric: tabular-nums;

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -405,6 +405,31 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                     const onNewAgentFromHere = () =>
                         console.warn("[hover-strip] new agent from here — not yet implemented");
 
+                    const handleRowKey = (e: KeyboardEvent): void => {
+                        if (e.metaKey || e.ctrlKey || e.altKey) return;
+                        switch (e.key.toLowerCase()) {
+                            case "e":
+                                if (canExpand()) { onExpand(); e.preventDefault(); }
+                                break;
+                            case "b":
+                                if (onBookmark != null) { onBookmark(node); e.preventDefault(); }
+                                break;
+                            case "p":
+                                if (onOpenInNewPane) { onOpenInNewPane(); e.preventDefault(); }
+                                break;
+                            case "w":
+                                onOpenInNewWindow(); e.preventDefault();
+                                break;
+                            case "n":
+                                onNewAgentFromHere(); e.preventDefault();
+                                break;
+                            case "escape":
+                                (e.currentTarget as HTMLElement).blur();
+                                e.preventDefault();
+                                break;
+                        }
+                    };
+
                     const handleContextMenu = (e: MouseEvent) => {
                         if (!onBookmark) return;
                         // Don't show bookmark menu on top of text selections — let the parent handle those.
@@ -431,6 +456,8 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
                                 "agent-node-search-match": highlightNodeId?.() === node.id,
                             }}
                             data-node-id={node.id}
+                            tabindex="0"
+                            onKeyDown={handleRowKey}
                             onContextMenu={handleContextMenu}
                         >
                             <DocumentNodeRenderer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.293",
+  "version": "0.33.294",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.293",
+      "version": "0.33.294",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.293",
+  "version": "0.33.294",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Final phase of hover-unification. Adds Tab-cycle focus to node rows and keyboard shortcuts that mirror every strip button.

- **`agent-view.scss`**: `&:focus` outline (`1px solid var(--accent-color, #3b82f6)`, `outline-offset: -1px`) inside `.agent-document-node-wrapper`. The `:focus-within .node-strip` rule (already in place since phase 2) makes the strip visible on keyboard focus.
- **`AgentDocumentView.tsx`**:
  - `tabindex="0"` on each node wrapper — rows are now Tab-navigable.
  - `onKeyDown={handleRowKey}` — `handleRowKey` closes over the per-node handlers computed in the `<For>` callback:

| Key | Action | Guard |
|-----|--------|-------|
| `e` | Expand / Collapse | `canExpand()` must be true |
| `b` | Bookmark / Unbookmark | `onBookmark` prop must exist |
| `p` | Open in new pane | tool rows only (`onOpenInNewPane` defined) |
| `w` | Open in new window | always (stub logs warn) |
| `n` | New agent from here | always (stub logs warn) |
| `Esc` | Blur row | — |

All shortcuts are skipped when `metaKey`, `ctrlKey`, or `altKey` is held, preserving existing global bindings.

## Test plan

- [ ] `Tab` in agent pane → focus moves row-to-row; strip appears and focus outline is visible.
- [ ] Press `e` on a focused tool row → overlay opens (pin toggles).
- [ ] Press `e` on a focused agent-message row → collapses/expands.
- [ ] Press `b` on any row → bookmark toggles (same as clicking 🔖).
- [ ] Press `p` on a tool row → console.warn (stub).
- [ ] Press `w` / `n` on any row → console.warn (stubs).
- [ ] Press `Esc` → row blurs, strip hides.
- [ ] `Ctrl+E` / `Meta+B` → no action (modifier guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)