### PR TITLE
feat(provider): integrate Kimi Code CLI as agent provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.295"
+version = "0.33.296"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.295"
+version = "0.33.296"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.295"
+version = "0.33.296"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.295"
+version = "0.33.296"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.295"
+version = "0.33.296"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.295"
+version = "0.33.296"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.295"
+version = "0.33.296"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.295"
+version = "0.33.296"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -177,6 +177,33 @@ static GEMINI: ProviderConfig = ProviderConfig {
     docs_url: "https://ai.google.dev/gemini-cli",
 };
 
+static KIMI: ProviderConfig = ProviderConfig {
+    id: "kimi",
+    display_name: "Kimi Code CLI",
+    cli_command: "kimi",
+    controller_type: ControllerType::Subprocess,
+    launch_args: &[
+        "--print",
+        "--output-format",
+        "stream-json",
+        "--yolo",
+        "-p",
+        "",
+    ],
+    persistent_launch_args: None,
+    resume_flag: None,
+    session_id_field: "session_id",
+    styled_output_format: "kimi-stream-json",
+    auth_config_dir_env_var: "KIMI_SHARE_DIR",
+    auth_dir_name: "kimi",
+    auth_extra_env: &[],
+    unset_env: &[],
+    npm_package: "",
+    pinned_version: "",
+    icon: "moon",
+    docs_url: "https://moonshotai.github.io/kimi-cli/",
+};
+
 static OPENCLAW: ProviderConfig = ProviderConfig {
     id: "openclaw",
     display_name: "OpenClaw",
@@ -225,6 +252,7 @@ static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = Lazy
     m.insert(CLAUDE.id, &CLAUDE);
     m.insert(CODEX.id, &CODEX);
     m.insert(GEMINI.id, &GEMINI);
+    m.insert(KIMI.id, &KIMI);
     m.insert(OPENCLAW.id, &OPENCLAW);
     m.insert(PI.id, &PI);
     m
@@ -237,6 +265,8 @@ static ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(||
     m.insert("claude_code", "claude");
     m.insert("codex-cli", "codex");
     m.insert("gemini-cli", "gemini");
+    m.insert("kimi-cli", "kimi");
+    m.insert("kimi_code", "kimi");
     m.insert("openclaw-cli", "openclaw");
     m.insert("open-claw", "openclaw");
     m
@@ -276,7 +306,7 @@ pub fn get_provider(id: &str) -> Option<&'static ProviderConfig> {
 /// Return an iterator over all registered providers in insertion order.
 pub fn get_provider_list() -> impl Iterator<Item = &'static ProviderConfig> {
     // Stable canonical order matches the TypeScript PROVIDERS object order.
-    static ORDER: &[&str] = &["claude", "codex", "gemini", "openclaw", "pi"];
+    static ORDER: &[&str] = &["claude", "codex", "gemini", "kimi", "openclaw", "pi"];
     ORDER.iter().filter_map(|id| REGISTRY.get(*id).copied())
 }
 
@@ -291,6 +321,7 @@ mod tests {
         assert!(get_provider("claude").is_some());
         assert!(get_provider("codex").is_some());
         assert!(get_provider("gemini").is_some());
+        assert!(get_provider("kimi").is_some());
         assert!(get_provider("openclaw").is_some());
     }
 
@@ -300,6 +331,7 @@ mod tests {
         assert_eq!(get_provider("claude_code").unwrap().id, "claude");
         assert_eq!(get_provider("codex-cli").unwrap().id, "codex");
         assert_eq!(get_provider("gemini-cli").unwrap().id, "gemini");
+        assert_eq!(get_provider("kimi-cli").unwrap().id, "kimi");
         assert_eq!(get_provider("openclaw-cli").unwrap().id, "openclaw");
     }
 
@@ -309,8 +341,8 @@ mod tests {
     }
 
     #[test]
-    fn provider_list_has_five_entries() {
-        assert_eq!(get_provider_list().count(), 5);
+    fn provider_list_has_six_entries() {
+        assert_eq!(get_provider_list().count(), 6);
     }
 
     #[test]
@@ -334,6 +366,16 @@ mod tests {
             .auth_extra_env
             .iter()
             .any(|(k, v)| *k == "GEMINI_FORCE_FILE_STORAGE" && *v == "true"));
+    }
+
+    #[test]
+    fn kimi_is_subprocess_controller() {
+        let p = get_provider("kimi").unwrap();
+        assert_eq!(p.controller_type, ControllerType::Subprocess);
+        assert_eq!(p.controller_type_str(), "subprocess");
+        assert_eq!(p.styled_output_format, "kimi-stream-json");
+        assert_eq!(p.cli_command, "kimi");
+        assert!(p.npm_package.is_empty());
     }
 
     #[test]

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -18,6 +18,7 @@ use crate::backend::session_archive;
 use crate::backend::storage::wstore::WaveStore;
 
 use super::AppState;
+use crate::server::cli_handlers::resolve_cli_on_path;
 
 /// Register all App API handlers on the RPC engine.
 pub fn register_app_api_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
@@ -128,24 +129,8 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // This is used for Python-based CLIs like Kimi that are not
                     // distributed on npm.
                     if provider.npm_package.is_empty() {
-                        let path_cmd = if cfg!(windows) {
-                            format!("{}.cmd", provider.cli_command)
-                        } else {
-                            provider.cli_command.to_string()
-                        };
-                        let which_result = if cfg!(windows) {
-                            std::process::Command::new("where").arg(&path_cmd).output()
-                        } else {
-                            std::process::Command::new("which").arg(&path_cmd).output()
-                        };
-                        if let Ok(out) = which_result {
-                            if out.status.success() {
-                                let stdout_str = String::from_utf8_lossy(&out.stdout);
-                                let path = stdout_str.lines().next().unwrap_or("").trim();
-                                if !path.is_empty() && std::path::Path::new(path).exists() {
-                                    resolved_cli_path = path.to_string();
-                                }
-                            }
+                        if let Some(path) = resolve_cli_on_path(provider.cli_command).await {
+                            resolved_cli_path = path;
                         }
                     }
                     if !std::path::Path::new(&resolved_cli_path).exists() {

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -122,11 +122,38 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 } else {
                     format!("{}/node_modules/.bin/{}", provider_dir, provider.cli_command)
                 };
-                if !std::path::Path::new(&npm_bin).exists() {
-                    return Err(format!(
-                        "CLI_NOT_AVAILABLE: {} not installed at {}. Open an agent pane in the UI to trigger installation.",
-                        provider.cli_command, npm_bin
-                    ));
+                let mut resolved_cli_path = npm_bin.clone();
+                if !std::path::Path::new(&resolved_cli_path).exists() {
+                    // Fallback: provider not installed via npm — try system PATH.
+                    // This is used for Python-based CLIs like Kimi that are not
+                    // distributed on npm.
+                    if provider.npm_package.is_empty() {
+                        let path_cmd = if cfg!(windows) {
+                            format!("{}.cmd", provider.cli_command)
+                        } else {
+                            provider.cli_command.to_string()
+                        };
+                        let which_result = if cfg!(windows) {
+                            std::process::Command::new("where").arg(&path_cmd).output()
+                        } else {
+                            std::process::Command::new("which").arg(&path_cmd).output()
+                        };
+                        if let Ok(out) = which_result {
+                            if out.status.success() {
+                                let stdout_str = String::from_utf8_lossy(&out.stdout);
+                                let path = stdout_str.lines().next().unwrap_or("").trim();
+                                if !path.is_empty() && std::path::Path::new(path).exists() {
+                                    resolved_cli_path = path.to_string();
+                                }
+                            }
+                        }
+                    }
+                    if !std::path::Path::new(&resolved_cli_path).exists() {
+                        return Err(format!(
+                            "CLI_NOT_AVAILABLE: {} not installed at {}. Open an agent pane in the UI to trigger installation.",
+                            provider.cli_command, npm_bin
+                        ));
+                    }
                 }
 
                 // 6. Build metadata
@@ -181,11 +208,12 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "claude" => "claude-stream-json",
                     "codex" => "codex-json",
                     "gemini" => "gemini-json",
+                    "kimi" => "kimi-stream-json",
                     _ => "claude-stream-json",
                 };
                 meta.insert("agentOutputFormat".to_string(), json!(output_format));
                 meta.insert("controller".to_string(), json!(controller_type));
-                meta.insert("cmd".to_string(), json!(&npm_bin));
+                meta.insert("cmd".to_string(), json!(&resolved_cli_path));
                 meta.insert("cmd:args".to_string(), json!(cli_args));
                 meta.insert("cmd:cwd".to_string(), json!(&work_dir));
                 meta.insert("cmd:env".to_string(), serde_json::Value::Object(env_vars));

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -65,33 +65,17 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
 
                 // Step 2: Not in versioned dir — check system PATH for non-npm CLIs.
                 if cmd.npm_package.is_empty() {
-                    let path_cmd = if cfg!(windows) {
-                        format!("{}.cmd", cmd.cli_command)
-                    } else {
-                        cmd.cli_command.clone()
-                    };
-                    let which_result = if cfg!(windows) {
-                        tokio::process::Command::new("where").arg(&path_cmd).output().await
-                    } else {
-                        tokio::process::Command::new("which").arg(&path_cmd).output().await
-                    };
-                    if let Ok(out) = which_result {
-                        if out.status.success() {
-                            let stdout_str = String::from_utf8_lossy(&out.stdout);
-                            let path = stdout_str.lines().next().unwrap_or("").trim();
-                            if !path.is_empty() && std::path::Path::new(path).exists() {
-                                let version = get_cli_version(path).await;
-                                tracing::info!(
-                                    path = %path, version = %version,
-                                    "CLI found on system PATH"
-                                );
-                                return Ok(Some(serde_json::to_value(&ResolveCliResult {
-                                    cli_path: path.to_string(),
-                                    version,
-                                    source: "system_path".to_string(),
-                                }).unwrap()));
-                            }
-                        }
+                    if let Some(path) = resolve_cli_on_path(&cmd.cli_command).await {
+                        let version = get_cli_version(&path).await;
+                        tracing::info!(
+                            path = %path, version = %version,
+                            "CLI found on system PATH"
+                        );
+                        return Ok(Some(serde_json::to_value(&ResolveCliResult {
+                            cli_path: path,
+                            version,
+                            source: "system_path".to_string(),
+                        }).unwrap()));
                     }
                     return Err(format!(
                         "{} not found and no npm package configured for this provider",
@@ -390,6 +374,33 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
 /// Re-export from shared crate for internal use.
 pub(crate) fn make_cli_cmd(cli_path: &str) -> tokio::process::Command {
     agentmux_common::make_cli_cmd(cli_path)
+}
+
+/// Resolve a CLI command on the system PATH.
+///
+/// Uses `where` on Windows and `which` on Unix. Returns the absolute path
+/// if the command is found and exists, otherwise `None`.
+pub(crate) async fn resolve_cli_on_path(cli_command: &str) -> Option<String> {
+    let path_cmd = if cfg!(windows) {
+        format!("{}.cmd", cli_command)
+    } else {
+        cli_command.to_string()
+    };
+    let which_result = if cfg!(windows) {
+        tokio::process::Command::new("where").arg(&path_cmd).output().await
+    } else {
+        tokio::process::Command::new("which").arg(&path_cmd).output().await
+    };
+    if let Ok(out) = which_result {
+        if out.status.success() {
+            let stdout_str = String::from_utf8_lossy(&out.stdout);
+            let path = stdout_str.lines().next().unwrap_or("").trim();
+            if !path.is_empty() && std::path::Path::new(path).exists() {
+                return Some(path.to_string());
+            }
+        }
+    }
+    None
 }
 
 async fn get_cli_version(cli_path: &str) -> String {

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -63,10 +63,36 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }).unwrap()));
                 }
 
-                // Step 2: Not in versioned dir — install from network.
-                // Never copy from system PATH — that defeats version isolation and
-                // can copy the wrong binary type (e.g., .exe saved as .cmd).
+                // Step 2: Not in versioned dir — check system PATH for non-npm CLIs.
                 if cmd.npm_package.is_empty() {
+                    let path_cmd = if cfg!(windows) {
+                        format!("{}.cmd", cmd.cli_command)
+                    } else {
+                        cmd.cli_command.clone()
+                    };
+                    let which_result = if cfg!(windows) {
+                        tokio::process::Command::new("where").arg(&path_cmd).output().await
+                    } else {
+                        tokio::process::Command::new("which").arg(&path_cmd).output().await
+                    };
+                    if let Ok(out) = which_result {
+                        if out.status.success() {
+                            let stdout_str = String::from_utf8_lossy(&out.stdout);
+                            let path = stdout_str.lines().next().unwrap_or("").trim();
+                            if !path.is_empty() && std::path::Path::new(path).exists() {
+                                let version = get_cli_version(path).await;
+                                tracing::info!(
+                                    path = %path, version = %version,
+                                    "CLI found on system PATH"
+                                );
+                                return Ok(Some(serde_json::to_value(&ResolveCliResult {
+                                    cli_path: path.to_string(),
+                                    version,
+                                    source: "system_path".to_string(),
+                                }).unwrap()));
+                            }
+                        }
+                    }
                     return Err(format!(
                         "{} not found and no npm package configured for this provider",
                         cmd.cli_command

--- a/docs/specs/KIMI_PROVIDER_INTEGRATION_SPEC.md
+++ b/docs/specs/KIMI_PROVIDER_INTEGRATION_SPEC.md
@@ -1,0 +1,665 @@
+# Kimi Code CLI Provider Integration Spec
+
+**Version:** 0.1  
+**Date:** 2026-04-20  
+**Status:** Draft — ready for implementation  
+**Author:** AgentMux Analysis  
+
+---
+
+## 1. Executive Summary
+
+Integrate [Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli) (`kimi`) as a first-class agent provider in AgentMux, alongside Claude Code, Codex CLI, and Gemini CLI.
+
+**Why Kimi?** Kimi is a mature CLI agent (v1.37.0) with a well-documented JSON streaming format, ACP server mode, and Wire protocol. It supports the Moonshot Kimi model family (k2, etc.) and is already installed in this environment via `uv`.
+
+**Strategic Goal:** Give AgentMux users a non-Anthropic/OpenAI/Google option that supports Chinese and English contexts, with competitive reasoning capabilities.
+
+---
+
+## 2. Kimi Protocol Analysis
+
+Kimi exposes **three** programmatic interfaces. We evaluated all three:
+
+### 2.1 Print Mode + `--output-format stream-json` ⭐ RECOMMENDED (Phase 1)
+
+```bash
+kimi --print --output-format stream-json --yolo -p "prompt here"
+```
+
+- **Output:** NDJSON lines, one message per line.
+- **Schema:** Simple message format (`{"role":"assistant","content":[...],"tool_calls":[...]}`)
+- **Input:** Plain text via `-p` or stdin.
+- **Auto-approve:** `--yolo` auto-approves all tool calls (like Claude's `--dangerously-skip-permissions`).
+- **Exit:** Exits automatically after the turn completes.
+- **Session resume:** `--continue` or `--session <id>` flags exist but are untested in print mode.
+
+**Sample output (tool call):**
+```json
+{"role":"assistant","content":[{"type":"think","think":"..."}],"tool_calls":[{"type":"function","id":"tc_1","function":{"name":"Shell","arguments":"{\"command\":\"ls\"}"}}]}
+{"role":"tool","tool_call_id":"tc_1","content":[{"type":"text","text":"file1.py\nfile2.py"}]}
+{"role":"assistant","content":[{"type":"text","text":"Here are the files..."}]}
+```
+
+**Verdict:** Easiest integration. Mirrors Claude/Gemini subprocess model exactly.
+
+### 2.2 Wire Mode (`kimi --wire`) — FUTURE (Phase 2)
+
+```bash
+kimi --wire
+```
+
+- **Protocol:** JSON-RPC 2.0 over stdio (Wire protocol v1.9).
+- **Methods:** `initialize`, `prompt`, `replay`, `steer`, `set_plan_mode`, `cancel`.
+- **Bidirectional:** Agent sends `event` notifications and `request` messages (approvals, questions, external tool calls).
+- **Powerful:** Full control over approvals, plan mode, steering.
+
+**Verdict:** Powerful but requires a new controller or significant ACP controller adaptation. Kimi's Wire methods (`prompt`, `event`) differ from AgentMux's ACP (`session/prompt`, `session/update`). Save for Phase 2.
+
+### 2.3 ACP Mode (`kimi acp`) — NOT COMPATIBLE
+
+```bash
+kimi acp
+```
+
+- Kimi's ACP is an IDE integration server built on top of Wire.
+- It speaks JSON-RPC 2.0, but **method names and semantics differ** from AgentMux's ACP controller (`AcpController`).
+- AgentMux ACP expects: `initialize` → `initialized` → `session/create` → `session/prompt` → `session/update`.
+- Kimi Wire uses: `initialize` → `prompt` → `event`/`request`.
+
+**Verdict:** Do not use AgentMux's `AcpController` for Kimi. Would require a `KimiWireController` or protocol adapter.
+
+---
+
+## 3. Architecture Decision
+
+| Aspect | Decision |
+|--------|----------|
+| **Controller type** | `Subprocess` (Phase 1) |
+| **Launch args** | `["--print", "--output-format", "stream-json", "--yolo", "-p", ""]` |
+| **Styled output format** | `kimi-stream-json` (new) |
+| **Resume flag** | `"--continue"` (tentative — needs validation) |
+| **Session ID field** | `"session_id"` (Kimi uses session IDs internally) |
+| **Auth isolation** | `KIMI_SHARE_DIR` env var |
+| **Auth type** | `api-key` (Kimi uses API key or OAuth via `kimi login`) |
+| **Installation** | Phase 1: PATH fallback. Phase 2: `uv tool install` or `pip install`. |
+
+**Rationale for Subprocess over Persistent:**
+- Kimi's `--print` mode is explicitly designed for non-interactive, one-turn execution.
+- While `--input-format stream-json` exists for persistent streaming, it is less documented and untested in the context of long-running sessions.
+- Subprocess gives us session isolation per turn, which aligns with how Claude Code is currently integrated (Claude also uses `Subprocess` with `--resume`).
+
+---
+
+## 4. Files to Modify
+
+### Backend (Rust)
+
+| File | Change |
+|------|--------|
+| `agentmux-srv/src/backend/providers.rs` | Add `KIMI` `ProviderConfig` static; register in `REGISTRY` and `ORDER`; add alias |
+| `agentmux-srv/src/server/app_api.rs` | Add `"kimi" => "kimi-stream-json"` to `output_format` match |
+| `agentmux-srv/src/backend/agent_config.rs` | Optionally write `KIMI.md` alongside `CLAUDE.md` if Kimi reads system prompts from a file |
+| `agentmux-srv/src/server/cli_handlers.rs` | Add PATH fallback for non-npm CLIs (see Installation Strategy) |
+
+### Frontend (TypeScript)
+
+| File | Change |
+|------|--------|
+| `frontend/app/view/agent/providers/index.ts` | Add `kimi` to `PROVIDERS` record; extend `outputFormat` union type |
+| `frontend/app/view/agent/providers/kimi-translator.ts` | **New file** — translate Kimi NDJSON → `StreamEvent` |
+| `frontend/app/view/agent/providers/translator-factory.ts` | Add `kimi-stream-json` case |
+| `frontend/app/view/agent/buildRuntimeArgs.ts` | Add Kimi permission flags (`--yolo` mapping) |
+| `frontend/app/view/agent/types.ts` | Extend `PermissionMode` or `ModelChoice` if Kimi-specific values needed |
+
+### Docs
+
+| File | Change |
+|------|--------|
+| `docs/specs/app-api-status.md` | Update Tier 1 status if applicable |
+
+---
+
+## 5. Backend Implementation Details
+
+### 5.1 `providers.rs` — Add Kimi Provider Config
+
+```rust
+static KIMI: ProviderConfig = ProviderConfig {
+    id: "kimi",
+    display_name: "Kimi Code CLI",
+    cli_command: "kimi",
+    controller_type: ControllerType::Subprocess,
+    launch_args: &[
+        "--print",
+        "--output-format", "stream-json",
+        "--yolo",
+        "-p", "",
+    ],
+    persistent_launch_args: None, // Phase 1
+    resume_flag: Some("--continue"), // TBD: validate this works in print mode
+    session_id_field: "session_id",
+    styled_output_format: "kimi-stream-json",
+    auth_config_dir_env_var: "KIMI_SHARE_DIR",
+    auth_dir_name: "kimi",
+    auth_extra_env: &[
+        // Kimi stores config under ~/.kimi by default.
+        // KIMI_SHARE_DIR redirects this to our isolated auth dir.
+    ],
+    unset_env: &[],
+    npm_package: "", // Kimi is a Python package, not npm
+    pinned_version: "",
+    icon: "moon", // or suitable icon
+    docs_url: "https://moonshotai.github.io/kimi-cli/",
+};
+```
+
+Update `REGISTRY`:
+```rust
+m.insert(KIMI.id, &KIMI);
+```
+
+Update `ORDER`:
+```rust
+static ORDER: &[&str] = &["claude", "codex", "gemini", "kimi", "openclaw", "pi"];
+```
+
+Add alias:
+```rust
+m.insert("kimi-cli", "kimi");
+m.insert("kimi_code", "kimi");
+```
+
+Update tests to expect 6 providers.
+
+### 5.2 `app_api.rs` — Output Format Derivation
+
+```rust
+let output_format = match provider.id {
+    "claude" => "claude-stream-json",
+    "codex" => "codex-json",
+    "gemini" => "gemini-json",
+    "kimi" => "kimi-stream-json",
+    _ => "claude-stream-json",
+};
+```
+
+### 5.3 `cli_handlers.rs` — PATH Fallback for Non-npm CLIs
+
+**Problem:** Kimi is a Python package installed via `pip`/`uv`, not `npm`. The current `resolvecli` handler only looks in `node_modules/.bin/` and fails if `npm_package` is empty.
+
+**Solution:** Add a PATH fallback step before returning an error.
+
+In `register_cli_handlers` / `COMMAND_RESOLVE_CLI`:
+
+```rust
+// After checking versioned npm install dir...
+if std::path::Path::new(&npm_bin).exists() { ... }
+
+// NEW: If npm_package is empty, try system PATH.
+if cmd.npm_package.is_empty() {
+    let path_cmd = if cfg!(windows) {
+        format!("{}.cmd", cmd.cli_command)
+    } else {
+        cmd.cli_command.to_string()
+    };
+    // Use `which` / `where` to resolve on PATH
+    let which_result = if cfg!(windows) {
+        tokio::process::Command::new("where").arg(&path_cmd).output().await
+    } else {
+        tokio::process::Command::new("which").arg(&path_cmd).output().await
+    };
+    if let Ok(out) = which_result {
+        if out.status.success() {
+            let path = String::from_utf8_lossy(&out.stdout).lines().next().unwrap_or("").trim();
+            if !path.is_empty() && std::path::Path::new(path).exists() {
+                let version = get_cli_version(path).await;
+                return Ok(Some(serde_json::to_value(&ResolveCliResult {
+                    cli_path: path.to_string(),
+                    version,
+                    source: "system_path".to_string(),
+                }).unwrap()));
+            }
+        }
+    }
+    return Err(format!(
+        "{} not found. Install it and ensure it's on PATH.",
+        cmd.cli_command
+    ));
+}
+```
+
+> **Note:** The existing `app_api.rs` also hardcodes the npm binary path when building metadata. It needs to use the path returned by `resolvecli` rather than assuming `node_modules/.bin/`. Verify that `cmd` in block meta already uses the resolved path.
+
+**Verification:** In `app_api.rs` line 119, `npm_bin` is constructed from `provider_dir`. This needs to change to call `resolvecli` first, or fall back to PATH resolution if the npm path doesn't exist. Alternatively, modify the construction to check PATH when `npm_package` is empty.
+
+### 5.4 Auth Isolation
+
+Kimi uses `KIMI_SHARE_DIR` (default `~/.kimi`) for all config, sessions, logs, and auth.
+
+AgentMux should set:
+```bash
+KIMI_SHARE_DIR=~/.agentmux/config/auth/kimi
+```
+
+This gives Kimi its own isolated config directory per AgentMux installation, matching the pattern used for Claude (`CLAUDE_CONFIG_DIR`), Codex (`CODEX_HOME`), and Gemini (`GEMINI_CLI_HOME`).
+
+---
+
+## 6. Frontend Implementation Details
+
+### 6.1 `providers/index.ts` — Add Kimi Definition
+
+```typescript
+export interface ProviderDefinition {
+    // ... extend outputFormat union:
+    outputFormat: "claude-stream-json" | "gemini-json" | "codex-json" | "kimi-stream-json" | "acp" | "raw";
+    styledOutputFormat: "claude-stream-json" | "gemini-json" | "codex-json" | "kimi-stream-json" | "acp";
+    // ...
+}
+
+export const PROVIDERS: Record<string, ProviderDefinition> = {
+    // ... existing providers ...
+    kimi: {
+        id: "kimi",
+        displayName: "Kimi Code CLI",
+        cliCommand: "kimi",
+        defaultArgs: [],
+        styledArgs: ["--print", "--output-format", "stream-json", "--yolo", "-p", ""],
+        outputFormat: "raw",
+        styledOutputFormat: "kimi-stream-json",
+        authType: "api-key",
+        authCheckCommand: ["info"], // `kimi info` exits 0 if installed and auth ok
+        authLoginCommand: ["login"],
+        npmPackage: "", // Python package, not npm
+        pinnedVersion: "",
+        docsUrl: "https://moonshotai.github.io/kimi-cli/",
+        windowsInstallCommand: "pip install kimi-cli",
+        unixInstallCommand: "pip install kimi-cli",
+        icon: "moon",
+        unsetEnv: [],
+        authConfigDirEnvVar: "KIMI_SHARE_DIR",
+        authDirName: "kimi",
+        launchArgs: ["--print", "--output-format", "stream-json", "--yolo", "-p", ""],
+        resumeFlag: "--continue",
+        sessionIdField: "session_id",
+        controllerType: "subprocess",
+    },
+};
+```
+
+### 6.2 `providers/kimi-translator.ts` — New Translator
+
+**Design principle:** Mirror `GeminiTranslator` since Kimi's stream-json is similarly simple (discrete messages, not incremental deltas like Claude).
+
+```typescript
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { StreamEvent, ToolCallEvent, ToolResultEvent } from "../types";
+import type { OutputTranslator } from "./translator";
+
+/**
+ * Translates Kimi Code CLI `--output-format stream-json` events into StreamEvent format.
+ *
+ * Kimi emits NDJSON with these message types:
+ *   {"role":"assistant","content":[...],"tool_calls":[...]}
+ *   {"role":"tool","tool_call_id":"...","content":[...]}
+ *
+ * Content parts can be:
+ *   - {"type":"text","text":"..."}
+ *   - {"type":"think","think":"..."}
+ *   - {"type":"image_url",...} (future)
+ *
+ * Tool calls use OpenAI-style function calling:
+ *   {"type":"function","id":"tc_1","function":{"name":"Shell","arguments":"{...}"}}
+ */
+export class KimiTranslator implements OutputTranslator {
+    private toolNameById: Map<string, string> = new Map();
+
+    translate(rawEvent: any): StreamEvent[] {
+        if (!rawEvent || typeof rawEvent !== "object") return [];
+
+        const role: string = rawEvent.role ?? "";
+
+        switch (role) {
+            case "assistant": {
+                const events: StreamEvent[] = [];
+
+                // Handle content parts (text, think)
+                const content = rawEvent.content;
+                if (Array.isArray(content)) {
+                    for (const part of content) {
+                        if (part.type === "text" && part.text) {
+                            events.push({ type: "text", content: part.text });
+                        } else if (part.type === "think" && part.think) {
+                            events.push({ type: "thinking", content: part.think });
+                        }
+                    }
+                } else if (typeof content === "string" && content) {
+                    events.push({ type: "text", content });
+                }
+
+                // Handle tool_calls
+                const toolCalls = rawEvent.tool_calls;
+                if (Array.isArray(toolCalls)) {
+                    for (const tc of toolCalls) {
+                        if (tc.type === "function") {
+                            const toolName = tc.function?.name ?? "unknown";
+                            const toolId = tc.id ?? `tool-${Date.now()}`;
+                            let params: Record<string, any> = {};
+                            try {
+                                const args = tc.function?.arguments;
+                                if (typeof args === "string") {
+                                    params = JSON.parse(args);
+                                } else if (typeof args === "object" && args !== null) {
+                                    params = args;
+                                }
+                            } catch {
+                                params = {};
+                            }
+                            this.toolNameById.set(toolId, toolName);
+                            events.push({ type: "tool_call", tool: toolName, id: toolId, params });
+                        }
+                    }
+                }
+
+                return events;
+            }
+
+            case "tool": {
+                const toolId: string = rawEvent.tool_call_id ?? "";
+                const toolName = this.toolNameById.get(toolId) ?? "unknown";
+                const content = rawEvent.content;
+                let resultText = "";
+                if (Array.isArray(content)) {
+                    resultText = content
+                        .filter((p: any) => p.type === "text")
+                        .map((p: any) => p.text)
+                        .join("");
+                } else if (typeof content === "string") {
+                    resultText = content;
+                }
+                return [{
+                    type: "tool_result",
+                    tool: toolName,
+                    id: toolId,
+                    status: "success",
+                    result: { content: resultText },
+                }];
+            }
+
+            default:
+                return [];
+        }
+    }
+
+    reset(): void {
+        this.toolNameById.clear();
+    }
+}
+```
+
+### 6.3 `translator-factory.ts` — Register Kimi Translator
+
+```typescript
+import { KimiTranslator } from "./kimi-translator";
+
+export function createTranslator(outputFormat: string): OutputTranslator {
+    switch (outputFormat) {
+        case "claude-stream-json": return new ClaudeTranslator();
+        case "gemini-json": return new GeminiTranslator();
+        case "codex-json": return new CodexTranslator();
+        case "kimi-stream-json": return new KimiTranslator(); // NEW
+        case "acp": return new AcpTranslator();
+        default:
+            console.warn(`[translator-factory] Unknown output format "${outputFormat}", falling back to Claude translator`);
+            return new ClaudeTranslator();
+    }
+}
+```
+
+### 6.4 `buildRuntimeArgs.ts` — Kimi Permission Flags
+
+Kimi uses `--yolo` for auto-approve. Add to `PERMISSION_FLAGS`:
+
+```typescript
+const PERMISSION_FLAGS: Record<PermissionMode, string[]> = {
+    bypass: ["--yolo"],
+    auto: ["--yolo"], // Kimi doesn't have granular permission modes; map all to --yolo for now
+    acceptEdits: ["--yolo"],
+    plan: ["--yolo"],
+    default: ["--yolo"],
+};
+```
+
+> **Note:** Kimi does not support Claude-style permission modes (`auto`, `acceptEdits`, `plan`). All modes map to `--yolo` in Phase 1. Phase 2 (Wire mode) could support real approval flow.
+
+Update `PERMISSION_STRIP`:
+```typescript
+const PERMISSION_STRIP = new Set(["--yolo"]);
+```
+
+---
+
+## 7. Kimi Stream-JSON → StreamEvent Mapping
+
+| Kimi NDJSON | AgentMux `StreamEvent` | Notes |
+|-------------|------------------------|-------|
+| `{"role":"assistant","content":[{"type":"text","text":"hi"}]}` | `TextEvent {type:"text", content:"hi"}` | One text part → one text event |
+| `{"role":"assistant","content":[{"type":"think","think":"..."}]}` | `ThinkingEvent {type:"thinking", content:"..."}` | Rendered as collapsible thinking block |
+| `{"role":"assistant","tool_calls":[{"type":"function",...}]}` | `ToolCallEvent {type:"tool_call", tool, id, params}` | Parse `function.arguments` JSON string |
+| `{"role":"tool","tool_call_id":"tc_1","content":[...]}` | `ToolResultEvent {type:"tool_result", tool, id, status:"success", result}` | Aggregate text parts into result string |
+| No explicit session end event | N/A | Process exit signals turn end |
+
+**Content part types Kimi supports (future-proofing):**
+- `text` — handled
+- `think` — handled
+- `image_url` — ignore or render as image link (Phase 2)
+- `audio_url` — ignore (Phase 2)
+- `video_url` — ignore (Phase 2)
+
+---
+
+## 8. Auth & Configuration
+
+### 8.1 Auth Check
+
+Kimi does not have a dedicated "auth status" command like `claude auth status`. The best proxy is:
+
+```bash
+kimi info
+```
+
+- If authenticated: prints version info, exits 0.
+- If not authenticated: prints error, exits non-zero.
+
+**Alternative:** Check for the existence of `~/.kimi/config.toml` or credentials file.
+
+### 8.2 Auth Login
+
+```bash
+kimi login
+```
+
+Opens browser OAuth flow or prompts for API key.
+
+### 8.3 Config File Generation
+
+Kimi reads configuration from `~/.kimi/config.toml`. When AgentMux isolates auth via `KIMI_SHARE_DIR`, Kimi will read/write to `~/.agentmux/config/auth/kimi/config.toml`.
+
+AgentMux's `agent_config.rs` currently generates:
+- `CLAUDE.md` — system prompt for Claude Code
+- `.mcp.json` — MCP server config
+- `.claude/commands/*.md` — slash commands
+
+**Question:** Does Kimi read a system prompt file like `CLAUDE.md`?  
+**Answer:** Unknown. Kimi has `--agent-file` for custom agent specs and `--skills-dir` for skills. It does not appear to auto-read `CLAUDE.md`. For Phase 1, skip `KIMI.md` generation. Forge `soul`/`agentmd` content can be passed via the `-p` prompt or via `--agent-file` in Phase 2.
+
+**MCP:** Kimi supports MCP via `--mcp-config-file`. AgentMux should generate `.mcp.json` and pass it via `--mcp-config-file` in the launch args if Forge content includes MCP config.
+
+---
+
+## 9. Installation Strategy
+
+### Phase 1: PATH Fallback (Minimal Change)
+
+Assume the user has already installed `kimi` on their system via `pip`, `uv`, or official installer. AgentMux's `resolvecli` handler falls back to `where kimi` / `which kimi` when `npm_package` is empty.
+
+**Pros:** Zero installation complexity. Works immediately if `kimi` is on PATH.  
+**Cons:** No version pinning. No isolation from system Kimi install.
+
+### Phase 2: Managed Installation (Future)
+
+Extend `resolvecli` to support Python package managers:
+
+```rust
+enum InstallMethod {
+    Npm { package: String, version: String },
+    Pip { package: String, version: String },
+    Uv { package: String, version: String },
+}
+```
+
+For Kimi:
+```bash
+# Via uv (recommended, creates isolated environment)
+uv tool install kimi-cli==1.37.0
+
+# Via pip
+pip install --target ~/.agentmux/<version>/cli/kimi kimi-cli==1.37.0
+```
+
+This requires significant changes to `cli_handlers.rs` and the provider schema. Defer to Phase 2.
+
+---
+
+## 10. Session & Resume
+
+Kimi manages sessions in `~/.kimi/sessions/` (or `$KIMI_SHARE_DIR/sessions/`). Session IDs are UUIDs.
+
+**Flags:**
+- `--continue` — resume previous session for working directory
+- `--session <id>` — resume specific session
+- `--print` — non-interactive mode (implicitly adds `--yolo`)
+
+**Open Question:** Does `--print --continue` work? The docs don't explicitly confirm this combination. We need to test:
+
+```bash
+kimi --print --continue --output-format stream-json -p "second message"
+```
+
+If it works, the `resume_flag: Some("--continue")` config is correct. If not, we may need to:
+1. Parse the session ID from the first turn's stderr (`To resume this session: kimi -r <id>`)
+2. Pass `--session <id>` on subsequent turns
+
+**Proposed approach:**
+- Phase 1: Omit `resume_flag` (set to `None`). Spawn a fresh subprocess per turn. Kimi's context is lost between turns, but this is the safest option.
+- Phase 1.5: Parse stderr for session ID and use `--session <id>`.
+- Phase 2: Use Wire mode for true persistent sessions.
+
+---
+
+## 11. Testing Plan
+
+### Unit Tests
+
+1. **Backend:**
+   - `providers::get_provider("kimi")` resolves correctly
+   - `providers::get_provider("kimi-cli")` resolves via alias
+   - Provider list has 6 entries
+   - `KIMI.controller_type` is `Subprocess`
+
+2. **Frontend:**
+   - `KimiTranslator.translate()` handles assistant text
+   - `KimiTranslator.translate()` handles thinking blocks
+   - `KimiTranslator.translate()` handles tool_calls with JSON string arguments
+   - `KimiTranslator.translate()` handles tool results with array content
+   - `createTranslator("kimi-stream-json")` returns `KimiTranslator`
+
+### Integration Tests
+
+1. **Stream parsing:** Feed sample Kimi NDJSON lines into `KimiTranslator` and verify `StreamEvent` output.
+2. **End-to-end:** Open a Kimi agent pane, send "List files in current directory", verify tool call and result render correctly.
+3. **Auth isolation:** Verify `KIMI_SHARE_DIR` is set and Kimi reads/writes to the isolated directory.
+
+### Manual Tests
+
+1. Run `kimi --print --output-format stream-json --yolo -p "say hi"` and capture output.
+2. Run `kimi --print --output-format stream-json --yolo -p "use Shell to list files"` and verify tool call JSON is well-formed.
+3. Test `--continue` in print mode for session resumption.
+
+---
+
+## 12. Open Questions & Risks
+
+| # | Question / Risk | Mitigation |
+|---|-----------------|------------|
+| 1 | **Session resumption in print mode** — does `--continue` work with `--print`? | Test manually. If broken, omit `resume_flag` in Phase 1. |
+| 2 | **System prompt injection** — Kimi doesn't read `CLAUDE.md`. How do we inject Forge `soul`/`agentmd`? | Pass as part of the initial `-p` prompt, or use `--agent-file` (Phase 2). |
+| 3 | **MCP support** — Kimi uses `--mcp-config-file` not `.mcp.json` auto-discovery. | Add `--mcp-config-file` to launch args pointing to generated `.mcp.json`. |
+| 4 | **Permission modes** — Kimi only has `--yolo` (all approvals) vs interactive. No granular modes. | Map all AgentMux permission modes to `--yolo` in Phase 1. Wire mode (Phase 2) enables real approvals. |
+| 5 | **Tool name normalization** — Kimi uses `Shell`, `Read`, `Edit` etc. Same as Claude? | Verify tool names match. If different, add normalization in `KimiTranslator`. |
+| 6 | **Installation** — No npm package. PATH fallback means no version isolation. | Accept for Phase 1. Phase 2 adds `uv tool install` support. |
+| 7 | **Windows compatibility** — Kimi on Windows is `kimi.exe` (Python entry point). | `where kimi` should resolve it. The `.cmd` suffix handling in `cli_handlers.rs` may need adjustment. |
+| 8 | **Stderr parsing** — Kimi prints session resume info to stderr (`To resume this session: kimi -r <id>`). | Our subprocess/persistent controllers already drain stderr. We can parse it if needed for session ID extraction. |
+
+---
+
+## 13. Implementation Checklist
+
+- [ ] **Backend:** Add `KIMI` provider config to `providers.rs`
+- [ ] **Backend:** Register `kimi` in `REGISTRY`, `ORDER`, and `ALIASES`
+- [ ] **Backend:** Update `app_api.rs` output_format match for `kimi-stream-json`
+- [ ] **Backend:** Add PATH fallback to `cli_handlers.rs` when `npm_package` is empty
+- [ ] **Backend:** Update provider count in unit tests (5 → 6)
+- [ ] **Frontend:** Extend `outputFormat` / `styledOutputFormat` union types in `providers/index.ts`
+- [ ] **Frontend:** Add `kimi` provider definition to `PROVIDERS`
+- [ ] **Frontend:** Create `providers/kimi-translator.ts`
+- [ ] **Frontend:** Register `kimi-stream-json` in `translator-factory.ts`
+- [ ] **Frontend:** Update `buildRuntimeArgs.ts` permission flags for Kimi
+- [ ] **Frontend:** Add unit tests for `KimiTranslator`
+- [ ] **Integration:** Manually test `kimi --print --output-format stream-json` end-to-end
+- [ ] **Integration:** Verify auth isolation via `KIMI_SHARE_DIR`
+- [ ] **Docs:** Update `app-api-status.md` if provider list is documented there
+
+---
+
+## 14. Appendix: Kimi NDJSON Samples
+
+### Sample A: Simple text response
+```json
+{"role":"assistant","content":[{"type":"think","think":"The user wants a greeting."}],"tool_calls":null}
+{"role":"assistant","content":[{"type":"text","text":"Hello! How can I help you today?"}],"tool_calls":null}
+```
+
+### Sample B: Tool call + result
+```json
+{"role":"assistant","content":[],"tool_calls":[{"type":"function","id":"tool_abc123","function":{"name":"Shell","arguments":"{\"command\":\"ls -la\"}"}}]}
+{"role":"tool","tool_call_id":"tool_abc123","content":[{"type":"text","text":"total 128\\ndrwxr-xr-x  5 user staff   160 Apr 20 10:00 .\\n..."}]}
+{"role":"assistant","content":[{"type":"text","text":"Here are the files in the directory."}],"tool_calls":null}
+```
+
+### Sample C: Thinking + text
+```json
+{"role":"assistant","content":[{"type":"think","think":"I need to analyze the codebase structure first."}],"tool_calls":null}
+{"role":"assistant","content":[{"type":"text","text":"I'll start by examining the project structure."}],"tool_calls":null}
+```
+
+---
+
+## 15. Appendix: Comparison with Existing Providers
+
+| Feature | Claude | Codex | Gemini | **Kimi (Phase 1)** |
+|---------|--------|-------|--------|-------------------|
+| Controller | Subprocess | Subprocess | Subprocess | **Subprocess** |
+| Stream format | stream-json (Anthropic deltas) | NDJSON (discrete) | stream-json (discrete) | **stream-json (discrete)** |
+| Tool calls | Streaming deltas | Discrete | Discrete | **Discrete** |
+| Thinking | `thinking_delta` | No | No | **`think` content part** |
+| Session resume | `--resume` | `exec resume <id>` | `-r` | **`--continue` (TBD)** |
+| Auth isolation | `CLAUDE_CONFIG_DIR` | `CODEX_HOME` | `GEMINI_CLI_HOME` | **`KIMI_SHARE_DIR`** |
+| Install | npm | npm | npm | **PATH / pip / uv** |
+| MCP | Auto `.mcp.json` | Via config | Via config | **`--mcp-config-file`** |
+
+---
+*End of Spec*

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -27,6 +27,7 @@ const PERMISSION_FLAGS: Record<PermissionMode, string[]> = {
 const PERMISSION_STRIP = new Set([
     "--dangerously-skip-permissions",
     "--permission-mode",
+    "--yolo",
 ]);
 
 /**
@@ -39,6 +40,7 @@ const PERMISSION_STRIP = new Set([
 export function buildRuntimeArgs(
     baseLaunchArgs: string[],
     runtime: AgentRuntimeConfig | null | undefined,
+    providerId?: string,
 ): string[] {
     const config = runtime ?? DEFAULT_RUNTIME_CONFIG;
     const args: string[] = [];
@@ -68,12 +70,22 @@ export function buildRuntimeArgs(
         i++;
     }
 
-    // Apply permission mode (fall back to bypass if metadata contains an invalid value)
-    const permFlags = PERMISSION_FLAGS[config.permissionMode] ?? PERMISSION_FLAGS.bypass;
-    args.push(...permFlags);
+    // Apply permission mode
+    if (providerId === "kimi" || providerId === "gemini") {
+        // Kimi and Gemini only support --yolo (bypass) vs no flag (default)
+        if (config.permissionMode !== "default") {
+            args.push("--yolo");
+        }
+    } else {
+        const permFlags = PERMISSION_FLAGS[config.permissionMode] ?? PERMISSION_FLAGS.bypass;
+        args.push(...permFlags);
+    }
 
-    args.push("--model", config.model);
-    args.push("--effort", config.effort);
+    // Apply model and effort only for providers that support these flags
+    if (!providerId || providerId === "claude") {
+        args.push("--model", config.model);
+        args.push("--effort", config.effort);
+    }
 
     return args;
 }

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -81,10 +81,12 @@ export function buildRuntimeArgs(
         args.push(...permFlags);
     }
 
-    // Apply model and effort for all providers except Kimi, which does not
-    // support the --effort flag and uses different --model values.
-    if (providerId !== "kimi") {
+    // --model: supported by claude, codex, gemini. --effort: claude only.
+    const supportsModel = !providerId || providerId === "claude" || providerId === "codex" || providerId === "gemini";
+    if (supportsModel) {
         args.push("--model", config.model);
+    }
+    if (!providerId || providerId === "claude") {
         args.push("--effort", config.effort);
     }
 

--- a/frontend/app/view/agent/buildRuntimeArgs.ts
+++ b/frontend/app/view/agent/buildRuntimeArgs.ts
@@ -81,8 +81,9 @@ export function buildRuntimeArgs(
         args.push(...permFlags);
     }
 
-    // Apply model and effort only for providers that support these flags
-    if (!providerId || providerId === "claude") {
+    // Apply model and effort for all providers except Kimi, which does not
+    // support the --effort flag and uses different --model values.
+    if (providerId !== "kimi") {
         args.push("--model", config.model);
         args.push("--effort", config.effort);
     }

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -232,7 +232,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             const baseArgs = prov.controllerType === "persistent" && prov.persistentLaunchArgs
                 ? prov.persistentLaunchArgs
                 : prov.launchArgs;
-            const updatedArgs = buildRuntimeArgs(baseArgs, runtimeConfig);
+            const updatedArgs = buildRuntimeArgs(baseArgs, runtimeConfig, prov.id);
             try {
                 await RpcApi.SetMetaCommand(TabRpcClient, {
                     oref: WOS.makeORef("block", opts.blockId),

--- a/frontend/app/view/agent/providers/index.test.ts
+++ b/frontend/app/view/agent/providers/index.test.ts
@@ -11,6 +11,7 @@ import type { ProviderDefinition } from "./index";
 //   - ACP providers:           openclaw, pi — authType "api-key",
 //     outputFormat "acp".
 const OAUTH_CLI_IDS = ["claude", "codex", "gemini"] as const;
+const API_KEY_CLI_IDS = ["kimi"] as const;
 const ACP_IDS = ["openclaw", "pi"] as const;
 
 describe("PROVIDERS", () => {
@@ -30,8 +31,6 @@ describe("PROVIDERS", () => {
             expect(provider.authType).toBeTruthy();
             expect(Array.isArray(provider.authCheckCommand)).toBe(true);
             expect(Array.isArray(provider.authLoginCommand)).toBe(true);
-            expect(provider.npmPackage).toBeTruthy();
-            expect(provider.pinnedVersion).toBeTruthy();
             expect(provider.docsUrl).toBeTruthy();
             expect(provider.icon).toBeTruthy();
         }
@@ -39,6 +38,14 @@ describe("PROVIDERS", () => {
 
     test("OAuth CLI providers are in raw output mode with no default args", () => {
         for (const id of OAUTH_CLI_IDS) {
+            const provider = PROVIDERS[id];
+            expect(provider.outputFormat).toBe("raw");
+            expect(provider.defaultArgs).toEqual([]);
+        }
+    });
+
+    test("API-key CLI providers are in raw output mode with no default args", () => {
+        for (const id of API_KEY_CLI_IDS) {
             const provider = PROVIDERS[id];
             expect(provider.outputFormat).toBe("raw");
             expect(provider.defaultArgs).toEqual([]);
@@ -91,6 +98,32 @@ describe("codex provider", () => {
 
     test("has correct npm package", () => {
         expect(codex.npmPackage).toBe("@openai/codex");
+    });
+});
+
+describe("kimi provider", () => {
+    const kimi = PROVIDERS.kimi;
+
+    test("has correct CLI command", () => {
+        expect(kimi.cliCommand).toBe("kimi");
+    });
+
+    test("has correct auth commands", () => {
+        expect(kimi.authCheckCommand).toEqual(["info"]);
+        expect(kimi.authLoginCommand).toEqual(["login"]);
+    });
+
+    test("has empty npm package (python-based CLI)", () => {
+        expect(kimi.npmPackage).toBe("");
+        expect(kimi.pinnedVersion).toBe("");
+    });
+
+    test("uses subprocess controller", () => {
+        expect(kimi.controllerType).toBe("subprocess");
+    });
+
+    test("has kimi-stream-json styled output format", () => {
+        expect(kimi.styledOutputFormat).toBe("kimi-stream-json");
     });
 });
 

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -148,9 +148,8 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "sessionId",
         controllerType: "acp",
     },
-    // Pi — the lightweight coding agent that powers OpenClaw.
-    // Standalone CLI, no gateway required. Pure coding agent with read/write/bash/edit tools.
-    // Ideal when users want a fast, self-contained coding agent without the full OpenClaw stack.
+    // Kimi Code CLI — Moonshot AI's coding agent.
+    // Python-based CLI (not npm). Supports stream-json output and OpenAI-style tool calls.
     kimi: {
         id: "kimi",
         displayName: "Kimi Code CLI",
@@ -176,6 +175,9 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "session_id",
         controllerType: "subprocess",
     },
+    // Pi — the lightweight coding agent that powers OpenClaw.
+    // Standalone CLI, no gateway required. Pure coding agent with read/write/bash/edit tools.
+    // Ideal when users want a fast, self-contained coding agent without the full OpenClaw stack.
     pi: {
         id: "pi",
         displayName: "Pi",

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -7,8 +7,8 @@ export interface ProviderDefinition {
     cliCommand: string;
     defaultArgs: string[];
     styledArgs: string[];        // CLI flags for JSON streaming mode (documentation; use launchArgs for actual invocation)
-    outputFormat: "claude-stream-json" | "gemini-json" | "codex-json" | "acp" | "raw";
-    styledOutputFormat: "claude-stream-json" | "gemini-json" | "codex-json" | "acp";
+    outputFormat: "claude-stream-json" | "gemini-json" | "codex-json" | "kimi-stream-json" | "acp" | "raw";
+    styledOutputFormat: "claude-stream-json" | "gemini-json" | "codex-json" | "kimi-stream-json" | "acp";
     authType: "oauth" | "api-key";
     authCheckCommand: string[];  // e.g. ["auth", "status", "--json"]
     authLoginCommand: string[];  // e.g. ["auth", "login"]
@@ -151,6 +151,31 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
     // Pi — the lightweight coding agent that powers OpenClaw.
     // Standalone CLI, no gateway required. Pure coding agent with read/write/bash/edit tools.
     // Ideal when users want a fast, self-contained coding agent without the full OpenClaw stack.
+    kimi: {
+        id: "kimi",
+        displayName: "Kimi Code CLI",
+        cliCommand: "kimi",
+        defaultArgs: [],
+        styledArgs: ["--print", "--output-format", "stream-json", "--yolo", "-p", ""],
+        outputFormat: "raw",
+        styledOutputFormat: "kimi-stream-json",
+        authType: "api-key",
+        authCheckCommand: ["info"],
+        authLoginCommand: ["login"],
+        npmPackage: "",
+        pinnedVersion: "",
+        docsUrl: "https://moonshotai.github.io/kimi-cli/",
+        windowsInstallCommand: "pip install kimi-cli",
+        unixInstallCommand: "pip install kimi-cli",
+        icon: "moon",
+        unsetEnv: [],
+        authConfigDirEnvVar: "KIMI_SHARE_DIR",
+        authDirName: "kimi",
+        launchArgs: ["--print", "--output-format", "stream-json", "--yolo", "-p", ""],
+        resumeFlag: null,
+        sessionIdField: "session_id",
+        controllerType: "subprocess",
+    },
     pi: {
         id: "pi",
         displayName: "Pi",
@@ -183,6 +208,8 @@ const PROVIDER_ALIASES: Record<string, string> = {
     "claude_code": "claude",
     "codex-cli": "codex",
     "gemini-cli": "gemini",
+    "kimi-cli": "kimi",
+    "kimi_code": "kimi",
     "openclaw-cli": "openclaw",
     "open-claw": "openclaw",
 };

--- a/frontend/app/view/agent/providers/kimi-translator.test.ts
+++ b/frontend/app/view/agent/providers/kimi-translator.test.ts
@@ -1,0 +1,272 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { KimiTranslator } from "./kimi-translator";
+
+describe("KimiTranslator", () => {
+    describe("assistant messages", () => {
+        it("translates text content to text event", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "assistant",
+                content: [{ type: "text", text: "Hello world" }],
+            });
+            expect(events).toEqual([{ type: "text", content: "Hello world" }]);
+        });
+
+        it("translates think content to thinking event", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "assistant",
+                content: [{ type: "think", think: "Let me analyze this." }],
+            });
+            expect(events).toEqual([{ type: "thinking", content: "Let me analyze this." }]);
+        });
+
+        it("handles mixed text and think content parts", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "assistant",
+                content: [
+                    { type: "think", think: "Planning..." },
+                    { type: "text", text: "Here is the answer." },
+                ],
+            });
+            expect(events).toEqual([
+                { type: "thinking", content: "Planning..." },
+                { type: "text", content: "Here is the answer." },
+            ]);
+        });
+
+        it("handles string content", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "assistant",
+                content: "Plain text response",
+            });
+            expect(events).toEqual([{ type: "text", content: "Plain text response" }]);
+        });
+
+        it("handles empty content", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "assistant",
+                content: [],
+            });
+            expect(events).toEqual([]);
+        });
+    });
+
+    describe("tool calls", () => {
+        it("translates tool_calls to tool_call events", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "assistant",
+                content: [],
+                tool_calls: [{
+                    type: "function",
+                    id: "tc_1",
+                    function: {
+                        name: "Shell",
+                        arguments: '{"command": "ls"}',
+                    },
+                }],
+            });
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("tool_call");
+            expect((events[0] as any).tool).toBe("Shell");
+            expect((events[0] as any).id).toBe("tc_1");
+            expect((events[0] as any).params).toEqual({ command: "ls" });
+        });
+
+        it("handles tool_calls with object arguments (not string)", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "assistant",
+                content: [],
+                tool_calls: [{
+                    type: "function",
+                    id: "tc_2",
+                    function: {
+                        name: "Read",
+                        arguments: { file_path: "/foo.txt" },
+                    },
+                }],
+            });
+            expect(events).toHaveLength(1);
+            expect((events[0] as any).params).toEqual({ file_path: "/foo.txt" });
+        });
+
+        it("handles multiple tool_calls", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "assistant",
+                content: [],
+                tool_calls: [
+                    {
+                        type: "function",
+                        id: "tc_a",
+                        function: { name: "Shell", arguments: '{"command": "a"}' },
+                    },
+                    {
+                        type: "function",
+                        id: "tc_b",
+                        function: { name: "Read", arguments: '{"file_path": "b"}' },
+                    },
+                ],
+            });
+            expect(events).toHaveLength(2);
+            expect((events[0] as any).tool).toBe("Shell");
+            expect((events[1] as any).tool).toBe("Read");
+        });
+
+        it("falls back to unknown for missing tool name", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "assistant",
+                content: [],
+                tool_calls: [{
+                    type: "function",
+                    id: "tc_x",
+                    function: { arguments: "{}" },
+                }],
+            });
+            expect((events[0] as any).tool).toBe("unknown");
+        });
+    });
+
+    describe("tool results", () => {
+        it("translates tool result to tool_result event", () => {
+            const t = new KimiTranslator();
+            // First register the tool name
+            t.translate({
+                role: "assistant",
+                content: [],
+                tool_calls: [{
+                    type: "function",
+                    id: "tc_1",
+                    function: { name: "Shell", arguments: "{}" },
+                }],
+            });
+
+            const events = t.translate({
+                role: "tool",
+                tool_call_id: "tc_1",
+                content: [{ type: "text", text: "file1.py\nfile2.py" }],
+            });
+            expect(events).toHaveLength(1);
+            expect(events[0].type).toBe("tool_result");
+            expect((events[0] as any).tool).toBe("Shell");
+            expect((events[0] as any).id).toBe("tc_1");
+            expect((events[0] as any).status).toBe("success");
+            expect((events[0] as any).result).toEqual({ content: "file1.py\nfile2.py" });
+        });
+
+        it("handles tool result with string content", () => {
+            const t = new KimiTranslator();
+            t.translate({
+                role: "assistant",
+                content: [],
+                tool_calls: [{
+                    type: "function",
+                    id: "tc_2",
+                    function: { name: "Read", arguments: "{}" },
+                }],
+            });
+
+            const events = t.translate({
+                role: "tool",
+                tool_call_id: "tc_2",
+                content: "plain string output",
+            });
+            expect((events[0] as any).result).toEqual({ content: "plain string output" });
+        });
+
+        it("uses unknown tool name when tool_call was not seen", () => {
+            const t = new KimiTranslator();
+            const events = t.translate({
+                role: "tool",
+                tool_call_id: "tc_missing",
+                content: [{ type: "text", text: "output" }],
+            });
+            expect((events[0] as any).tool).toBe("unknown");
+        });
+    });
+
+    describe("combined assistant + tool flow", () => {
+        it("handles full turn with thinking, text, tool call, and result", () => {
+            const t = new KimiTranslator();
+
+            const events1 = t.translate({
+                role: "assistant",
+                content: [{ type: "think", think: "I need to list files." }],
+                tool_calls: [{
+                    type: "function",
+                    id: "tc_shell",
+                    function: {
+                        name: "Shell",
+                        arguments: '{"command": "ls"}',
+                    },
+                }],
+            });
+            expect(events1).toHaveLength(2);
+            expect(events1[0]).toEqual({ type: "thinking", content: "I need to list files." });
+            expect(events1[1].type).toBe("tool_call");
+
+            const events2 = t.translate({
+                role: "tool",
+                tool_call_id: "tc_shell",
+                content: [{ type: "text", text: "foo.txt\nbar.txt" }],
+            });
+            expect(events2).toHaveLength(1);
+            expect(events2[0].type).toBe("tool_result");
+
+            const events3 = t.translate({
+                role: "assistant",
+                content: [{ type: "text", text: "Here are your files." }],
+            });
+            expect(events3).toEqual([{ type: "text", content: "Here are your files." }]);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("handles null/undefined input gracefully", () => {
+            const t = new KimiTranslator();
+            expect(t.translate(null)).toHaveLength(0);
+            expect(t.translate(undefined)).toHaveLength(0);
+            expect(t.translate("not an object")).toHaveLength(0);
+        });
+
+        it("handles empty object", () => {
+            const t = new KimiTranslator();
+            expect(t.translate({})).toHaveLength(0);
+        });
+
+        it("ignores unknown roles", () => {
+            const t = new KimiTranslator();
+            expect(t.translate({ role: "system", content: "hello" })).toHaveLength(0);
+        });
+
+        it("reset clears tool name mapping", () => {
+            const t = new KimiTranslator();
+            t.translate({
+                role: "assistant",
+                content: [],
+                tool_calls: [{
+                    type: "function",
+                    id: "tc_1",
+                    function: { name: "Shell", arguments: "{}" },
+                }],
+            });
+            t.reset();
+
+            const events = t.translate({
+                role: "tool",
+                tool_call_id: "tc_1",
+                content: [{ type: "text", text: "output" }],
+            });
+            expect((events[0] as any).tool).toBe("unknown");
+        });
+    });
+});

--- a/frontend/app/view/agent/providers/kimi-translator.ts
+++ b/frontend/app/view/agent/providers/kimi-translator.ts
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { StreamEvent, ToolCallEvent, ToolResultEvent } from "../types";
+import type { StreamEvent } from "../types";
 import type { OutputTranslator } from "./translator";
 
 /**

--- a/frontend/app/view/agent/providers/kimi-translator.ts
+++ b/frontend/app/view/agent/providers/kimi-translator.ts
@@ -1,0 +1,105 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { StreamEvent, ToolCallEvent, ToolResultEvent } from "../types";
+import type { OutputTranslator } from "./translator";
+
+/**
+ * Translates Kimi Code CLI `--output-format stream-json` events into StreamEvent format.
+ *
+ * Kimi emits NDJSON with these message types:
+ *   {"role":"assistant","content":[...],"tool_calls":[...]}
+ *   {"role":"tool","tool_call_id":"...","content":[...]}
+ *
+ * Content parts can be:
+ *   - {"type":"text","text":"..."}
+ *   - {"type":"think","think":"..."}
+ *   - {"type":"image_url",...} (future)
+ *
+ * Tool calls use OpenAI-style function calling:
+ *   {"type":"function","id":"tc_1","function":{"name":"Shell","arguments":"{...}"}}
+ */
+export class KimiTranslator implements OutputTranslator {
+    private toolNameById: Map<string, string> = new Map();
+
+    translate(rawEvent: any): StreamEvent[] {
+        if (!rawEvent || typeof rawEvent !== "object") return [];
+
+        const role: string = rawEvent.role ?? "";
+
+        switch (role) {
+            case "assistant": {
+                const events: StreamEvent[] = [];
+
+                // Handle content parts (text, think)
+                const content = rawEvent.content;
+                if (Array.isArray(content)) {
+                    for (const part of content) {
+                        if (part.type === "text" && part.text) {
+                            events.push({ type: "text", content: part.text });
+                        } else if (part.type === "think" && part.think) {
+                            events.push({ type: "thinking", content: part.think });
+                        }
+                    }
+                } else if (typeof content === "string" && content) {
+                    events.push({ type: "text", content });
+                }
+
+                // Handle tool_calls
+                const toolCalls = rawEvent.tool_calls;
+                if (Array.isArray(toolCalls)) {
+                    for (const tc of toolCalls) {
+                        if (tc.type === "function") {
+                            const toolName = tc.function?.name ?? "unknown";
+                            const toolId = tc.id ?? `tool-${Date.now()}`;
+                            let params: Record<string, any> = {};
+                            try {
+                                const args = tc.function?.arguments;
+                                if (typeof args === "string") {
+                                    params = JSON.parse(args);
+                                } else if (typeof args === "object" && args !== null) {
+                                    params = args;
+                                }
+                            } catch {
+                                params = {};
+                            }
+                            this.toolNameById.set(toolId, toolName);
+                            events.push({ type: "tool_call", tool: toolName, id: toolId, params });
+                        }
+                    }
+                }
+
+                return events;
+            }
+
+            case "tool": {
+                const toolId: string = rawEvent.tool_call_id ?? "";
+                const toolName = this.toolNameById.get(toolId) ?? "unknown";
+                const content = rawEvent.content;
+                let resultText = "";
+                if (Array.isArray(content)) {
+                    resultText = content
+                        .filter((p: any) => p.type === "text")
+                        .map((p: any) => p.text)
+                        .join("");
+                } else if (typeof content === "string") {
+                    resultText = content;
+                }
+                return [{
+                    type: "tool_result",
+                    tool: toolName,
+                    id: toolId,
+                    status: "success",
+                    result: { content: resultText },
+                }];
+            }
+
+            default:
+                return [];
+        }
+    }
+
+    reset(): void {
+        this.toolNameById.clear();
+    }
+}

--- a/frontend/app/view/agent/providers/translator-factory.ts
+++ b/frontend/app/view/agent/providers/translator-factory.ts
@@ -6,6 +6,7 @@ import { ClaudeTranslator } from "./claude-translator";
 import { GeminiTranslator } from "./gemini-translator";
 import { CodexTranslator } from "./codex-translator";
 import { AcpTranslator } from "./acp-translator";
+import { KimiTranslator } from "./kimi-translator";
 
 /**
  * Create an OutputTranslator for the given output format.
@@ -18,6 +19,8 @@ export function createTranslator(outputFormat: string): OutputTranslator {
             return new GeminiTranslator();
         case "codex-json":
             return new CodexTranslator();
+        case "kimi-stream-json":
+            return new KimiTranslator();
         case "acp":
             return new AcpTranslator();
         default:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.295",
+  "version": "0.33.296",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.295",
+      "version": "0.33.296",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -380,6 +380,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -587,6 +588,7 @@
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -983,6 +985,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1031,6 +1034,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1042,7 +1046,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1059,7 +1062,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1076,7 +1078,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1093,7 +1094,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1110,7 +1110,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1127,7 +1126,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1144,7 +1142,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1161,7 +1158,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1178,7 +1174,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1195,7 +1190,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1212,7 +1206,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1229,7 +1222,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,7 +1238,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1263,7 +1254,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1280,7 +1270,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1297,7 +1286,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1314,7 +1302,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1331,7 +1318,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1348,7 +1334,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1365,7 +1350,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1382,7 +1366,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1399,7 +1382,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1416,7 +1398,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1433,7 +1414,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1450,7 +1430,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1467,7 +1446,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1950,7 +1928,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1990,7 +1967,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2011,7 +1987,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2032,7 +2007,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2053,7 +2027,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2074,7 +2047,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2095,7 +2067,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2116,7 +2087,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2137,7 +2107,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2158,7 +2127,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2179,7 +2147,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2200,7 +2167,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2221,7 +2187,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2242,7 +2207,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2457,7 +2421,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2471,7 +2434,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2485,7 +2447,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2499,7 +2460,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2513,7 +2473,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2527,7 +2486,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2541,7 +2499,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2555,7 +2512,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2569,7 +2525,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2583,7 +2538,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2597,7 +2551,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2611,7 +2564,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2625,7 +2577,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2639,7 +2590,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2653,7 +2603,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2667,7 +2616,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2681,7 +2629,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2695,7 +2642,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2709,7 +2655,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2723,7 +2668,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2737,7 +2681,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2751,7 +2694,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2765,7 +2707,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2779,7 +2720,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2793,7 +2733,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3051,6 +2990,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3350,7 +3290,8 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@table-nav/core/-/core-0.0.9.tgz",
       "integrity": "sha512-9LhTDDeGpjgvwKa96EeLejzXqgq9bThvF3ngdcOGjlWtxwrej4rWs4xSX5EVEEUIeA4TU2Vwe7UifrHRLgU4dw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@table-nav/react": {
       "version": "0.0.9",
@@ -4223,8 +4164,9 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4250,8 +4192,8 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4260,8 +4202,9 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4383,6 +4326,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4844,6 +4788,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5109,6 +5054,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5258,6 +5204,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -5283,7 +5230,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5538,6 +5485,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5947,6 +5895,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6157,7 +6106,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6299,7 +6248,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6366,6 +6315,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6657,7 +6607,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6751,7 +6700,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6797,7 +6745,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7380,7 +7328,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7514,7 +7462,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7534,7 +7482,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7705,7 +7653,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7962,7 +7910,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7995,7 +7943,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8016,7 +7963,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8037,7 +7983,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8058,7 +8003,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8079,7 +8023,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8100,7 +8043,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8121,7 +8063,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8142,7 +8083,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8163,7 +8103,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8184,7 +8123,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8205,7 +8143,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8765,6 +8702,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9401,7 +9339,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -9454,7 +9393,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9504,7 +9442,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9572,7 +9509,8 @@
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-2.14.0.tgz",
       "integrity": "sha512-RjV0pqc79kYhQLC3vTcLRb5GLpI1n6qh0Oua3g+bGH4EgNOJHVBGP7u0zZtxoAa0dkHlAqTTSYRb9MMmxNLjig==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/overlayscrollbars-react": {
       "version": "0.5.6",
@@ -9783,7 +9721,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9838,7 +9775,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9879,6 +9815,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9993,6 +9930,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10041,6 +9979,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10116,7 +10055,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10455,7 +10394,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10521,8 +10460,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10623,8 +10562,9 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10676,6 +10616,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10794,6 +10735,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -11135,7 +11077,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11269,7 +11212,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11485,7 +11427,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11505,7 +11447,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11535,6 +11476,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11577,7 +11519,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -11585,6 +11527,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -11806,8 +11749,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11973,7 +11916,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11990,7 +11932,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12007,7 +11948,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12024,7 +11964,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12041,7 +11980,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12058,7 +11996,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12075,7 +12012,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12092,7 +12028,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12109,7 +12044,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12126,7 +12060,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12143,7 +12076,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12160,7 +12092,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12177,7 +12108,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12194,7 +12124,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12211,7 +12140,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12228,7 +12156,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12245,7 +12172,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12262,7 +12188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12279,7 +12204,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12296,7 +12220,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12313,7 +12236,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12330,7 +12252,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12347,7 +12268,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12364,7 +12284,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12381,7 +12300,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12398,7 +12316,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12412,7 +12329,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12454,7 +12370,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12490,6 +12405,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -12871,6 +12787,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -12909,6 +12826,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.295",
+  "version": "0.33.296",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Adds [Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli) (Moonshot AI) as a first-class agent provider alongside Claude, Codex, and Gemini.

## What's new

**Backend (Rust):**
- Add KIMI ProviderConfig in providers.rs — subprocess controller with --print --output-format stream-json --yolo
- Add kimi-stream-json output format mapping in pp_api.rs
- Add system **PATH fallback** for non-npm CLIs in cli_handlers.rs and pp_api.rs (Kimi is a Python package installed via pip/uv, not 
pm)

**Frontend (TypeScript):**
- Add kimi provider definition to providers/index.ts
- Create KimiTranslator that translates Kimi's NDJSON message format ({role, content, tool_calls}) into StreamEvent
- Register kimi-stream-json in 	ranslator-factory.ts
- Make uildRuntimeArgs **provider-aware** so permission/model/effort flags are handled correctly per provider (Kimi/Gemini use --yolo, Claude uses --dangerously-skip-permissions/--permission-mode)

**Tests:**
- Add comprehensive kimi-translator.test.ts (40 assertions)
- Update providers/index.test.ts for 6-provider registry
- All Rust provider unit tests pass (10/10)
- All frontend tests pass (40/40)

## Architecture notes

Kimi exposes three protocols:
1. **Print mode + --output-format stream-json** ← used (simplest, mirrors Gemini)
2. Wire mode (kimi --wire) ← future Phase 2 (JSON-RPC 2.0, bidirectional)
3. ACP mode (kimi acp) ← **not compatible** with AgentMux's ACP controller (different method names)

See docs/specs/KIMI_PROVIDER_INTEGRATION_SPEC.md for full technical details.