### PR TITLE
fix(agent): resolve ~/.agentmux/ prefix to agentmuxHome() at launch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.296"
+version = "0.33.297"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.296"
+version = "0.33.297"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.296"
+version = "0.33.297"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.296"
+version = "0.33.297"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.296 | 2026-04-20 | 159.7 MiB | 333.1 MiB | |
 | 0.33.284 | 2026-04-19 | 159.7 MiB | 333.1 MiB | |
 | 0.33.245 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |
 | 0.33.240 | 2026-04-17 | 158.6 MiB | 330.9 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.296"
+version = "0.33.297"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.296"
+version = "0.33.297"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.296"
+version = "0.33.297"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.296"
+version = "0.33.297"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/forge-seed.json
+++ b/agentmux-srv/forge-seed.json
@@ -6,7 +6,7 @@
       "name": "AgentX",
       "icon": "🔴",
       "description": "Primary coding agent",
-      "working_directory": "~/.agentmux/agents/agentx",
+      "working_directory": "",
       "shell": "pwsh",
       "agent_bus_id": "agentx",
       "content": {
@@ -28,7 +28,7 @@
       "name": "AgentY",
       "icon": "🟡",
       "description": "Secondary coding agent",
-      "working_directory": "~/.agentmux/agents/agenty",
+      "working_directory": "",
       "shell": "pwsh",
       "agent_bus_id": "agenty",
       "content": {
@@ -50,7 +50,7 @@
       "name": "AgentZ",
       "icon": "🔵",
       "description": "Tertiary coding agent",
-      "working_directory": "~/.agentmux/agents/agentz",
+      "working_directory": "",
       "shell": "pwsh",
       "agent_bus_id": "agentz",
       "content": {

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -254,7 +254,16 @@ export class AgentViewModel implements ViewModel {
         // Falls back to the legacy name-derived form if slug is empty
         // (defensive — the v4 migration backfills slug for every row).
         const slug = agent.slug || agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
-        const workDir = agent.working_directory || `${agentmuxHome()}/agents/${slug}`;
+        // If the persisted working_directory was seeded with a literal `~/.agentmux/...`
+        // path (see `scripts/gen-seed.js`), rewrite its prefix to the host-resolved
+        // `agentmuxHome()`. On portable builds that points into the portable data dir;
+        // on installed builds it matches the original `~/.agentmux/` verbatim. Without
+        // this rewrite the backend rejects the path with "path traversal denied"
+        // because `~/` never gets expanded to an absolute path at the OS layer.
+        const persisted = agent.working_directory ?? "";
+        const workDir = persisted.startsWith("~/.agentmux/")
+            ? `${agentmuxHome()}${persisted.slice("~/.agentmux".length)}`
+            : (persisted || `${agentmuxHome()}/agents/${slug}`);
 
         // Build CLI args: use persistent args if available, otherwise standard launch args
         const isPersistent = provider.controllerType === "persistent";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.296",
+  "version": "0.33.297",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.296",
+      "version": "0.33.297",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.296",
+  "version": "0.33.297",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/gen-seed.js
+++ b/scripts/gen-seed.js
@@ -85,9 +85,15 @@ const CONTAINER_SKILL = { ...SKILL, content: SKILL.content.replace(", secrets ac
 const manifest = {
     version: 4,
     agents: [
-        { id: "agentx", name: "AgentX", icon: "\ud83d\udd34", description: "Primary coding agent", working_directory: "~/.agentmux/agents/agentx", shell: "pwsh", agent_bus_id: "agentx", content: { env: "AGENT_NAME=agentx\nAGENTMUX_AGENT_ID=AgentX", startup: HOST_STARTUP }, skills: [SKILL] },
-        { id: "agenty", name: "AgentY", icon: "\ud83d\udfe1", description: "Secondary coding agent", working_directory: "~/.agentmux/agents/agenty", shell: "pwsh", agent_bus_id: "agenty", content: { env: "AGENT_NAME=agenty\nAGENTMUX_AGENT_ID=AgentY", startup: HOST_STARTUP }, skills: [SKILL] },
-        { id: "agentz", name: "AgentZ", icon: "\ud83d\udd35", description: "Tertiary coding agent", working_directory: "~/.agentmux/agents/agentz", shell: "pwsh", agent_bus_id: "agentz", content: { env: "AGENT_NAME=agentz\nAGENTMUX_AGENT_ID=AgentZ", startup: HOST_STARTUP }, skills: [SKILL] },
+        // working_directory intentionally empty for the default host agents so
+        // agent-model.ts resolves it at launch-time via `agentmuxHome()`. That
+        // picks up the portable data dir on portable builds and `~/.agentmux`
+        // on installed builds. Hardcoding `~/.agentmux/agents/<slug>` here
+        // would defeat portable isolation (PR #475) and leave the literal `~`
+        // in the persisted value, which the backend path-canonicaliser rejects.
+        { id: "agentx", name: "AgentX", icon: "\ud83d\udd34", description: "Primary coding agent", working_directory: "", shell: "pwsh", agent_bus_id: "agentx", content: { env: "AGENT_NAME=agentx\nAGENTMUX_AGENT_ID=AgentX", startup: HOST_STARTUP }, skills: [SKILL] },
+        { id: "agenty", name: "AgentY", icon: "\ud83d\udfe1", description: "Secondary coding agent", working_directory: "", shell: "pwsh", agent_bus_id: "agenty", content: { env: "AGENT_NAME=agenty\nAGENTMUX_AGENT_ID=AgentY", startup: HOST_STARTUP }, skills: [SKILL] },
+        { id: "agentz", name: "AgentZ", icon: "\ud83d\udd35", description: "Tertiary coding agent", working_directory: "", shell: "pwsh", agent_bus_id: "agentz", content: { env: "AGENT_NAME=agentz\nAGENTMUX_AGENT_ID=AgentZ", startup: HOST_STARTUP }, skills: [SKILL] },
         { id: "agent1", name: "Agent1", icon: "\ud83d\udfe2", description: "Sandboxed coding agent", working_directory: "/workspace", shell: "bash", agent_bus_id: "agent1", restart_on_crash: true, content: { env: "AGENT_NAME=agent1\nAGENTMUX_AGENT_ID=Agent1", startup: CONTAINER_STARTUP }, skills: [CONTAINER_SKILL] },
         { id: "agent2", name: "Agent2", icon: "\ud83d\udfe0", description: "Sandboxed coding agent", working_directory: "/workspace", shell: "bash", agent_bus_id: "agent2", restart_on_crash: true, content: { env: "AGENT_NAME=agent2\nAGENTMUX_AGENT_ID=Agent2", startup: CONTAINER_STARTUP }, skills: [CONTAINER_SKILL] },
         { id: "agent3", name: "Agent3", icon: "\ud83d\udfe3", description: "Sandboxed coding agent", working_directory: "/workspace", shell: "bash", agent_bus_id: "agent3", restart_on_crash: true, content: { env: "AGENT_NAME=agent3\nAGENTMUX_AGENT_ID=Agent3", startup: CONTAINER_STARTUP }, skills: [CONTAINER_SKILL] },


### PR DESCRIPTION
## Summary

Follow-up to #475. The Forge seed hardcodes \`working_directory: \"~/.agentmux/agents/<slug>\"\` for agentx/y/z. Since it's truthy, \`agent-model.ts:257\`'s \`||\` never falls through to the host-resolved \`agentmuxHome()\` — so portable builds still land agents under \`~/.agentmux/\`, and because \`~/\` isn't expanded the backend's path canonicaliser rejects every subpath with \`path traversal denied: .claude/commands/startup.md escapes working dir\` at launch.

## Fix

1. **Seed** (\`scripts/gen-seed.js\` + regenerated \`agentmux-srv/forge-seed.json\`): host agents now have an empty \`working_directory\` so the frontend computes it from \`agentmuxHome()\`.
2. **Frontend** (\`agent-model.ts:257\`): if persisted \`working_directory\` starts with \`~/.agentmux/\`, rewrite the prefix to \`agentmuxHome()\`. Handles already-seeded DBs without a wipe.

Container agents (agent1–3) keep their \`/workspace\` path — resolved inside the container.

## Observed symptom

Running v0.33.296 portable:
- Host log: \`WriteAgentConfig working_dir=~/.agentmux/agents/agentx file_count=3\` (leaks out of portable)
- Followed by: \`Failed to launch forge agent: path traversal denied: .claude/commands/startup.md escapes working dir\`

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Portable: launch, start agentx → verify \`<portable>/data/agents/agentx/\` is created, no \`~/.agentmux/\` leak
- [ ] Existing portable DB with the seeded \`~/.agentmux/...\` string: should be silently rewritten to \`<portable>/data/agents/<slug>/\` on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)