### PR TITLE
feat(forge): identity accounts + agent instances + definition branching (backend)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.299"
+version = "0.33.300"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.299"
+version = "0.33.300"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.299"
+version = "0.33.300"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.299"
+version = "0.33.300"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.299"
+version = "0.33.300"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.299"
+version = "0.33.300"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.299"
+version = "0.33.300"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.299"
+version = "0.33.300"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/forge_seed.rs
+++ b/agentmux-srv/src/backend/forge_seed.rs
@@ -161,6 +161,8 @@ pub fn seed_forge_agents(wstore: &Arc<WaveStore>) -> Result<SeedReport, StoreErr
             agent_bus_id: agent_def.agent_bus_id.clone(),
             is_seeded: 1,
             accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
         };
         wstore.forge_insert(&mut agent)?;
 
@@ -330,6 +332,8 @@ fn reseed_if_needed(
             agent_bus_id: agent_def.agent_bus_id.clone(),
             is_seeded: 1,
             accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
         };
 
         if let Some(existing_agent) = existing_map.get(agent_def.id.as_str()) {

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -287,6 +287,27 @@ pub const COMMAND_IMPORT_FORGE_FROM_CLAW: &str = "importforgefromclaw";
 // Forge Seed
 pub const COMMAND_RESEED_FORGE_AGENTS: &str = "reseedforgeagents";
 
+// Identity accounts (v6 — replaces localStorage)
+pub const COMMAND_LIST_IDENTITY_ACCOUNTS: &str = "listidentityaccounts";
+pub const COMMAND_GET_IDENTITY_ACCOUNT: &str = "getidentityaccount";
+pub const COMMAND_UPSERT_IDENTITY_ACCOUNT: &str = "upsertidentityaccount";
+pub const COMMAND_DELETE_IDENTITY_ACCOUNT: &str = "deleteidentityaccount";
+
+// Agent ↔ Identity junction
+pub const COMMAND_LINK_AGENT_IDENTITY: &str = "linkagentidentity";
+pub const COMMAND_UNLINK_AGENT_IDENTITY: &str = "unlinkagentidentity";
+pub const COMMAND_LIST_AGENT_IDENTITIES: &str = "listagentidentities";
+
+// Agent instances
+pub const COMMAND_LIST_AGENT_INSTANCES: &str = "listagentinstances";
+pub const COMMAND_GET_AGENT_INSTANCE: &str = "getagentinstance";
+pub const COMMAND_CREATE_AGENT_INSTANCE: &str = "createagentinstance";
+pub const COMMAND_UPDATE_AGENT_INSTANCE: &str = "updateagentinstance";
+pub const COMMAND_DELETE_AGENT_INSTANCE: &str = "deleteagentinstance";
+
+// Agent definition branching
+pub const COMMAND_FORK_AGENT_DEFINITION: &str = "forkagentdefinition";
+
 // App API Tier 1 — agent lifecycle commands
 pub const COMMAND_AGENT_OPEN: &str = "agent.open";
 pub const COMMAND_AGENT_SEND: &str = "agent.send";
@@ -1260,6 +1281,99 @@ pub struct InstallToolResult {
 pub struct InstallFailure {
     pub id: String,
     pub error: String,
+}
+
+// ====================================================================
+// Identity / Instance / Fork payloads (v6)
+// See specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_IMPL_2026_04_20.md.
+// Strings use snake_case for cross-language parity with wstore.
+// ====================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommandListIdentityAccountsData {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandGetIdentityAccountData {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandDeleteIdentityAccountData {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandLinkAgentIdentityData {
+    pub agent_id: String,
+    pub account_id: String,
+    pub provider: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandUnlinkAgentIdentityData {
+    pub agent_id: String,
+    pub provider: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandListAgentIdentitiesData {
+    pub agent_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommandListAgentInstancesData {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub definition_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandGetAgentInstanceData {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandCreateAgentInstanceData {
+    pub definition_id: String,
+    #[serde(default)]
+    pub block_id: String,
+    #[serde(default)]
+    pub parent_instance_id: String,
+}
+
+/// Mutable subset of AgentInstance for PATCH-style updates. Every field is
+/// optional — absent fields preserve their current value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandUpdateAgentInstanceData {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub block_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// JSON-encoded `GitHubContext` or empty string. `None` = leave as-is;
+    /// `Some("")` = explicitly clear.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ended_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandDeleteAgentInstanceData {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandForkAgentDefinitionData {
+    pub source_id: String,
+    #[serde(default)]
+    pub branch_label: String,
 }
 
 // ====================================================================

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -79,6 +79,7 @@ pub fn run_forge_migrations(conn: &Connection) -> Result<(), StoreError> {
     run_forge_v3_migrations(conn)?;
     run_forge_v4_migrations(conn)?;
     run_forge_v5_migrations(conn)?;
+    run_forge_v6_migrations(conn)?;
     Ok(())
 }
 
@@ -291,6 +292,102 @@ pub fn run_forge_v5_migrations(conn: &Connection) -> Result<(), StoreError> {
     Ok(())
 }
 
+/// Forge v6 migrations: identity accounts + agent instances + definition
+/// branching. See specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_IMPL_2026_04_20.md.
+///
+/// - `db_identity_accounts`: replaces the browser-localStorage identity store
+///   with a real, portable-aware, DB-backed record.
+/// - `db_forge_agent_identities`: junction table linking agents to identities
+///   (replaces the unused v5 `accounts` JSON blob).
+/// - `db_agent_instances`: one row per running/historical execution of an
+///   agent definition. Tracks which pane it lives in, which provider
+///   session, and optional GitHub context (which PR/branch this run is
+///   operating against).
+/// - `parent_id` + `branch_label` columns on `db_forge_agents`: lets a
+///   definition be forked from another with lineage preserved.
+///
+/// Since no user has populated the v5 `accounts` column meaningfully (it's
+/// always been dev-only localStorage in practice), we don't migrate data from
+/// it — existing identities must be recreated. The `accounts` column itself
+/// stays in the schema as dead weight for now rather than risk a `DROP COLUMN`
+/// on rows that might have partial data; a future v7 can clean it up.
+pub fn run_forge_v6_migrations(conn: &Connection) -> Result<(), StoreError> {
+    // ---- Lineage columns on existing agents table ----
+    let alter_statements = [
+        "ALTER TABLE db_forge_agents ADD COLUMN parent_id TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_forge_agents ADD COLUMN branch_label TEXT NOT NULL DEFAULT ''",
+    ];
+    for stmt in &alter_statements {
+        match conn.execute_batch(stmt) {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                if !msg.contains("duplicate column") {
+                    return Err(StoreError::Sqlite(match e {
+                        rusqlite::Error::SqliteFailure(code, _) => {
+                            rusqlite::Error::SqliteFailure(code, Some(msg))
+                        }
+                        other => other,
+                    }));
+                }
+            }
+        }
+    }
+
+    // ---- New tables ----
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS db_identity_accounts (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            display_name TEXT NOT NULL DEFAULT '',
+            secret_ref TEXT NOT NULL,
+            context TEXT NOT NULL DEFAULT '{}',
+            status TEXT NOT NULL DEFAULT 'unknown',
+            created_at INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_identity_accounts_provider
+            ON db_identity_accounts(provider);
+
+        CREATE TABLE IF NOT EXISTS db_forge_agent_identities (
+            agent_id TEXT NOT NULL,
+            account_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            PRIMARY KEY (agent_id, provider),
+            FOREIGN KEY (agent_id) REFERENCES db_forge_agents(id) ON DELETE CASCADE,
+            FOREIGN KEY (account_id) REFERENCES db_identity_accounts(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_forge_agent_identities_account
+            ON db_forge_agent_identities(account_id);
+
+        CREATE TABLE IF NOT EXISTS db_agent_instances (
+            id TEXT PRIMARY KEY,
+            definition_id TEXT NOT NULL,
+            parent_instance_id TEXT NOT NULL DEFAULT '',
+            block_id TEXT NOT NULL DEFAULT '',
+            session_id TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'running',
+            github_context TEXT NOT NULL DEFAULT '',
+            started_at INTEGER NOT NULL DEFAULT 0,
+            ended_at INTEGER NOT NULL DEFAULT 0,
+            created_at INTEGER NOT NULL DEFAULT 0,
+            FOREIGN KEY (definition_id) REFERENCES db_forge_agents(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_agent_instances_definition
+            ON db_agent_instances(definition_id);
+        CREATE INDEX IF NOT EXISTS idx_agent_instances_block
+            ON db_agent_instances(block_id);
+        CREATE INDEX IF NOT EXISTS idx_agent_instances_status
+            ON db_agent_instances(status);
+        CREATE INDEX IF NOT EXISTS idx_agent_instances_parent
+            ON db_agent_instances(parent_instance_id);",
+    )?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -405,5 +502,98 @@ mod tests {
             )
             .unwrap();
         assert_eq!(idx_count, 1);
+    }
+
+    #[test]
+    fn test_forge_v6_migrations_create_tables_and_columns() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        // Full forge migration chain creates v1..v6
+        run_forge_migrations(&conn).unwrap();
+
+        // All three new tables exist
+        for table in &["db_identity_accounts", "db_forge_agent_identities", "db_agent_instances"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [table],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "table {table} should exist");
+        }
+
+        // Lineage columns added to db_forge_agents
+        let cols: Vec<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(db_forge_agents)").unwrap();
+            stmt.query_map([], |row| row.get::<_, String>(1))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        assert!(cols.contains(&"parent_id".to_string()));
+        assert!(cols.contains(&"branch_label".to_string()));
+
+        // Indexes created
+        for idx in &[
+            "idx_identity_accounts_provider",
+            "idx_forge_agent_identities_account",
+            "idx_agent_instances_definition",
+            "idx_agent_instances_block",
+            "idx_agent_instances_status",
+            "idx_agent_instances_parent",
+        ] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='index' AND name=?1",
+                    [idx],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "index {idx} should exist");
+        }
+    }
+
+    #[test]
+    fn test_forge_v6_migrations_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        run_forge_migrations(&conn).unwrap();
+        run_forge_migrations(&conn).unwrap();  // second pass must not error
+
+        // Insert an identity + agent + junction to exercise the FKs
+        conn.execute(
+            "INSERT INTO db_forge_agents (id, name, provider, description, slug)
+             VALUES ('ag1', 'AgentX', 'claude', '', 'agentx')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO db_identity_accounts (id, name, provider, kind, secret_ref, created_at, updated_at)
+             VALUES ('id1', 'asaf-github', 'github', 'pat', '{\"backend\":\"env\",\"env_var\":\"GITHUB_TOKEN\"}', 0, 0)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO db_forge_agent_identities (agent_id, account_id, provider)
+             VALUES ('ag1', 'id1', 'github')",
+            [],
+        )
+        .unwrap();
+
+        // FK cascade: deleting the agent removes the junction row
+        conn.execute("DELETE FROM db_forge_agents WHERE id='ag1'", []).unwrap();
+        let remaining: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM db_forge_agent_identities WHERE agent_id='ag1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 0, "junction row should cascade-delete");
     }
 }

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -433,11 +433,22 @@ pub struct ForgeAgent {
     #[serde(default)]
     pub is_seeded: i64,
     /// JSON-encoded per-provider account references.
-    /// Shape: `{"github":"acct-id"|null,"aws":"acct-id"|null,...}`
-    /// Null or missing provider key = no account assigned for that provider.
-    /// See SPEC_AGENT_IDENTITY_RESTRUCTURE_2026_04_14.md §3.3.
+    /// **Deprecated in v6** — superseded by the `db_forge_agent_identities`
+    /// junction table. Still populated on read for backward compat with
+    /// any existing DB rows; new writes leave it empty. See
+    /// specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_IMPL_2026_04_20.md.
     #[serde(default)]
     pub accounts: String,
+    /// Parent definition id (forge_agents.id). Empty string = root
+    /// definition; non-empty = this agent was forked from another.
+    /// Added in v6. See spec §Phase 1.
+    #[serde(default)]
+    pub parent_id: String,
+    /// Label describing the branch (e.g. `"pr-422-review"`,
+    /// `"experiment-refactor"`). Empty for root definitions and for
+    /// branches that didn't set a label. Added in v6.
+    #[serde(default)]
+    pub branch_label: String,
 }
 
 /// Derive a filesystem-safe slug from a display name. Lowercase,
@@ -512,7 +523,8 @@ impl WaveStore {
         let mut stmt = conn.prepare(
             "SELECT id, slug, name, icon, provider, description, working_directory, shell,
                     provider_flags, auto_start, restart_on_crash, idle_timeout_minutes, created_at,
-                    agent_type, environment, agent_bus_id, is_seeded, accounts
+                    agent_type, environment, agent_bus_id, is_seeded, accounts,
+                    parent_id, branch_label
              FROM db_forge_agents ORDER BY created_at ASC",
         )?;
         let rows = stmt.query_map([], |row| {
@@ -535,6 +547,8 @@ impl WaveStore {
                 agent_bus_id: row.get(15)?,
                 is_seeded: row.get(16)?,
                 accounts: row.get(17)?,
+                parent_id: row.get(18)?,
+                branch_label: row.get(19)?,
             })
         })?;
         let mut agents = Vec::new();
@@ -600,8 +614,9 @@ impl WaveStore {
             "INSERT INTO db_forge_agents (id, slug, name, icon, provider, description,
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
              idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
-             is_seeded, accounts)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)",
+             is_seeded, accounts, parent_id, branch_label)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
+                     ?17, ?18, ?19, ?20)",
             params![
                 agent.id,
                 agent.slug,
@@ -620,13 +635,18 @@ impl WaveStore {
                 agent.environment,
                 agent.agent_bus_id,
                 agent.is_seeded,
-                agent.accounts
+                agent.accounts,
+                agent.parent_id,
+                agent.branch_label,
             ],
         )?;
         Ok(())
     }
 
     /// Update an existing forge agent (all fields except id, created_at, is_seeded).
+    /// `parent_id` and `branch_label` are NOT updatable post-insert — they
+    /// describe the agent's provenance; renaming or re-branching is done by
+    /// creating a new fork, not mutating the original.
     pub fn forge_update(&self, agent: &ForgeAgent) -> Result<bool, StoreError> {
         let conn = self.conn.lock().unwrap();
         let rows = conn.execute(
@@ -969,6 +989,496 @@ fn format_epoch_date(days_since_epoch: u64) -> String {
 }
 
 // ====================================================================
+// Identity Accounts + Agent Instances + Junction
+// (Phase 2 of SPEC_FORGE_IDENTITY_AGENT_INSTANCES_IMPL_2026_04_20.md)
+// ====================================================================
+
+/// Provider-specific credential reference. Stored as JSON in
+/// `db_identity_accounts.secret_ref`. `backend` is the discriminator.
+/// The actual secret value is NEVER stored in the DB — only how to
+/// look it up at launch time (env var, secrets-manager path, etc.).
+/// `PlaintextDev` exists for local dev convenience and must never be
+/// the default path in production builds.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "backend", rename_all = "snake_case")]
+pub enum SecretRef {
+    Env {
+        env_var: String,
+    },
+    SecretsManager {
+        sm_path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        sm_json_path: Option<String>,
+    },
+    PlaintextDev {
+        plaintext_dev: String,
+    },
+}
+
+/// An identity account (reusable credential, linked to agents via the
+/// `db_forge_agent_identities` junction). Replaces the browser
+/// localStorage identity store.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityAccount {
+    pub id: String,
+    pub name: String,
+    pub provider: String, // "github" | "aws" | "anthropic" | "custom"
+    pub kind: String,     // "pat" | "role" | "api_key" | "env_ref"
+    #[serde(default)]
+    pub display_name: String,
+    pub secret_ref: SecretRef,
+    /// Free-form JSON context (username, scopes, role ARN, etc.). Stored
+    /// verbatim; frontend types it by `provider`.
+    #[serde(default = "default_context_json")]
+    pub context: serde_json::Value,
+    #[serde(default = "default_identity_status")]
+    pub status: String, // "unknown" | "ok" | "expired" | "invalid"
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+fn default_context_json() -> serde_json::Value {
+    serde_json::json!({})
+}
+
+fn default_identity_status() -> String {
+    "unknown".to_string()
+}
+
+/// Junction row: which identity an agent uses for a given provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeAgentIdentity {
+    pub agent_id: String,
+    pub account_id: String,
+    pub provider: String,
+}
+
+/// Instance lifecycle status. Serialised lowercase to match the DB text.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum InstanceStatus {
+    Running,
+    Paused,
+    Stopped,
+    Crashed,
+    Detached,
+}
+
+impl InstanceStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Paused => "paused",
+            Self::Stopped => "stopped",
+            Self::Crashed => "crashed",
+            Self::Detached => "detached",
+        }
+    }
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "running" => Some(Self::Running),
+            "paused" => Some(Self::Paused),
+            "stopped" => Some(Self::Stopped),
+            "crashed" => Some(Self::Crashed),
+            "detached" => Some(Self::Detached),
+            _ => None,
+        }
+    }
+}
+
+/// Optional context describing which GitHub-side unit of work a specific
+/// instance is operating on. Stored as JSON in
+/// `db_agent_instances.github_context` (empty string when unset).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubContext {
+    pub repo: String, // "owner/repo"
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub issue_number: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_run_id: Option<u64>,
+}
+
+/// One row per running/historical execution of an agent definition.
+/// `block_id` / `session_id` / `github_context` are modelled as empty
+/// strings on the wire rather than `Option<String>` to match the
+/// existing forge schema conventions (`NOT NULL DEFAULT ''`). Callers
+/// that need structured absence can use `.is_empty()`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentInstance {
+    pub id: String,
+    pub definition_id: String,
+    #[serde(default)]
+    pub parent_instance_id: String,
+    #[serde(default)]
+    pub block_id: String,
+    #[serde(default)]
+    pub session_id: String,
+    pub status: String,
+    /// JSON-encoded `GitHubContext`, or empty string.
+    #[serde(default)]
+    pub github_context: String,
+    pub started_at: i64,
+    #[serde(default)]
+    pub ended_at: i64,
+    pub created_at: i64,
+}
+
+impl WaveStore {
+    // ---- Identity account CRUD ----
+
+    /// List identity accounts. If `provider` is `Some`, filter to that
+    /// provider; otherwise return every account, ordered by most recent
+    /// update first (so the identity panel shows live accounts on top).
+    pub fn identity_list(
+        &self,
+        provider: Option<&str>,
+    ) -> Result<Vec<IdentityAccount>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut rows_vec = Vec::new();
+        let map_row = |row: &rusqlite::Row| -> rusqlite::Result<IdentityAccount> {
+            let secret_ref_json: String = row.get(5)?;
+            let context_json: String = row.get(6)?;
+            Ok(IdentityAccount {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                provider: row.get(2)?,
+                kind: row.get(3)?,
+                display_name: row.get(4)?,
+                secret_ref: serde_json::from_str(&secret_ref_json).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        5,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?,
+                context: serde_json::from_str(&context_json).unwrap_or_else(|_| serde_json::json!({})),
+                status: row.get(7)?,
+                created_at: row.get(8)?,
+                updated_at: row.get(9)?,
+            })
+        };
+        match provider {
+            Some(p) => {
+                let mut stmt = conn.prepare(
+                    "SELECT id, name, provider, kind, display_name, secret_ref, context,
+                            status, created_at, updated_at
+                     FROM db_identity_accounts
+                     WHERE provider = ?1
+                     ORDER BY updated_at DESC",
+                )?;
+                let iter = stmt.query_map(params![p], map_row)?;
+                for r in iter {
+                    rows_vec.push(r?);
+                }
+            }
+            None => {
+                let mut stmt = conn.prepare(
+                    "SELECT id, name, provider, kind, display_name, secret_ref, context,
+                            status, created_at, updated_at
+                     FROM db_identity_accounts
+                     ORDER BY updated_at DESC",
+                )?;
+                let iter = stmt.query_map([], map_row)?;
+                for r in iter {
+                    rows_vec.push(r?);
+                }
+            }
+        }
+        Ok(rows_vec)
+    }
+
+    pub fn identity_get(&self, id: &str) -> Result<Option<IdentityAccount>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, provider, kind, display_name, secret_ref, context,
+                    status, created_at, updated_at
+             FROM db_identity_accounts WHERE id = ?1",
+        )?;
+        let result = stmt.query_row(params![id], |row| {
+            let secret_ref_json: String = row.get(5)?;
+            let context_json: String = row.get(6)?;
+            Ok(IdentityAccount {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                provider: row.get(2)?,
+                kind: row.get(3)?,
+                display_name: row.get(4)?,
+                secret_ref: serde_json::from_str(&secret_ref_json).map_err(|e| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        5,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })?,
+                context: serde_json::from_str(&context_json).unwrap_or_else(|_| serde_json::json!({})),
+                status: row.get(7)?,
+                created_at: row.get(8)?,
+                updated_at: row.get(9)?,
+            })
+        });
+        match result {
+            Ok(a) => Ok(Some(a)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Upsert an identity account. If `account.id` is empty the caller
+    /// must generate one first (we don't silently mint ids here — callers
+    /// should know whether they're creating vs updating).
+    pub fn identity_upsert(&self, account: &IdentityAccount) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let secret_ref_json = serde_json::to_string(&account.secret_ref)?;
+        let context_json = serde_json::to_string(&account.context)?;
+        conn.execute(
+            "INSERT INTO db_identity_accounts
+                (id, name, provider, kind, display_name, secret_ref, context,
+                 status, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+             ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                provider = excluded.provider,
+                kind = excluded.kind,
+                display_name = excluded.display_name,
+                secret_ref = excluded.secret_ref,
+                context = excluded.context,
+                status = excluded.status,
+                updated_at = excluded.updated_at",
+            params![
+                account.id,
+                account.name,
+                account.provider,
+                account.kind,
+                account.display_name,
+                secret_ref_json,
+                context_json,
+                account.status,
+                account.created_at,
+                account.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn identity_delete(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute("DELETE FROM db_identity_accounts WHERE id = ?1", params![id])?;
+        Ok(rows > 0)
+    }
+
+    // ---- Agent ↔ Identity junction ----
+
+    /// Link an agent to an identity for a given provider. Overwrites any
+    /// existing link for the same (agent_id, provider) — each agent has
+    /// at most one account per provider.
+    pub fn agent_identity_link(
+        &self,
+        agent_id: &str,
+        account_id: &str,
+        provider: &str,
+    ) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_forge_agent_identities (agent_id, account_id, provider)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(agent_id, provider) DO UPDATE SET account_id = excluded.account_id",
+            params![agent_id, account_id, provider],
+        )?;
+        Ok(())
+    }
+
+    /// Remove the identity link for a given (agent_id, provider).
+    /// Returns true iff a link existed.
+    pub fn agent_identity_unlink(
+        &self,
+        agent_id: &str,
+        provider: &str,
+    ) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "DELETE FROM db_forge_agent_identities WHERE agent_id = ?1 AND provider = ?2",
+            params![agent_id, provider],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// List all (agent_id, account_id, provider) triples for an agent.
+    pub fn agent_identity_list_for_agent(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<ForgeAgentIdentity>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT agent_id, account_id, provider
+             FROM db_forge_agent_identities
+             WHERE agent_id = ?1
+             ORDER BY provider",
+        )?;
+        let iter = stmt.query_map(params![agent_id], |row| {
+            Ok(ForgeAgentIdentity {
+                agent_id: row.get(0)?,
+                account_id: row.get(1)?,
+                provider: row.get(2)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in iter {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    // ---- Agent instance CRUD ----
+
+    /// List instances. Both filters are optional — pass `None` to scan all
+    /// instances. Ordered by `created_at` descending (most recent first).
+    pub fn instance_list(
+        &self,
+        definition_id: Option<&str>,
+        status: Option<&str>,
+    ) -> Result<Vec<AgentInstance>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        // Build the query dynamically. The parameter count varies, so we
+        // can't reuse a single prepared statement across filter combos.
+        let mut sql = String::from(
+            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
+                    status, github_context, started_at, ended_at, created_at
+             FROM db_agent_instances",
+        );
+        let mut clauses: Vec<&str> = Vec::new();
+        if definition_id.is_some() {
+            clauses.push("definition_id = ?");
+        }
+        if status.is_some() {
+            clauses.push("status = ?");
+        }
+        if !clauses.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
+        }
+        sql.push_str(" ORDER BY created_at DESC");
+
+        let mut stmt = conn.prepare(&sql)?;
+        // Build a Vec<String> so parameter lifetimes outlive the query call.
+        // Borrowing the `&str` args directly caused E0597 because they're
+        // bound to the match arms, not the outer scope.
+        let mut param_vals: Vec<String> = Vec::new();
+        if let Some(d) = definition_id {
+            param_vals.push(d.to_string());
+        }
+        if let Some(s) = status {
+            param_vals.push(s.to_string());
+        }
+        let iter = stmt.query_map(rusqlite::params_from_iter(param_vals.iter()), |row| {
+            Ok(AgentInstance {
+                id: row.get(0)?,
+                definition_id: row.get(1)?,
+                parent_instance_id: row.get(2)?,
+                block_id: row.get(3)?,
+                session_id: row.get(4)?,
+                status: row.get(5)?,
+                github_context: row.get(6)?,
+                started_at: row.get(7)?,
+                ended_at: row.get(8)?,
+                created_at: row.get(9)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in iter {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    pub fn instance_get(&self, id: &str) -> Result<Option<AgentInstance>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
+                    status, github_context, started_at, ended_at, created_at
+             FROM db_agent_instances WHERE id = ?1",
+        )?;
+        let result = stmt.query_row(params![id], |row| {
+            Ok(AgentInstance {
+                id: row.get(0)?,
+                definition_id: row.get(1)?,
+                parent_instance_id: row.get(2)?,
+                block_id: row.get(3)?,
+                session_id: row.get(4)?,
+                status: row.get(5)?,
+                github_context: row.get(6)?,
+                started_at: row.get(7)?,
+                ended_at: row.get(8)?,
+                created_at: row.get(9)?,
+            })
+        });
+        match result {
+            Ok(a) => Ok(Some(a)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Insert a new instance row. Caller is responsible for the id (UUID).
+    pub fn instance_create(&self, inst: &AgentInstance) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_agent_instances
+                (id, definition_id, parent_instance_id, block_id, session_id, status,
+                 github_context, started_at, ended_at, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            params![
+                inst.id,
+                inst.definition_id,
+                inst.parent_instance_id,
+                inst.block_id,
+                inst.session_id,
+                inst.status,
+                inst.github_context,
+                inst.started_at,
+                inst.ended_at,
+                inst.created_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Update mutable instance fields. `id`, `definition_id`,
+    /// `parent_instance_id`, `started_at`, `created_at` are immutable
+    /// after insert (they describe provenance, not state).
+    pub fn instance_update(&self, inst: &AgentInstance) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "UPDATE db_agent_instances SET
+                block_id = ?1,
+                session_id = ?2,
+                status = ?3,
+                github_context = ?4,
+                ended_at = ?5
+             WHERE id = ?6",
+            params![
+                inst.block_id,
+                inst.session_id,
+                inst.status,
+                inst.github_context,
+                inst.ended_at,
+                inst.id,
+            ],
+        )?;
+        Ok(rows > 0)
+    }
+
+    pub fn instance_delete(&self, id: &str) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute("DELETE FROM db_agent_instances WHERE id = ?1", params![id])?;
+        Ok(rows > 0)
+    }
+}
+
+// ====================================================================
 // Tests
 // ====================================================================
 
@@ -1277,6 +1787,8 @@ mod tests {
             agent_bus_id: String::new(),
             is_seeded: 0,
             accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
         };
         store.forge_insert(&mut a1).unwrap();
         // "Agent X" → "agent-x"
@@ -1336,6 +1848,8 @@ mod tests {
             agent_bus_id: String::new(),
             is_seeded: 0,
             accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
         };
         store.forge_insert(&mut a1).unwrap();
         assert_eq!(a1.slug, "explicit");
@@ -1347,5 +1861,202 @@ mod tests {
         a2.slug = "explicit".to_string();
         store.forge_insert(&mut a2).unwrap();
         assert_eq!(a2.slug, "explicit-2");
+    }
+
+    // ---- v6 identity / instance CRUD ----
+
+    fn v6_test_store() -> WaveStore {
+        WaveStore::open_in_memory().unwrap()
+    }
+
+    fn sample_account(id: &str, provider: &str) -> IdentityAccount {
+        IdentityAccount {
+            id: id.to_string(),
+            name: format!("asaf-{provider}"),
+            provider: provider.to_string(),
+            kind: "pat".to_string(),
+            display_name: "".to_string(),
+            secret_ref: SecretRef::Env { env_var: format!("{}_TOKEN", provider.to_uppercase()) },
+            context: serde_json::json!({"username": "asaf"}),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    fn sample_agent(id: &str, slug: &str) -> ForgeAgent {
+        ForgeAgent {
+            id: id.to_string(),
+            slug: slug.to_string(),
+            name: id.to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: "".to_string(),
+            working_directory: "".to_string(),
+            shell: "".to_string(),
+            provider_flags: "".to_string(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: "host".to_string(),
+            environment: "".to_string(),
+            agent_bus_id: "".to_string(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_identity_upsert_round_trip() {
+        let store = v6_test_store();
+        let acct = sample_account("id-gh", "github");
+        store.identity_upsert(&acct).unwrap();
+
+        let fetched = store.identity_get("id-gh").unwrap().expect("row");
+        assert_eq!(fetched.name, "asaf-github");
+        assert_eq!(fetched.provider, "github");
+        assert!(matches!(fetched.secret_ref, SecretRef::Env { ref env_var } if env_var == "GITHUB_TOKEN"));
+        assert_eq!(fetched.context["username"], "asaf");
+    }
+
+    #[test]
+    fn test_identity_list_filtered_by_provider() {
+        let store = v6_test_store();
+        store.identity_upsert(&sample_account("id-gh", "github")).unwrap();
+        store.identity_upsert(&sample_account("id-aws", "aws")).unwrap();
+        store.identity_upsert(&sample_account("id-gh2", "github")).unwrap();
+
+        let all = store.identity_list(None).unwrap();
+        assert_eq!(all.len(), 3);
+        let gh = store.identity_list(Some("github")).unwrap();
+        assert_eq!(gh.len(), 2);
+        assert!(gh.iter().all(|a| a.provider == "github"));
+    }
+
+    #[test]
+    fn test_identity_delete() {
+        let store = v6_test_store();
+        store.identity_upsert(&sample_account("id-gh", "github")).unwrap();
+        assert!(store.identity_delete("id-gh").unwrap());
+        assert!(store.identity_get("id-gh").unwrap().is_none());
+        // Second delete is a no-op.
+        assert!(!store.identity_delete("id-gh").unwrap());
+    }
+
+    #[test]
+    fn test_agent_identity_link_and_unlink() {
+        let store = v6_test_store();
+        let mut agent = sample_agent("ag1", "agent-x");
+        store.forge_insert(&mut agent).unwrap();
+        store.identity_upsert(&sample_account("id-gh", "github")).unwrap();
+
+        store.agent_identity_link("ag1", "id-gh", "github").unwrap();
+        let links = store.agent_identity_list_for_agent("ag1").unwrap();
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].account_id, "id-gh");
+
+        // Re-link with a different account overwrites (one account per provider per agent)
+        store.identity_upsert(&sample_account("id-gh2", "github")).unwrap();
+        store.agent_identity_link("ag1", "id-gh2", "github").unwrap();
+        let links = store.agent_identity_list_for_agent("ag1").unwrap();
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].account_id, "id-gh2");
+
+        assert!(store.agent_identity_unlink("ag1", "github").unwrap());
+        assert!(store.agent_identity_list_for_agent("ag1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_agent_identity_cascade_on_agent_delete() {
+        let store = v6_test_store();
+        let mut agent = sample_agent("ag1", "agent-x");
+        store.forge_insert(&mut agent).unwrap();
+        store.identity_upsert(&sample_account("id-gh", "github")).unwrap();
+        store.agent_identity_link("ag1", "id-gh", "github").unwrap();
+
+        store.forge_delete("ag1").unwrap();
+        assert!(store.agent_identity_list_for_agent("ag1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_instance_create_update_filter() {
+        let store = v6_test_store();
+        let mut agent = sample_agent("def1", "agent-x");
+        store.forge_insert(&mut agent).unwrap();
+
+        let inst = AgentInstance {
+            id: "inst1".to_string(),
+            definition_id: "def1".to_string(),
+            parent_instance_id: String::new(),
+            block_id: "block-abc".to_string(),
+            session_id: String::new(),
+            status: InstanceStatus::Running.as_str().to_string(),
+            github_context: String::new(),
+            started_at: 1000,
+            ended_at: 0,
+            created_at: 1000,
+        };
+        store.instance_create(&inst).unwrap();
+
+        let fetched = store.instance_get("inst1").unwrap().expect("row");
+        assert_eq!(fetched.block_id, "block-abc");
+        assert_eq!(fetched.status, "running");
+
+        // Update status → stopped
+        let mut updated = fetched.clone();
+        updated.status = InstanceStatus::Stopped.as_str().to_string();
+        updated.ended_at = 2000;
+        assert!(store.instance_update(&updated).unwrap());
+        assert_eq!(store.instance_get("inst1").unwrap().unwrap().status, "stopped");
+
+        // Filter queries
+        let all = store.instance_list(None, None).unwrap();
+        assert_eq!(all.len(), 1);
+        let by_def = store.instance_list(Some("def1"), None).unwrap();
+        assert_eq!(by_def.len(), 1);
+        let running = store.instance_list(None, Some("running")).unwrap();
+        assert_eq!(running.len(), 0);
+        let stopped = store.instance_list(None, Some("stopped")).unwrap();
+        assert_eq!(stopped.len(), 1);
+    }
+
+    #[test]
+    fn test_instance_cascade_on_definition_delete() {
+        let store = v6_test_store();
+        let mut agent = sample_agent("def1", "agent-x");
+        store.forge_insert(&mut agent).unwrap();
+        let inst = AgentInstance {
+            id: "inst1".to_string(),
+            definition_id: "def1".to_string(),
+            parent_instance_id: String::new(),
+            block_id: String::new(),
+            session_id: String::new(),
+            status: "running".to_string(),
+            github_context: String::new(),
+            started_at: 0,
+            ended_at: 0,
+            created_at: 0,
+        };
+        store.instance_create(&inst).unwrap();
+
+        store.forge_delete("def1").unwrap();
+        assert!(store.instance_get("inst1").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_instance_status_enum_roundtrip() {
+        for s in &[
+            InstanceStatus::Running,
+            InstanceStatus::Paused,
+            InstanceStatus::Stopped,
+            InstanceStatus::Crashed,
+            InstanceStatus::Detached,
+        ] {
+            assert_eq!(Some(*s), InstanceStatus::parse(s.as_str()));
+        }
+        assert_eq!(None, InstanceStatus::parse("nonsense"));
     }
 }

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -41,8 +41,16 @@ impl WaveStore {
 
     fn configure_and_migrate(conn: Connection) -> Result<Self, StoreError> {
         conn.execute_batch(
+            // `foreign_keys=ON` is per-connection and defaults to OFF in
+            // SQLite. The v6 schema (`db_forge_agent_identities`,
+            // `db_agent_instances`) relies on `ON DELETE CASCADE` to clean
+            // up junction rows and instances when a parent agent or
+            // identity is removed. Without this pragma on the production
+            // connection, cascades silently no-op; migration tests set it
+            // explicitly, which would have masked the gap.
             "PRAGMA journal_mode=WAL;
              PRAGMA busy_timeout=5000;
+             PRAGMA foreign_keys=ON;
              PRAGMA synchronous=NORMAL;
              PRAGMA cache_size=-8000;
              PRAGMA mmap_size=268435456;

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -19,8 +19,26 @@ use crate::backend::rpc_types::{
     CommandDeleteForgeSkillData,
     CommandAppendForgeHistoryData, CommandListForgeHistoryData, CommandSearchForgeHistoryData,
     CommandImportForgeFromClawData,
+    // v6 identity / instance / fork
+    COMMAND_LIST_IDENTITY_ACCOUNTS, COMMAND_GET_IDENTITY_ACCOUNT,
+    COMMAND_UPSERT_IDENTITY_ACCOUNT, COMMAND_DELETE_IDENTITY_ACCOUNT,
+    COMMAND_LINK_AGENT_IDENTITY, COMMAND_UNLINK_AGENT_IDENTITY,
+    COMMAND_LIST_AGENT_IDENTITIES,
+    COMMAND_LIST_AGENT_INSTANCES, COMMAND_GET_AGENT_INSTANCE,
+    COMMAND_CREATE_AGENT_INSTANCE, COMMAND_UPDATE_AGENT_INSTANCE,
+    COMMAND_DELETE_AGENT_INSTANCE,
+    COMMAND_FORK_AGENT_DEFINITION,
+    CommandListIdentityAccountsData, CommandGetIdentityAccountData,
+    CommandDeleteIdentityAccountData,
+    CommandLinkAgentIdentityData, CommandUnlinkAgentIdentityData,
+    CommandListAgentIdentitiesData,
+    CommandListAgentInstancesData, CommandGetAgentInstanceData,
+    CommandCreateAgentInstanceData, CommandUpdateAgentInstanceData,
+    CommandDeleteAgentInstanceData,
+    CommandForkAgentDefinitionData,
 };
 use crate::backend::storage::{ForgeAgent, ForgeContent, ForgeSkill};
+use crate::backend::storage::wstore::{AgentInstance, IdentityAccount, InstanceStatus};
 
 use super::AppState;
 
@@ -562,6 +580,449 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "created": report.created,
                     "skipped": report.skipped,
                 })))
+            })
+        }),
+    );
+
+    register_v6_handlers(engine, state);
+}
+
+/// v6 handlers — identity accounts, agent instances, definition branching.
+/// See specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_IMPL_2026_04_20.md §Phase 3.
+fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    // ---- Identity account CRUD ----
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_IDENTITY_ACCOUNTS,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandListIdentityAccountsData =
+                    serde_json::from_value(data).unwrap_or_default();
+                let accounts = wstore
+                    .identity_list(cmd.provider.as_deref())
+                    .map_err(|e| format!("listidentityaccounts: {e}"))?;
+                Ok(Some(serde_json::to_value(&accounts).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_GET_IDENTITY_ACCOUNT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandGetIdentityAccountData =
+                    serde_json::from_value(data).map_err(|e| format!("getidentityaccount: {e}"))?;
+                match wstore
+                    .identity_get(&cmd.id)
+                    .map_err(|e| format!("getidentityaccount: {e}"))?
+                {
+                    Some(a) => Ok(Some(serde_json::to_value(&a).unwrap_or_default())),
+                    None => Err(format!("getidentityaccount: not found id={}", cmd.id)),
+                }
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_UPSERT_IDENTITY_ACCOUNT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                // Accept the full IdentityAccount payload. Missing `id` → mint
+                // a fresh UUID; `created_at` and `updated_at` are server-set
+                // so callers don't have to know the current time.
+                let mut account: IdentityAccount = serde_json::from_value(data)
+                    .map_err(|e| format!("upsertidentityaccount: {e}"))?;
+                if account.id.is_empty() {
+                    account.id = uuid::Uuid::new_v4().to_string();
+                }
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                if account.created_at == 0 {
+                    account.created_at = now;
+                }
+                account.updated_at = now;
+                wstore
+                    .identity_upsert(&account)
+                    .map_err(|e| format!("upsertidentityaccount: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "identityaccounts:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&account).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_DELETE_IDENTITY_ACCOUNT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandDeleteIdentityAccountData = serde_json::from_value(data)
+                    .map_err(|e| format!("deleteidentityaccount: {e}"))?;
+                let deleted = wstore
+                    .identity_delete(&cmd.id)
+                    .map_err(|e| format!("deleteidentityaccount: {e}"))?;
+                if deleted {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "identityaccounts:changed".to_string(),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                }
+                Ok(Some(json!({ "deleted": deleted })))
+            })
+        }),
+    );
+
+    // ---- Agent ↔ Identity junction ----
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_LINK_AGENT_IDENTITY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandLinkAgentIdentityData = serde_json::from_value(data)
+                    .map_err(|e| format!("linkagentidentity: {e}"))?;
+                wstore
+                    .agent_identity_link(&cmd.agent_id, &cmd.account_id, &cmd.provider)
+                    .map_err(|e| format!("linkagentidentity: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: format!("agentidentities:changed:{}", cmd.agent_id),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(None)
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_UNLINK_AGENT_IDENTITY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandUnlinkAgentIdentityData = serde_json::from_value(data)
+                    .map_err(|e| format!("unlinkagentidentity: {e}"))?;
+                let removed = wstore
+                    .agent_identity_unlink(&cmd.agent_id, &cmd.provider)
+                    .map_err(|e| format!("unlinkagentidentity: {e}"))?;
+                if removed {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: format!("agentidentities:changed:{}", cmd.agent_id),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                }
+                Ok(Some(json!({ "unlinked": removed })))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_AGENT_IDENTITIES,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandListAgentIdentitiesData = serde_json::from_value(data)
+                    .map_err(|e| format!("listagentidentities: {e}"))?;
+                let rows = wstore
+                    .agent_identity_list_for_agent(&cmd.agent_id)
+                    .map_err(|e| format!("listagentidentities: {e}"))?;
+                Ok(Some(serde_json::to_value(&rows).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // ---- Agent instance CRUD ----
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_AGENT_INSTANCES,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandListAgentInstancesData =
+                    serde_json::from_value(data).unwrap_or_default();
+                let rows = wstore
+                    .instance_list(cmd.definition_id.as_deref(), cmd.status.as_deref())
+                    .map_err(|e| format!("listagentinstances: {e}"))?;
+                Ok(Some(serde_json::to_value(&rows).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_GET_AGENT_INSTANCE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandGetAgentInstanceData = serde_json::from_value(data)
+                    .map_err(|e| format!("getagentinstance: {e}"))?;
+                match wstore
+                    .instance_get(&cmd.id)
+                    .map_err(|e| format!("getagentinstance: {e}"))?
+                {
+                    Some(i) => Ok(Some(serde_json::to_value(&i).unwrap_or_default())),
+                    None => Err(format!("getagentinstance: not found id={}", cmd.id)),
+                }
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_CREATE_AGENT_INSTANCE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandCreateAgentInstanceData = serde_json::from_value(data)
+                    .map_err(|e| format!("createagentinstance: {e}"))?;
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                let inst = AgentInstance {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    definition_id: cmd.definition_id,
+                    parent_instance_id: cmd.parent_instance_id,
+                    block_id: cmd.block_id,
+                    session_id: String::new(),
+                    status: InstanceStatus::Running.as_str().to_string(),
+                    github_context: String::new(),
+                    started_at: now,
+                    ended_at: 0,
+                    created_at: now,
+                };
+                wstore
+                    .instance_create(&inst)
+                    .map_err(|e| format!("createagentinstance: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: format!("agentinstances:changed:{}", inst.definition_id),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&inst).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_UPDATE_AGENT_INSTANCE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandUpdateAgentInstanceData = serde_json::from_value(data)
+                    .map_err(|e| format!("updateagentinstance: {e}"))?;
+                let existing = wstore
+                    .instance_get(&cmd.id)
+                    .map_err(|e| format!("updateagentinstance: {e}"))?
+                    .ok_or_else(|| format!("updateagentinstance: not found id={}", cmd.id))?;
+                let merged = AgentInstance {
+                    id: existing.id.clone(),
+                    definition_id: existing.definition_id.clone(),
+                    parent_instance_id: existing.parent_instance_id.clone(),
+                    block_id: cmd.block_id.unwrap_or(existing.block_id),
+                    session_id: cmd.session_id.unwrap_or(existing.session_id),
+                    status: cmd.status.unwrap_or(existing.status),
+                    github_context: cmd.github_context.unwrap_or(existing.github_context),
+                    started_at: existing.started_at,
+                    ended_at: cmd.ended_at.unwrap_or(existing.ended_at),
+                    created_at: existing.created_at,
+                };
+                wstore
+                    .instance_update(&merged)
+                    .map_err(|e| format!("updateagentinstance: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: format!("agentinstances:changed:{}", merged.definition_id),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&merged).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_DELETE_AGENT_INSTANCE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandDeleteAgentInstanceData = serde_json::from_value(data)
+                    .map_err(|e| format!("deleteagentinstance: {e}"))?;
+                // Read the row first so we can emit a scoped event after.
+                let definition_id = wstore
+                    .instance_get(&cmd.id)
+                    .map_err(|e| format!("deleteagentinstance: {e}"))?
+                    .map(|i| i.definition_id);
+                let deleted = wstore
+                    .instance_delete(&cmd.id)
+                    .map_err(|e| format!("deleteagentinstance: {e}"))?;
+                if let Some(def_id) = definition_id.filter(|_| deleted) {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: format!("agentinstances:changed:{}", def_id),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                }
+                Ok(Some(json!({ "deleted": deleted })))
+            })
+        }),
+    );
+
+    // ---- Definition fork ----
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_FORK_AGENT_DEFINITION,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandForkAgentDefinitionData = serde_json::from_value(data)
+                    .map_err(|e| format!("forkagentdefinition: {e}"))?;
+
+                // Find the source definition by id.
+                let source = wstore
+                    .forge_list()
+                    .map_err(|e| format!("forkagentdefinition: {e}"))?
+                    .into_iter()
+                    .find(|a| a.id == cmd.source_id)
+                    .ok_or_else(|| format!("forkagentdefinition: source not found: {}", cmd.source_id))?;
+
+                // Build a new definition that shares the source's content but
+                // has a fresh id/slug and records the lineage. Seed-bit is
+                // cleared — forks are always user-owned, not built-in.
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                let branch_slug_part = if cmd.branch_label.is_empty() {
+                    "fork".to_string()
+                } else {
+                    crate::backend::storage::wstore::derive_slug(&cmd.branch_label)
+                };
+                let mut fork = ForgeAgent {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    // Empty slug → forge_insert derives + resolves collisions.
+                    slug: format!("{}-{}", source.slug, branch_slug_part),
+                    name: if cmd.branch_label.is_empty() {
+                        format!("{} (fork)", source.name)
+                    } else {
+                        format!("{} [{}]", source.name, cmd.branch_label)
+                    },
+                    icon: source.icon.clone(),
+                    provider: source.provider.clone(),
+                    description: source.description.clone(),
+                    working_directory: String::new(), // force re-resolve via agentmuxHome()
+                    shell: source.shell.clone(),
+                    provider_flags: source.provider_flags.clone(),
+                    auto_start: 0, // forks don't auto-start; explicit launch only
+                    restart_on_crash: source.restart_on_crash,
+                    idle_timeout_minutes: source.idle_timeout_minutes,
+                    created_at: now,
+                    agent_type: source.agent_type.clone(),
+                    environment: source.environment.clone(),
+                    agent_bus_id: String::new(), // fresh bus id so broadcasts don't cross
+                    is_seeded: 0,
+                    accounts: String::new(),
+                    parent_id: source.id.clone(),
+                    branch_label: cmd.branch_label.clone(),
+                };
+                wstore
+                    .forge_insert(&mut fork)
+                    .map_err(|e| format!("forkagentdefinition: {e}"))?;
+
+                // Deep-copy content blobs + skills from source. Cascade foreign
+                // keys on the source are unaffected — we're copying out, not
+                // moving.
+                let source_contents = wstore
+                    .forge_get_all_content(&source.id)
+                    .map_err(|e| format!("forkagentdefinition content: {e}"))?;
+                for c in source_contents {
+                    let new_content = ForgeContent {
+                        agent_id: fork.id.clone(),
+                        content_type: c.content_type,
+                        content: c.content,
+                        updated_at: now,
+                    };
+                    wstore
+                        .forge_set_content(&new_content)
+                        .map_err(|e| format!("forkagentdefinition content: {e}"))?;
+                }
+                let source_skills = wstore
+                    .forge_list_skills(&source.id)
+                    .map_err(|e| format!("forkagentdefinition skills: {e}"))?;
+                for s in source_skills {
+                    let new_skill = ForgeSkill {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        agent_id: fork.id.clone(),
+                        name: s.name,
+                        trigger: s.trigger,
+                        skill_type: s.skill_type,
+                        description: s.description,
+                        content: s.content,
+                        created_at: now,
+                    };
+                    wstore
+                        .forge_insert_skill(&new_skill)
+                        .map_err(|e| format!("forkagentdefinition skill: {e}"))?;
+                }
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "forgeagents:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+
+                Ok(Some(serde_json::to_value(&fork).unwrap_or_default()))
             })
         }),
     );

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -76,6 +76,8 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     agent_bus_id: cmd.agent_bus_id,
                     is_seeded: 0,
                     accounts: String::new(),
+                    parent_id: String::new(),
+                    branch_label: String::new(),
                 };
                 wstore.forge_insert(&mut agent).map_err(|e| format!("createforgeagent: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
@@ -132,6 +134,11 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // don't carry accounts, so falling back to old.accounts prevents
                     // silently wiping saved assignments.
                     accounts: if cmd.accounts.is_empty() { old.accounts.clone() } else { cmd.accounts },
+                    // parent_id + branch_label describe provenance and
+                    // are immutable post-insert (forks are separate rows,
+                    // not in-place edits).
+                    parent_id: old.parent_id.clone(),
+                    branch_label: old.branch_label.clone(),
                 };
                 let found = wstore.forge_update(&agent).map_err(|e| format!("updateforgeagent: {e}"))?;
                 if !found {
@@ -481,6 +488,8 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     agent_bus_id: String::new(),
                     is_seeded: 0,
                     accounts: String::new(),
+                    parent_id: String::new(),
+                    branch_label: String::new(),
                 };
                 wstore.forge_insert(&mut agent).map_err(|e| format!("importforgefromclaw: {e}"))?;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.299",
+  "version": "0.33.300",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.299",
+      "version": "0.33.300",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.299",
+  "version": "0.33.300",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md
+++ b/specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md
@@ -1,0 +1,224 @@
+# Spec: Forge + Identity + Agent Instances Refinement
+**Date:** 2026-04-20  
+**Status:** Draft
+
+---
+
+## Current State (Problems)
+
+| Issue | Where |
+|---|---|
+| Identity stored in localStorage — not portable, not persistent | `identity-model.ts:116` |
+| No agent definition vs instance distinction at data layer | `wstore.rs:399` |
+| No branching/lineage — can't fork an agent and track lineage | missing |
+| No export of identity/forge as a portable bundle | only session JSONL export exists |
+| `accounts` on ForgeAgent is a JSON blob — no relational integrity | `wstore.rs:441` |
+
+---
+
+## Core Concepts
+
+```
+AgentDefinition (what an agent IS)
+    └── has many ForgeContent blobs (soul, agentmd, mcp, env, hooks, memory)
+    └── has many ForgeSkills
+    └── references many Identities (via junction table)
+    └── may have a parent_definition_id (branched from another)
+
+AgentInstance (a running/historical execution of a definition)
+    └── belongs to one AgentDefinition
+    └── has a pane/block_id (which pane it's running in)
+    └── has session_id (provider session — for Claude Code resume)
+    └── has optional github_context (repo, pr, branch — for async GitHub work)
+    └── has status: running | paused | stopped | crashed | detached
+    └── may have a parent_instance_id (if spawned from another instance)
+
+Identity (an account credential, reusable)
+    └── persisted in DB (not localStorage)
+    └── has provider: github | aws | anthropic | custom
+    └── has secret_ref (env var, secrets manager path, or dev plaintext)
+    └── has context (username, scopes, role ARN, etc.)
+    └── referenced by many AgentDefinitions
+```
+
+---
+
+## Proposed Schema
+
+### `db_identity_accounts` — move from localStorage → DB
+
+```sql
+CREATE TABLE db_identity_accounts (
+    id           TEXT PRIMARY KEY,   -- UUID
+    name         TEXT NOT NULL,      -- user-facing label, e.g. "asaf-github"
+    provider     TEXT NOT NULL,      -- github | aws | anthropic | custom
+    kind         TEXT NOT NULL,      -- pat | role | api_key | env_ref
+    display_name TEXT,
+    secret_ref   TEXT NOT NULL,      -- JSON: {backend, env_var?, sm_path?, sm_json_path?}
+    context      TEXT NOT NULL,      -- JSON: provider-specific (username, scopes, arn, etc.)
+    status       TEXT DEFAULT 'unknown',
+    created_at   INTEGER NOT NULL,
+    updated_at   INTEGER NOT NULL
+);
+```
+
+### `db_forge_agent_identities` — junction table (replaces accounts JSON blob)
+
+```sql
+CREATE TABLE db_forge_agent_identities (
+    agent_id    TEXT NOT NULL REFERENCES db_forge_agents(id) ON DELETE CASCADE,
+    account_id  TEXT NOT NULL REFERENCES db_identity_accounts(id) ON DELETE CASCADE,
+    provider    TEXT NOT NULL,   -- denormalized for fast lookup
+    PRIMARY KEY (agent_id, provider)
+    -- only one account per provider per agent
+);
+```
+
+### `db_forge_agents` — add lineage fields
+
+```sql
+ALTER TABLE db_forge_agents ADD COLUMN parent_id TEXT;
+-- NULL = root definition; non-null = branched from another definition
+
+ALTER TABLE db_forge_agents ADD COLUMN branch_label TEXT;
+-- e.g. "pr-422-review", "experiment-refactor"
+```
+
+### `db_agent_instances` — new table
+
+```sql
+CREATE TABLE db_agent_instances (
+    id                 TEXT PRIMARY KEY,   -- UUID
+    definition_id      TEXT NOT NULL REFERENCES db_forge_agents(id),
+    parent_instance_id TEXT,               -- NULL if first launch; set if forked from running instance
+    block_id           TEXT,               -- pane block (NULL if not currently in a pane)
+    session_id         TEXT,               -- provider session ID (e.g. Claude Code --resume target)
+    status             TEXT NOT NULL DEFAULT 'running',
+    -- running | paused | stopped | crashed | detached
+    github_context     TEXT,
+    -- JSON: {repo, pr_number?, branch?, issue_number?, workflow_run_id?}
+    -- populated when instance is doing async GitHub work
+    started_at         INTEGER NOT NULL,
+    ended_at           INTEGER,
+    created_at         INTEGER NOT NULL
+);
+
+CREATE INDEX idx_agent_instances_definition ON db_agent_instances(definition_id);
+CREATE INDEX idx_agent_instances_block      ON db_agent_instances(block_id);
+CREATE INDEX idx_agent_instances_status     ON db_agent_instances(status);
+```
+
+---
+
+## Two User Situations
+
+### New user (no accounts, no definitions)
+- First-launch wizard walks through creating one Identity per provider they use
+- Then walks through creating first ForgeAgent, auto-linked to those identities
+- Seeded built-in agents (AgentX/Y/Z) stay as-is but with `accounts` migrated to junction table
+
+### Existing user (accounts + working identity already set up)
+- Migration reads existing `accounts` JSON blob from each ForgeAgent
+- Matches each account by provider against any existing `db_identity_accounts` rows
+- If an account entry exists in localStorage → imports it into DB on first startup
+- Existing sessions/instances get a "legacy" `db_agent_instances` record with `status = stopped` and `session_id` populated from block metadata
+
+---
+
+## Agent Branching & Instance Tracking
+
+```
+ForgeAgent(slug="agentx")                                       ← definition, root
+    │
+    ├─ Instance A  [block:pane-1, running, github_context: PR #422]
+    └─ Instance B  [block:pane-3, paused]
+
+ForgeAgent(slug="agentx-pr-455-fork", parent_id="agentx-id")   ← branched definition
+    │
+    └─ Instance C  [block:pane-2, running, parent_instance_id: Instance A]
+```
+
+- **Interpane coordination:** `db_agent_instances.block_id` lets the bus know which pane
+  an instance lives in; broadcast messages can target by `definition_id` (all instances of
+  this agent) or `instance_id` (specific one)
+- **GitHub async:** `github_context` on the instance (not the definition) captures what
+  PR/branch/workflow a specific run is operating against — same definition can have multiple
+  instances each on different PRs simultaneously
+
+---
+
+## Export Format
+
+A portable `.agentbundle` file (gzipped JSON):
+
+```jsonc
+{
+  "version": 1,
+  "exported_at": "2026-04-20T...",
+  "agent": {
+    "id": "...",
+    "slug": "agentx",
+    "name": "AgentX",
+    "provider": "claude",
+    "description": "...",
+    "parent_id": null,
+    "branch_label": null,
+    "content": {
+      "soul": "...",
+      "agentmd": "...",
+      "mcp": "...",
+      "env": "..."
+    },
+    "skills": [
+      { "name": "Startup", "trigger": "startup", "skill_type": "prompt", "content": "..." }
+    ]
+  },
+  "identities": [
+    {
+      "name": "asaf-github",
+      "provider": "github",
+      "kind": "pat",
+      "secret_ref": { "backend": "env", "env_var": "GITHUB_TOKEN" },
+      "context": { "github_username": "AgentA-asaf" }
+      // NOTE: actual secret value is never exported — only the reference
+    }
+  ],
+  "instance_summary": {
+    "total_instances": 3,
+    "last_active": "2026-04-19T...",
+    "github_prs_touched": [422, 418]
+  }
+}
+```
+
+**Key design decisions:**
+- Secrets are **never** exported — only the reference (`env_var` name or `sm_path`)
+- A `--include-dev-secrets` flag can optionally include `plaintext_dev` values for local transfer
+- Bundle is self-contained enough to `import` into a fresh AgentMux install and reconstruct
+  the agent (minus actual secret values)
+
+---
+
+## Migration Path
+
+1. **DB migration v6:** Create `db_identity_accounts`, `db_forge_agent_identities`,
+   `db_agent_instances`; add `parent_id`/`branch_label` to `db_forge_agents`
+2. **Data migration:** Read localStorage accounts (via startup RPC from frontend), upsert
+   into `db_identity_accounts`, build junction rows from existing `accounts` JSON blob on
+   each ForgeAgent
+3. **Deprecate** `accounts` column on `db_forge_agents` — zero it out post-migration, remove in v7
+4. **Frontend:** Update IdentityViewModel to read/write DB via new RPC instead of localStorage
+
+---
+
+## Affected Files
+
+| File | Change |
+|---|---|
+| `agentmux-srv/src/backend/storage/wstore.rs` | Add `ForgeAgentIdentity`, `AgentInstance` structs; add `parent_id`/`branch_label` to `ForgeAgent` |
+| `agentmux-srv/src/backend/storage/migrations.rs` | Add migration v6 |
+| `agentmux-srv/src/backend/rpc_types.rs` | New RPC commands for identity CRUD, instance CRUD, bundle export/import |
+| `agentmux-srv/src/server/forge_handlers.rs` | Implement new handlers |
+| `frontend/app/view/identity/identity-model.ts` | Replace localStorage with DB-backed RPCs |
+| `frontend/app/view/agent/agent-model.ts` | Track instance on launch; support branch |
+| `frontend/types/gotypes.d.ts` | Add `AgentInstance`, `IdentityAccount` TS types |

--- a/specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_IMPL_2026_04_20.md
+++ b/specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_IMPL_2026_04_20.md
@@ -1,0 +1,365 @@
+# Implementation Spec: Forge + Identity + Agent Instances
+
+**Date:** 2026-04-20
+**Status:** Draft (implementation-ready)
+**Companion:** `SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md` (design / motivation)
+
+---
+
+## Scope
+
+Implements the data-model refinement laid out in the companion spec — moves identity accounts to the DB, splits agent definitions from instances, adds branching, and ships a `.agentbundle` export/import format.
+
+**No migration.** AgentMux is pre-1.0; the `objects.db` rename PR (#478) already established the precedent of dropping data on schema changes. Fresh install creates the new schema cleanly. Existing localStorage identity data is treated as user-must-recreate (one-time hit, dev users only — public users haven't shipped). The spec's "two user situations" section is descoped accordingly.
+
+---
+
+## Phase order
+
+Land in this order so each phase is independently revertible:
+
+1. **Schema** — add tables to migration set, regenerate seed.
+2. **Rust types + storage** — `IdentityAccount`, `AgentInstance`, junction row, lineage fields on `ForgeAgent`.
+3. **RPC commands** — CRUD for identities + instances; bundle export/import.
+4. **Frontend identity model** — swap localStorage backing for DB-backed RPCs.
+5. **Frontend agent launch wiring** — create an `AgentInstance` row on launch, update `block_id`/`status`/`session_id`.
+6. **Branching UI** — fork action on agent definition; lineage rendering.
+7. **Bundle export/import UI** — buttons in the identity/forge panel.
+
+Phases 1-3 are backend-only and can ship as one PR. Phases 4-5 ship together (frontend depends on RPCs landing first). Phases 6-7 are independent UI follow-ups.
+
+---
+
+## Phase 1 — Schema
+
+### Files
+
+- `agentmux-srv/src/backend/storage/migrations.rs` — add migration v6 (or whatever the next slot is; verify when implementing).
+
+### Tables to add
+
+```sql
+-- Identity accounts (replaces localStorage)
+CREATE TABLE db_identity_accounts (
+    id           TEXT PRIMARY KEY,
+    name         TEXT NOT NULL,
+    provider     TEXT NOT NULL,           -- github | aws | anthropic | custom
+    kind         TEXT NOT NULL,           -- pat | role | api_key | env_ref
+    display_name TEXT,
+    secret_ref   TEXT NOT NULL,           -- JSON: { backend, env_var?, sm_path?, sm_json_path?, plaintext_dev? }
+    context      TEXT NOT NULL,           -- JSON: provider-specific (username, scopes, arn, etc.)
+    status       TEXT NOT NULL DEFAULT 'unknown',
+    created_at   INTEGER NOT NULL,
+    updated_at   INTEGER NOT NULL
+);
+
+CREATE INDEX idx_identity_accounts_provider ON db_identity_accounts(provider);
+
+-- Junction: agents → identities (replaces ForgeAgent.accounts JSON blob)
+CREATE TABLE db_forge_agent_identities (
+    agent_id    TEXT NOT NULL REFERENCES db_forge_agents(id) ON DELETE CASCADE,
+    account_id  TEXT NOT NULL REFERENCES db_identity_accounts(id) ON DELETE CASCADE,
+    provider    TEXT NOT NULL,
+    PRIMARY KEY (agent_id, provider)
+);
+
+CREATE INDEX idx_forge_agent_identities_account ON db_forge_agent_identities(account_id);
+
+-- Agent instances
+CREATE TABLE db_agent_instances (
+    id                 TEXT PRIMARY KEY,
+    definition_id      TEXT NOT NULL REFERENCES db_forge_agents(id) ON DELETE CASCADE,
+    parent_instance_id TEXT REFERENCES db_agent_instances(id) ON DELETE SET NULL,
+    block_id           TEXT,
+    session_id         TEXT,
+    status             TEXT NOT NULL DEFAULT 'running',
+    -- enum: running | paused | stopped | crashed | detached
+    github_context     TEXT,                            -- JSON
+    started_at         INTEGER NOT NULL,
+    ended_at           INTEGER,
+    created_at         INTEGER NOT NULL
+);
+
+CREATE INDEX idx_agent_instances_definition ON db_agent_instances(definition_id);
+CREATE INDEX idx_agent_instances_block      ON db_agent_instances(block_id);
+CREATE INDEX idx_agent_instances_status     ON db_agent_instances(status);
+CREATE INDEX idx_agent_instances_parent     ON db_agent_instances(parent_instance_id);
+```
+
+### Changes to existing tables
+
+```sql
+ALTER TABLE db_forge_agents ADD COLUMN parent_id TEXT REFERENCES db_forge_agents(id) ON DELETE SET NULL;
+ALTER TABLE db_forge_agents ADD COLUMN branch_label TEXT;
+
+-- Drop the now-unused accounts column on db_forge_agents (junction table replaces it)
+ALTER TABLE db_forge_agents DROP COLUMN accounts;
+```
+
+### Forge seed update
+
+`scripts/gen-seed.js` + regenerated `agentmux-srv/forge-seed.json`:
+
+- Default agents (agentx/y/z) get `parent_id = null`, `branch_label = null`.
+- No `accounts` field.
+- No identity rows seeded — identities are user-created on first launch (or at all).
+
+---
+
+## Phase 2 — Rust types + storage
+
+### Files
+
+- `agentmux-srv/src/backend/storage/wstore.rs` — add `IdentityAccount`, `AgentInstance`, `ForgeAgentIdentity` structs, CRUD methods (`get_identity_account`, `list_identity_accounts`, `upsert_identity_account`, `delete_identity_account`, etc.).
+- `agentmux-srv/src/backend/obj.rs` (or wherever `ForgeAgent` lives) — add `parent_id: Option<String>` and `branch_label: Option<String>` fields; remove `accounts` field.
+
+### Struct shapes
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityAccount {
+    pub id: String,
+    pub name: String,
+    pub provider: String,         // "github" | "aws" | "anthropic" | "custom"
+    pub kind: String,              // "pat" | "role" | "api_key" | "env_ref"
+    pub display_name: Option<String>,
+    pub secret_ref: SecretRef,     // serialized as JSON in `secret_ref` column
+    pub context: serde_json::Value, // free-form per provider
+    pub status: String,            // "unknown" | "ok" | "expired" | "invalid"
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "backend", rename_all = "snake_case")]
+pub enum SecretRef {
+    Env { env_var: String },
+    SecretsManager { sm_path: String, sm_json_path: Option<String> },
+    PlaintextDev { plaintext_dev: String }, // dev-mode only; warn on prod
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentInstance {
+    pub id: String,
+    pub definition_id: String,
+    pub parent_instance_id: Option<String>,
+    pub block_id: Option<String>,
+    pub session_id: Option<String>,
+    pub status: InstanceStatus,
+    pub github_context: Option<GitHubContext>,
+    pub started_at: i64,
+    pub ended_at: Option<i64>,
+    pub created_at: i64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum InstanceStatus {
+    Running,
+    Paused,
+    Stopped,
+    Crashed,
+    Detached,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubContext {
+    pub repo: String,                       // "owner/repo"
+    pub pr_number: Option<u32>,
+    pub branch: Option<String>,
+    pub issue_number: Option<u32>,
+    pub workflow_run_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeAgentIdentity {
+    pub agent_id: String,
+    pub account_id: String,
+    pub provider: String,
+}
+```
+
+### Notes
+
+- `SecretRef` uses an internally-tagged enum (`#[serde(tag = "backend")]`) so the JSON shape matches what the frontend already half-expects (`{ backend: "env", env_var: "GITHUB_TOKEN" }`).
+- `InstanceStatus` as a Rust enum + matching TS literal-union — locks down the spec's loose string list.
+- Drop the loose `accounts: Option<Value>` field on `ForgeAgent`; junction table replaces it.
+
+---
+
+## Phase 3 — RPC commands
+
+### Files
+
+- `agentmux-srv/src/backend/rpc_types.rs` — add command constants + payload structs.
+- `agentmux-srv/src/server/forge_handlers.rs` (or new `identity_handlers.rs` / `instance_handlers.rs` if it grows large enough).
+- `agentmux-srv/src/server/websocket.rs` — register the new handlers.
+
+### Commands
+
+| Command | Payload | Returns |
+|---|---|---|
+| `listidentityaccounts` | `{ provider?: string }` | `IdentityAccount[]` |
+| `getidentityaccount` | `{ id }` | `IdentityAccount` |
+| `upsertidentityaccount` | `IdentityAccount` (id optional → server generates UUID) | `IdentityAccount` (with id) |
+| `deleteidentityaccount` | `{ id }` | `null` |
+| `linkagentidentity` | `{ agent_id, account_id, provider }` | `null` |
+| `unlinkagentidentity` | `{ agent_id, provider }` | `null` |
+| `listagentidentities` | `{ agent_id }` | `ForgeAgentIdentity[]` (joined with account names for convenience) |
+| `listagentinstances` | `{ definition_id?, status? }` | `AgentInstance[]` |
+| `createagentinstance` | `{ definition_id, block_id?, parent_instance_id? }` | `AgentInstance` |
+| `updateagentinstance` | `{ id, status?, session_id?, block_id?, github_context?, ended_at? }` | `AgentInstance` |
+| `deleteagentinstance` | `{ id }` | `null` |
+| `forkagentdefinition` | `{ source_id, branch_label }` | `ForgeAgent` (the new branched definition) |
+| `exportagentbundle` | `{ agent_id, include_dev_secrets?: bool }` | `{ bundle: <gzip-base64> }` |
+| `importagentbundle` | `{ bundle: <gzip-base64> }` | `ForgeAgent` (new agent + identity rows created) |
+
+### Validation rules
+
+- `upsertidentityaccount`: enforce `provider` ∈ allowed set; enforce `kind` consistent with `secret_ref.backend`.
+- `linkagentidentity`: must respect the `(agent_id, provider)` PK — replace existing link rather than error.
+- `createagentinstance`: must reference an existing definition; `parent_instance_id` if set must reference an existing instance.
+- `forkagentdefinition`: copies the source's `content` blobs and skills verbatim, sets `parent_id = source_id`, generates a new id and slug (e.g. `<source_slug>-<branch_label>`).
+
+---
+
+## Phase 4 — Frontend identity model
+
+### Files
+
+- `frontend/app/view/identity/identity-model.ts` — swap `localStorage` reads/writes for `RpcApi.UpsertIdentityAccountCommand` / `ListIdentityAccountsCommand` / etc.
+- `frontend/app/view/identity/identity-model.test.ts` — update tests; mock `RpcApi` instead of `localStorage`.
+- `frontend/types/gotypes.d.ts` — add TS types matching Rust structs (`IdentityAccount`, `SecretRef`, `AgentInstance`, `InstanceStatus`, `GitHubContext`, `ForgeAgentIdentity`).
+- `frontend/app/store/rpc-api.ts` — bind the new commands.
+
+### Notes
+
+- The identity panel's load path becomes async (`await listIdentityAccounts()`) — most call sites are already `async`. Add a loading skeleton if any aren't.
+- Drop all `localStorage.getItem("agentmux-identity-accounts")` and friends in one sweep; grep the frontend tree to catch every site.
+
+---
+
+## Phase 5 — Frontend agent launch wiring
+
+### Files
+
+- `frontend/app/view/agent/agent-model.ts` — in `launchAgent`, after the block has its CLI metadata set, call `createAgentInstance({ definition_id: agentId, block_id: this.blockId })` and stash the returned `instance.id` into block meta as `agentInstanceId`.
+- Hook controller status changes (`controllerstatus` events) to call `updateAgentInstance` with new `status`.
+- On agent stop / pane close, call `updateAgentInstance({ id, status: "stopped", ended_at: now() })`.
+
+### Edge cases
+
+- Pane closed without graceful stop → background reconciler marks orphaned instances as `crashed` after a heartbeat-loss timeout (defer to a follow-up; not required for v1).
+- Multiple panes for the same definition → each gets its own instance row. The bus already handles broadcast targeting; surface `instance_id` as an addressable channel.
+
+---
+
+## Phase 6 — Branching UI
+
+### Files
+
+- `frontend/app/view/agent/components/AgentDefinitionMenu.tsx` (or wherever the agent context menu lives) — add a "Fork agent…" action that prompts for `branch_label`, calls `forkAgentDefinition`, then sets the current pane's block to the new definition.
+- New `AgentLineageView` component — small tree visualisation showing parent → branched children for the focused definition. Renderable in the forge panel.
+
+### Notes
+
+- Forking does not auto-launch — user picks a pane to launch the new branch into.
+- Lineage queries can be O(n) walks of `parent_id` chains; cap depth at 50 to avoid pathological loops.
+
+---
+
+## Phase 7 — Bundle export/import UI
+
+### Files
+
+- `frontend/app/view/identity/IdentityPanel.tsx` (or forge panel) — "Export agent bundle" button → `exportagentbundle` → save via `getApi().saveFile()`. "Import bundle…" → file picker → base64 → `importagentbundle`.
+- `frontend/app/view/identity/BundleImportPreview.tsx` — show what the bundle contains BEFORE confirming import. Highlight any identity references that don't resolve in the current install (env var not set, etc.).
+
+### Bundle format
+
+Per design spec; one addition: include a `schema_version: 1` field at the root so we can evolve the format without breaking importers.
+
+```jsonc
+{
+  "schema_version": 1,
+  "exported_at": "2026-04-20T22:00:00Z",
+  "agentmux_version": "0.33.300",
+  "agent": { /* ForgeAgent + content + skills */ },
+  "identities": [ /* IdentityAccount[] minus secret values unless --include-dev-secrets */ ],
+  "instance_summary": {
+    "total_instances": 0,
+    "last_active": null,
+    "github_prs_touched": []
+  }
+}
+```
+
+Bundle is gzip-compressed JSON encoded as base64 in the RPC payload (small enough to wire-transfer; large bundles are still <100KB).
+
+---
+
+## Out of scope (defer)
+
+- Migration from existing localStorage identities — we're starting fresh.
+- Multi-parent instance lineage (DAG) — current tree-only `parent_instance_id` is enough.
+- Cross-machine instance sync — instances are local to the AgentMux DB, by design.
+- Bundle signing / verification — bundles are user-trusted artefacts for now; revisit if we ever ship a marketplace.
+
+---
+
+## Test plan
+
+### Phase 1-3 (backend)
+
+- Migration test: empty DB → run migration → all four new tables present, indexes created, foreign keys enforced.
+- Round-trip: `upsertidentityaccount` → `getidentityaccount` returns identical struct.
+- Cascade delete: deleting a `ForgeAgent` removes its junction rows AND its `AgentInstance` rows.
+- `forkagentdefinition`: source's content/skills are deep-copied (modifying the fork doesn't mutate source).
+- `exportagentbundle` round-trip: export → import into a clean DB → identical agent reappears.
+
+### Phase 4-5 (frontend)
+
+- Identity panel CRUD: create/edit/delete an account, refresh page, verify persistence.
+- Launch agent: row appears in `db_agent_instances` with correct `block_id`/`session_id`.
+- Stop agent: row's `status` flips to `stopped` with `ended_at` set.
+- Two panes, same definition: two instance rows.
+
+### Phase 6-7 (UI)
+
+- Fork agent → new definition appears in picker with branch_label badge.
+- Export bundle → save to file → import into different portable extract → agent reappears.
+
+---
+
+## Affected files (summary)
+
+| File | Phase | Change |
+|---|---|---|
+| `agentmux-srv/src/backend/storage/migrations.rs` | 1 | Add migration v6 |
+| `agentmux-srv/forge-seed.json` | 1 | Drop `accounts` field, add `parent_id`/`branch_label` (null) |
+| `scripts/gen-seed.js` | 1 | Match seed schema |
+| `agentmux-srv/src/backend/storage/wstore.rs` | 2 | New CRUD methods, struct definitions |
+| `agentmux-srv/src/backend/obj.rs` | 2 | New structs (`IdentityAccount`, `AgentInstance`, `ForgeAgentIdentity`); update `ForgeAgent` |
+| `agentmux-srv/src/backend/rpc_types.rs` | 3 | Command constants + payload structs |
+| `agentmux-srv/src/server/forge_handlers.rs` | 3 | Implement handlers (or split into `identity_handlers.rs` + `instance_handlers.rs`) |
+| `agentmux-srv/src/server/websocket.rs` | 3 | Register handlers |
+| `frontend/app/view/identity/identity-model.ts` | 4 | Swap localStorage for RPC |
+| `frontend/app/view/identity/identity-model.test.ts` | 4 | Update tests |
+| `frontend/types/gotypes.d.ts` | 4 | TS types |
+| `frontend/app/store/rpc-api.ts` | 4 | Bind new commands |
+| `frontend/app/view/agent/agent-model.ts` | 5 | Create/update instance on launch/stop |
+| `frontend/app/view/agent/components/AgentDefinitionMenu.tsx` | 6 | Fork action |
+| `frontend/app/view/agent/components/AgentLineageView.tsx` | 6 | New component |
+| `frontend/app/view/identity/IdentityPanel.tsx` | 7 | Export/import buttons |
+| `frontend/app/view/identity/BundleImportPreview.tsx` | 7 | New component |
+
+---
+
+## Rollout
+
+- **PR 1:** Phases 1-3 (backend complete). Merge gates frontend work.
+- **PR 2:** Phases 4-5 (frontend identity DB-backing + instance tracking). Bumps version, ships portable.
+- **PR 3:** Phase 6 (branching UI).
+- **PR 4:** Phase 7 (bundle export/import).
+
+Each PR independently revertible. PR 1 is the riskiest because of the schema drop (`accounts` column); call it out in the PR body and tag `@asaf` for explicit sign-off.


### PR DESCRIPTION
**Draft** — Phase 1 of 3 in this PR is landed; Phases 2 (Rust types + CRUD) and 3 (RPC handlers) still pushing to this branch. Marking ready for review once all three phases are in.

Implements backend half of [\`specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_IMPL_2026_04_20.md\`](./specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_IMPL_2026_04_20.md). Design rationale in the companion spec written by AgentX at [\`specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md\`](./specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md).

## Phase 1 (landed)

Migration v6 — new tables + lineage columns.

| Table | Purpose |
|---|---|
| \`db_identity_accounts\` | Moves identity from browser localStorage to DB. Portable-aware, queryable, FK-able. |
| \`db_forge_agent_identities\` | Junction table (agent_id, account_id, provider). Replaces v5's unused \`accounts\` JSON blob. |
| \`db_agent_instances\` | One row per running/historical execution. Tracks pane (\`block_id\`), provider session (\`session_id\`), status, optional \`github_context\` JSON. |
| \`db_forge_agents.parent_id\` + \`branch_label\` | Definition-level branching / lineage. |

## Phase 2 (pushing next)

Rust types + \`WaveStore\` CRUD methods for \`IdentityAccount\`, \`AgentInstance\`, \`ForgeAgentIdentity\`; lineage fields on \`ForgeAgent\`.

## Phase 3 (after Phase 2)

RPC commands — identity CRUD, instance CRUD, fork, bundle export/import handlers wired through \`websocket.rs\`.

## No migration

Existing \`accounts\` column on \`db_forge_agents\` was never populated with user data — identity lived only in \`localStorage\` with a visible "dev/testing only" warning in the identity panel. Fresh-install schema only; existing identities recreated by user.

## Test plan

- [x] 5/5 migration tests pass including two new v6 tests (table+index+column creation, FK cascade)
- [ ] Phase 2 CRUD round-trip tests (upsert → get → identical)
- [ ] Phase 3 RPC command tests
- [ ] Integration: portable build, launch, create an identity through the UI, verify row in \`db_identity_accounts\`