### PR TITLE
feat(browser-pane): default URL + in-pane popup redirect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.301"
+version = "0.33.302"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.301"
+version = "0.33.302"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.301"
+version = "0.33.302"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.301"
+version = "0.33.302"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.302"
+version = "0.33.303"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.302"
+version = "0.33.303"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.302"
+version = "0.33.303"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.302"
+version = "0.33.303"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -2358,9 +2358,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.302"
+version = "0.33.303"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.301"
+version = "0.33.302"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -203,6 +203,41 @@ impl AgentMuxHandler {
         false
     }
 
+    /// Intercept `target="_blank"` / `window.open()` from embedded pages so
+    /// they don't spawn rogue top-level CEF windows. Instead navigate the
+    /// **current** frame to the target URL — matches the UX expectation
+    /// that AgentMux owns window management, not the page.
+    ///
+    /// Returning non-zero cancels popup creation. Applies to both main
+    /// and pane clients: main's frontend never relies on `window.open`
+    /// (link clicks go through `openExternal` IPC), and panes explicitly
+    /// don't want popups. See
+    /// specs/SPEC_BROWSER_PANE_DEFAULT_URL_AND_POPUP_2026_04_21.md.
+    fn on_before_popup(
+        &mut self,
+        browser: Option<&mut Browser>,
+        _frame: Option<&mut Frame>,
+        target_url: Option<&CefString>,
+        _target_disposition: WindowOpenDisposition,
+    ) -> bool {
+        let url = target_url.map(|s| s.to_string()).unwrap_or_default();
+        if url.is_empty() {
+            // Nothing useful to navigate to; just cancel the popup.
+            return true;
+        }
+        if let Some(b) = browser {
+            if let Some(frame) = b.main_frame() {
+                frame.load_url(Some(&CefString::from(url.as_str())));
+            }
+        }
+        tracing::info!(
+            is_pane = %self.is_pane,
+            url = %url,
+            "popup intercepted — navigated current frame in place",
+        );
+        true // cancel the top-level popup creation
+    }
+
     fn on_before_close(&mut self, browser: Option<&mut Browser>) {
         debug_assert_ne!(currently_on(ThreadId::UI), 0);
 
@@ -898,6 +933,30 @@ wrap_life_span_handler! {
         fn on_before_close(&self, browser: Option<&mut Browser>) {
             let mut inner = self.inner.lock();
             inner.on_before_close(browser);
+        }
+
+        fn on_before_popup(
+            &self,
+            browser: Option<&mut Browser>,
+            frame: Option<&mut Frame>,
+            _popup_id: ::std::os::raw::c_int,
+            target_url: Option<&CefString>,
+            _target_frame_name: Option<&CefString>,
+            target_disposition: WindowOpenDisposition,
+            _user_gesture: ::std::os::raw::c_int,
+            _popup_features: Option<&PopupFeatures>,
+            _window_info: Option<&mut WindowInfo>,
+            _client: Option<&mut Option<Client>>,
+            _settings: Option<&mut BrowserSettings>,
+            _extra_info: Option<&mut Option<DictionaryValue>>,
+            _no_javascript_access: Option<&mut ::std::os::raw::c_int>,
+        ) -> ::std::os::raw::c_int {
+            let mut inner = self.inner.lock();
+            if inner.on_before_popup(browser, frame, target_url, target_disposition) {
+                1
+            } else {
+                0
+            }
         }
     }
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.301"
+version = "0.33.302"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.302"
+version = "0.33.303"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.301"
+version = "0.33.302"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.302"
+version = "0.33.303"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.302"
+version = "0.33.303"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.301"
+version = "0.33.302"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -39,7 +39,7 @@
         "blockdef": {
             "meta": {
                 "view": "browser",
-                "url": ""
+                "url": "https://agentmux.ai"
             }
         }
     },

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -12,6 +12,14 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, createSignal, type Accessor } from "solid-js";
 
+/**
+ * Fallback URL for browser panes created without an explicit `meta.url`.
+ * Keeps blank-spawned panes from landing on about:blank (no signposting,
+ * no backlink). Callers that want a blank pane can pass `"about:blank"`
+ * explicitly. See specs/SPEC_BROWSER_PANE_DEFAULT_URL_AND_POPUP_2026_04_21.md.
+ */
+const DEFAULT_BROWSER_URL = "https://agentmux.ai";
+
 export class BrowserViewModel implements ViewModel {
     viewType = "browser";
     blockId: string;
@@ -73,11 +81,13 @@ export class BrowserViewModel implements ViewModel {
             return title || "Browser";
         });
 
-        // Load URL from block meta on init
+        // Load URL from block meta on init. An empty/missing `url` falls
+        // back to DEFAULT_BROWSER_URL so fresh panes aren't blank (the
+        // widget definition in widgets.json also ships this URL, but the
+        // fallback covers panes created through the API with no meta.url).
         const meta = this.blockAtom()?.meta;
-        if (meta?.["url"]) {
-            this.navigate(meta["url"] as string);
-        }
+        const initialUrl = ((meta?.["url"] as string | undefined) ?? "").trim() || DEFAULT_BROWSER_URL;
+        this.navigate(initialUrl);
     }
 
     navigate(url: string): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.302",
+  "version": "0.33.303",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.302",
+      "version": "0.33.303",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.301",
+  "version": "0.33.302",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.301",
+      "version": "0.33.302",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.301",
+  "version": "0.33.302",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.302",
+  "version": "0.33.303",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_BROWSER_PANE_DEFAULT_URL_AND_POPUP_2026_04_21.md
+++ b/specs/SPEC_BROWSER_PANE_DEFAULT_URL_AND_POPUP_2026_04_21.md
@@ -1,0 +1,169 @@
+# Spec: Browser pane default URL + in-pane popup redirect
+
+**Date:** 2026-04-21
+**Status:** Draft (implementation-ready)
+**Scope:** Two small, independent changes to the embedded browser pane.
+
+---
+
+## Problem
+
+1. **Default URL.** A freshly-created browser pane loads about:blank because the widget definition ships `url: ""`. First-time users see a blank page with no signposting.
+2. **Popup explosion.** Clicking a link with `target="_blank"` (or any `window.open()` from the page) spawns a CEF-level top-level window outside the AgentMux host. The new window is orphaned — it has its own chrome, can't be embedded, and survives after the agent/workspace is gone. Every "Read more" link in the wild opens a rogue window.
+
+Both are low-friction to fix and together make the browser pane usable without surprises.
+
+---
+
+## Change 1 — Default URL
+
+### Desired behaviour
+
+Blank-spawned browser panes load **`https://agentmux.ai`** unless the widget caller explicitly passes a URL. Callers who want blank still can by passing `"about:blank"` explicitly.
+
+### Files
+
+- `agentmux-srv/src/config/widgets.json` — `defwidget@browser.blockdef.meta.url` flips from `""` to `"https://agentmux.ai"`.
+
+### Frontend fallback
+
+`frontend/app/view/browser/browser-model.ts:78` already reads `meta.url` and calls `navigate()` when truthy. An empty string is falsy, so historically these panes do nothing until the user types a URL. With the default filled in, `navigate()` runs on mount.
+
+One defensive tweak: if a block is created with no `url` meta at all (not just empty string), fall back to the default URL constant rather than leaving the pane blank. Single source of truth in the frontend:
+
+```ts
+// frontend/app/view/browser/browser-model.ts
+const DEFAULT_BROWSER_URL = "https://agentmux.ai";
+
+// In the constructor, replace:
+if (meta?.["url"]) {
+    this.navigate(meta["url"] as string);
+}
+// With:
+const initialUrl = (meta?.["url"] as string | undefined) || DEFAULT_BROWSER_URL;
+this.navigate(initialUrl);
+```
+
+### Non-goals
+
+- Making the default URL user-configurable via settings. Defer until someone asks.
+- Branding or onboarding content on the default landing page itself — that's `https://agentmux.ai`'s job, not ours.
+
+### Test plan
+
+- [ ] Fresh portable: widget tray → drag/click browser widget → pane opens to `https://agentmux.ai`.
+- [ ] Explicitly passing `{ meta: { view: "browser", url: "about:blank" } }` through the API still lands on `about:blank`.
+- [ ] `{ meta: { view: "browser" } }` with no `url` → fallback to `https://agentmux.ai`.
+
+---
+
+## Change 2 — Popup redirect (in-pane)
+
+### Desired behaviour
+
+When code inside the embedded page calls `window.open(url, "_blank")` or a user clicks a link with `target="_blank"`, **navigate the current pane to that URL** instead of spawning a new CEF top-level window. "Open in new tab" in the page's own UI becomes "navigate this pane" — which matches what AgentMux users expect (the agent, not the page, decides how tabs work).
+
+### How CEF hands us the hook
+
+CEF's `LifeSpanHandler::on_before_popup` fires before the new browser is created. Return `true` to cancel; the parent browser's current frame is still valid, so we can call `browser.main_frame().load_url(target_url)` to navigate the current pane to where the popup would have gone.
+
+The signature (cef-rs):
+
+```rust
+fn on_before_popup(
+    &self,
+    browser: Option<&mut Browser>,
+    frame: Option<&mut Frame>,
+    popup_id: i32,
+    target_url: Option<&CefString>,
+    target_frame_name: Option<&CefString>,
+    target_disposition: WindowOpenDisposition,
+    user_gesture: i32,
+    popup_features: &PopupFeatures,
+    window_info: &mut WindowInfo,
+    client: &mut Option<Client>,
+    settings: &mut BrowserSettings,
+    extra_info: &mut Option<DictionaryValue>,
+    no_javascript_access: &mut i32,
+) -> i32;  // non-zero = cancel
+```
+
+### Files
+
+- `agentmux-cef/src/client.rs`:
+  - Add `fn on_before_popup(...)` to `impl AgentMuxHandler`. Body:
+    ```rust
+    // Intercept target="_blank" / window.open() so embedded browser
+    // panes never spawn rogue CEF top-level windows. Instead navigate
+    // the current pane to the target URL. Matches the UX expectation
+    // that the agent/workspace owns window management, not the page.
+    //
+    // Returning non-zero cancels the popup creation entirely. Safe to
+    // apply to MAIN client too — the main window's frontend owns
+    // its own link-routing; any top-level popup it wants would route
+    // through `app-api.pane.open` or similar, never through window.open.
+    fn on_before_popup(
+        &mut self,
+        browser: Option<&mut Browser>,
+        _frame: Option<&mut Frame>,
+        _popup_id: i32,
+        target_url: Option<&CefString>,
+        _target_frame_name: Option<&CefString>,
+        _target_disposition: WindowOpenDisposition,
+        _user_gesture: i32,
+        _popup_features: &PopupFeatures,
+        _window_info: &mut WindowInfo,
+        _client: &mut Option<Client>,
+        _settings: &mut BrowserSettings,
+        _extra_info: &mut Option<DictionaryValue>,
+        _no_javascript_access: &mut i32,
+    ) -> i32 {
+        let url = target_url.map(|s| s.to_string()).unwrap_or_default();
+        if url.is_empty() {
+            return 1;  // cancel; nothing useful to navigate to
+        }
+        if let Some(b) = browser {
+            if let Some(mut frame) = b.main_frame() {
+                frame.load_url(Some(&CefString::from(url.as_str())));
+            }
+        }
+        tracing::info!(
+            is_pane = %self.is_pane,
+            url = %url,
+            "popup intercepted — navigated current frame",
+        );
+        1  // cancel the popup
+    }
+    ```
+  - Wire it into the `wrap_life_span_handler!` block. The macro currently lists `on_after_created` / `do_close` / `on_before_close`; add `on_before_popup`.
+
+### Devtools exception
+
+The existing DevTools path goes through `on_popup_browser_view_created` (Views-runtime popup) which is a different hook entirely — that stays unchanged. `on_before_popup` fires for content-initiated popups only (page-side `window.open`, `target="_blank"`). DevTools popups go through the Views path and bypass this handler.
+
+### Known special cases
+
+- **`WindowOpenDisposition::NEW_BACKGROUND_TAB` / `NEW_FOREGROUND_TAB`** — we don't have tabs inside a pane, so same behaviour as `NEW_POPUP`: navigate in place.
+- **`SAVE_TO_DISK`** — Chromium asks the host for download handling via a different path (`DownloadHandler`). Not affected.
+- **User gesture vs automatic popup** — both routed the same. Automatic popups from ads/pop-unders are now effectively blocked (navigated-in-place consumes the action). Acceptable.
+- **Router-style SPAs** that rely on `window.open` for new tabs (e.g. GitHub's file-tree "open in new tab") — user sees the target loaded in the same pane. Workaround: `Ctrl+Click` to open in a new AgentMux pane programmatically is a frontend feature we can add later if it becomes a real friction point. Not in this spec.
+
+### Test plan
+
+- [ ] Create browser pane → navigate to a page with `target="_blank"` links (e.g. any GitHub repo) → click such a link → pane navigates to that URL, no new CEF window spawns.
+- [ ] Run `window.open("https://example.com")` in devtools console of the pane → pane navigates to example.com.
+- [ ] Run `window.open("")` → cancelled (no navigation, no window).
+- [ ] DevTools popup (F12) still opens as a separate window — verify the Views popup path isn't broken.
+- [ ] Main window: if any UI code uses `target="_blank"` that we missed, verify it now navigates-in-place (may need to audit main-window links; expected count is 0 since the frontend routes link clicks through `openExternal`).
+
+---
+
+## Rollout
+
+Single PR, single bump. Title: `feat(browser-pane): default URL + in-pane popup redirect`. Merge after reagent approval. Build portable and verify both changes.
+
+## Non-goals for this PR
+
+- A "new tab" pane action that clones the current browser pane beside itself — possible future feature but out of scope; users can drag the widget again for a second pane.
+- Ctrl+Click to open in a new pane — frontend-layer, deferrable.
+- Download handling — separate spec if needed.


### PR DESCRIPTION
Implements [\`specs/SPEC_BROWSER_PANE_DEFAULT_URL_AND_POPUP_2026_04_21.md\`](./specs/SPEC_BROWSER_PANE_DEFAULT_URL_AND_POPUP_2026_04_21.md). Two small UX cleanups for the embedded browser pane.

## 1. Default URL → \`https://agentmux.ai\`

Freshly-spawned browser panes used to land on about:blank with no signposting. Now they open \`https://agentmux.ai\` by default.

- \`widgets.json\`: \`defwidget@browser\` ships \`url: "https://agentmux.ai"\`.
- \`browser-model.ts\`: adds a \`DEFAULT_BROWSER_URL\` constant and falls back to it when \`meta.url\` is missing or empty. Explicit \`"about:blank"\` still works.

## 2. \`target="_blank"\` / \`window.open\` → navigate in place

Clicking an external link in an embedded pane used to spawn a rogue CEF top-level window (outside AgentMux chrome, impossible to embed, survives past workspace close). Now the target URL loads in the current pane instead.

- New \`on_before_popup\` handler in \`AgentMuxHandler\`, wired through \`AgentMuxLifeSpanHandler\`.
- Returns non-zero to cancel popup creation; \`frame.load_url(target_url)\` on the current pane instead.
- Applies to both main and pane clients (main never uses \`window.open\` in practice, so it's a no-op there).
- DevTools popups are unaffected — they go through the Views runtime path (\`on_popup_browser_view_created\`), which this handler doesn't intercept.

## Test plan

- [ ] Fresh portable: drag browser widget → pane opens to \`agentmux.ai\`.
- [ ] Navigate to any GitHub repo, click a \`target="_blank"\` file-tree link → pane navigates to that URL (no new CEF window spawned).
- [ ] In devtools console: \`window.open("https://example.com")\` → pane navigates to example.com.
- [ ] F12 / right-click → Inspect → DevTools still opens as a separate window (Views path).

## Non-goals

- Ctrl+click to open in a new pane (frontend-layer, deferrable).
- Settings to override the default URL (defer until asked).
- New-tab-by-cloning-current-pane action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)