### PR TITLE
fix(forge-seed): UTF-8 mojibake in icons + startup text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.304"
+version = "0.33.305"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.304"
+version = "0.33.305"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.304"
+version = "0.33.305"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.304"
+version = "0.33.305"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.303"
+version = "0.33.304"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.303"
+version = "0.33.304"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.303"
+version = "0.33.304"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.303"
+version = "0.33.304"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.303"
+version = "0.33.304"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.304"
+version = "0.33.305"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.304"
+version = "0.33.305"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.303"
+version = "0.33.304"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.303"
+version = "0.33.304"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.304"
+version = "0.33.305"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.304"
+version = "0.33.305"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.303"
+version = "0.33.304"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/forge-seed.json
+++ b/agentmux-srv/forge-seed.json
@@ -1,1 +1,163 @@
-{   "version": 4,   "agents": [     {       "id": "agentx",       "name": "AgentX",       "icon": "≡ƒö┤",       "description": "Primary coding agent",       "working_directory": "",       "shell": "pwsh",       "agent_bus_id": "agentx",       "content": {         "env": "AGENT_NAME=agentx\nAGENTMUX_AGENT_ID=AgentX",         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity ΓÇö list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete ΓÇö ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."       },       "skills": [         {           "name": "Startup Verification",           "trigger": "startup",           "skill_type": "prompt",           "description": "Re-run tool verification checks and report status table",           "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages ΓÇö install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."         }       ]     },     {       "id": "agenty",       "name": "AgentY",       "icon": "≡ƒƒí",       "description": "Secondary coding agent",       "working_directory": "",       "shell": "pwsh",       "agent_bus_id": "agenty",       "content": {         "env": "AGENT_NAME=agenty\nAGENTMUX_AGENT_ID=AgentY",         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity ΓÇö list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete ΓÇö ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."       },       "skills": [         {           "name": "Startup Verification",           "trigger": "startup",           "skill_type": "prompt",           "description": "Re-run tool verification checks and report status table",           "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages ΓÇö install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."         }       ]     },     {       "id": "agentz",       "name": "AgentZ",       "icon": "≡ƒö╡",       "description": "Tertiary coding agent",       "working_directory": "",       "shell": "pwsh",       "agent_bus_id": "agentz",       "content": {         "env": "AGENT_NAME=agentz\nAGENTMUX_AGENT_ID=AgentZ",         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity ΓÇö list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete ΓÇö ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."       },       "skills": [         {           "name": "Startup Verification",           "trigger": "startup",           "skill_type": "prompt",           "description": "Re-run tool verification checks and report status table",           "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages ΓÇö install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."         }       ]     },     {       "id": "agentk",       "name": "AgentK",       "icon": "≡ƒîÖ",       "description": "Kimi Code CLI agent",       "working_directory": "",       "shell": "pwsh",       "agent_bus_id": "agentk",       "provider": "kimi",       "content": {         "env": "AGENT_NAME=agentk\nAGENTMUX_AGENT_ID=AgentK",         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity ΓÇö list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete ΓÇö ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."       },       "skills": [         {           "name": "Startup Verification",           "trigger": "startup",           "skill_type": "prompt",           "description": "Re-run tool verification checks and report status table",           "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages ΓÇö install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."         }       ]     },     {       "id": "agent1",       "name": "Agent1",       "icon": "≡ƒƒó",       "description": "Sandboxed coding agent",       "working_directory": "/workspace",       "shell": "bash",       "agent_bus_id": "agent1",       "restart_on_crash": true,       "content": {         "env": "AGENT_NAME=agent1\nAGENTMUX_AGENT_ID=Agent1",         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\n\n### 2. Dev Tools\nInstall if missing:\n```bash\nnpm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli\n```\n\n### 3. MCP Servers\nCheck AgentBus connectivity ΓÇö list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete ΓÇö ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."       },       "skills": [         {           "name": "Startup Verification",           "trigger": "startup",           "skill_type": "prompt",           "description": "Re-run tool verification checks and report status table",           "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages ΓÇö install if missing), and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."         }       ]     },     {       "id": "agent2",       "name": "Agent2",       "icon": "≡ƒƒá",       "description": "Sandboxed coding agent",       "working_directory": "/workspace",       "shell": "bash",       "agent_bus_id": "agent2",       "restart_on_crash": true,       "content": {         "env": "AGENT_NAME=agent2\nAGENTMUX_AGENT_ID=Agent2",         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\n\n### 2. Dev Tools\nInstall if missing:\n```bash\nnpm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli\n```\n\n### 3. MCP Servers\nCheck AgentBus connectivity ΓÇö list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete ΓÇö ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."       },       "skills": [         {           "name": "Startup Verification",           "trigger": "startup",           "skill_type": "prompt",           "description": "Re-run tool verification checks and report status table",           "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages ΓÇö install if missing), and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."         }       ]     },     {       "id": "agent3",       "name": "Agent3",       "icon": "≡ƒƒú",       "description": "Sandboxed coding agent",       "working_directory": "/workspace",       "shell": "bash",       "agent_bus_id": "agent3",       "restart_on_crash": true,       "content": {         "env": "AGENT_NAME=agent3\nAGENTMUX_AGENT_ID=Agent3",         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\n\n### 2. Dev Tools\nInstall if missing:\n```bash\nnpm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli\n```\n\n### 3. MCP Servers\nCheck AgentBus connectivity ΓÇö list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete ΓÇö ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."       },       "skills": [         {           "name": "Startup Verification",           "trigger": "startup",           "skill_type": "prompt",           "description": "Re-run tool verification checks and report status table",           "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages ΓÇö install if missing), and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."         }       ]     }   ] }
+{
+  "version": 4,
+  "agents": [
+    {
+      "id": "agentx",
+      "name": "AgentX",
+      "icon": "🔴",
+      "description": "Primary coding agent",
+      "working_directory": "",
+      "shell": "pwsh",
+      "agent_bus_id": "agentx",
+      "content": {
+        "env": "AGENT_NAME=agentx\nAGENTMUX_AGENT_ID=AgentX",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks and report status table",
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+        }
+      ]
+    },
+    {
+      "id": "agenty",
+      "name": "AgentY",
+      "icon": "🟡",
+      "description": "Secondary coding agent",
+      "working_directory": "",
+      "shell": "pwsh",
+      "agent_bus_id": "agenty",
+      "content": {
+        "env": "AGENT_NAME=agenty\nAGENTMUX_AGENT_ID=AgentY",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks and report status table",
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+        }
+      ]
+    },
+    {
+      "id": "agentz",
+      "name": "AgentZ",
+      "icon": "🔵",
+      "description": "Tertiary coding agent",
+      "working_directory": "",
+      "shell": "pwsh",
+      "agent_bus_id": "agentz",
+      "content": {
+        "env": "AGENT_NAME=agentz\nAGENTMUX_AGENT_ID=AgentZ",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks and report status table",
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+        }
+      ]
+    },
+    {
+      "id": "agentk",
+      "name": "AgentK",
+      "icon": "🌙",
+      "description": "Kimi Code CLI agent",
+      "working_directory": "",
+      "shell": "pwsh",
+      "agent_bus_id": "agentk",
+      "provider": "kimi",
+      "content": {
+        "env": "AGENT_NAME=agentk\nAGENTMUX_AGENT_ID=AgentK",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks and report status table",
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+        }
+      ]
+    },
+    {
+      "id": "agent1",
+      "name": "Agent1",
+      "icon": "🟢",
+      "description": "Sandboxed coding agent",
+      "working_directory": "/workspace",
+      "shell": "bash",
+      "agent_bus_id": "agent1",
+      "restart_on_crash": true,
+      "content": {
+        "env": "AGENT_NAME=agent1\nAGENTMUX_AGENT_ID=Agent1",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\n\n### 2. Dev Tools\nInstall if missing:\n```bash\nnpm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli\n```\n\n### 3. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks and report status table",
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+        }
+      ]
+    },
+    {
+      "id": "agent2",
+      "name": "Agent2",
+      "icon": "🟠",
+      "description": "Sandboxed coding agent",
+      "working_directory": "/workspace",
+      "shell": "bash",
+      "agent_bus_id": "agent2",
+      "restart_on_crash": true,
+      "content": {
+        "env": "AGENT_NAME=agent2\nAGENTMUX_AGENT_ID=Agent2",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\n\n### 2. Dev Tools\nInstall if missing:\n```bash\nnpm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli\n```\n\n### 3. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks and report status table",
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+        }
+      ]
+    },
+    {
+      "id": "agent3",
+      "name": "Agent3",
+      "icon": "🟣",
+      "description": "Sandboxed coding agent",
+      "working_directory": "/workspace",
+      "shell": "bash",
+      "agent_bus_id": "agent3",
+      "restart_on_crash": true,
+      "content": {
+        "env": "AGENT_NAME=agent3\nAGENTMUX_AGENT_ID=Agent3",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\n\n### 2. Dev Tools\nInstall if missing:\n```bash\nnpm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli\n```\n\n### 3. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks and report status table",
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+        }
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.304",
+  "version": "0.33.305",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.304",
+      "version": "0.33.305",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.303",
+  "version": "0.33.304",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.303",
+      "version": "0.33.304",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.304",
+  "version": "0.33.305",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.303",
+  "version": "0.33.304",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/gen-seed.js
+++ b/scripts/gen-seed.js
@@ -101,4 +101,29 @@ const manifest = {
     ]
 };
 
-process.stdout.write(JSON.stringify(manifest, null, 2) + "\n");
+// Write the manifest to `agentmux-srv/forge-seed.json` directly rather
+// than emitting it on stdout. Previously this script did
+// `process.stdout.write(...)` and callers redirected via
+// `node gen-seed.js > forge-seed.json`. On Windows PowerShell, stdout
+// redirection transcodes the Node UTF-8 output through the console code
+// page (cp437 / cp1252), corrupting the emoji icons (🔴 → "≡ƒö┤") and
+// em-dashes (— → "ΓÇö"). Git Bash preserves bytes but there was no way
+// to enforce the caller's shell. Writing directly sidesteps the issue.
+//
+// Kept the stdout emit too for callers that pipe elsewhere (e.g. diff
+// tools); gated behind `--stdout`.
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const json = JSON.stringify(manifest, null, 2) + "\n";
+
+if (process.argv.includes("--stdout")) {
+    process.stdout.write(json);
+} else {
+    const outPath = resolve(__dirname, "..", "agentmux-srv", "forge-seed.json");
+    writeFileSync(outPath, json, { encoding: "utf8" });
+    process.stdout.write(`wrote ${outPath}\n`);
+}


### PR DESCRIPTION
## Summary

Every agent's icon in the picker was showing \`≡ƒö┤\`/\`≡ƒƒí\`/\`≡ƒö╡\` etc. instead of 🔴/🟡/🔵 — classic double-encoding mojibake. Em-dashes in the startup markdown were similarly corrupted (\`ΓÇö\` instead of \`—\`).

## Root cause

#476/#477 regenerated \`forge-seed.json\` on Windows via \`node scripts/gen-seed.js > forge-seed.json\`. PowerShell (and cmd.exe) redirect Node's UTF-8 stdout through the console code page (cp437 in a Western locale). The emoji bytes \`f0 9f 94 b4\` (🔴) got interpreted as the four cp437 glyphs \`≡ƒö┤\` and re-emitted as UTF-8 of those glyphs → final file contains \`e2 89 a1 c6 92 c3 b6 e2 94 a4\` which the DB stores and the frontend renders verbatim as four garbage symbols.

## Fix

**\`scripts/gen-seed.js\`:** write the file directly via \`writeFileSync(outPath, json, \"utf8\")\` instead of \`process.stdout.write(...)\`. Shell redirection can no longer transcode the bytes because there IS no shell redirection. A \`--stdout\` flag preserves the old behaviour for callers that want to diff.

Also converted \`require\` calls to ESM imports (repo has \`\"type\": \"module\"\`) — the old CommonJS form threw \`ReferenceError: require is not defined\` the first time I tried to run it.

**\`agentmux-srv/forge-seed.json\`:** regenerated from the fixed script. Verified via \`xxd\` that the \`icon\` bytes are now \`f0 9f 94 b4\` (clean U+1F534 UTF-8) instead of the corrupt sequence. Every agent row and every em-dash in the embedded startup markdown is now correct.

## Test plan

- [x] \`xxd\` confirms correct UTF-8 bytes for all icons + em-dashes.
- [ ] Fresh dev: agent picker shows 🔴 🟡 🔵 🌙 🟢 🟠 🟤 for agentx/y/z/k/1/2/3.

## Why reagent didn't catch this on #476

The bot reviews diffs as text. It sees \`icon: \"≡ƒö┤\"\` and has no signal that those bytes should have been \`🔴\`. A CI byte-check on \`forge-seed.json\` (grep for the cp437 replacement chars \`≡ƒ\`) would be a cheap regression guard — not in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)