### PR TITLE
fix(browser-pane): inset placeholder 2px so focus border is visible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.305"
+version = "0.33.306"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.305"
+version = "0.33.306"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.305"
+version = "0.33.306"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.305"
+version = "0.33.306"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.305"
+version = "0.33.306"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.305"
+version = "0.33.306"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.305"
+version = "0.33.306"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.305"
+version = "0.33.306"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/browser/browser-view.scss
+++ b/frontend/app/view/browser/browser-view.scss
@@ -96,8 +96,9 @@
 
 .browser-placeholder {
     flex: 1;
-    width: 100%;
+    width: auto; /* was 100% — auto lets flex stretch respect margin */
     position: relative;
+    margin: 2px; /* inset to reveal the 2px pane border drawn by .block-mask */
 }
 
 .browser-empty {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.305",
+  "version": "0.33.306",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.305",
+      "version": "0.33.306",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.305",
+  "version": "0.33.306",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Originally diagnosed and fixed by **AgentK (Kimi agent) running inside AgentMux itself** — cherry-picked into this branch so it can ship.

Matches Fix A from [\`SPEC_BROWSER_PANE_Z_ORDER_2026_04_21.md\`](./specs/SPEC_BROWSER_PANE_Z_ORDER_2026_04_21.md).

## Problem

Browser panes are native CEF child HWNDs; they composite ABOVE the parent's render surface at the OS level, not via CSS. The \`.block-mask\` focus border (\`border: 2px solid accent-color\`, positioned absolutely at \`inset: 0\`) renders in main's Chromium widget, which the pane HWND covers. The blue focus border was invisible on the sides meeting the pane content — classic "airspace" bug.

## Fix

```diff
 .browser-placeholder {
     flex: 1;
-    width: 100%;
+    width: auto; /* was 100% — auto lets flex stretch respect margin */
     position: relative;
+    margin: 2px; /* inset to reveal the 2px pane border drawn by .block-mask */
 }
```

The pane HWND is positioned from \`placeholderRef.getBoundingClientRect()\`, so inset-ing the placeholder inset-s the pane. The border strip now has visible DOM real estate where the pane doesn't paint.

\`width: auto\` replaces \`width: 100%\` because with \`margin: 2px\` in place, \`100% + 2+2px\` would overflow the flex container; \`auto\` lets \`flex: 1\` size correctly.

## Not covered

- Popups over the pane (widget bar "… more" dropdown, context menus). That's Fix B in the Z-order spec — bigger surface change, separate PR.

## Test plan

- [x] Focus a browser pane in \`task dev\` — blue border visible on all four sides.
- [ ] Unfocus / refocus, resize — border stays correctly proportioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code), fix by AgentK (Kimi)