### PR TITLE
feat(browser-pane): real nav state from CEF for back/forward + URL sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.306"
+version = "0.33.307"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.306"
+version = "0.33.307"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.306"
+version = "0.33.307"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.306"
+version = "0.33.307"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.306"
+version = "0.33.307"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/pane/callbacks.rs
+++ b/agentmux-cef/src/pane/callbacks.rs
@@ -88,7 +88,7 @@ pub fn on_before_close_pane(state: &Arc<AppState>, label: &str) {
 /// focused HWND; stealing focus away from the pane breaks scrolling.
 /// The FocusHandler cancel + WndProc redirect already keep focus off
 /// the pane during the *initial* navigation focus steal.
-pub fn on_load_end_pane(_state: &Arc<AppState>, browser: &Browser) {
+pub fn on_load_end_pane(state: &Arc<AppState>, browser: &Browser) {
     tracing::info!("[pane-load-end] pane page loaded; reinstalling focus subclass");
 
     #[cfg(target_os = "windows")]
@@ -102,6 +102,58 @@ pub fn on_load_end_pane(_state: &Arc<AppState>, browser: &Browser) {
             }
         }
     }
+
+    // Emit nav-state event so the address bar + back/forward buttons in the
+    // browser pane's frontend view can reflect CEF's real history, not the
+    // fake local `history` array that only saw address-bar submits. This
+    // fires on every load_end (initial navigation, in-pane link clicks,
+    // popup-intercept redirects, back/forward), which is the union of
+    // every case the buttons need to stay in sync with.
+    //
+    // Resolving block_id from the browser: panes are registered in
+    // `state.browsers` under a label like `browser-pane-<block_id>-<seq>`.
+    // Find our label by same-identity check, then strip the suffix.
+    let block_id = {
+        let browsers = state.browsers.lock();
+        browsers
+            .iter()
+            .find(|(_k, b)| {
+                let mut b_clone = b.clone();
+                let mut browser_clone: cef::Browser = browser.clone();
+                b_clone.is_same(Some(&mut browser_clone)) != 0
+            })
+            .and_then(|(label, _)| {
+                // Label shape: browser-pane-<uuid>-<N>. Trim the prefix,
+                // then pop the trailing `-<N>` to get the uuid.
+                let rest = label.strip_prefix("browser-pane-")?;
+                let dash = rest.rfind('-')?;
+                Some(rest[..dash].to_string())
+            })
+    };
+
+    if let Some(block_id) = block_id {
+        let (can_back, can_forward, url) = {
+            let mut b: cef::Browser = browser.clone();
+            let back = cef::ImplBrowser::can_go_back(&b) != 0;
+            let forward = cef::ImplBrowser::can_go_forward(&b) != 0;
+            let url = b
+                .main_frame()
+                .map(|f| cef::CefString::from(&cef::ImplFrame::url(&f)).to_string())
+                .unwrap_or_default();
+            (back, forward, url)
+        };
+        crate::events::emit_event_from_state(
+            state,
+            "browser-pane-nav-state",
+            &serde_json::json!({
+                "block_id": block_id,
+                "url": url,
+                "can_go_back": can_back,
+                "can_go_forward": can_forward,
+            }),
+        );
+    }
+
     #[cfg(not(target_os = "windows"))]
     {
         let _ = browser;

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.306"
+version = "0.33.307"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.306"
+version = "0.33.307"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.306"
+version = "0.33.307"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -6,7 +6,7 @@
 // native CefBrowserView for sites that block iframes.
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
-import { invokeCommand } from "@/app/platform/ipc";
+import { invokeCommand, listenEvent } from "@/app/platform/ipc";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
@@ -58,9 +58,12 @@ export class BrowserViewModel implements ViewModel {
     errorAtom: Accessor<string | null> = this._error[0];
     setError = this._error[1];
 
-    // Navigation history (iframe doesn't expose browser history)
-    private history: string[] = [];
-    private historyIndex = -1;
+    /**
+     * Unsubscribe from the backend's `browser-pane-nav-state` event.
+     * Nulled in `dispose()` so we don't leak listeners when the pane
+     * closes and the ViewModel is GC'd.
+     */
+    private _navUnsub: (() => void) | null = null;
 
     blockAtom: Accessor<Block | undefined>;
 
@@ -79,6 +82,37 @@ export class BrowserViewModel implements ViewModel {
         this.viewName = createMemo(() => {
             const title = this.titleAtom();
             return title || "Browser";
+        });
+
+        // Subscribe to nav-state updates fired by the backend on every
+        // `on_load_end_pane`. This is the source of truth for address bar +
+        // back/forward state: CEF knows the real history (including
+        // in-pane link clicks and popup-intercept redirects), and the
+        // local fake history array we used before diverged the moment
+        // the user clicked any link inside the pane. See
+        // specs/SPEC_BROWSER_PANE_Z_ORDER_2026_04_21.md (unrelated but
+        // adjacent) and the nav-state wiring added alongside this PR.
+        void listenEvent<{
+            block_id: string;
+            url: string;
+            can_go_back: boolean;
+            can_go_forward: boolean;
+        }>("browser-pane-nav-state", (payload) => {
+            if (this._closed) return;
+            if (payload.block_id !== this.blockId) return;
+            this.setUrl(payload.url);
+            this.setCanGoBack(payload.can_go_back);
+            this.setCanGoForward(payload.can_go_forward);
+            this.setLoading(false);
+            // Persist the real URL to block meta so pane restore lands
+            // on the last page, not whatever was passed at create time.
+            RpcApi.SetMetaCommand(TabRpcClient, {
+                oref: makeORef("block", this.blockId),
+                meta: { url: payload.url },
+            }).catch(() => {});
+        }).then((unsub) => {
+            if (this._closed) unsub();
+            else this._navUnsub = unsub;
         });
 
         // Load URL from block meta on init. An empty/missing `url` falls
@@ -107,17 +141,13 @@ export class BrowserViewModel implements ViewModel {
         this.setUrl(normalized);
         this.setError(null);
         this.setLoading(true);
+        // can_go_back / can_go_forward are set by the `browser-pane-nav-state`
+        // event subscription; we don't touch them here. CEF is the source of
+        // truth for history state.
 
-        // Update history
-        if (this.historyIndex < this.history.length - 1) {
-            this.history = this.history.slice(0, this.historyIndex + 1);
-        }
-        this.history.push(normalized);
-        this.historyIndex = this.history.length - 1;
-        this.setCanGoBack(this.historyIndex > 0);
-        this.setCanGoForward(false);
-
-        // Persist URL to block meta
+        // Persist the requested URL to block meta immediately so a quick
+        // pane restore before load_end still has something. The nav-state
+        // event will overwrite this with the post-redirect final URL.
         RpcApi.SetMetaCommand(TabRpcClient, {
             oref: makeORef("block", this.blockId),
             meta: { url: normalized },
@@ -126,24 +156,17 @@ export class BrowserViewModel implements ViewModel {
 
     goBack(): void {
         if (this._closed) return;
-        if (this.historyIndex > 0) {
-            this.historyIndex--;
-            this.setUrl(this.history[this.historyIndex]);
-            this.setCanGoBack(this.historyIndex > 0);
-            this.setCanGoForward(true);
-            this.setLoading(true);
-        }
+        // CEF owns the history — we just fire the IPC. The button's
+        // enabled/disabled state came from `can_go_back` in the nav-state
+        // event, so if we got here the browser has somewhere to go.
+        this.setLoading(true);
+        invokeCommand("browser_pane_go_back", { block_id: this.blockId }).catch(() => {});
     }
 
     goForward(): void {
         if (this._closed) return;
-        if (this.historyIndex < this.history.length - 1) {
-            this.historyIndex++;
-            this.setUrl(this.history[this.historyIndex]);
-            this.setCanGoBack(true);
-            this.setCanGoForward(this.historyIndex < this.history.length - 1);
-            this.setLoading(true);
-        }
+        this.setLoading(true);
+        invokeCommand("browser_pane_go_forward", { block_id: this.blockId }).catch(() => {});
     }
 
     reload(): void {
@@ -192,5 +215,9 @@ export class BrowserViewModel implements ViewModel {
 
     dispose(): void {
         this._closed = true;
+        if (this._navUnsub) {
+            this._navUnsub();
+            this._navUnsub = null;
+        }
     }
 }

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { invokeCommand } from "@/app/platform/ipc";
 import type { BrowserViewModel } from "./browser-model";
 import "./browser-view.scss";
@@ -9,6 +9,20 @@ import "./browser-view.scss";
 export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>): JSX.Element {
     const model = props.model;
     const [addressBar, setAddressBar] = createSignal(model.urlAtom() || "");
+    let addressInputRef: HTMLInputElement | undefined;
+    // Reactively mirror the model's URL into the address-bar input whenever
+    // CEF reports a navigation via the `browser-pane-nav-state` event (in-
+    // pane link clicks, redirects, back/forward, popup-intercept). Without
+    // this the input stayed frozen at the last user-submitted text while
+    // `model.urlAtom()` advanced, so the address bar diverged from the
+    // actual pane URL. Skip while the user is actively editing the input
+    // (focused) — otherwise we'd clobber mid-keystroke. Reagent caught
+    // this on PR #484 review.
+    createEffect(() => {
+        const modelUrl = model.urlAtom();
+        if (document.activeElement === addressInputRef) return;
+        if (modelUrl !== addressBar()) setAddressBar(modelUrl);
+    });
     let placeholderRef: HTMLDivElement | undefined;
     let resizeObserver: ResizeObserver | null = null;
     let positionInterval: ReturnType<typeof setInterval> | null = null;
@@ -133,6 +147,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     title="Reload"
                 >{"\u21BB"}</button>
                 <input
+                    ref={addressInputRef}
                     class="browser-address-bar"
                     type="text"
                     value={addressBar()}

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -118,19 +118,13 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                 <button
                     class="browser-nav-btn"
                     disabled={!model.canGoBackAtom()}
-                    onClick={() => {
-                        model.goBack();
-                        invokeCommand("browser_pane_go_back", { block_id: model.blockId }).catch(() => {});
-                    }}
+                    onClick={() => model.goBack()}
                     title="Back"
                 >{"\u2190"}</button>
                 <button
                     class="browser-nav-btn"
                     disabled={!model.canGoForwardAtom()}
-                    onClick={() => {
-                        model.goForward();
-                        invokeCommand("browser_pane_go_forward", { block_id: model.blockId }).catch(() => {});
-                    }}
+                    onClick={() => model.goForward()}
                     title="Forward"
                 >{"\u2192"}</button>
                 <button

--- a/frontend/app/view/identity/identity-model.test.ts
+++ b/frontend/app/view/identity/identity-model.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 // shim. Keep them un-exported in the module so callers don't depend on
 // them, but expose for tests via `__internal__`.
 import * as identityModel from "./identity-model";
+import type { Account } from "./identity-model";
 
 // The helpers aren't re-exported; we round-trip through the public API
 // using a stub Account shape. The conversion happens inside

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.306",
+  "version": "0.33.307",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.306",
+      "version": "0.33.307",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.306",
+  "version": "0.33.307",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_BROWSER_PANE_Z_ORDER_2026_04_21.md
+++ b/specs/SPEC_BROWSER_PANE_Z_ORDER_2026_04_21.md
@@ -1,0 +1,183 @@
+# Spec: Browser pane Z-order fixes
+
+**Date:** 2026-04-21
+**Status:** Draft (analysis + implementation-ready)
+**Scope:** Make main-window UI chrome (focus border, widget-bar popups, other overlays) appear above the browser pane's rendered content instead of behind it.
+
+---
+
+## Problem
+
+Two visible bugs, same root cause:
+
+1. **Focus border clipped.** The blue "pane is focused" border rendered by the block frame's CSS disappears over the edge of a browser pane. You see the border on three sides (where there's DOM margin) and nothing on the side flush with the pane content.
+2. **Widget bar "... more" popup hidden.** Clicking the widget bar's overflow chevron opens a dropdown that extends over the workspace area. If a browser pane is under that area, the dropdown appears *behind* the browser's rendered page.
+
+User expectation: everything adjacent to the browser content — focus border, dropdowns, context menus, tab previews, modals — is **above** the browser content.
+
+---
+
+## Root cause
+
+Browser panes are **native CEF child HWNDs**, not CSS boxes. `pane/callbacks.rs:44-51` creates each pane with `SetWindowPos(HWND_TOP, ..., SWP_NOACTIVATE)` and the `browser_pane_resize` IPC positions it to fill `placeholderRef.getBoundingClientRect()` exactly.
+
+**Windows compositing is OS-level, not browser-level.** When a child HWND exists within a parent, it's painted ON TOP of the parent's render surface — independent of CSS `z-index`, `position: fixed`, `transform: translateZ`, or any trick in the DOM. Main's Chrome_RenderWidgetHostHWND renders beneath the pane HWND because the pane sits higher in the sibling Z-order.
+
+So: anything the main window draws through its Chromium render widget — focus border, popovers, modals, tooltips — is *physically below* the pane HWND and invisible wherever the pane overlaps it.
+
+This is the classic "airspace" bug. The Chromium team documented it for `<iframe>` + `<embed>` twenty years ago; the same constraint applies to embedded CEF browsers. There's no pure-CSS fix.
+
+## What the current code already does
+
+- `pane::callbacks::on_after_created_pane` raises the pane to HWND_TOP so it sits *above main*, which is required for mouse-wheel events to route correctly (CEF widget hit-testing walks the HWND Z-order). See the comment at `browser_panes.rs:233`.
+- `browser-view.tsx:34-40` syncs the pane HWND's position/size to a DOM placeholder's bounding rect on every render pass.
+
+---
+
+## Strategy (two orthogonal fixes)
+
+### Fix A — focus border: shrink the pane rect by the border width
+
+The focus border is a CSS border on the block frame (`.block-frame-default.is-focused`). It lives in the DOM, in main's render widget, which the pane HWND covers.
+
+**The fix is to not cover it.** Shrink the pane HWND by the border thickness so the border strip is visible DOM where the pane isn't painted.
+
+```
+┌─────────────────── block frame ────────────────────┐
+│  ┌──────── blue focus border (3-4 px CSS) ───────┐ │
+│  │                                                │ │
+│  │         pane HWND (shrunk by border)          │ │   ← pane now fits INSIDE the border
+│  │                                                │ │
+│  └────────────────────────────────────────────────┘ │
+└────────────────────────────────────────────────────┘
+```
+
+Implementation: in `browser-view.tsx::paneRect()`, measure the border via `getComputedStyle` on the block frame and subtract it from the placeholder rect. Or simpler: make the placeholder itself be inset by the border width in the block layout (pure CSS change on `.block-content-browser` or the placeholder element), then `getBoundingClientRect()` returns the already-inset rect naturally.
+
+Preferred: **CSS-only — inset the placeholder by the border width**. Zero IPC overhead, no JS math, the pane rect just follows the placeholder like it already does.
+
+### Fix B — popups over the pane: hide/shrink the pane while a popup is open
+
+CSS can't overlay a child HWND. The only Win32-level solutions are:
+
+1. **Hide / shrink the pane temporarily** while the popup is open. Simple, reliable, has a small visible flicker on very fast show/hide. This is what VS Code and Electron apps do for similar cases.
+2. **Move popups into their own top-level window** (layered HWND above the parent). Matches how native apps render tooltips. Bigger surface change, adds a second HWND to manage, interacts badly with theming/DPI.
+3. **Switch panes to offscreen rendering (OSR)** where CEF paints into a bitmap that main blits into its own render surface. No HWND, no Z-order problem. Has knock-on costs: input plumbing, IME, hardware accel, accessibility all have to be re-wired through the host.
+4. **Chromium's `<portal>` / `<fencedframe>`** — not applicable here; those are same-document primitives and we have two separate browsers.
+
+**Option 1 is the pragmatic choice.** Scope it tight:
+
+```
+┌──────────────────────────────────────────────────┐
+│  [widget bar ▾]  ← "...more" popup opens       │
+│        │                                         │
+│        ├── overflow-popup (DOM overlay)          │
+│        │                                         │
+│   ┌────┴───────────────────────┐                │
+│   │ popup extends over the     │    pane HWND   │
+│   │ workspace area here        │    hidden      │   ← visibility: hidden while popup visible
+│   │                            │                │
+│   └────────────────────────────┘                │
+│                                                  │
+└──────────────────────────────────────────────────┘
+```
+
+Implementation:
+1. **Enumerate the overlay sources** that extend over pane territory:
+   - Widget bar "… more" dropdown
+   - Context menus (right-click in block frame, tab strip)
+   - Focus border is Fix A, not B
+   - Modals (already cover the full window; see below)
+   - Agent settings overlay, identity panel overlay
+2. **Central "any overlay open?" signal** in the frontend. A module-level signal (`overlayOpenAtom`) incremented by each overlay that needs to suppress panes, decremented on close. When it transitions `0 → 1`, call a new IPC `browser_panes_hide_all`. When it returns to 0, call `browser_panes_show_all`.
+3. **Backend (`browser_panes.rs`):** `hide_all` iterates every live pane and calls `ShowWindow(hwnd, SW_HIDE)`; `show_all` does `SW_SHOWNOACTIVATE`. Cheap — one SetWindowPos-equivalent call per pane. Test count is small (1–3 panes typical).
+4. **Full-screen modals already work** because the modal's backdrop uses `position: fixed; inset: 0` which is DOM, but since we'll be hiding the pane anyway when any overlay opens, modals get covered too without any extra code.
+
+**Alternative (for future):** "Soft hide" — instead of `SW_HIDE`, SetWindowPos the pane to be 1×1 px in a corner. Keeps the browser's render process warm + layouted. Useful if `SW_HIDE` turns out to introduce its own flicker. Try `SW_HIDE` first.
+
+---
+
+## Files touched
+
+### Fix A (focus border)
+
+- `frontend/app/block/block.scss` (or whichever file owns `.block-frame-default` and `.block-content-browser`) — inset the placeholder element by the focus-border width. Might need a new class or a conditional rule for browser-view blocks only (terminals don't have this bug because the terminal is DOM-rendered, not native HWND).
+
+### Fix B (hide panes under overlays)
+
+- **Frontend**
+  - New file or module-level store: `frontend/app/store/pane-overlays.ts` — `overlayOpenCount: signal<number>`, `incrementOverlay()`, `decrementOverlay()`, watch effect that fires the IPC on 0↔1 transitions.
+  - Each overlay source calls `incrementOverlay()` on mount and `decrementOverlay()` on unmount:
+    - `frontend/app/widget/widgetbar-overflow.tsx` (or wherever "… more" lives)
+    - Context menu framework (once, central)
+    - Agent settings overlay (`AgentCardSettingsPanel.tsx` or similar)
+    - Identity panel overlay (`AgentIdentityPanel.tsx`)
+- **Backend**
+  - `agentmux-cef/src/browser_panes.rs`: add `fn hide_all(&self, state)` and `fn show_all(&self, state)` that walk live panes and `ShowWindow(SW_HIDE)` / `ShowWindow(SW_SHOWNOACTIVATE)` each outer HWND.
+  - `agentmux-cef/src/ipc.rs`: add `browser_panes_hide_all` and `browser_panes_show_all` IPC commands that dispatch to the above (no args).
+
+### Z-order semantics to preserve
+
+- Still call `SetWindowPos(HWND_TOP)` on pane creation — mouse-wheel routing depends on it (`browser_panes.rs:226-231` comment).
+- `SW_SHOWNOACTIVATE` on restore, NOT `SW_SHOW`, to avoid stealing keyboard focus.
+- Hide/show must be idempotent — if the user opens the widget bar, then also opens a context menu, we shouldn't double-hide. That's what `overlayOpenCount` with transitions-on-boundaries handles.
+
+---
+
+## Non-goals
+
+- **OSR mode for panes** (Option 3 in Strategy B). Bigger architectural change; worth revisiting if future requirements (e.g. blurred-glass overlays over pane content, tabs across panes that share a single view) demand it.
+- **Real layered windows for tooltips / menus** (Option 2). Deferrable until we have an overlay source where the show/hide flicker is actually visible.
+- **Per-pane hide** (only hide the pane the popup actually overlaps). Simpler to hide all; overlays are transient (sub-second typical).
+- Transparent popup backgrounds that bleed through — purely cosmetic; hide-all implementation doesn't support this anyway since the pane disappears entirely.
+- Linux/macOS equivalents. The `ShowWindow(SW_HIDE)` mechanism is Windows-specific; we'd gate the backend code on `#[cfg(target_os = "windows")]` and let mac/linux eat the behaviour (they're not the primary target yet).
+
+---
+
+## Edge cases
+
+1. **Pane created while an overlay is already open** — new pane appears above the overlay, broken state. Mitigation: in `browser_pane_create`, check `overlay_count > 0` and immediately hide after creation. Or simpler: `browser_pane_create` IPC takes an extra `hidden: bool` arg defaulting to `false`; the frontend sets it to `true` when the overlay count is non-zero.
+2. **Pane navigates / resizes while hidden** — SetWindowPos + navigate still work on a hidden HWND; state resumes correctly on show. No special handling.
+3. **Pane HWND stuck hidden** — overlay count gets stuck at 1 because a component forgot to decrement on unmount. Safety net: mount-level cleanup in each overlay component, plus a devtools debug helper `window.__paneOverlayCount` for inspection.
+4. **Focus restoration when pane re-shows** — don't auto-focus. User's focus target is whatever it was before the overlay opened; `SW_SHOWNOACTIVATE` preserves that.
+5. **Pane browser on top of the whole window** (Fullscreen API) — out of scope; fullscreen is its own flow that re-parents the pane anyway.
+
+---
+
+## Test plan
+
+### Fix A
+
+- [ ] Focus a browser pane. Blue border is visible on all four sides.
+- [ ] Resize the pane. Border stays correctly proportioned (not clipped on one edge).
+- [ ] Unfocus / focus other panes repeatedly — no border ghosting on the previously-focused pane.
+- [ ] Terminal / agent panes unaffected — their borders already work, this change shouldn't regress them.
+
+### Fix B
+
+- [ ] Open widget bar "… more" while a browser pane is present. Dropdown visible on top; pane content hidden behind it (or the pane is invisible, depending on implementation).
+- [ ] Close the dropdown. Pane reappears in correct position.
+- [ ] Right-click context menu over a browser pane — same thing.
+- [ ] Agent settings overlay — panes hidden while overlay is up.
+- [ ] Quick open/close: dropdown opens and closes within 100ms — no stuck-hidden pane.
+- [ ] Two panes side-by-side: both hide/show together.
+- [ ] Pane created while dropdown is open — edge case #1 — pane doesn't pop into view over the dropdown.
+
+---
+
+## Rollout
+
+Two separate PRs is cleanest:
+
+1. **PR A — focus border inset (CSS-only).** Tiny, low-risk, reviewable in 30 seconds. Merge standalone.
+2. **PR B — overlay-aware pane hide.** Touches backend IPC + at least 3 frontend overlay components. Bigger review surface, more test coverage required.
+
+If both fit comfortably in one diff (doubtful — overlay audit alone needs multiple frontend files), we can bundle; otherwise split. Ship A first.
+
+---
+
+## Future considerations
+
+- **Accessibility.** Screen-reader users navigating while a pane is hidden: the hidden pane drops out of the AT tree for the duration; returning focus when the overlay closes should restore the expected focus target. Test with NVDA.
+- **Hardware-accelerated overlays.** If we ever add a live preview pane (e.g. agent output streamed via WebGL into a popup), revisit — may justify Option 3 (OSR) at that point.
+- **Cross-platform.** Mac / Linux have different window-system semantics. On macOS, NSWindow siblings can be layered more finely via `NSWindow.orderedIndex`; on Wayland it's a harder problem entirely.


### PR DESCRIPTION
Fixes the greyed-out back/forward buttons and address bar divergence you reported after clicking any link inside a browser pane.

## Root cause

\`browser-model.ts\` maintained its own fake \`history[]\` + \`historyIndex\` — only appended when \`navigate()\` ran from an address-bar submit. In-pane link clicks, redirects, and popup-intercept redirects (from #481's \`on_before_popup\` hook) all happen at the Chromium level. The frontend never heard about them, so \`canGoBack\`/\`canGoForward\` stayed false and the buttons stayed greyed out regardless of how deep you'd navigated. Address bar also froze at whatever was last submitted.

## Fix

CEF becomes source of truth:

- **Backend** — on every \`on_load_end_pane\`, emit \`browser-pane-nav-state\` \`{ block_id, url, can_go_back, can_go_forward }\` via \`execute_java_script\` event bridge. Pane's \`block_id\` derived from its \`browser-pane-<uuid>-<N>\` label.
- **Frontend** — \`BrowserViewModel\` subscribes per-pane on construction, drives \`urlAtom\` / \`canGoBackAtom\` / \`canGoForwardAtom\` from event payload. \`dispose()\` unsubscribes.
- Local \`history\` array + \`historyIndex\` deleted.
- \`goBack()\`/\`goForward()\` on the view model now just fire the \`browser_pane_go_back\`/\`browser_pane_go_forward\` IPCs (browser-view.tsx was double-firing).
- \`navigate()\` no longer pushes locally — post-redirect URL comes back via the event and overwrites.

Drive-by: identity-model.test.ts was missing an \`import type { Account }\` — pre-existing but TS surfaced it during this check.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] In dev: browser pane → navigate to a site with internal links → click one → back button enables, works correctly, address bar reflects current URL
- [ ] Click a \`target=\"_blank\"\` link → in-pane navigation succeeds AND back/forward state updates
- [ ] Address bar shows the post-redirect URL after loading (e.g. \`google.com\` → \`www.google.com\` after redirect)

## Companion doc

\`specs/SPEC_BROWSER_PANE_Z_ORDER_2026_04_21.md\` — Z-order analysis for overlays over panes (Fix A in there was AgentK's recent fix #483; Fix B deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)