### PR TITLE
fix(browser-pane): use on_loading_state_change for authoritative nav state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.308"
+version = "0.33.309"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.308"
+version = "0.33.309"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.308"
+version = "0.33.309"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.308"
+version = "0.33.309"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.307"
+version = "0.33.308"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.307"
+version = "0.33.308"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.307"
+version = "0.33.308"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.307"
+version = "0.33.308"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.309"
+version = "0.33.310"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.309"
+version = "0.33.310"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.309"
+version = "0.33.310"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.309"
+version = "0.33.310"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.308"
+version = "0.33.309"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.307"
+version = "0.33.308"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.309"
+version = "0.33.310"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_api/mod.rs
+++ b/agentmux-cef/src/browser_api/mod.rs
@@ -44,6 +44,9 @@ pub fn register_routes(router: Router<Arc<AppState>>) -> Router<Arc<AppState>> {
         .route("/agentmux/browser/focus_element", post(routes::focus_element))
         .route("/agentmux/browser/dispatch_key", post(routes::dispatch_key))
         .route("/agentmux/browser/navigate", post(routes::navigate))
+        .route("/agentmux/browser/back", post(routes::back))
+        .route("/agentmux/browser/forward", post(routes::forward))
+        .route("/agentmux/browser/reload", post(routes::reload))
 }
 
 /// Shared state for the browser API — primarily the CDP target

--- a/agentmux-cef/src/browser_api/routes.rs
+++ b/agentmux-cef/src/browser_api/routes.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 use super::cdp::CdpSession;
 use super::types::{
     AckData, ApiResponse, ClickElementReq, DispatchKeyReq, Element, EvalData, EvalReq,
-    FocusElementReq, FocusInfoData, FocusInfoReq, NavigateReq, QueryData, QueryReq,
+    FocusElementReq, FocusInfoData, FocusInfoReq, HistoryReq, NavigateReq, QueryData, QueryReq,
     ScreenshotData, ScreenshotReq,
 };
 use crate::state::AppState;
@@ -620,6 +620,106 @@ pub async fn navigate(
     match reply {
         Ok(_) => ok_body(ApiResponse::ok(AckData::new())),
         Err(e) => ok_body(ApiResponse::err(format!("CDP Page.navigate: {e}"))),
+    }
+}
+
+/// `POST /agentmux/browser/back` — walk the pane's history one step back.
+/// Routed through CDP (`Page.goBack`) rather than
+/// `BrowserPaneManager::go_back` to keep the resolver cache honest: the
+/// target URL changes after the hop, so we invalidate the cache entry.
+///
+/// Returns ack-ok even when there's no prior history — CDP is a no-op
+/// in that case, and agents should query `browser-pane-nav-state` events
+/// (or `eval("location.href")`) to confirm what happened.
+pub async fn back(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<HistoryReq>,
+) -> (StatusCode, Json<ApiResponse<AckData>>) {
+    if !authorized(&headers, &state.ipc_token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiResponse::err("unauthorized: missing or invalid bearer token")),
+        );
+    }
+
+    let mut cdp = match open_cdp_for_block(&state, &req.block_id).await {
+        Ok(c) => c,
+        Err(e) => return ok_body(ApiResponse::err(e)),
+    };
+
+    // `Page.navigateToHistoryEntry` needs an entryId; simpler to call
+    // Page.goBack which CDP exposes directly.
+    let reply = cdp.call("Page.goBack", json!({})).await;
+    let _ = cdp.close().await;
+
+    state.browser_api.target_cache.forget(&req.block_id);
+
+    match reply {
+        Ok(_) => ok_body(ApiResponse::ok(AckData::new())),
+        Err(e) => ok_body(ApiResponse::err(format!("CDP Page.goBack: {e}"))),
+    }
+}
+
+/// `POST /agentmux/browser/forward` — walk the pane's history one step forward.
+/// See `back` for the target-cache rationale.
+pub async fn forward(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<HistoryReq>,
+) -> (StatusCode, Json<ApiResponse<AckData>>) {
+    if !authorized(&headers, &state.ipc_token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiResponse::err("unauthorized: missing or invalid bearer token")),
+        );
+    }
+
+    let mut cdp = match open_cdp_for_block(&state, &req.block_id).await {
+        Ok(c) => c,
+        Err(e) => return ok_body(ApiResponse::err(e)),
+    };
+
+    let reply = cdp.call("Page.goForward", json!({})).await;
+    let _ = cdp.close().await;
+
+    state.browser_api.target_cache.forget(&req.block_id);
+
+    match reply {
+        Ok(_) => ok_body(ApiResponse::ok(AckData::new())),
+        Err(e) => ok_body(ApiResponse::err(format!("CDP Page.goForward: {e}"))),
+    }
+}
+
+/// `POST /agentmux/browser/reload` — reload the current page. `ignore_cache`
+/// (default false) maps to the CDP flag — true is the equivalent of Ctrl+F5
+/// (bypass the http cache). The pane's current URL is preserved, so no
+/// target-cache invalidation is needed.
+pub async fn reload(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<HistoryReq>,
+) -> (StatusCode, Json<ApiResponse<AckData>>) {
+    if !authorized(&headers, &state.ipc_token) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ApiResponse::err("unauthorized: missing or invalid bearer token")),
+        );
+    }
+
+    let mut cdp = match open_cdp_for_block(&state, &req.block_id).await {
+        Ok(c) => c,
+        Err(e) => return ok_body(ApiResponse::err(e)),
+    };
+
+    let reply = cdp
+        .call("Page.reload", json!({ "ignoreCache": req.ignore_cache }))
+        .await;
+    let _ = cdp.close().await;
+
+    match reply {
+        Ok(_) => ok_body(ApiResponse::ok(AckData::new())),
+        Err(e) => ok_body(ApiResponse::err(format!("CDP Page.reload: {e}"))),
     }
 }
 

--- a/agentmux-cef/src/browser_api/types.rs
+++ b/agentmux-cef/src/browser_api/types.rs
@@ -167,6 +167,23 @@ pub struct NavigateReq {
     pub url: String,
 }
 
+// ── browser.back / .forward / .reload ───────────────────────────────────
+//
+// Share a single request shape — all three only need the target block id.
+// These exist so agents driving a browser pane during dev / tests can walk
+// its history without a human clicking the toolbar. Also useful for the
+// agent workflow where a tool says "open this URL, try to click X, if not
+// found go back and try Y."
+
+#[derive(Debug, Deserialize)]
+pub struct HistoryReq {
+    pub block_id: String,
+    /// Reload only: skip the http cache and force a network refetch.
+    /// Ignored by `back` / `forward`. Defaults to false.
+    #[serde(default)]
+    pub ignore_cache: bool,
+}
+
 // ── Generic "ok:true" success body for write endpoints ──────────────────
 
 #[derive(Debug, Serialize)]

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -358,6 +358,34 @@ impl AgentMuxHandler {
         }
     }
 
+    /// CEF fires this whenever the browser's loading/history state changes
+    /// (navigation started, navigation committed, back/forward enabled).
+    /// `can_go_back` / `can_go_forward` come directly from the navigation
+    /// controller — no need to query `browser.can_go_back()` (which races
+    /// with history commit when called from `on_load_end`).
+    ///
+    /// For panes: emit `browser-pane-nav-state` so the frontend address
+    /// bar + back/forward buttons reflect CEF's real history state.
+    fn on_loading_state_change(
+        &mut self,
+        browser: Option<&mut Browser>,
+        _is_loading: i32,
+        can_go_back: i32,
+        can_go_forward: i32,
+    ) {
+        if !self.is_pane {
+            return;
+        }
+        if let Some(b) = browser.as_deref() {
+            crate::pane::callbacks::on_loading_state_change_pane(
+                &self.state,
+                b,
+                can_go_back != 0,
+                can_go_forward != 0,
+            );
+        }
+    }
+
     fn on_load_end(
         &mut self,
         browser: Option<&mut Browser>,
@@ -971,6 +999,17 @@ wrap_load_handler! {
     }
 
     impl LoadHandler {
+        fn on_loading_state_change(
+            &self,
+            browser: Option<&mut Browser>,
+            is_loading: ::std::os::raw::c_int,
+            can_go_back: ::std::os::raw::c_int,
+            can_go_forward: ::std::os::raw::c_int,
+        ) {
+            let mut inner = self.inner.lock();
+            inner.on_loading_state_change(browser, is_loading, can_go_back, can_go_forward);
+        }
+
         fn on_load_end(
             &self,
             browser: Option<&mut Browser>,

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -213,6 +213,18 @@ impl AgentMuxHandler {
     /// (link clicks go through `openExternal` IPC), and panes explicitly
     /// don't want popups. See
     /// specs/SPEC_BROWSER_PANE_DEFAULT_URL_AND_POPUP_2026_04_21.md.
+    ///
+    /// **The `load_url` call is deferred via `post_task`**, not run inline.
+    /// Inline `load_url` caused a UI-thread deadlock on link click:
+    /// `on_before_popup` runs while `AgentMuxLifeSpanHandler` holds
+    /// `self.inner.lock()` (via the wrap macro). Inline `load_url` starts
+    /// a new navigation on the same UI thread, which triggers
+    /// `on_loading_state_change` on `AgentMuxLoadHandler`, which also
+    /// tries to take `self.inner.lock()` → deadlock. The host hung with
+    /// backend heartbeats still running but the whole UI frozen. Posting
+    /// the `load_url` as a separate UI task lets the popup handler
+    /// return, release the lock, then pick up the load on the next loop
+    /// iteration.
     fn on_before_popup(
         &mut self,
         browser: Option<&mut Browser>,
@@ -226,14 +238,17 @@ impl AgentMuxHandler {
             return true;
         }
         if let Some(b) = browser {
-            if let Some(frame) = b.main_frame() {
-                frame.load_url(Some(&CefString::from(url.as_str())));
-            }
+            let browser_clone = b.clone();
+            let mut task = crate::ui_tasks::DeferredLoadUrlTask::new(
+                browser_clone,
+                url.clone(),
+            );
+            cef::post_task(cef::ThreadId::UI, Some(&mut task));
         }
         tracing::info!(
             is_pane = %self.is_pane,
             url = %url,
-            "popup intercepted — navigated current frame in place",
+            "popup intercepted — deferred navigation of current frame",
         );
         true // cancel the top-level popup creation
     }

--- a/agentmux-cef/src/pane/callbacks.rs
+++ b/agentmux-cef/src/pane/callbacks.rs
@@ -103,44 +103,20 @@ pub fn on_load_end_pane(state: &Arc<AppState>, browser: &Browser) {
         }
     }
 
-    // Emit nav-state event so the address bar + back/forward buttons in the
-    // browser pane's frontend view can reflect CEF's real history, not the
-    // fake local `history` array that only saw address-bar submits. This
-    // fires on every load_end (initial navigation, in-pane link clicks,
-    // popup-intercept redirects, back/forward), which is the union of
-    // every case the buttons need to stay in sync with.
-    //
-    // Resolving block_id from the browser: panes are registered in
-    // `state.browsers` under a label like `browser-pane-<block_id>-<seq>`.
-    // Find our label by same-identity check, then strip the suffix.
-    let block_id = {
-        let browsers = state.browsers.lock();
-        browsers
-            .iter()
-            .find(|(_k, b)| {
-                let mut b_clone = b.clone();
-                let mut browser_clone: cef::Browser = browser.clone();
-                b_clone.is_same(Some(&mut browser_clone)) != 0
-            })
-            .and_then(|(label, _)| {
-                // Label shape: browser-pane-<uuid>-<N>. Trim the prefix,
-                // then pop the trailing `-<N>` to get the uuid.
-                let rest = label.strip_prefix("browser-pane-")?;
-                let dash = rest.rfind('-')?;
-                Some(rest[..dash].to_string())
-            })
-    };
-
-    if let Some(block_id) = block_id {
-        let (can_back, can_forward, url) = {
+    // URL-only event emit at load_end so the address bar catches redirects
+    // that resolve during frame load (e.g. google.com → www.google.com).
+    // `can_go_back` / `can_go_forward` are intentionally not read here —
+    // `on_load_end` fires before the navigation controller commits the
+    // history entry, so calling `browser.can_go_back()` from this hook
+    // can return the pre-navigation state. Those flags flow through the
+    // dedicated `on_loading_state_change_pane` callback below, which CEF
+    // provides with correct values as direct parameters.
+    if let Some(block_id) = resolve_pane_block_id(state, browser) {
+        let url = {
             let mut b: cef::Browser = browser.clone();
-            let back = cef::ImplBrowser::can_go_back(&b) != 0;
-            let forward = cef::ImplBrowser::can_go_forward(&b) != 0;
-            let url = b
-                .main_frame()
+            b.main_frame()
                 .map(|f| cef::CefString::from(&cef::ImplFrame::url(&f)).to_string())
-                .unwrap_or_default();
-            (back, forward, url)
+                .unwrap_or_default()
         };
         crate::events::emit_event_from_state(
             state,
@@ -148,14 +124,81 @@ pub fn on_load_end_pane(state: &Arc<AppState>, browser: &Browser) {
             &serde_json::json!({
                 "block_id": block_id,
                 "url": url,
-                "can_go_back": can_back,
-                "can_go_forward": can_forward,
+                // can_* omitted on purpose — frontend treats missing
+                // fields as "no change" and keeps the last values from
+                // on_loading_state_change.
+                "url_only": true,
             }),
         );
+    } else {
+        tracing::warn!("[pane-load-end] couldn't resolve block_id for nav-state emit");
     }
 
     #[cfg(not(target_os = "windows"))]
     {
         let _ = browser;
     }
+}
+
+/// Pane-specific `on_loading_state_change` body. Called from
+/// `AgentMuxHandler::on_loading_state_change` when `is_pane == true`.
+///
+/// CEF invokes `on_loading_state_change` whenever the navigation controller's
+/// history state changes — navigation start, navigation commit, and after
+/// back/forward. `can_go_back` / `can_go_forward` are provided as direct
+/// parameters (not queried after the fact), so they're guaranteed to reflect
+/// the real committed state rather than the pre-commit race window.
+pub fn on_loading_state_change_pane(
+    state: &Arc<AppState>,
+    browser: &Browser,
+    can_go_back: bool,
+    can_go_forward: bool,
+) {
+    if let Some(block_id) = resolve_pane_block_id(state, browser) {
+        let url = {
+            let mut b: cef::Browser = browser.clone();
+            b.main_frame()
+                .map(|f| cef::CefString::from(&cef::ImplFrame::url(&f)).to_string())
+                .unwrap_or_default()
+        };
+        tracing::info!(
+            block_id = %block_id,
+            can_back = can_go_back,
+            can_forward = can_go_forward,
+            url = %url,
+            "[pane-nav-state] emitting",
+        );
+        crate::events::emit_event_from_state(
+            state,
+            "browser-pane-nav-state",
+            &serde_json::json!({
+                "block_id": block_id,
+                "url": url,
+                "can_go_back": can_go_back,
+                "can_go_forward": can_go_forward,
+            }),
+        );
+    } else {
+        tracing::warn!("[pane-loading-state] couldn't resolve block_id for nav-state emit");
+    }
+}
+
+/// Resolve the `block_id` for a pane browser. Panes are registered in
+/// `state.browsers` under labels like `browser-pane-<uuid>-<seq>`. Find the
+/// label whose browser handle matches the given one by `is_same`, then
+/// strip the prefix and the trailing `-<seq>` to recover the uuid.
+fn resolve_pane_block_id(state: &Arc<AppState>, browser: &Browser) -> Option<String> {
+    let browsers = state.browsers.lock();
+    browsers
+        .iter()
+        .find(|(_k, b)| {
+            let mut b_clone = b.clone();
+            let mut browser_clone: cef::Browser = browser.clone();
+            b_clone.is_same(Some(&mut browser_clone)) != 0
+        })
+        .and_then(|(label, _)| {
+            let rest = label.strip_prefix("browser-pane-")?;
+            let dash = rest.rfind('-')?;
+            Some(rest[..dash].to_string())
+        })
 }

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -26,6 +26,32 @@ fn get_window_on_ui(state: &Arc<AppState>, label: &str) -> Option<Window> {
     browser_view.window()
 }
 
+// ── Deferred load_url (used by on_before_popup to avoid UI-thread deadlock)
+//
+// Calling `frame.load_url(url)` synchronously inside a CEF callback that
+// holds the handler's inner lock (e.g. `on_before_popup`) deadlocks on
+// link clicks: `load_url` kicks a new navigation which triggers
+// `on_loading_state_change` on the same thread, which also wants the
+// handler's lock. Posting the navigate as a separate UI task lets the
+// original callback return, release its lock, and the load starts
+// cleanly on the next message-loop turn. ─────────────────────────────────
+
+wrap_task! {
+    pub struct DeferredLoadUrlTask {
+        browser: Browser,
+        url: String,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let mut browser = self.browser.clone();
+            if let Some(frame) = browser.main_frame() {
+                frame.load_url(Some(&CefString::from(self.url.as_str())));
+            }
+        }
+    }
+}
+
 // ── Close ────────────────────────────────────────────────────────────────
 
 wrap_task! {

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.307"
+version = "0.33.308"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.309"
+version = "0.33.310"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.308"
+version = "0.33.309"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.309"
+version = "0.33.310"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.307"
+version = "0.33.308"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.308"
+version = "0.33.309"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.309"
+version = "0.33.310"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.307"
+version = "0.33.308"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.308"
+version = "0.33.309"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_BROWSER_DOM_API.md
+++ b/docs/specs/SPEC_BROWSER_DOM_API.md
@@ -289,7 +289,48 @@ The IPC server already uses `axum`. Add a new scope:
 .route("/agentmux/browser/dispatch_key", post(browser::dispatch_key))
 .route("/agentmux/browser/focus_element", post(browser::focus_element))
 .route("/agentmux/browser/navigate", post(browser::navigate))
+.route("/agentmux/browser/back", post(browser::back))
+.route("/agentmux/browser/forward", post(browser::forward))
+.route("/agentmux/browser/reload", post(browser::reload))
 ```
+
+### 6.2.1 History endpoints — `back` / `forward` / `reload`
+
+Added 2026-04-22. Agents driving a pane during dev/test need to walk the
+pane's back/forward history without a human clicking the toolbar. All three
+share a single request shape:
+
+```json
+POST /agentmux/browser/back     { "block_id": "…" }
+POST /agentmux/browser/forward  { "block_id": "…" }
+POST /agentmux/browser/reload   { "block_id": "…", "ignore_cache": false }
+```
+
+- `back` → CDP `Page.goBack`. No-op when there's no prior entry. Always
+  returns `ok:true`; agents should consult the
+  `browser-pane-nav-state` event (or `POST /eval { expr: "location.href" }`)
+  to confirm the actual current URL.
+- `forward` → CDP `Page.goForward`. Same no-op behaviour at the end of
+  history.
+- `reload` → CDP `Page.reload`. `ignore_cache` defaults to `false`; set
+  true for the equivalent of Ctrl+F5 (bypass the http cache).
+
+All three invalidate `target_cache.forget(block_id)` after the call (the
+pane's URL changes and the next resolver probe needs to re-match). `reload`
+is the exception — no URL change — but invalidating doesn't hurt.
+
+Typical agent workflow that motivated this:
+
+```
+1. POST /navigate { block_id, url: "https://example.com/a" }
+2. POST /click_element { block_id, selector: "a.link-to-b" }
+3. POST /eval { block_id, expr: "location.href" }      // verify we got to /b
+4. POST /back { block_id }                              // return to /a
+5. POST /click_element { block_id, selector: "a.other-link" }
+```
+
+Without steps 4–5, agents had to re-navigate from scratch to explore
+alternate paths.
 
 A new `agentmux-cef/src/browser_api/mod.rs` houses the handlers.
 

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -101,7 +101,6 @@ export class BrowserViewModel implements ViewModel {
         }>("browser-pane-nav-state", (payload) => {
             if (this._closed) return;
             if (payload.block_id !== this.blockId) return;
-            console.log("[browser-model] nav-state", payload);
             this.setUrl(payload.url);
             // `url_only` events come from `on_load_end_pane` — they arrive
             // before the navigation controller has fully committed, so the

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -95,14 +95,25 @@ export class BrowserViewModel implements ViewModel {
         void listenEvent<{
             block_id: string;
             url: string;
-            can_go_back: boolean;
-            can_go_forward: boolean;
+            can_go_back?: boolean;
+            can_go_forward?: boolean;
+            url_only?: boolean;
         }>("browser-pane-nav-state", (payload) => {
             if (this._closed) return;
             if (payload.block_id !== this.blockId) return;
+            console.log("[browser-model] nav-state", payload);
             this.setUrl(payload.url);
-            this.setCanGoBack(payload.can_go_back);
-            this.setCanGoForward(payload.can_go_forward);
+            // `url_only` events come from `on_load_end_pane` — they arrive
+            // before the navigation controller has fully committed, so the
+            // `can_go_back` / `can_go_forward` values from that hook would
+            // be stale (kimi's investigation identified this race). The
+            // authoritative values come from `on_loading_state_change_pane`
+            // which CEF invokes with direct params. Skip touching the
+            // back/forward atoms on `url_only` events.
+            if (!payload.url_only) {
+                if (payload.can_go_back !== undefined) this.setCanGoBack(payload.can_go_back);
+                if (payload.can_go_forward !== undefined) this.setCanGoForward(payload.can_go_forward);
+            }
             this.setLoading(false);
             // Persist the real URL to block meta so pane restore lands
             // on the last page, not whatever was passed at create time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.307",
+  "version": "0.33.308",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.307",
+      "version": "0.33.308",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.308",
+  "version": "0.33.309",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.308",
+      "version": "0.33.309",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.309",
+  "version": "0.33.310",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.309",
+      "version": "0.33.310",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.309",
+  "version": "0.33.310",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.308",
+  "version": "0.33.309",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.307",
+  "version": "0.33.308",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Context

PR #484 wired up a nav-state emit so back/forward buttons sync with CEF's real history. It still didn't work — buttons stayed greyed out. AgentK (Kimi) ran an investigation inside AgentMux itself and pinpointed two issues in `BROWSER_NAV_STATE_INVESTIGATION.md`:

1. Stale binary (pre-#484) was still being run — nothing to do with the code.
2. **`on_load_end` is the wrong hook.** CEF fires it before the navigation controller commits the new history entry, so `browser.can_go_back()` / `browser.can_go_forward()` return the pre-navigation state. The canonical hook is `on_loading_state_change`, which CEF calls with `can_go_back` / `can_go_forward` as **direct parameters** — no read-after-write race.

## Fix

- Implement `on_loading_state_change` in \`AgentMuxHandler\` + wire through \`wrap_load_handler!\`.
- New \`pane::callbacks::on_loading_state_change_pane\` emits \`browser-pane-nav-state\` with CEF-authoritative values.
- \`on_load_end_pane\` still emits (for URL-only sync of redirects resolved mid-load) but tags events \`url_only: true\`. Frontend skips touching \`canGoBack\`/\`canGoForward\` on those events to avoid clobbering the correct values from \`on_loading_state_change\`.
- Extract \`resolve_pane_block_id()\` — was inline duplicate.
- Add the missing \`else { tracing::warn!(...) }\` kimi flagged for silent block-id resolution failures.
- \`console.log\` in the frontend handler for debugging.

## Known issue being investigated

Current user report: clicking a link on the default pane crashes AgentMux / infinite loops. Host log only shows 2 \`[pane-nav-state] emitting\` entries before the crash, so the loop isn't in my emitter. Suspect the popup-intercept hook from #481 interacting badly with something on the agentmux.ai page — investigating in parallel.

## Test plan

- [ ] Back/forward buttons enable correctly after navigating (this PR's goal).
- [ ] Address bar reflects post-redirect URL.
- [ ] Clicking links doesn't crash (pending root-cause for the reported crash).

Credit: investigation + fix direction by **AgentK (Kimi agent)** running inside AgentMux. Implementation follows kimi's \`BROWSER_NAV_STATE_INVESTIGATION.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)