### PR TITLE
fix(browser-pane): emit browser-pane-clicked so clicks select the block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.311"
+version = "0.33.312"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.311"
+version = "0.33.312"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.311"
+version = "0.33.312"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.311"
+version = "0.33.312"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.310"
+version = "0.33.311"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.310"
+version = "0.33.311"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.310"
+version = "0.33.311"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.310"
+version = "0.33.311"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.311 | 2026-04-21 | 159.8 MiB | 333.4 MiB | |
 | 0.33.298 | 2026-04-20 | 159.7 MiB | 333.1 MiB | |
 | 0.33.296 | 2026-04-20 | 159.7 MiB | 333.1 MiB | |
 | 0.33.284 | 2026-04-19 | 159.7 MiB | 333.1 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.310"
+version = "0.33.311"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.311"
+version = "0.33.312"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/pane/callbacks.rs
+++ b/agentmux-cef/src/pane/callbacks.rs
@@ -83,6 +83,19 @@ pub fn on_after_created_pane(state: &Arc<AppState>, browser: &Browser) {
 /// explicit `close()` path already drained it, this is a no-op.
 pub fn on_before_close_pane(state: &Arc<AppState>, label: &str) {
     state.browser_panes.drain_closed_label(label);
+
+    // Labels are `browser-pane-<uuid>-<seq>`; strip prefix + trailing `-<seq>`
+    // to recover the block_id, then wipe any HWND context entries the
+    // WndProc subclass registered for that block.
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(rest) = label.strip_prefix("browser-pane-") {
+            if let Some(dash) = rest.rfind('-') {
+                let block_id = &rest[..dash];
+                crate::pane::hwnd::remove_contexts_for_block(block_id);
+            }
+        }
+    }
 }
 
 /// Called from `AgentMuxHandler::on_load_end` when `is_pane` is true.

--- a/agentmux-cef/src/pane/callbacks.rs
+++ b/agentmux-cef/src/pane/callbacks.rs
@@ -32,7 +32,7 @@ use crate::state::AppState;
 /// 2. Install the WM_SETFOCUS redirect subclass on the pane's HWND tree so
 ///    Chromium's internal focus-steals on page load don't yank keyboard
 ///    focus away from the main window.
-pub fn on_after_created_pane(_state: &Arc<AppState>, browser: &Browser) {
+pub fn on_after_created_pane(state: &Arc<AppState>, browser: &Browser) {
     #[cfg(target_os = "windows")]
     {
         if let Some(host) = browser.host() {
@@ -52,16 +52,25 @@ pub fn on_after_created_pane(_state: &Arc<AppState>, browser: &Browser) {
                 tracing::info!("[pane-zorder] raised pane to top of Z-order");
 
                 // Subclass the pane HWND + its descendants so WM_SETFOCUS
-                // from Chromium gets redirected to the parent.
+                // from Chromium gets redirected to the parent. The state
+                // and block_id let the subclass emit `browser-pane-clicked`
+                // directly on WM_LBUTTONDOWN without relying on CEF focus
+                // callbacks (which don't fire for clicks inside an already-
+                // focused pane).
+                let block_id = resolve_pane_block_id(state, browser).unwrap_or_default();
                 unsafe {
-                    crate::pane::hwnd::install_pane_focus_redirect(hwnd);
+                    crate::pane::hwnd::install_pane_focus_redirect(
+                        hwnd,
+                        state.clone(),
+                        block_id,
+                    );
                 }
             }
         }
     }
     #[cfg(not(target_os = "windows"))]
     {
-        let _ = browser;
+        let _ = (state, browser);
     }
 }
 
@@ -96,8 +105,13 @@ pub fn on_load_end_pane(state: &Arc<AppState>, browser: &Browser) {
         if let Some(host) = browser.host() {
             let wh = host.window_handle();
             if !wh.0.is_null() {
+                let block_id = resolve_pane_block_id(state, browser).unwrap_or_default();
                 unsafe {
-                    crate::pane::hwnd::install_pane_focus_redirect(wh.0 as *mut std::ffi::c_void);
+                    crate::pane::hwnd::install_pane_focus_redirect(
+                        wh.0 as *mut std::ffi::c_void,
+                        state.clone(),
+                        block_id,
+                    );
                 }
             }
         }

--- a/agentmux-cef/src/pane/hwnd.rs
+++ b/agentmux-cef/src/pane/hwnd.rs
@@ -40,6 +40,28 @@ static PANE_HWND_CONTEXT: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<usize, PaneContext>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
+/// Remove every `PANE_HWND_CONTEXT` entry whose context refers to the given
+/// `block_id`. Called from `on_before_close_pane` so the map doesn't grow
+/// unbounded as panes are opened and closed over the session. Keyed by
+/// block_id (not HWND) because the close path has the label/block_id
+/// immediately but not the HWND — by the time CEF fires on_before_close,
+/// the browser's HWND may already be invalid.
+pub fn remove_contexts_for_block(block_id: &str) {
+    if let Ok(mut map) = PANE_HWND_CONTEXT.lock() {
+        let before = map.len();
+        map.retain(|_hwnd, ctx| ctx.block_id != block_id);
+        let removed = before - map.len();
+        if removed > 0 {
+            tracing::info!(
+                block_id = %block_id,
+                removed = removed,
+                remaining = map.len(),
+                "[pane-hwnd] cleaned up hwnd context entries",
+            );
+        }
+    }
+}
+
 /// When `true`, the next `WM_SETFOCUS` delivered to a subclassed pane HWND
 /// is allowed through instead of being redirected back to the parent.
 ///

--- a/agentmux-cef/src/pane/hwnd.rs
+++ b/agentmux-cef/src/pane/hwnd.rs
@@ -15,12 +15,29 @@
 
 #![cfg(target_os = "windows")]
 
+use std::sync::{Arc, Weak};
+
 /// Map of pane HWND -> original WndProc, so the subclass hook can delegate
 /// to the real handler after running its interception logic. The mutex is
 /// held only while mutating the map — hooks that read on the UI thread
 /// copy out the pointer quickly.
 static PANE_WNDPROCS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<usize, isize>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Per-pane context, keyed by the pane's outer HWND. Populated by
+/// `install_pane_focus_redirect`. The WndProc hook uses it to emit the
+/// `browser-pane-clicked` event on `WM_LBUTTONDOWN` without needing to
+/// round-trip through CEF callbacks — only the outer HWND is keyed here;
+/// descendants walk up via `GetParent` to find their context.
+#[derive(Clone)]
+struct PaneContext {
+    state: Weak<crate::state::AppState>,
+    block_id: String,
+}
+
+static PANE_HWND_CONTEXT: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<usize, PaneContext>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 /// When `true`, the next `WM_SETFOCUS` delivered to a subclassed pane HWND
@@ -47,13 +64,49 @@ pub static ALLOW_PANE_FOCUS_ONCE: std::sync::atomic::AtomicBool =
 /// by `pane::callbacks::on_load_end_pane` after every navigation — Chromium
 /// recreates the `Chrome_RenderWidgetHostHWND` on every page load, so the
 /// subclass has to follow along or it ends up stranded on a destroyed HWND.
-pub unsafe fn install_pane_focus_redirect(hwnd: *mut std::ffi::c_void) {
+pub unsafe fn install_pane_focus_redirect(
+    hwnd: *mut std::ffi::c_void,
+    state: Arc<crate::state::AppState>,
+    block_id: String,
+) {
     use std::sync::atomic::Ordering;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         CallWindowProcW, GetAncestor, SetWindowLongPtrW, GA_ROOT, GWLP_WNDPROC,
         WM_SETFOCUS, WM_KILLFOCUS, WM_LBUTTONDOWN,
     };
     use windows_sys::Win32::UI::Input::KeyboardAndMouse::SetFocus;
+
+    // Register context so the WndProc's WM_LBUTTONDOWN handler can emit
+    // the click event without going through CEF callbacks (which only
+    // fire on Windows-level focus CHANGE — clicks inside an already-
+    // focused pane wouldn't produce a CEF focus callback at all).
+    if let Ok(mut map) = PANE_HWND_CONTEXT.lock() {
+        map.insert(hwnd as usize, PaneContext {
+            state: Arc::downgrade(&state),
+            block_id: block_id.clone(),
+        });
+    }
+
+    /// Walk from `hwnd` up the parent chain looking for a registered pane
+    /// context. Child HWNDs (Chrome_WidgetWin_1, Chrome_RenderWidgetHostHWND)
+    /// aren't themselves in the map — the outer pane HWND is. Safety bound
+    /// of 8 jumps is plenty; Chromium's pane hierarchy is only 2-3 deep.
+    unsafe fn find_context(mut hwnd: *mut std::ffi::c_void) -> Option<PaneContext> {
+        use windows_sys::Win32::UI::WindowsAndMessaging::GetParent;
+        for _ in 0..8 {
+            if let Ok(map) = PANE_HWND_CONTEXT.lock() {
+                if let Some(ctx) = map.get(&(hwnd as usize)) {
+                    return Some(ctx.clone());
+                }
+            }
+            let parent = GetParent(hwnd);
+            if parent.is_null() || parent == hwnd {
+                return None;
+            }
+            hwnd = parent;
+        }
+        None
+    }
 
     unsafe extern "system" fn wndproc_hook(
         hwnd: *mut std::ffi::c_void,
@@ -92,7 +145,30 @@ pub unsafe fn install_pane_focus_redirect(hwnd: *mut std::ffi::c_void) {
         // intercepts the click at Win32 level, not DOM level).
         if msg == WM_LBUTTONDOWN {
             ALLOW_PANE_FOCUS_ONCE.store(true, Ordering::Relaxed);
-            tracing::info!("[pane-wndproc] WM_LBUTTONDOWN — arming focus allow");
+            // Emit the click event directly from the WndProc. We can't
+            // rely on CEF's FocusHandler::on_set_focus to emit, because
+            // CEF only fires that callback when Windows-level focus
+            // *changes* — clicks inside a pane that already has keyboard
+            // focus (the user clicked another DOM pane, then clicked
+            // back into this pane content) produce WM_LBUTTONDOWN but
+            // no CEF focus callback, leaving a flag armed forever.
+            if let Some(ctx) = find_context(hwnd) {
+                if let Some(state) = ctx.state.upgrade() {
+                    tracing::info!(
+                        block_id = %ctx.block_id,
+                        "[pane-wndproc] WM_LBUTTONDOWN — emitting browser-pane-clicked",
+                    );
+                    crate::events::emit_event_from_state(
+                        &state,
+                        "browser-pane-clicked",
+                        &serde_json::json!({ "block_id": ctx.block_id }),
+                    );
+                } else {
+                    tracing::warn!("[pane-wndproc] WM_LBUTTONDOWN — state dropped, skipping emit");
+                }
+            } else {
+                tracing::warn!("[pane-wndproc] WM_LBUTTONDOWN — no pane context for hwnd {:p}", hwnd);
+            }
         }
 
         if msg == WM_SETFOCUS {

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.311"
+version = "0.33.312"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.310"
+version = "0.33.311"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.311"
+version = "0.33.312"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.310"
+version = "0.33.311"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.310"
+version = "0.33.311"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.311"
+version = "0.33.312"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -7,6 +7,7 @@
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
 import { invokeCommand, listenEvent } from "@/app/platform/ipc";
+import { refocusNode } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
@@ -64,6 +65,15 @@ export class BrowserViewModel implements ViewModel {
      * closes and the ViewModel is GC'd.
      */
     private _navUnsub: (() => void) | null = null;
+
+    /**
+     * Unsubscribe from the backend's `browser-pane-clicked` event.
+     * Fired when the user clicks inside the pane content (which the
+     * DOM never sees because the pane HWND intercepts the click at
+     * Win32 level). We use it to drive `refocusNode` so the block
+     * shows the blue focus border and keyboard shortcuts target it.
+     */
+    private _clickUnsub: (() => void) | null = null;
 
     blockAtom: Accessor<Block | undefined>;
 
@@ -123,6 +133,21 @@ export class BrowserViewModel implements ViewModel {
         }).then((unsub) => {
             if (this._closed) unsub();
             else this._navUnsub = unsub;
+        });
+
+        // Click-to-focus: the pane HWND captures clicks at the Win32 level,
+        // so the DOM onMouseDown on `.browser-placeholder` never fires. The
+        // backend detects the click in the WndProc subclass, sets a flag,
+        // and emits this event when CEF's FocusHandler::on_set_focus fires
+        // shortly after. We drive refocusNode so the layout marks this block
+        // as focused (blue border + keyboard shortcut target).
+        void listenEvent<{ block_id: string }>("browser-pane-clicked", (payload) => {
+            if (this._closed) return;
+            if (payload.block_id !== this.blockId) return;
+            refocusNode(this.blockId);
+        }).then((unsub) => {
+            if (this._closed) unsub();
+            else this._clickUnsub = unsub;
         });
 
         // Load URL from block meta on init. An empty/missing `url` falls
@@ -228,6 +253,10 @@ export class BrowserViewModel implements ViewModel {
         if (this._navUnsub) {
             this._navUnsub();
             this._navUnsub = null;
+        }
+        if (this._clickUnsub) {
+            this._clickUnsub();
+            this._clickUnsub = null;
         }
     }
 }

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -137,10 +137,10 @@ export class BrowserViewModel implements ViewModel {
 
         // Click-to-focus: the pane HWND captures clicks at the Win32 level,
         // so the DOM onMouseDown on `.browser-placeholder` never fires. The
-        // backend detects the click in the WndProc subclass, sets a flag,
-        // and emits this event when CEF's FocusHandler::on_set_focus fires
-        // shortly after. We drive refocusNode so the layout marks this block
-        // as focused (blue border + keyboard shortcut target).
+        // backend emits this event directly from its WndProc's WM_LBUTTONDOWN
+        // handler (see `pane/hwnd.rs`) using a HWND→block_id map registered
+        // at pane creation. We drive refocusNode so the layout marks this
+        // block as focused (blue border + keyboard shortcut target).
         void listenEvent<{ block_id: string }>("browser-pane-clicked", (payload) => {
             if (this._closed) return;
             if (payload.block_id !== this.blockId) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.311",
+  "version": "0.33.312",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.311",
+      "version": "0.33.312",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.310",
+  "version": "0.33.311",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.310",
+      "version": "0.33.311",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.310",
+  "version": "0.33.311",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.311",
+  "version": "0.33.312",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Clicking inside a browser pane's DOM content didn't mark the block as selected — the pane HWND captures clicks at the Win32 level before any DOM `onMouseDown` fires, so the layout model never learned about the click.

## Approach

Emit `browser-pane-clicked` directly from the WndProc's `WM_LBUTTONDOWN` handler. On pane creation, register a `HWND → (Weak<AppState>, block_id)` map entry so the subclass can resolve the block without a CEF callback; child HWNDs walk up via `GetParent` to find their outer pane's context.

Frontend subscribes to the event and calls `refocusNode` → layout model marks block focused → blue focus border + keyboard shortcut routing.

### Why not FocusHandler::on_set_focus?

Earlier prototype routed through CEF's focus callback gated on a `PANE_LBUTTONDOWN_ARMED` flag. That only fires when Windows-level focus *changes* — clicks inside a pane that already holds keyboard focus (the common case, since the pane grabs focus on create) produce no CEF focus callback at all, so the flag stayed armed forever and no event ever fired. WndProc emission sidesteps the whole focus-callback dependency.

## Test plan

- [ ] Open a browser pane, click another pane to select it, then click inside the browser pane's DOM content → browser pane gets the blue focus border
- [ ] Repeat the click inside the already-selected browser pane → no regression (still selected, no errors)
- [ ] Navigate within the pane (link click, form submit) → focus subclass still reinstalls via `on_load_end_pane` after HWND recreation
- [ ] No deadlocks on popup links (previous bug from PR #485)

## Follow-up

Issue 1 from `BROWSER_PANE_Z_ORDER_FOCUS_REPORT.md` (widget-bar dropdown hidden behind pane content — native HWND airspace bug) is still open; separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)