### PR TITLE
feat(browser-pane): clip region so DOM overlays render over pane HWNDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.312"
+version = "0.33.313"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.312"
+version = "0.33.313"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.312"
+version = "0.33.313"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.312"
+version = "0.33.313"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.312"
+version = "0.33.313"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -326,6 +326,113 @@ impl BrowserPaneManager {
         }
     }
 
+    /// Apply a clip region to every live pane HWND that subtracts the given
+    /// overlay rects (in main-window client coordinates). The pane renders
+    /// normally outside the overlay region; inside it, the HWND is
+    /// transparent so the DOM overlay painted at the same screen position
+    /// shows through.
+    ///
+    /// This is the Win32 "airspace" workaround — native HWNDs always paint
+    /// above DOM regardless of CSS z-index, and `SetWindowRgn` is the one
+    /// mechanism that lets DOM bleed through a specific region of a child
+    /// HWND. Empty `overlay_rects` restores full pane visibility (same as
+    /// calling `clear_pane_overlay_clip`).
+    ///
+    /// No-op on non-Windows: other platforms don't use native child HWNDs
+    /// for panes, so there's no airspace to work around.
+    #[cfg(target_os = "windows")]
+    pub fn set_pane_overlay_clip(&self, state: &Arc<AppState>, overlay_rects: &[(i32, i32, i32, i32)]) {
+        use windows_sys::Win32::Foundation::{POINT, RECT};
+        use windows_sys::Win32::Graphics::Gdi::{
+            CombineRgn, CreateRectRgn, DeleteObject, MapWindowPoints, SetWindowRgn, RGN_DIFF,
+        };
+        use windows_sys::Win32::UI::WindowsAndMessaging::{GetParent, GetWindowRect};
+
+        let labels = self.lifecycle.live_labels();
+        let browsers = state.browsers.lock();
+        for label in &labels {
+            let browser = match browsers.get(label).cloned() {
+                Some(b) => b,
+                None => continue,
+            };
+            let host = match browser.host() {
+                Some(h) => h,
+                None => continue,
+            };
+            let hwnd_raw = host.window_handle();
+            if hwnd_raw.0.is_null() {
+                continue;
+            }
+            let pane_hwnd = hwnd_raw.0 as *mut std::ffi::c_void;
+
+            unsafe {
+                // Empty overlay list = restore full visibility (region=NULL).
+                if overlay_rects.is_empty() {
+                    SetWindowRgn(pane_hwnd as _, std::ptr::null_mut(), 1);
+                    continue;
+                }
+
+                // Resolve the pane's position in its parent (main window)
+                // client coords so we can translate overlay rects (which
+                // arrive in main-window client coords from the frontend)
+                // into pane-local coords for the region API.
+                let parent = GetParent(pane_hwnd as _);
+                if parent.is_null() {
+                    continue;
+                }
+                let mut pane_rect: RECT = std::mem::zeroed();
+                if GetWindowRect(pane_hwnd as _, &mut pane_rect) == 0 {
+                    continue;
+                }
+                // Convert pane_rect from screen coords to parent client
+                // coords by mapping its two corner points.
+                let pts_ptr = &mut pane_rect as *mut RECT as *mut POINT;
+                MapWindowPoints(std::ptr::null_mut(), parent, pts_ptr, 2);
+
+                let pane_w = pane_rect.right - pane_rect.left;
+                let pane_h = pane_rect.bottom - pane_rect.top;
+                if pane_w <= 0 || pane_h <= 0 {
+                    continue;
+                }
+
+                // Build region in pane-local coords: start with full pane,
+                // subtract every overlay rect that intersects it.
+                let region = CreateRectRgn(0, 0, pane_w, pane_h);
+                if region.is_null() {
+                    continue;
+                }
+                for (ox, oy, ow, oh) in overlay_rects {
+                    // Translate overlay rect (window client coords) →
+                    // pane-local coords by subtracting pane's window pos.
+                    let left = ox - pane_rect.left;
+                    let top = oy - pane_rect.top;
+                    let right = left + ow;
+                    let bottom = top + oh;
+                    // Skip if no intersection with the pane's local bounds.
+                    if right <= 0 || bottom <= 0 || left >= pane_w || top >= pane_h {
+                        continue;
+                    }
+                    let overlay_rgn = CreateRectRgn(left, top, right, bottom);
+                    if !overlay_rgn.is_null() {
+                        CombineRgn(region, region, overlay_rgn, RGN_DIFF);
+                        DeleteObject(overlay_rgn as _);
+                    }
+                }
+                // SetWindowRgn takes ownership of the region handle on
+                // success; the system frees it when the window is destroyed
+                // or a new region is set.
+                SetWindowRgn(pane_hwnd as _, region as _, 1);
+            }
+        }
+        tracing::info!(
+            pane_count = labels.len(),
+            overlay_count = overlay_rects.len(),
+            "[pane-airspace] applied overlay clip to pane HWNDs",
+        );
+    }
+    #[cfg(not(target_os = "windows"))]
+    pub fn set_pane_overlay_clip(&self, _state: &Arc<AppState>, _overlay_rects: &[(i32, i32, i32, i32)]) {}
+
     /// Give keyboard focus to the pane's child HWND so keystrokes reach the
     /// embedded page. Called by the frontend's ViewModel.giveFocus() when the
     /// pane becomes the active layout node — without this, focus falls back to

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -344,6 +344,32 @@ async fn route_command(
             state.browser_panes.focus(block_id, state);
             Ok(serde_json::json!(true))
         }
+        "browser_panes_set_overlay_clip" => {
+            // Apply a clip region to every pane HWND that excludes the given
+            // overlay rectangles. The pane stays visible everywhere except
+            // under the overlays — DOM overlays render through the holes.
+            // Empty list restores full visibility. See
+            // BROWSER_PANE_Z_ORDER_FOCUS_REPORT.md Issue 1.
+            //
+            // Each rect: { x, y, w, h } in main-window client pixel coords.
+            let rects: Vec<(i32, i32, i32, i32)> = args
+                .get("rects")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|item| {
+                            let x = item.get("x")?.as_i64()? as i32;
+                            let y = item.get("y")?.as_i64()? as i32;
+                            let w = item.get("w")?.as_i64()? as i32;
+                            let h = item.get("h")?.as_i64()? as i32;
+                            Some((x, y, w, h))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            state.browser_panes.set_pane_overlay_clip(state, &rects);
+            Ok(serde_json::json!(true))
+        }
         "main_window_focus" => {
             // Move keyboard focus back to the main browser when the user
             // clicks a main-DOM input (address bar, etc). Previously this

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.312"
+version = "0.33.313"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.312"
+version = "0.33.313"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.312"
+version = "0.33.313"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/platform/pane-overlay.ts
+++ b/frontend/app/platform/pane-overlay.ts
@@ -1,0 +1,72 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Native browser pane HWNDs composite above DOM at the Win32 level
+// regardless of CSS z-index (the "airspace" problem). Any DOM overlay
+// that can overlap a pane area — widget-bar dropdown, popovers, modals —
+// will appear *behind* the pane content unless we cut a transparent hole
+// through the pane HWND.
+//
+// Strategy: the backend applies a `SetWindowRgn` clip to each pane HWND
+// that subtracts the union of all currently-open overlay rectangles. The
+// pane renders normally outside the overlay region; inside it, the HWND
+// is transparent so the DOM overlay painted at the same screen position
+// shows through. Empty overlay set → clip cleared → full pane visibility.
+//
+// See `BROWSER_PANE_Z_ORDER_FOCUS_REPORT.md` Issue 1 for the full diagnosis.
+
+import { invokeCommand } from "@/app/platform/ipc";
+import { onCleanup, onMount, type Accessor } from "solid-js";
+
+interface OverlayRect {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+}
+
+const overlayRects = new Map<number, OverlayRect>();
+let nextOverlayId = 1;
+
+function sendClip(): void {
+    const rects = Array.from(overlayRects.values());
+    invokeCommand("browser_panes_set_overlay_clip", { rects }).catch(() => {});
+}
+
+function rectFromElement(el: HTMLElement): OverlayRect {
+    const r = el.getBoundingClientRect();
+    return {
+        x: Math.round(r.left),
+        y: Math.round(r.top),
+        w: Math.round(r.width),
+        h: Math.round(r.height),
+    };
+}
+
+/**
+ * Cut a transparent hole through every browser pane HWND matching the
+ * given overlay element's screen rect, so the overlay renders visually
+ * *over* the pane instead of being occluded by it. Call this inside any
+ * component rendering a DOM overlay that could overlap a pane.
+ *
+ * The hook reads the element's bounding rect on mount and unmount — for
+ * dynamically-sized or -positioned overlays, add a ResizeObserver /
+ * IntersectionObserver on top (not yet needed; MoreDropdown is static).
+ *
+ * Safe to nest — each call registers its own rect, the union is applied.
+ * No-op on platforms without native pane HWNDs (backend IPC is a no-op).
+ */
+export function usePaneOverlay(getEl: Accessor<HTMLElement | null | undefined>): void {
+    const id = nextOverlayId++;
+    onMount(() => {
+        const el = getEl();
+        if (!el) return;
+        overlayRects.set(id, rectFromElement(el));
+        sendClip();
+    });
+    onCleanup(() => {
+        if (overlayRects.delete(id)) {
+            sendClip();
+        }
+    });
+}

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -19,6 +19,7 @@ import { TabRpcClient } from "@/app/store/rpc-util";
 import { atoms, createBlock, getApi } from "@/store/global";
 import { fireAndForget, isBlank, makeIconClass } from "@/util/util";
 import { invokeCommand } from "@/app/platform/ipc";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { createEffect, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import "./action-widgets.scss";
@@ -155,6 +156,12 @@ const MoreDropdown = ({
     wmap: () => Record<string, WidgetConfigType>;
     ref?: (el: HTMLDivElement) => void;
 }): JSX.Element => {
+    let overlayEl: HTMLDivElement | undefined;
+    // Cut a transparent hole through any browser pane HWND behind this
+    // dropdown so DOM renders above the pane in this rect.
+    // See `frontend/app/platform/pane-overlay.ts`.
+    usePaneOverlay(() => overlayEl);
+
     const handleItemClick = (widget: WidgetConfigType) => {
         handleWidgetSelect(widget);
         onClose();
@@ -181,7 +188,10 @@ const MoreDropdown = ({
 
     return (
         <div
-            ref={ref}
+            ref={(el) => {
+                overlayEl = el;
+                ref?.(el);
+            }}
             class="action-widget-more-dropdown"
             style={{ position: "fixed", top: `${pos().top}px`, right: `${pos().right}px` }}
         >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.312",
+  "version": "0.33.313",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.312",
+      "version": "0.33.313",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.312",
+  "version": "0.33.313",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Native browser pane HWNDs composite above DOM at the Win32 level regardless of CSS z-index — the classic "airspace" problem. `MoreDropdown` and other DOM overlays were rendering behind pane content wherever they visually overlapped.

Use `SetWindowRgn` to cut a transparent hole through each pane HWND matching every currently-open overlay's bounding rect. The pane stays visible everywhere *except* under the overlay, which renders normally through the hole.

## Approach

- **Backend** (`browser_panes.rs`): `set_pane_overlay_clip(state, &[(x,y,w,h)])` iterates live panes, translates each overlay rect from main-window client coords into pane-local coords, subtracts via `RGN_DIFF`, applies with `SetWindowRgn`. Empty list restores full visibility.
- **IPC** (`ipc.rs`): new `browser_panes_set_overlay_clip` route accepting `{ rects: [{x,y,w,h}, ...] }`.
- **Frontend hook** (`pane-overlay.ts`): `usePaneOverlay(elementAccessor)` registers the element's rect in a shared map on mount, unregisters on cleanup. Any mutation syncs the full list to the backend.
- **MoreDropdown wired** as the first consumer — this was the reported case.

## Why not SW_HIDE

First attempt hid the whole pane HWND with `ShowWindow(SW_HIDE)` while any overlay was open. Dropdown rendered over the pane correctly, but everywhere else in the pane turned black (parent-window background). Visually jarring. `SetWindowRgn` keeps the pane visible outside the overlay region.

## Test plan

- [ ] Open a browser pane, click widget bar "… more" → dropdown renders over the pane; rest of the pane stays visible
- [ ] Close the dropdown → pane fully restored, no residual clip
- [ ] Dropdown near pane edge / overlapping half of it → correct clipping
- [ ] No regression on pane interactions (scroll, click, nav)

## Follow-up

Other DOM overlays (modals, popovers, flyouts, tool blocks) have the same underlying airspace issue. Each is a one-line `usePaneOverlay(…)` wire-up when it surfaces — deferred until reported rather than wiring them all speculatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)