### PR TITLE
feat(agent-pane): Esc feedback — "Stopping…" label + Interrupted chat row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.315"
+version = "0.33.316"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.315"
+version = "0.33.316"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.315"
+version = "0.33.316"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.315"
+version = "0.33.316"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.315"
+version = "0.33.316"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.315"
+version = "0.33.316"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.315"
+version = "0.33.316"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.315"
+version = "0.33.316"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -150,6 +150,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // `documentVersion` is bumped whenever we mutate the document externally
     // (history load / prepend), causing useAgentStream to rebuild its
     // nodeIdSet and nodeIndexMap.
+    const stoppingAtom = agentAtoms().stoppingAtom;
     useAgentStream({
         blockId: model.blockId,
         outputFormat: outputFormat(),
@@ -159,6 +160,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         currentToolAtom: agentAtoms().currentToolAtom,
         turnTokensAtom: agentAtoms().turnTokensAtom,
         turnActiveAtom: agentAtoms().turnActiveAtom,
+        stoppingAtom,
         enabled: true,
         documentVersion: history.documentVersion,
     });
@@ -186,6 +188,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // defers this to the next animation frame so the mounted node is
         // included in scrollHeight. See SPEC_AGENT_PANE_FOLLOWUPS item #1.
         onSent: () => scrollToBottomFn?.(),
+        stoppingAtom,
     });
 
     // Clear session stats and mark turn as active when the user sends a message.
@@ -411,7 +414,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     )}
                 </Show>
                 <AgentStatusLine
-                    loading={status.isLoading() || agentAtoms().turnActiveAtom[0]()}
+                    loading={status.isLoading() || agentAtoms().turnActiveAtom[0]() || stoppingAtom[0]()}
+                    stopping={stoppingAtom[0]()}
                     currentTool={agentAtoms().currentToolAtom[0]()}
                     sessionStats={agentAtoms().sessionStatsAtom[0]()}
                     turnTokens={agentAtoms().turnTokensAtom[0]()}

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -35,6 +35,10 @@ function fmtTokens(t: TurnTokens): string {
 
 interface AgentStatusLineProps {
     loading?: boolean;
+    /** True after Esc → SIGINT, until session_end arrives. Overrides the
+     *  cycling "Working…" phrase with a static "Stopping…" label so the
+     *  user has immediate acknowledgement that the interrupt was received. */
+    stopping?: boolean;
     currentTool?: string | null;
     sessionStats?: SessionStats | null;
     turnTokens?: TurnTokens | null;
@@ -111,7 +115,11 @@ export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
             <span class="agent-status-line agent-status-line--loading">
                 <span class="agent-spinner-dot" />
                 <span class="agent-status-left">
-                    {props.currentTool ? props.currentTool : `${phrase()}\u2026`}
+                    {props.stopping
+                        ? "Stopping\u2026"
+                        : props.currentTool
+                            ? props.currentTool
+                            : `${phrase()}\u2026`}
                 </span>
                 <span class="agent-status-right">{rightText()}</span>
             </span>

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -60,6 +60,13 @@ export interface UseAgentCommandsOptions {
      * See SPEC_AGENT_PANE_FOLLOWUPS item #1.
      */
     onSent?: () => void;
+    /**
+     * Flips true when `stopAgent` fires (user pressed Esc on an empty
+     * composer) and back to false when the subsequent `session_end`
+     * arrives. Drives the "Stopping…" status label and the
+     * "⏹ Interrupted by user" chat row appended by `useAgentStream`.
+     */
+    stoppingAtom?: SignalPair<boolean>;
 }
 
 export interface UseAgentCommands {
@@ -258,11 +265,19 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
     };
 
     const stopAgent = (): void => {
+        // Flip stopping → status line renders "Stopping…" immediately.
+        // `useAgentStream` owns the finalization: when `session_end`
+        // arrives it clears stopping + appends the "⏹ Interrupted" row,
+        // and it also runs a fallback timer that does the same cleanup
+        // if `session_end` never arrives (killing a subprocess prevents
+        // the CLI from emitting its own terminating result event).
+        opts.stoppingAtom?.[1](true);
         RpcApi.ControllerInputCommand(TabRpcClient, {
             blockid: opts.blockId,
             signame: "SIGINT",
         }).catch((err) => {
             opts.log("warn", `stop failed: ${err?.message ?? String(err)}`, "warn");
+            opts.stoppingAtom?.[1](false);
         });
     };
 

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -34,6 +34,14 @@ export interface AgentAtoms {
     turnTokensAtom: SignalPair<TurnTokens | null>;
     /** True from the moment the user sends a message until session_end arrives. */
     turnActiveAtom: SignalPair<boolean>;
+    /**
+     * True from the moment the user presses Esc (stopAgent) until session_end
+     * arrives. Drives the "Stopping…" label on the status line and triggers
+     * an "⏹ Interrupted by user" chat row to be appended when the session
+     * actually ends — so the user gets immediate acknowledgment *and*
+     * confirmation that the interrupt landed.
+     */
+    stoppingAtom: SignalPair<boolean>;
 }
 
 /**
@@ -65,5 +73,6 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         currentToolAtom: createSignal<string | null>(null),
         turnTokensAtom: createSignal<TurnTokens | null>(null),
         turnActiveAtom: createSignal<boolean>(false),
+        stoppingAtom: createSignal<boolean>(false),
     };
 }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -26,6 +26,14 @@ interface UseAgentStreamOpts {
     currentToolAtom: SignalPair<string | null>;
     turnTokensAtom: SignalPair<TurnTokens | null>;
     turnActiveAtom: SignalPair<boolean>;
+    /**
+     * True while a user-initiated stop (Esc → SIGINT) is pending. When
+     * session_end arrives and this is true, the hook appends an
+     * "⏹ Interrupted by user" markdown node so the user has durable
+     * visual confirmation that the stop landed. Always cleared on
+     * session_end regardless of whether the row was appended.
+     */
+    stoppingAtom?: SignalPair<boolean>;
     enabled: boolean;
     /**
      * Version signal bumped by external document mutations (e.g. history
@@ -48,6 +56,7 @@ export function useAgentStream({
     currentToolAtom,
     turnTokensAtom,
     turnActiveAtom,
+    stoppingAtom,
     enabled,
     documentVersion,
 }: UseAgentStreamOpts): void {
@@ -57,6 +66,8 @@ export function useAgentStream({
     const [, setTurnActive] = turnActiveAtom;
     const [, setCurrentTool] = currentToolAtom;
     const [, setTurnTokens] = turnTokensAtom;
+    const getStopping = stoppingAtom?.[0];
+    const setStopping = stoppingAtom?.[1];
 
     // Mutable state that doesn't trigger re-renders
     let lineBuffer = "";
@@ -156,6 +167,66 @@ export function useAgentStream({
         pendingUpdates = [];
 
         const [doc] = documentAtom;
+
+        /**
+         * Shared finalization for "the turn is over." Called by both the
+         * real `session_end` event from the CLI's result line AND the
+         * fallback timer armed when the user presses Esc (killing the
+         * subprocess prevents it from emitting its own result event).
+         *
+         * If `getStopping()` is true when this runs, the ending was user-
+         * initiated — append a visible "⏹ Interrupted by user" row to
+         * the document so the user has durable confirmation that the
+         * stop landed.
+         */
+        const finalizeTurn = (stats: SessionStats | null) => {
+            parser.flushPending();
+            setSessionStats(stats);
+            setCurrentTool(null);
+            setTurnTokens(null);
+            setTurnActive(false);
+            if (getStopping?.()) {
+                const interruptedNode: DocumentNode = {
+                    type: "markdown",
+                    id: `interrupted-${Date.now()}`,
+                    content: "⏹ _Interrupted by user_",
+                    timestamp: Date.now(),
+                };
+                if (!nodeIdSet.has(interruptedNode.id)) {
+                    nodeIdSet.add(interruptedNode.id);
+                    pendingNew.push(interruptedNode);
+                    scheduleFlush();
+                }
+                setStopping?.(false);
+            }
+        };
+
+        // Fallback timer: if the user presses Esc and the CLI doesn't
+        // emit `session_end` within 1.5s (normal for a killed subprocess
+        // — TerminateProcess skips any final output), run the same
+        // finalization locally so the UI doesn't hang on "Stopping…".
+        let stopFallbackTimer: number | null = null;
+        if (getStopping && setStopping) {
+            createEffect(() => {
+                const stopping = getStopping();
+                if (stopFallbackTimer != null) {
+                    clearTimeout(stopFallbackTimer);
+                    stopFallbackTimer = null;
+                }
+                if (stopping) {
+                    stopFallbackTimer = window.setTimeout(() => {
+                        stopFallbackTimer = null;
+                        if (getStopping()) finalizeTurn(null);
+                    }, 1500);
+                }
+            });
+            onCleanup(() => {
+                if (stopFallbackTimer != null) {
+                    clearTimeout(stopFallbackTimer);
+                    stopFallbackTimer = null;
+                }
+            });
+        }
 
         // Rebuild dedup set + index map from whatever is currently in the
         // document. `doc()` is wrapped in `untrack` so the createEffect
@@ -305,11 +376,7 @@ export function useAgentStream({
                     // NEXT turn creates fresh nodes instead of appending to the
                     // previous response (which sits above the user's message).
                     if (event.type === "session_end") {
-                        parser.flushPending();
-                        setSessionStats(event.stats ?? null);
-                        setCurrentTool(null);
-                        setTurnTokens(null);
-                        setTurnActive(false);
+                        finalizeTurn(event.stats ?? null);
                         continue;
                     }
                     // Track the currently-running tool for the status line

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.315",
+  "version": "0.33.316",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.315",
+      "version": "0.33.316",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.315",
+  "version": "0.33.316",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Pressing Esc while an agent turn was in flight sent SIGINT correctly, but the UI gave zero feedback — "Working…" kept spinning indefinitely. Root cause: frontend only clears `turnActive` on `session_end`, and a killed subprocess (Windows TerminateProcess) can't flush its final result event.

Three layers of feedback now:

1. **Immediate**: new `stoppingAtom` flips true on Esc → status line renders "Stopping…" instead of the cycling thinking phrase.
2. **Finalization**: `useAgentStream` now has a shared `finalizeTurn` helper called by both the real `session_end` event AND a 1.5s fallback timer armed when stopping. Clears `turnActive`, session stats, current tool, turn tokens — same cleanup session_end does.
3. **Durable**: when finalization runs with stopping still true, a markdown node `⏹ _Interrupted by user_` is appended so the user has a permanent chat-row receipt.

## Test plan

- [ ] Press Esc during a turn → label flips to "Stopping…" immediately
- [ ] Within ~1.5s, spinner clears and "⏹ _Interrupted by user_" appears in the conversation
- [ ] Composer is re-usable after stop; next message starts a fresh turn
- [ ] Regular session_end (turn completes normally) still works — no spurious Interrupted row

🤖 Generated with [Claude Code](https://claude.com/claude-code)