### PR TITLE
feat(agent-pane): auto-collapse large user_messages (startup payload)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.316"
+version = "0.33.317"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.316"
+version = "0.33.317"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.316"
+version = "0.33.317"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.316"
+version = "0.33.317"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.317"
+version = "0.33.318"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.317"
+version = "0.33.318"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.317"
+version = "0.33.318"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.317"
+version = "0.33.318"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.317 | 2026-04-22 | 159.8 MiB | 333.4 MiB | |
 | 0.33.314 | 2026-04-22 | 159.8 MiB | 333.4 MiB | |
 | 0.33.311 | 2026-04-21 | 159.8 MiB | 333.4 MiB | |
 | 0.33.298 | 2026-04-20 | 159.7 MiB | 333.1 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.317"
+version = "0.33.318"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.316"
+version = "0.33.317"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.317"
+version = "0.33.318"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.316"
+version = "0.33.317"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.317"
+version = "0.33.318"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.316"
+version = "0.33.317"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.317"
+version = "0.33.318"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.316"
+version = "0.33.317"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -1876,6 +1876,16 @@
                 word-break: break-word;
             }
         }
+
+        // Collapsed state: show only the first line (ellipsis-truncated).
+        // Driven by AgentDocumentView auto-collapse for large user messages
+        // like the startup session-context payload. The hover strip's expand
+        // button toggles this off.
+        &--collapsed .agent-user-message-content pre {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 
     // === Section Headings ===

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -137,6 +137,33 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, logLines, a
 
     if (scrollToBottomRef) scrollToBottomRef(jumpToBottom);
 
+    // Auto-collapse large user_messages on first arrival. The startup
+    // session-context payload that `buildStartupPayload` sends is a huge
+    // JSON block that visually dominates the pane; short user turns
+    // (one-line prompts) fit unchanged. Tracked per-node via `seenIds`
+    // so we don't re-collapse after the user has explicitly expanded.
+    const seenUserMessageIds = new Set<string>();
+    createEffect(() => {
+        const doc = document();
+        const toCollapse: string[] = [];
+        for (const n of doc) {
+            if (n.type !== "user_message") continue;
+            if (seenUserMessageIds.has(n.id)) continue;
+            seenUserMessageIds.add(n.id);
+            const msg = (n as any).message ?? "";
+            if (msg.length > 200 || msg.includes("\n")) {
+                toCollapse.push(n.id);
+            }
+        }
+        if (toCollapse.length > 0) {
+            setDocumentState((prev) => {
+                const next = new Set(prev.collapsedNodes);
+                for (const id of toCollapse) next.add(id);
+                return { ...prev, collapsedNodes: next };
+            });
+        }
+    });
+
     // Toggle collapsed state for collapsible nodes (agent messages, sections, user messages).
     const toggleCollapse = (nodeId: string) => {
         setDocumentState((prev) => {
@@ -503,7 +530,10 @@ const DocumentNodeRenderer = (props: DocumentNodeRendererProps): JSX.Element => 
         case "user_message": {
             const node = props.node;
             return (
-                <div class="agent-user-message">
+                <div
+                    class="agent-user-message"
+                    classList={{ "agent-user-message--collapsed": props.collapsed }}
+                >
                     <div class="agent-user-message-content">
                         <pre>{node.message}</pre>
                     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.316",
+  "version": "0.33.317",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.316",
+      "version": "0.33.317",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.317",
+  "version": "0.33.318",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.317",
+      "version": "0.33.318",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.316",
+  "version": "0.33.317",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.317",
+  "version": "0.33.318",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

The startup session-context payload (JSON blob from `buildStartupPayload`) was rendering fully expanded as the very first `user_message` in every agent session, visually dominating the pane before the first reply even arrived. Auto-collapse it to a single ellipsis-truncated line.

## Changes

- `DocumentNodeRenderer` — pass `collapsed` prop through to the `user_message` case (was ignoring it)
- `agent-view.scss` — `.agent-user-message--collapsed .agent-user-message-content pre` truncates to single line with ellipsis
- `AgentDocumentView` — new `createEffect` watches for incoming `user_message` nodes; any whose content exceeds 200 chars or contains newlines is auto-added to `collapsedNodes`. A `seenUserMessageIds` set ensures we only seed on first arrival, so user-initiated expansion sticks.

## UX

- Short user prompts (single-line) render unchanged — the size threshold skips them
- Startup payload collapses automatically → pane is quiet on first connect
- Hover strip's expand button (already wired for `user_message` via `canExpand`) toggles the collapse off

## Test plan

- [ ] Cold-start an agent → startup context message appears as a single truncated line
- [ ] Hover → expand button → click `⊞` → full payload reveals
- [ ] Click `⊟` → collapses back to one line
- [ ] Send a short user message (< 200 chars, no newlines) → renders normally, no auto-collapse
- [ ] Send a multi-line paste → auto-collapses; expanding works

🤖 Generated with [Claude Code](https://claude.com/claude-code)