### PR TITLE
fix: use AGENTMUX_CONFIG_HOME for auth_dir and GH_CONFIG_DIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.318"
+version = "0.33.319"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.318"
+version = "0.33.319"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.318"
+version = "0.33.319"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.318"
+version = "0.33.319"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.318"
+version = "0.33.319"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.318"
+version = "0.33.319"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.318"
+version = "0.33.319"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.318"
+version = "0.33.319"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -166,15 +166,19 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 for key in provider.unset_env {
                     env_vars.insert(key.to_string(), json!(""));
                 }
+                // Use AGENTMUX_CONFIG_HOME so portable installs stay self-contained.
+                // Falls back to ~/.agentmux/config for non-portable installs.
+                let config_home = std::env::var("AGENTMUX_CONFIG_HOME")
+                    .unwrap_or_else(|_| format!("{}/.agentmux/config", home));
                 // Auth dir
-                let auth_dir = format!("{}/.agentmux/config/auth/{}", home, provider.auth_dir_name);
+                let auth_dir = format!("{}/auth/{}", config_home, provider.auth_dir_name);
                 let _ = std::fs::create_dir_all(&auth_dir);
                 env_vars.insert(provider.auth_config_dir_env_var.to_string(), json!(auth_dir));
                 for (k, v) in provider.auth_extra_env {
                     env_vars.insert(k.to_string(), json!(v));
                 }
                 // Agent identity
-                env_vars.insert("GH_CONFIG_DIR".to_string(), json!(format!("~/.agentmux/config/gh-{}", agent_slug)));
+                env_vars.insert("GH_CONFIG_DIR".to_string(), json!(format!("{}/gh-{}", config_home, agent_slug)));
                 env_vars.insert("AGENTMUX_AGENT_ID".to_string(), json!(&agent.name));
                 // Exit delay only for subprocess
                 if !is_persistent {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.318",
+  "version": "0.33.319",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.318",
+      "version": "0.33.319",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.318",
+  "version": "0.33.319",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- `app_api.rs` was constructing `auth_dir` and `GH_CONFIG_DIR` using hardcoded `~/.agentmux/config/...` (system home) instead of `AGENTMUX_CONFIG_HOME`
- In portable installs, `AGENTMUX_CONFIG_HOME` points to the portable data directory — not the system home — so credentials were silently leaking outside the portable install
- Added a `config_home` local that reads `AGENTMUX_CONFIG_HOME` with a `~/.agentmux/config` fallback for non-portable installs

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| Portable install | `gh` config written to `~/.agentmux/config/gh-{slug}` (system home) | Written to `<portable>/data/config/gh-{slug}` |
| Provider auth dir | Written to `~/.agentmux/config/auth/...` (system home) | Written to `<portable>/data/config/auth/...` |
| Non-portable install | `~/.agentmux/config/...` (unchanged) | `~/.agentmux/config/...` (unchanged, fallback) |

## Related

Identified during agent identity & forge audit (2026-04-22). See `docs/audit-agent-identity-forge-2026-04-22.md` for full findings.

## Test plan

- [ ] Launch an agent in a portable install — verify `GH_CONFIG_DIR` is set to a path inside the portable data dir
- [ ] Confirm `gh auth login` inside an agent writes to the portable config, not system home
- [ ] Launch in non-portable mode — verify fallback to `~/.agentmux/config` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)