### PR TITLE
feat(agent-pane): persistent action bar — Add Agent, Import, Export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.319"
+version = "0.33.320"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.319"
+version = "0.33.320"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.319"
+version = "0.33.320"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.319"
+version = "0.33.320"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.319"
+version = "0.33.320"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.319"
+version = "0.33.320"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.319"
+version = "0.33.320"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.319"
+version = "0.33.320"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -283,6 +283,10 @@ pub const COMMAND_SEARCH_FORGE_HISTORY: &str = "searchforgehistory";
 
 // Forge Import
 pub const COMMAND_IMPORT_FORGE_FROM_CLAW: &str = "importforgefromclaw";
+pub const COMMAND_IMPORT_FORGE_AGENTS: &str = "importforgeagents";
+
+// Forge Export
+pub const COMMAND_EXPORT_FORGE_AGENTS: &str = "exportforgeagents";
 
 // Forge Seed
 pub const COMMAND_RESEED_FORGE_AGENTS: &str = "reseedforgeagents";
@@ -1252,6 +1256,80 @@ pub struct CommandSearchForgeHistoryData {
 pub struct CommandImportForgeFromClawData {
     pub workspace_path: String,
     pub agent_name: String,
+}
+
+/// Input for importforgeagents
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandImportForgeAgentsData {
+    pub agents: Vec<ForgeAgentImport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeAgentImport {
+    pub id: String,
+    pub name: String,
+    pub icon: String,
+    pub description: String,
+    pub provider: String,
+    pub shell: String,
+    pub working_directory: String,
+    pub agent_bus_id: String,
+    pub agent_type: String,
+    pub environment: String,
+    pub restart_on_crash: bool,
+    pub content: std::collections::HashMap<String, String>,
+    pub skills: Vec<ForgeSkillImport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeSkillImport {
+    pub name: String,
+    pub trigger: String,
+    pub skill_type: String,
+    pub description: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportForgeAgentsResult {
+    pub imported: Vec<String>,
+    pub skipped: Vec<String>,
+    pub failed: Vec<String>,
+}
+
+/// Response for exportforgeagents
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportForgeAgentsResult {
+    pub version: u32,
+    pub exported_at: String,
+    pub source: String,
+    pub agents: Vec<ForgeAgentExport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeAgentExport {
+    pub id: String,
+    pub name: String,
+    pub icon: String,
+    pub description: String,
+    pub provider: String,
+    pub shell: String,
+    pub working_directory: String,
+    pub agent_bus_id: String,
+    pub agent_type: String,
+    pub environment: String,
+    pub restart_on_crash: bool,
+    pub content: std::collections::HashMap<String, String>,
+    pub skills: Vec<ForgeSkillExport>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgeSkillExport {
+    pub name: String,
+    pub trigger: String,
+    pub skill_type: String,
+    pub description: String,
+    pub content: String,
 }
 
 // ====================================================================

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -11,7 +11,7 @@ use crate::backend::rpc_types::{
     COMMAND_LIST_FORGE_SKILLS, COMMAND_CREATE_FORGE_SKILL, COMMAND_UPDATE_FORGE_SKILL,
     COMMAND_DELETE_FORGE_SKILL,
     COMMAND_APPEND_FORGE_HISTORY, COMMAND_LIST_FORGE_HISTORY, COMMAND_SEARCH_FORGE_HISTORY,
-    COMMAND_IMPORT_FORGE_FROM_CLAW,
+    COMMAND_IMPORT_FORGE_FROM_CLAW, COMMAND_IMPORT_FORGE_AGENTS, COMMAND_EXPORT_FORGE_AGENTS,
     COMMAND_RESEED_FORGE_AGENTS,
     CommandCreateForgeAgentData, CommandUpdateForgeAgentData, CommandDeleteForgeAgentData,
     CommandGetForgeContentData, CommandSetForgeContentData, CommandGetAllForgeContentData,
@@ -19,6 +19,8 @@ use crate::backend::rpc_types::{
     CommandDeleteForgeSkillData,
     CommandAppendForgeHistoryData, CommandListForgeHistoryData, CommandSearchForgeHistoryData,
     CommandImportForgeFromClawData,
+    CommandImportForgeAgentsData, ImportForgeAgentsResult,
+    ExportForgeAgentsResult, ForgeAgentExport, ForgeSkillExport,
     // v6 identity / instance / fork
     COMMAND_LIST_IDENTITY_ACCOUNTS, COMMAND_GET_IDENTITY_ACCOUNT,
     COMMAND_UPSERT_IDENTITY_ACCOUNT, COMMAND_DELETE_IDENTITY_ACCOUNT,
@@ -580,6 +582,188 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "created": report.created,
                     "skipped": report.skipped,
                 })))
+            })
+        }),
+    );
+
+    // importforgeagents — bulk import from JSON export format
+    let wstore_ifa = state.wstore.clone();
+    let broker_ifa = state.broker.clone();
+    engine.register_handler(
+        COMMAND_IMPORT_FORGE_AGENTS,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore_ifa.clone();
+            let broker = broker_ifa.clone();
+            Box::pin(async move {
+                let cmd: CommandImportForgeAgentsData = serde_json::from_value(data)
+                    .map_err(|e| format!("importforgeagents: {e}"))?;
+
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as i64;
+
+                let mut imported: Vec<String> = Vec::new();
+                let mut skipped: Vec<String> = Vec::new();
+                let mut failed: Vec<String> = Vec::new();
+
+                for agent_import in cmd.agents {
+                    // Check for existing agent by slug (id field from export)
+                    let existing = wstore.forge_list()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .any(|a| a.slug == agent_import.id);
+
+                    if existing {
+                        skipped.push(agent_import.name.clone());
+                        continue;
+                    }
+
+                    let mut agent = ForgeAgent {
+                        id: uuid::Uuid::new_v4().to_string(),
+                        slug: agent_import.id.clone(),
+                        name: agent_import.name.clone(),
+                        icon: agent_import.icon.clone(),
+                        provider: agent_import.provider.clone(),
+                        description: agent_import.description.clone(),
+                        working_directory: agent_import.working_directory.clone(),
+                        shell: agent_import.shell.clone(),
+                        provider_flags: String::new(),
+                        auto_start: 0,
+                        restart_on_crash: if agent_import.restart_on_crash { 1 } else { 0 },
+                        idle_timeout_minutes: 0,
+                        created_at: now,
+                        agent_type: agent_import.agent_type.clone(),
+                        environment: agent_import.environment.clone(),
+                        agent_bus_id: agent_import.agent_bus_id.clone(),
+                        is_seeded: 0,
+                        accounts: String::new(),
+                        parent_id: String::new(),
+                        branch_label: String::new(),
+                    };
+
+                    if let Err(e) = wstore.forge_insert(&mut agent) {
+                        failed.push(format!("{}: {e}", agent_import.name));
+                        continue;
+                    }
+
+                    // Insert content types
+                    for (content_type, content) in &agent_import.content {
+                        let fc = ForgeContent {
+                            agent_id: agent.id.clone(),
+                            content_type: content_type.clone(),
+                            content: content.clone(),
+                            updated_at: now,
+                        };
+                        let _ = wstore.forge_set_content(&fc);
+                    }
+
+                    // Insert skills
+                    for skill_import in &agent_import.skills {
+                        let skill = ForgeSkill {
+                            id: uuid::Uuid::new_v4().to_string(),
+                            agent_id: agent.id.clone(),
+                            name: skill_import.name.clone(),
+                            trigger: skill_import.trigger.clone(),
+                            skill_type: skill_import.skill_type.clone(),
+                            description: skill_import.description.clone(),
+                            content: skill_import.content.clone(),
+                            created_at: now,
+                        };
+                        let _ = wstore.forge_insert_skill(&skill);
+                    }
+
+                    imported.push(agent_import.name.clone());
+                }
+
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "forgeagents:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+
+                let result = ImportForgeAgentsResult { imported, skipped, failed };
+                Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // exportforgeagents — export all forge agents with content and skills
+    let wstore_efa = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_EXPORT_FORGE_AGENTS,
+        Box::new(move |_data, _ctx| {
+            let wstore = wstore_efa.clone();
+            Box::pin(async move {
+                let agents = wstore.forge_list()
+                    .map_err(|e| format!("exportforgeagents: list: {e}"))?;
+
+                let mut agent_exports: Vec<ForgeAgentExport> = Vec::new();
+
+                for agent in agents {
+                    let content_map = wstore.forge_get_all_content(&agent.id)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|fc| (fc.content_type, fc.content))
+                        .collect::<std::collections::HashMap<String, String>>();
+
+                    let skills = wstore.forge_list_skills(&agent.id)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|s| ForgeSkillExport {
+                            name: s.name,
+                            trigger: s.trigger,
+                            skill_type: s.skill_type,
+                            description: s.description,
+                            content: s.content,
+                        })
+                        .collect::<Vec<_>>();
+
+                    agent_exports.push(ForgeAgentExport {
+                        id: agent.slug.clone(),
+                        name: agent.name,
+                        icon: agent.icon,
+                        description: agent.description,
+                        provider: agent.provider,
+                        shell: agent.shell,
+                        working_directory: agent.working_directory,
+                        agent_bus_id: agent.agent_bus_id,
+                        agent_type: agent.agent_type,
+                        environment: agent.environment,
+                        restart_on_crash: agent.restart_on_crash != 0,
+                        content: content_map,
+                        skills,
+                    });
+                }
+
+                let exported_at = {
+                    let now = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    // Format as ISO 8601 (basic)
+                    let secs = now;
+                    let s = secs % 60;
+                    let m = (secs / 60) % 60;
+                    let h = (secs / 3600) % 24;
+                    let days = secs / 86400;
+                    // Approximate date from epoch (good enough for export metadata)
+                    let year = 1970 + days / 365;
+                    let day_of_year = days % 365;
+                    let month = day_of_year / 30 + 1;
+                    let day = day_of_year % 30 + 1;
+                    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}Z")
+                };
+
+                let result = ExportForgeAgentsResult {
+                    version: 4,
+                    exported_at,
+                    source: "agentmux-export".to_string(),
+                    agents: agent_exports,
+                };
+                Ok(Some(serde_json::to_value(&result).unwrap_or_default()))
             })
         }),
     );

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -685,7 +685,7 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     if content_ok && skills_ok {
                         imported.push(agent_import.name.clone());
                     } else {
-                        skipped.push(agent_import.name.clone());
+                        failed.push(agent_import.name.clone());
                     }
                 }
 

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use chrono::Utc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde_json::json;
@@ -648,6 +649,7 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     }
 
                     // Insert content types
+                    let mut content_ok = true;
                     for (content_type, content) in &agent_import.content {
                         let fc = ForgeContent {
                             agent_id: agent.id.clone(),
@@ -655,10 +657,14 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             content: content.clone(),
                             updated_at: now,
                         };
-                        let _ = wstore.forge_set_content(&fc);
+                        if let Err(e) = wstore.forge_set_content(&fc) {
+                            log::warn!("import: failed to set content for agent {}: {e}", agent.id);
+                            content_ok = false;
+                        }
                     }
 
                     // Insert skills
+                    let mut skills_ok = true;
                     for skill_import in &agent_import.skills {
                         let skill = ForgeSkill {
                             id: uuid::Uuid::new_v4().to_string(),
@@ -670,10 +676,17 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                             content: skill_import.content.clone(),
                             created_at: now,
                         };
-                        let _ = wstore.forge_insert_skill(&skill);
+                        if let Err(e) = wstore.forge_insert_skill(&skill) {
+                            log::warn!("import: failed to insert skill '{}' for agent {}: {e}", skill.name, agent.id);
+                            skills_ok = false;
+                        }
                     }
 
-                    imported.push(agent_import.name.clone());
+                    if content_ok && skills_ok {
+                        imported.push(agent_import.name.clone());
+                    } else {
+                        skipped.push(agent_import.name.clone());
+                    }
                 }
 
                 broker.publish(crate::backend::wps::WaveEvent {
@@ -738,24 +751,7 @@ pub fn register_forge_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     });
                 }
 
-                let exported_at = {
-                    let now = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs();
-                    // Format as ISO 8601 (basic)
-                    let secs = now;
-                    let s = secs % 60;
-                    let m = (secs / 60) % 60;
-                    let h = (secs / 3600) % 24;
-                    let days = secs / 86400;
-                    // Approximate date from epoch (good enough for export metadata)
-                    let year = 1970 + days / 365;
-                    let day_of_year = days % 365;
-                    let month = day_of_year / 30 + 1;
-                    let day = day_of_year % 30 + 1;
-                    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}Z")
-                };
+                let exported_at = Utc::now().to_rfc3339();
 
                 let result = ExportForgeAgentsResult {
                     version: 4,

--- a/docs/specs/SPEC_AGENT_PANE_BOTTOM_BUTTONS_2026_04_22.md
+++ b/docs/specs/SPEC_AGENT_PANE_BOTTOM_BUTTONS_2026_04_22.md
@@ -1,0 +1,436 @@
+# Spec: Agent Pane Bottom Action Bar
+**Date:** 2026-04-22  
+**Status:** Draft  
+**Scope:** Frontend (SolidJS) + Backend (Rust RPC)  
+
+---
+
+## 1. Goal
+
+Add a persistent, always-visible action bar pinned to the bottom of the agent pane containing three buttons:
+
+1. **Add Agent** — create a new forge agent
+2. **Import Agents** — bulk import agents from a JSON file
+3. **Export Agents** — bulk export all forge agents to a JSON file
+
+This gives users a consistent entry point for agent management directly from the agent pane, without navigating to the Forge pane. It also makes the portable seeding system accessible from the UI — the import/export format is compatible with `forge-seed.json`.
+
+---
+
+## 2. Visual Design
+
+### Placement
+
+The bar is appended as the last child of `.agent-view` (the root flex column), below `.agent-composer-region`. It is **always visible** regardless of whether the AgentPicker or a running agent session is showing.
+
+```
+┌─────────────────────────────────────────┐
+│  .agent-view (flex column)              │
+├─────────────────────────────────────────┤
+│  .agent-document (flex: 1, scrollable)  │
+├─────────────────────────────────────────┤
+│  .agent-composer-region                 │
+│  └─ AgentFooter (textarea + hint)       │
+├─────────────────────────────────────────┤  ← NEW
+│  .agent-action-bar                      │
+│  [ + Add Agent ][ ↓ Import ][ ↑ Export ]│
+└─────────────────────────────────────────┘
+```
+
+### Button Row
+
+```
+┌──────────────────────────────────────────────────────┐
+│  [+ Add Agent]          [↓ Import]       [↑ Export]  │
+└──────────────────────────────────────────────────────┘
+```
+
+- Three equal-width buttons, `flex: 1`, with a gap between them
+- Subtle styling — secondary/ghost buttons, not primary CTA weight
+- Icons: `+` (add), `↓` (import), `↑` (export) — use existing icon system or unicode
+- Border-top separates bar from composer region
+- Bar height: ~32px (compact, does not compete with conversation area)
+- Font size: 12px, matching `.agent-input-hint` scale
+- No hover tooltip required at MVP; can be added later
+
+### SCSS Pattern (follows existing agent-view.scss conventions)
+
+```scss
+.agent-action-bar {
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+    padding: 4px 6px;
+    border-top: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+    flex-shrink: 0;
+
+    .agent-action-btn {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+        height: 24px;
+        font-size: 12px;
+        color: var(--secondary-text-color);
+        background: transparent;
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        cursor: pointer;
+        white-space: nowrap;
+        transition: background 0.1s, color 0.1s;
+
+        &:hover {
+            background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
+            color: var(--main-text-color);
+        }
+
+        &:active {
+            background: color-mix(in srgb, var(--main-text-color) 14%, transparent);
+        }
+
+        &.agent-action-btn-disabled {
+            opacity: 0.4;
+            cursor: default;
+            pointer-events: none;
+        }
+    }
+}
+```
+
+---
+
+## 3. Button Behaviours
+
+### 3.1 Add Agent
+
+**Trigger:** Click `+ Add Agent`
+
+**Behaviour:**
+1. Call `createforgeagent` RPC with minimal defaults (name: `"New Agent"`, provider: `"claude"`, icon: `"✦"`)
+2. On success: open the AgentFocusedPanel to the Forge tab for the newly created agent (same as clicking ⚙ on an agent card)
+3. Focus the agent name field so the user can immediately rename
+
+**RPC:** `createforgeagent` (already exists — `CommandCreateForgeAgentData` in rpc_types.rs)
+
+**Error handling:** Show a transient error toast if RPC fails. No modal.
+
+---
+
+### 3.2 Import Agents
+
+**Trigger:** Click `↓ Import`
+
+**Behaviour:**
+1. Open a native file picker (`<input type="file" accept=".json">`) — triggered programmatically, no visible input element in DOM
+2. User selects a `.json` file
+3. Parse the file client-side; validate it matches the import format (see §4)
+4. Show a preview modal:
+   - List of agents to be imported (name, provider, icon)
+   - Warning count: "N agents already exist and will be skipped" (match by slug)
+   - Options: `[Cancel]` `[Import N agents]`
+5. On confirm: call `importforgeagents` RPC (new — see §5.1) with parsed payload
+6. On success: broadcast `forgeagents:changed` event → picker refreshes automatically
+7. Show a brief success banner: "Imported N agents"
+
+**Error handling:**
+- Invalid JSON → show inline error: "Invalid file — expected AgentMux export format"
+- Version mismatch → show warning: "Format version X — some fields may be ignored"
+- Partial failure → show which agents failed to import
+
+---
+
+### 3.3 Export Agents
+
+**Trigger:** Click `↑ Export`
+
+**Behaviour:**
+1. Call `exportforgeagents` RPC (new — see §5.2) — returns full agent list with content and skills
+2. Construct a JSON blob matching the import format (see §4)
+3. Trigger browser download:
+   - Filename: `agentmux-agents-{YYYY-MM-DD}.json`
+   - MIME type: `application/json`
+   - Encoding: UTF-8 (same pattern as existing session export via `atob`)
+4. Show a brief success banner: "Exported N agents"
+
+**Loading state:** Button shows spinner/disabled state while RPC is in flight.
+
+**Error handling:** Toast on RPC failure.
+
+---
+
+## 4. Import/Export JSON Format
+
+The format is intentionally **compatible with `forge-seed.json`** so exports can be dropped in as seeds and vice versa. Version field allows future evolution.
+
+```json
+{
+  "version": 4,
+  "exported_at": "2026-04-22T10:00:00Z",
+  "source": "agentmux-export",
+  "agents": [
+    {
+      "id": "agentx",
+      "name": "AgentX",
+      "icon": "🔴",
+      "description": "Primary coding agent",
+      "provider": "claude",
+      "shell": "pwsh",
+      "working_directory": "",
+      "agent_bus_id": "agentx",
+      "agent_type": "host",
+      "environment": "windows",
+      "restart_on_crash": false,
+      "content": {
+        "soul": "...",
+        "agentmd": "...",
+        "startup": "...",
+        "env": "AGENT_NAME=agentx\nAGENTMUX_AGENT_ID=AgentX",
+        "mcp": "",
+        "hooks": ""
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks",
+          "content": "..."
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Fields omitted from export** (runtime/identity state, not portable):
+- `id` (UUID — regenerated on import; `slug`/`agent_bus_id` used for dedup)
+- `created_at`
+- `parent_id`, `branch_label`
+- `is_seeded`
+- `accounts` (identity — contains auth refs, not exported for security)
+
+**Dedup on import:** match by `id` field (slug). If an agent with the same `id` already exists → skip and report. No merge/overwrite at MVP.
+
+---
+
+## 5. New Backend RPC Commands
+
+### 5.1 `importforgeagents`
+
+**Handler:** `forge_handlers.rs` — new function `handle_import_forge_agents()`
+
+**Request:**
+```rust
+pub struct CommandImportForgeAgentsData {
+    pub agents: Vec<ForgeAgentImport>,  // parsed from JSON
+}
+
+pub struct ForgeAgentImport {
+    pub id: String,          // used as slug for dedup check
+    pub name: String,
+    pub icon: String,
+    pub description: String,
+    pub provider: String,
+    pub shell: String,
+    pub working_directory: String,
+    pub agent_bus_id: String,
+    pub agent_type: String,
+    pub environment: String,
+    pub restart_on_crash: bool,
+    pub content: HashMap<String, String>,   // content_type → content
+    pub skills: Vec<ForgeSkillImport>,
+}
+
+pub struct ForgeSkillImport {
+    pub name: String,
+    pub trigger: String,
+    pub skill_type: String,
+    pub description: String,
+    pub content: String,
+}
+```
+
+**Response:**
+```rust
+pub struct ImportForgeAgentsResult {
+    pub imported: Vec<String>,   // names of agents successfully imported
+    pub skipped: Vec<String>,    // names of agents skipped (already exist)
+    pub failed: Vec<String>,     // names of agents that failed
+}
+```
+
+**Logic:**
+1. For each agent in payload:
+   - Check if `db_forge_agents` has a row with `slug = agent.id` → skip if found
+   - Otherwise: insert ForgeAgent row, then insert ForgeContent rows, then insert ForgeSkill rows
+2. Fire `forgeagents:changed` event after all inserts
+3. Return result summary
+
+---
+
+### 5.2 `exportforgeagents`
+
+**Handler:** `forge_handlers.rs` — new function `handle_export_forge_agents()`
+
+**Request:** empty (`{}`)
+
+**Response:**
+```rust
+pub struct ExportForgeAgentsResult {
+    pub version: u32,
+    pub exported_at: String,   // ISO 8601
+    pub agents: Vec<ForgeAgentExport>,
+}
+
+pub struct ForgeAgentExport {
+    // all ForgeAgent fields except id, created_at, parent_id, branch_label, is_seeded, accounts
+    pub id: String,            // slug used as export id
+    pub name: String,
+    pub icon: String,
+    pub description: String,
+    pub provider: String,
+    pub shell: String,
+    pub working_directory: String,
+    pub agent_bus_id: String,
+    pub agent_type: String,
+    pub environment: String,
+    pub restart_on_crash: bool,
+    pub content: HashMap<String, String>,
+    pub skills: Vec<ForgeSkillExport>,
+}
+```
+
+**Logic:**
+1. Call `wstore.forge_list()` to get all agents
+2. For each agent: call `wstore.forge_content_get_all(agent_id)` and `wstore.forge_skills_list(agent_id)`
+3. Assemble `ForgeAgentExport` — use `slug` as the export `id`, omit identity/runtime fields
+4. Return assembled payload
+
+---
+
+## 6. Component Structure
+
+### New component: `AgentActionBar.tsx`
+
+```
+frontend/app/view/agent/components/AgentActionBar.tsx   ← NEW
+frontend/app/view/agent/agent-view.scss                 ← ADD .agent-action-bar styles
+frontend/app/view/agent/agent-view.tsx                  ← ADD <AgentActionBar> at bottom
+agentmux-srv/src/server/forge_handlers.rs               ← ADD handle_import/export_forge_agents
+agentmux-srv/src/backend/rpc_types.rs                   ← ADD command structs
+frontend/app/store/rpc-api.ts                           ← ADD ImportForgeAgentsCommand, ExportForgeAgentsCommand
+```
+
+### AgentActionBar.tsx skeleton
+
+```tsx
+import { createSignal } from "solid-js";
+import { RpcApi } from "@/store/rpc-api";
+import { TabRpcClient } from "@/store/global";
+
+export function AgentActionBar() {
+    const [importing, setImporting] = createSignal(false);
+    const [exporting, setExporting] = createSignal(false);
+
+    async function handleAddAgent() {
+        await RpcApi.CreateForgeAgentCommand(TabRpcClient, { /* defaults */ });
+        // open forge panel for new agent
+    }
+
+    async function handleImport() {
+        // trigger file picker → parse → preview modal → RpcApi.ImportForgeAgentsCommand
+    }
+
+    async function handleExport() {
+        setExporting(true);
+        try {
+            const result = await RpcApi.ExportForgeAgentsCommand(TabRpcClient, {});
+            // trigger download
+        } finally {
+            setExporting(false);
+        }
+    }
+
+    return (
+        <div class="agent-action-bar">
+            <button class="agent-action-btn" onClick={handleAddAgent}>
+                + Add Agent
+            </button>
+            <button class="agent-action-btn" onClick={handleImport} disabled={importing()}>
+                ↓ Import
+            </button>
+            <button class="agent-action-btn" onClick={handleExport} disabled={exporting()}>
+                ↑ Export
+            </button>
+        </div>
+    );
+}
+```
+
+---
+
+## 7. Import Preview Modal
+
+A lightweight modal (not a full page) shown before confirming import:
+
+```
+┌────────────────────────────────────────────┐
+│  Import Agents                             │
+├────────────────────────────────────────────┤
+│  Found 7 agents in file:                   │
+│                                            │
+│  ✅ 🔴 AgentX — Primary coding agent       │
+│  ✅ 🟡 AgentY — Secondary coding agent     │
+│  ⏭️  🔵 AgentZ — Already exists, skip      │
+│  ✅ 🌙 AgentK — Kimi Code CLI agent        │
+│  ✅ 🟢 Agent1 — Sandboxed coding agent     │
+│  ✅ 🟠 Agent2 — Sandboxed coding agent     │
+│  ✅ 🟣 Agent3 — Sandboxed coding agent     │
+│                                            │
+│  6 will be imported · 1 will be skipped    │
+├────────────────────────────────────────────┤
+│  [Cancel]              [Import 6 Agents]   │
+└────────────────────────────────────────────┘
+```
+
+Use existing overlay/modal patterns in the codebase (check `AgentFocusedPanel` or any existing modal component for the pattern to reuse).
+
+---
+
+## 8. Out of Scope (MVP)
+
+- Merge/overwrite existing agents on import (dedup is skip-only at MVP)
+- Selective export (export subset of agents)
+- Import from URL
+- Import format version migration
+- Agent identity/account data in export (security risk — always omitted)
+- Drag-and-drop import
+- Undo/undo-import
+
+---
+
+## 9. File Change Summary
+
+| File | Change |
+|------|--------|
+| `frontend/app/view/agent/components/AgentActionBar.tsx` | **CREATE** — new component |
+| `frontend/app/view/agent/agent-view.tsx` | **EDIT** — add `<AgentActionBar>` as last child of `.agent-view` |
+| `frontend/app/view/agent/agent-view.scss` | **EDIT** — add `.agent-action-bar` + `.agent-action-btn` styles |
+| `frontend/app/view/agent/components/ImportPreviewModal.tsx` | **CREATE** — import confirmation modal |
+| `frontend/app/store/rpc-api.ts` | **EDIT** — add `ImportForgeAgentsCommand`, `ExportForgeAgentsCommand` |
+| `agentmux-srv/src/backend/rpc_types.rs` | **EDIT** — add `CommandImportForgeAgentsData`, `ImportForgeAgentsResult`, `ExportForgeAgentsResult`, `ForgeAgentExport`, `ForgeAgentImport` |
+| `agentmux-srv/src/server/forge_handlers.rs` | **EDIT** — add `handle_import_forge_agents()`, `handle_export_forge_agents()`, register in `register_v6_handlers()` |
+
+---
+
+## 10. Relationship to Portable Seeding System
+
+The export format is intentionally a superset of `forge-seed.json`:
+
+- An **export** from the UI can be dropped directly into `agentmux-srv/forge-seed.json` (after removing `exported_at`/`source` fields) and recompiled
+- A **forge-seed.json** can be imported via the UI without modification
+- This closes the loop: the visual agent management system and the binary seed manifest share a common format
+
+Future: expose a "Set as default seed" option that writes the export to a `forge-seed.override.json` file in the data directory, allowing runtime seed customization without recompilation.

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -549,6 +549,16 @@ class RpcApiType {
         return client.rpcCall("importforgefromclaw", data, opts);
     }
 
+    // command "importforgeagents" [call]
+    ImportForgeAgentsCommand(client: RpcClient, data: CommandImportForgeAgentsData, opts?: RpcOpts): Promise<ImportForgeAgentsResult> {
+        return client.rpcCall("importforgeagents", data, opts);
+    }
+
+    // command "exportforgeagents" [call]
+    ExportForgeAgentsCommand(client: RpcClient, opts?: RpcOpts): Promise<ExportForgeAgentsResult> {
+        return client.rpcCall("exportforgeagents", {}, opts);
+    }
+
     // command "reseedforgeagents" [call]
     ReseedForgeAgentsCommand(client: RpcClient, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("reseedforgeagents", {}, opts);

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -2254,6 +2254,191 @@
         }
     }
 
+    // === Agent Action Bar (bottom buttons) ===
+    .agent-action-bar {
+        display: flex;
+        flex-direction: row;
+        gap: 4px;
+        padding: 4px 6px;
+        border-top: 1px solid var(--border-color);
+        background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
+        flex-shrink: 0;
+
+        .agent-action-btn {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 4px;
+            height: 24px;
+            font-size: 12px;
+            color: var(--secondary-text-color);
+            background: transparent;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: background 0.1s, color 0.1s;
+
+            &:hover {
+                background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
+                color: var(--main-text-color);
+            }
+
+            &:active {
+                background: color-mix(in srgb, var(--main-text-color) 14%, transparent);
+            }
+
+            &.agent-action-btn-disabled {
+                opacity: 0.4;
+                cursor: default;
+                pointer-events: none;
+            }
+        }
+    }
+
+    // === Import Preview Modal ===
+    .agent-import-overlay {
+        position: absolute;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.5);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 200;
+
+        .agent-import-modal {
+            background: var(--main-bg-color);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            width: 420px;
+            max-width: 90vw;
+            max-height: 70vh;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+
+            .agent-import-modal-header {
+                padding: 12px 16px;
+                border-bottom: 1px solid var(--border-color);
+                font-size: 14px;
+                font-weight: 600;
+                color: var(--main-text-color);
+                flex-shrink: 0;
+            }
+
+            .agent-import-modal-body {
+                padding: 12px 16px;
+                overflow-y: auto;
+                flex: 1;
+
+                .agent-import-count {
+                    font-size: 12px;
+                    color: var(--secondary-text-color);
+                    margin-bottom: 8px;
+                }
+
+                .agent-import-list {
+                    display: flex;
+                    flex-direction: column;
+                    gap: 4px;
+                    margin-bottom: 10px;
+
+                    .agent-import-row {
+                        display: flex;
+                        align-items: center;
+                        gap: 6px;
+                        font-size: 12px;
+                        color: var(--main-text-color);
+                        padding: 2px 0;
+
+                        &.agent-import-row-skip {
+                            opacity: 0.5;
+                        }
+
+                        .agent-import-row-status {
+                            width: 16px;
+                            text-align: center;
+                            flex-shrink: 0;
+                        }
+
+                        .agent-import-row-icon {
+                            flex-shrink: 0;
+                        }
+
+                        .agent-import-row-name {
+                            font-weight: 500;
+                        }
+
+                        .agent-import-row-desc,
+                        .agent-import-row-skip-label {
+                            color: var(--secondary-text-color);
+                            font-size: 11px;
+                        }
+                    }
+                }
+
+                .agent-import-summary {
+                    font-size: 12px;
+                    color: var(--secondary-text-color);
+                    border-top: 1px solid var(--border-color);
+                    padding-top: 8px;
+                }
+
+                .agent-import-result {
+                    font-size: 13px;
+                    color: var(--main-text-color);
+                    text-align: center;
+                    padding: 20px 0;
+                }
+            }
+
+            .agent-import-modal-footer {
+                display: flex;
+                justify-content: flex-end;
+                gap: 8px;
+                padding: 10px 16px;
+                border-top: 1px solid var(--border-color);
+                flex-shrink: 0;
+
+                .agent-import-btn {
+                    height: 28px;
+                    padding: 0 14px;
+                    font-size: 12px;
+                    border-radius: 4px;
+                    cursor: pointer;
+                    border: 1px solid var(--border-color);
+                    transition: background 0.1s, color 0.1s;
+
+                    &.agent-import-btn-cancel {
+                        background: transparent;
+                        color: var(--secondary-text-color);
+
+                        &:hover {
+                            background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
+                            color: var(--main-text-color);
+                        }
+                    }
+
+                    &.agent-import-btn-confirm {
+                        background: color-mix(in srgb, var(--main-text-color) 12%, transparent);
+                        color: var(--main-text-color);
+
+                        &:hover {
+                            background: color-mix(in srgb, var(--main-text-color) 20%, transparent);
+                        }
+
+                        &.agent-action-btn-disabled {
+                            opacity: 0.4;
+                            cursor: default;
+                            pointer-events: none;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // === Setup Wizard ===
     .setup-wizard {
         display: flex;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -26,6 +26,7 @@ import { AgentFooter, AgentStatusLine } from "./components/AgentFooter";
 import { AgentPicker, useForgeAgents } from "./components/AgentPicker";
 import { AgentSearchBar } from "./components/AgentSearchBar";
 import { AgentFocusedPanel } from "./components/AgentFocusedPanel";
+import { AgentActionBar } from "./components/AgentActionBar";
 import { SlashCommandPicker } from "./components/SlashCommandPicker";
 import { SlashHelpPanel } from "./components/SlashHelpPanel";
 import { BookmarksPanel } from "./components/BookmarksPanel";
@@ -433,6 +434,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     getCompletions={commands.completions}
                 />
             </div>
+            <AgentActionBar />
         </div>
     );
 };

--- a/frontend/app/view/agent/components/AgentActionBar.tsx
+++ b/frontend/app/view/agent/components/AgentActionBar.tsx
@@ -1,0 +1,128 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createSignal, type JSX } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { ImportPreviewModal } from "./ImportPreviewModal";
+
+export const AgentActionBar = (): JSX.Element => {
+    const [importing, setImporting] = createSignal(false);
+    const [exporting, setExporting] = createSignal(false);
+    const [importPayload, setImportPayload] = createSignal<ExportForgeAgentsResult | null>(null);
+    const [addingAgent, setAddingAgent] = createSignal(false);
+
+    async function handleAddAgent() {
+        if (addingAgent()) return;
+        setAddingAgent(true);
+        try {
+            await RpcApi.CreateForgeAgentCommand(TabRpcClient, {
+                name: "New Agent",
+                provider: "claude",
+                icon: "✦",
+                description: "",
+            });
+        } catch (err) {
+            console.error("AgentActionBar: failed to create agent", err);
+        } finally {
+            setAddingAgent(false);
+        }
+    }
+
+    function handleImportClick() {
+        if (importing()) return;
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = ".json";
+        input.style.display = "none";
+        input.onchange = async () => {
+            const file = input.files?.[0];
+            if (!file) return;
+            setImporting(true);
+            try {
+                const text = await file.text();
+                let parsed: ExportForgeAgentsResult;
+                try {
+                    parsed = JSON.parse(text);
+                } catch {
+                    alert("Invalid file — expected AgentMux export format (JSON parse error)");
+                    return;
+                }
+                if (!parsed?.agents || !Array.isArray(parsed.agents)) {
+                    alert("Invalid file — expected AgentMux export format (missing agents array)");
+                    return;
+                }
+                setImportPayload(parsed);
+            } catch (err) {
+                console.error("AgentActionBar: import read error", err);
+                alert("Failed to read file");
+            } finally {
+                setImporting(false);
+            }
+        };
+        document.body.appendChild(input);
+        input.click();
+        document.body.removeChild(input);
+    }
+
+    async function handleExport() {
+        if (exporting()) return;
+        setExporting(true);
+        try {
+            const result = await RpcApi.ExportForgeAgentsCommand(TabRpcClient);
+            const json = JSON.stringify(result, null, 2);
+            const blob = new Blob([json], { type: "application/json" });
+            const url = URL.createObjectURL(blob);
+            const today = new Date().toISOString().slice(0, 10);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = `agentmux-agents-${today}.json`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        } catch (err) {
+            console.error("AgentActionBar: export error", err);
+            alert("Export failed");
+        } finally {
+            setExporting(false);
+        }
+    }
+
+    return (
+        <>
+            <div class="agent-action-bar">
+                <button
+                    class="agent-action-btn"
+                    classList={{ "agent-action-btn-disabled": addingAgent() }}
+                    onClick={handleAddAgent}
+                    title="Create a new forge agent"
+                >
+                    + Add Agent
+                </button>
+                <button
+                    class="agent-action-btn"
+                    classList={{ "agent-action-btn-disabled": importing() }}
+                    onClick={handleImportClick}
+                    title="Import agents from a JSON file"
+                >
+                    ↓ Import
+                </button>
+                <button
+                    class="agent-action-btn"
+                    classList={{ "agent-action-btn-disabled": exporting() }}
+                    onClick={handleExport}
+                    title="Export all agents to a JSON file"
+                >
+                    ↑ Export
+                </button>
+            </div>
+            <ImportPreviewModal
+                payload={importPayload()}
+                onClose={() => setImportPayload(null)}
+            />
+        </>
+    );
+};
+
+AgentActionBar.displayName = "AgentActionBar";

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -19,6 +19,7 @@ import type { AgentViewModel } from "../agent-model";
 import { AgentCard } from "./AgentCard";
 import { NewAgentCard } from "./NewAgentCard";
 import { AgentCardSettingsPanel, type SettingsTab } from "./AgentCardSettingsPanel";
+import { AgentActionBar } from "./AgentActionBar";
 
 // ── useForgeAgents hook ───────────────────────────────────────────────────────
 
@@ -219,6 +220,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                             />
                         </Show>
                     </div>
+                    <AgentActionBar />
                 </div>
             }
         >
@@ -278,6 +280,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         </div>
                     </Show>
                 </div>
+                <AgentActionBar />
             </div>
         </Show>
     );

--- a/frontend/app/view/agent/components/ImportPreviewModal.tsx
+++ b/frontend/app/view/agent/components/ImportPreviewModal.tsx
@@ -1,0 +1,139 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createMemo, createSignal, For, onMount, Show, type JSX } from "solid-js";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+interface ImportPreviewModalProps {
+    payload: ExportForgeAgentsResult | null;
+    onClose: () => void;
+}
+
+export const ImportPreviewModal = (props: ImportPreviewModalProps): JSX.Element => {
+    const [existingSlugs, setExistingSlugs] = createSignal<Set<string>>(new Set());
+    const [importing, setImporting] = createSignal(false);
+    const [resultMsg, setResultMsg] = createSignal<string | null>(null);
+
+    onMount(async () => {
+        try {
+            const agents = await RpcApi.ListForgeAgentsCommand(TabRpcClient);
+            setExistingSlugs(new Set((agents ?? []).map((a) => a.slug)));
+        } catch {
+            // proceed without dedup info
+        }
+    });
+
+    const agentRows = createMemo(() => {
+        if (!props.payload?.agents) return [];
+        return props.payload.agents.map((a) => ({
+            agent: a,
+            skip: existingSlugs().has(a.id),
+        }));
+    });
+
+    const toImportCount = createMemo(() => agentRows().filter((r) => !r.skip).length);
+    const skipCount = createMemo(() => agentRows().filter((r) => r.skip).length);
+
+    async function handleConfirm() {
+        if (importing() || toImportCount() === 0) return;
+        setImporting(true);
+        try {
+            const result = await RpcApi.ImportForgeAgentsCommand(TabRpcClient, {
+                agents: (props.payload?.agents ?? []).map((a) => ({
+                    id: a.id,
+                    name: a.name,
+                    icon: a.icon,
+                    description: a.description,
+                    provider: a.provider,
+                    shell: a.shell,
+                    working_directory: a.working_directory,
+                    agent_bus_id: a.agent_bus_id,
+                    agent_type: a.agent_type,
+                    environment: a.environment,
+                    restart_on_crash: a.restart_on_crash,
+                    content: a.content,
+                    skills: a.skills,
+                })),
+            });
+            const parts: string[] = [];
+            if (result.imported.length > 0) parts.push(`Imported ${result.imported.length} agent${result.imported.length !== 1 ? "s" : ""}`);
+            if (result.skipped.length > 0) parts.push(`${result.skipped.length} skipped`);
+            if (result.failed.length > 0) parts.push(`${result.failed.length} failed`);
+            setResultMsg(parts.join(" · "));
+            setTimeout(() => {
+                props.onClose();
+            }, 1500);
+        } catch (err) {
+            setResultMsg(`Import failed: ${err}`);
+        } finally {
+            setImporting(false);
+        }
+    }
+
+    function handleBackdropClick(e: MouseEvent) {
+        if (e.target === e.currentTarget) props.onClose();
+    }
+
+    return (
+        <Show when={props.payload != null}>
+            <div class="agent-import-overlay" onClick={handleBackdropClick}>
+                <div class="agent-import-modal">
+                    <div class="agent-import-modal-header">Import Agents</div>
+                    <div class="agent-import-modal-body">
+                        <Show
+                            when={resultMsg() == null}
+                            fallback={<div class="agent-import-result">{resultMsg()}</div>}
+                        >
+                            <div class="agent-import-count">
+                                Found {agentRows().length} agent{agentRows().length !== 1 ? "s" : ""} in file:
+                            </div>
+                            <div class="agent-import-list">
+                                <For each={agentRows()}>
+                                    {(row) => (
+                                        <div classList={{
+                                            "agent-import-row": true,
+                                            "agent-import-row-skip": row.skip,
+                                        }}>
+                                            <span class="agent-import-row-status">
+                                                {row.skip ? "⏭" : "✓"}
+                                            </span>
+                                            <span class="agent-import-row-icon">{row.agent.icon}</span>
+                                            <span class="agent-import-row-name">{row.agent.name}</span>
+                                            <Show when={row.agent.description}>
+                                                <span class="agent-import-row-desc"> — {row.agent.description}</span>
+                                            </Show>
+                                            <Show when={row.skip}>
+                                                <span class="agent-import-row-skip-label"> (already exists)</span>
+                                            </Show>
+                                        </div>
+                                    )}
+                                </For>
+                            </div>
+                            <div class="agent-import-summary">
+                                {toImportCount()} will be imported
+                                <Show when={skipCount() > 0}>
+                                    {" "}&middot; {skipCount()} will be skipped
+                                </Show>
+                            </div>
+                        </Show>
+                    </div>
+                    <div class="agent-import-modal-footer">
+                        <button class="agent-import-btn agent-import-btn-cancel" onClick={props.onClose}>
+                            Cancel
+                        </button>
+                        <button
+                            class="agent-import-btn agent-import-btn-confirm"
+                            classList={{ "agent-action-btn-disabled": importing() || toImportCount() === 0 }}
+                            onClick={handleConfirm}
+                        >
+                            {importing() ? "Importing…" : `Import ${toImportCount()} Agent${toImportCount() !== 1 ? "s" : ""}`}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Show>
+    );
+};
+
+ImportPreviewModal.displayName = "ImportPreviewModal";

--- a/frontend/app/view/agent/components/ImportPreviewModal.tsx
+++ b/frontend/app/view/agent/components/ImportPreviewModal.tsx
@@ -1,7 +1,7 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createMemo, createSignal, For, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 
@@ -15,7 +15,8 @@ export const ImportPreviewModal = (props: ImportPreviewModalProps): JSX.Element 
     const [importing, setImporting] = createSignal(false);
     const [resultMsg, setResultMsg] = createSignal<string | null>(null);
 
-    onMount(async () => {
+    createEffect(async () => {
+        if (props.payload == null) return;
         try {
             const agents = await RpcApi.ListForgeAgentsCommand(TabRpcClient);
             setExistingSlugs(new Set((agents ?? []).map((a) => a.slug)));

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1844,6 +1844,73 @@ declare global {
         byte_count: number;
     };
 
+    // CommandImportForgeAgentsData
+    type ForgeSkillImport = {
+        name: string;
+        trigger: string;
+        skill_type: string;
+        description: string;
+        content: string;
+    };
+
+    type ForgeAgentImport = {
+        id: string;
+        name: string;
+        icon: string;
+        description: string;
+        provider: string;
+        shell: string;
+        working_directory: string;
+        agent_bus_id: string;
+        agent_type: string;
+        environment: string;
+        restart_on_crash: boolean;
+        content: Record<string, string>;
+        skills: ForgeSkillImport[];
+    };
+
+    type CommandImportForgeAgentsData = {
+        agents: ForgeAgentImport[];
+    };
+
+    type ImportForgeAgentsResult = {
+        imported: string[];
+        skipped: string[];
+        failed: string[];
+    };
+
+    // ExportForgeAgentsResult
+    type ForgeSkillExport = {
+        name: string;
+        trigger: string;
+        skill_type: string;
+        description: string;
+        content: string;
+    };
+
+    type ForgeAgentExport = {
+        id: string;
+        name: string;
+        icon: string;
+        description: string;
+        provider: string;
+        shell: string;
+        working_directory: string;
+        agent_bus_id: string;
+        agent_type: string;
+        environment: string;
+        restart_on_crash: boolean;
+        content: Record<string, string>;
+        skills: ForgeSkillExport[];
+    };
+
+    type ExportForgeAgentsResult = {
+        version: number;
+        exported_at: string;
+        source: string;
+        agents: ForgeAgentExport[];
+    };
+
 }
 
 export {}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.319",
+  "version": "0.33.320",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Adds a compact 3-button bar (`+ Add Agent`, `↓ Import`, `↑ Export`) pinned to the bottom of the agent pane — always visible in both picker and presentation views
- Import/export format is intentionally compatible with `forge-seed.json`, closing the loop between the visual agent management UI and the binary seed manifest
- Dedup on import by slug — existing agents are skipped and reported

## Backend changes

- **`rpc_types.rs`**: new constants `COMMAND_IMPORT_FORGE_AGENTS`, `COMMAND_EXPORT_FORGE_AGENTS` and all supporting structs (`ForgeAgentImport`, `ForgeSkillImport`, `ImportForgeAgentsResult`, `ForgeAgentExport`, `ForgeSkillExport`, `ExportForgeAgentsResult`)
- **`forge_handlers.rs`**: `importforgeagents` handler — inserts agents/content/skills with dedup-by-slug; `exportforgeagents` handler — queries all agents, content, and skills and returns a portable JSON payload

## Frontend changes

- **`gotypes.d.ts`**: matching TypeScript types for all new RPC structs
- **`rpc-api.ts`**: `ImportForgeAgentsCommand`, `ExportForgeAgentsCommand`
- **`AgentActionBar.tsx`** _(new)_: self-contained component; Add Agent calls `CreateForgeAgentCommand`; Import triggers a native file picker → parse → `ImportPreviewModal`; Export calls `ExportForgeAgentsCommand` and downloads a dated JSON file
- **`ImportPreviewModal.tsx`** _(new)_: preview modal with per-agent skip/import status, confirm/cancel flow, dedup checked against current agent list
- **`agent-view.tsx`**: mount `<AgentActionBar />` at bottom of presentation view
- **`AgentPicker.tsx`**: mount `<AgentActionBar />` at bottom of both picker branches (with agents / empty fallback)
- **`agent-view.scss`**: `.agent-action-bar`, `.agent-action-btn`, `.agent-import-overlay` + modal styles following existing CSS variable conventions

## Spec

`docs/specs/SPEC_AGENT_PANE_BOTTOM_BUTTONS_2026_04_22.md`

## Test plan

- [ ] Click `+ Add Agent` — new "New Agent" appears in picker with forge panel open
- [ ] Click `↓ Import` — file picker opens; select a valid `agentmux-agents-*.json` or `forge-seed.json`; preview modal shows per-agent status with skip for existing slugs; confirm imports agents correctly
- [ ] Click `↓ Import` with an invalid JSON file — shows error alert
- [ ] Click `↑ Export` — downloads `agentmux-agents-YYYY-MM-DD.json`; file contains all agents with content and skills; can be re-imported via Import
- [ ] Bar visible in picker view (no agent selected)
- [ ] Bar visible in presentation view (agent running)
- [ ] Import a `forge-seed.json` directly — should work without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)