### PR TITLE
feat(swarm): Activity tab — per-agent process tracker view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.324"
+version = "0.33.325"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.324"
+version = "0.33.325"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.324"
+version = "0.33.325"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.324"
+version = "0.33.325"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.324"
+version = "0.33.325"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.324"
+version = "0.33.325"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.324"
+version = "0.33.325"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.324"
+version = "0.33.325"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -706,6 +706,37 @@ class RpcApiType {
         return client.rpcCall("agentstop", data, opts);
     }
 
+    // command "agent.process-list" [call]
+    // Returns the OS processes currently tracked under a given agent
+    // block — via Windows Job Objects (or cgroups v2 / process groups
+    // on future platforms). Consumed by the swarm Activity tab.
+    AgentProcessListCommand(
+        client: RpcClient,
+        data: { block_id: string },
+        opts?: RpcOpts,
+    ): Promise<{
+        block_id: string;
+        confidence: "high" | "best_effort" | "none";
+        processes: Array<{
+            pid: number;
+            command: string;
+            rss_bytes: number;
+            started_at_ms: number;
+        }>;
+    }> {
+        return client.rpcCall("agent.process-list", data, opts);
+    }
+
+    // command "agent.tracked-blocks" [call]
+    // Block IDs for which a process tracker is currently registered.
+    AgentTrackedBlocksCommand(
+        client: RpcClient,
+        data: Record<string, never>,
+        opts?: RpcOpts,
+    ): Promise<{ block_ids: string[] }> {
+        return client.rpcCall("agent.tracked-blocks", data, opts);
+    }
+
     // command "writeagentconfig" [call]
     WriteAgentConfigCommand(client: RpcClient, data: CommandWriteAgentConfigData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("writeagentconfig", data, opts);

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { callBackendService } from "@/store/wos";
 import { createSignal, type Accessor, type Setter } from "solid-js";
@@ -66,7 +68,39 @@ export interface HistorySession {
     messages: HistoryMessage[];
 }
 
-export type SwarmTab = "overview" | "history" | "search";
+export type SwarmTab = "overview" | "activity" | "history" | "search";
+
+// ── Activity tab types ──────────────────────────────────────────────────
+// Mirrors `backend::process_tracker::TrackedProcess` + RPC responses
+// `AgentProcessListResult` / `AgentTrackedBlocksResult`.
+
+/**
+ * Tracking confidence for a block's process tracker. `"high"` on
+ * Windows (Job Objects) and Linux (cgroups v2); `"best_effort"` on
+ * macOS (process groups — escape via `setsid` or launchd is possible);
+ * `"none"` when no tracker is registered.
+ */
+export type TrackingConfidence = "high" | "best_effort" | "none";
+
+export interface AgentProcessInfo {
+    pid: number;
+    command: string;
+    rss_bytes: number;
+    started_at_ms: number;
+}
+
+/**
+ * Per-block tracker snapshot. Keyed by block_id in the UI. The
+ * swarm Activity tab groups agents by block and renders their
+ * processes below each group header.
+ */
+export interface AgentProcessGroup {
+    block_id: string;
+    /** Display name for the agent (resolved from block meta at render time). */
+    agent_name?: string;
+    confidence: TrackingConfidence;
+    processes: AgentProcessInfo[];
+}
 
 // ── ViewModel ────────────────────────────────────────────────────────────
 
@@ -97,6 +131,12 @@ export class SwarmViewModel implements ViewModel {
     private _subagents = createSignal<ActiveSubagent[]>([]);
     subagentsAtom: Accessor<ActiveSubagent[]> = this._subagents[0];
     private setSubagents: Setter<ActiveSubagent[]> = this._subagents[1];
+
+    // Activity tab — per-block process-tracker groups. Populated by the
+    // swarm-side `refreshActivity()` call plus delta events.
+    private _activity = createSignal<AgentProcessGroup[]>([]);
+    activityAtom: Accessor<AgentProcessGroup[]> = this._activity[0];
+    private setActivity: Setter<AgentProcessGroup[]> = this._activity[1];
 
     // Search
     private _searchQuery = createSignal<string>("");
@@ -165,7 +205,62 @@ export class SwarmViewModel implements ViewModel {
             handler: () => this.loadSubagents(),
         });
         if (unsubCompleted) this.unsubs.push(unsubCompleted);
+
+        // Process tracker deltas — refresh the Activity tab on every
+        // add/exit. Cheap (one RPC returning a small JSON), debouncing
+        // isn't needed since events fire on a ~2s cadence from the
+        // backend poller.
+        const unsubProcAdded = waveEventSubscribe({
+            eventType: "agent:process-added",
+            handler: () => this.refreshActivity(),
+        });
+        if (unsubProcAdded) this.unsubs.push(unsubProcAdded);
+        const unsubProcExited = waveEventSubscribe({
+            eventType: "agent:process-exited",
+            handler: () => this.refreshActivity(),
+        });
+        if (unsubProcExited) this.unsubs.push(unsubProcExited);
+
+        // Seed the Activity tab on mount so the list is populated
+        // before the user clicks the tab (avoids empty-on-open flash).
+        this.refreshActivity();
     }
+
+    /**
+     * Refresh the Activity tab: list every tracked block, then fetch
+     * each block's process list + confidence level, then set the atom.
+     * Runs serially — block counts are small (a few agents at most).
+     */
+    refreshActivity = async (): Promise<void> => {
+        try {
+            const { block_ids } = await RpcApi.AgentTrackedBlocksCommand(TabRpcClient, {});
+            const groups: AgentProcessGroup[] = await Promise.all(
+                block_ids.map(async (block_id) => {
+                    try {
+                        const res = await RpcApi.AgentProcessListCommand(TabRpcClient, {
+                            block_id,
+                        });
+                        return {
+                            block_id: res.block_id,
+                            confidence: res.confidence,
+                            processes: res.processes,
+                        };
+                    } catch {
+                        return {
+                            block_id,
+                            confidence: "none" as TrackingConfidence,
+                            processes: [],
+                        };
+                    }
+                }),
+            );
+            this.setActivity(groups);
+        } catch {
+            // Silent fail — tracker global may not be initialized (tests),
+            // or backend may not have the new RPC yet (older version
+            // running in dev). Empty list is a safe default.
+        }
+    };
 
     loadOverview = async (): Promise<void> => {
         this.setLoading(true);

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -601,6 +601,118 @@
     overflow: hidden;
 }
 
+// ── Activity tab ────────────────────────────────────────────────────────
+// Per-agent process tracker groups, one per block. Compact monospace
+// table, amber confidence badge for anything less than "high".
+// See `agentmux-ai/AGENT_SPAWNED_PROCESSES_SPEC.md` + PR #497 backend.
+
+.swarm-activity {
+    padding: 6px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    overflow-y: auto;
+}
+
+.swarm-activity-summary {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    opacity: 0.7;
+    padding: 2px 4px;
+}
+
+.swarm-activity-group {
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
+}
+
+.swarm-activity-group-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border-color);
+    font-family: var(--fixed-font, monospace);
+    font-size: 12px;
+}
+
+.swarm-activity-group-id {
+    color: var(--accent-color);
+    font-weight: 500;
+}
+
+.swarm-activity-group-count {
+    margin-left: auto;
+    font-size: 11px;
+    opacity: 0.7;
+    font-variant-numeric: tabular-nums;
+}
+
+.swarm-activity-confidence {
+    font-size: 10px;
+    padding: 1px 5px;
+    border-radius: 10px;
+    font-weight: 500;
+
+    &--best-effort {
+        color: var(--warning-color);
+        background: color-mix(in srgb, var(--warning-color) 15%, transparent);
+    }
+    &--none {
+        color: var(--error-color);
+        background: color-mix(in srgb, var(--error-color) 15%, transparent);
+    }
+}
+
+.swarm-activity-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--fixed-font, monospace);
+    font-size: 11px;
+
+    thead th {
+        padding: 3px 8px;
+        text-align: left;
+        font-weight: normal;
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        opacity: 0.6;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    td {
+        padding: 2px 8px;
+        border-bottom: 1px solid color-mix(in srgb, var(--border-color) 40%, transparent);
+    }
+
+    tr:last-child td {
+        border-bottom: none;
+    }
+}
+
+.swarm-activity-pid {
+    font-variant-numeric: tabular-nums;
+    color: var(--secondary-text-color);
+    width: 60px;
+}
+
+.swarm-activity-command {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 300px;
+}
+
+.swarm-activity-rss {
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    width: 80px;
+    color: var(--secondary-text-color);
+}
+
 // ── Animations ──────────────────────────────────────────────────────────
 
 @keyframes swarm-pulse {

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -2,7 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createSignal, For, Show, type JSX } from "solid-js";
-import type { SwarmViewModel, ActiveSubagent, HistorySessionMeta, HistoryMessage } from "./swarm-model";
+import type {
+    SwarmViewModel,
+    ActiveSubagent,
+    HistorySessionMeta,
+    HistoryMessage,
+    AgentProcessGroup,
+    AgentProcessInfo,
+} from "./swarm-model";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import "./swarm-view.scss";
 
@@ -20,6 +27,15 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
                         onClick={() => model.setTab("overview")}
                     >
                         Overview
+                    </button>
+                    <button
+                        class={`swarm-tab ${model.tabAtom() === "activity" ? "active" : ""}`}
+                        onClick={() => {
+                            model.setTab("activity");
+                            void model.refreshActivity();
+                        }}
+                    >
+                        Activity
                     </button>
                     <button
                         class={`swarm-tab ${model.tabAtom() === "history" ? "active" : ""}`}
@@ -42,6 +58,9 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
             <div class="swarm-content">
                 <Show when={model.tabAtom() === "overview"}>
                     <SwarmOverview model={model} />
+                </Show>
+                <Show when={model.tabAtom() === "activity"}>
+                    <SwarmActivity model={model} />
                 </Show>
                 <Show when={model.tabAtom() === "history"}>
                     <SwarmHistory model={model} />
@@ -447,5 +466,118 @@ function SwarmSearch({ model }: { model: SwarmViewModel }): JSX.Element {
                 <div class="swarm-empty">No results found</div>
             </Show>
         </div>
+    );
+}
+
+// ── Activity Tab ────────────────────────────────────────────────────────
+// Read-only view of every OS process each agent has spawned — via the
+// per-platform tracker mechanism (Windows Job Objects today; Linux +
+// macOS in follow-up PRs). Driven by `agent.tracked-blocks` +
+// `agent.process-list` RPCs, refreshed on every `agent:process-added`
+// / `agent:process-exited` delta event.
+//
+// Kill / kill-tree buttons + close-time confirm are a later PR.
+// See `agentmux-ai/AGENT_SPAWNED_PROCESSES_SPEC.md`.
+
+function SwarmActivity({ model }: { model: SwarmViewModel }): JSX.Element {
+    const groups = () => model.activityAtom();
+    const totalProcesses = () =>
+        groups().reduce((sum, g) => sum + g.processes.length, 0);
+
+    return (
+        <div class="swarm-activity">
+            <Show when={groups().length === 0}>
+                <div class="swarm-empty">
+                    No active agents. Open an agent pane and run a turn —
+                    processes the agent spawns will appear here.
+                </div>
+            </Show>
+
+            <Show when={groups().length > 0}>
+                <div class="swarm-activity-summary">
+                    Tracking {groups().length}{" "}
+                    {groups().length === 1 ? "agent" : "agents"} ·{" "}
+                    {totalProcesses()}{" "}
+                    {totalProcesses() === 1 ? "process" : "processes"}
+                </div>
+                <For each={groups()}>
+                    {(group) => <SwarmActivityGroup group={group} />}
+                </For>
+            </Show>
+        </div>
+    );
+}
+
+function SwarmActivityGroup({ group }: { group: AgentProcessGroup }): JSX.Element {
+    return (
+        <div class="swarm-activity-group">
+            <div class="swarm-activity-group-header">
+                <span class="swarm-activity-group-id" title={group.block_id}>
+                    {group.block_id.slice(0, 8)}…
+                </span>
+                <Show when={group.confidence !== "high"}>
+                    <span
+                        class="swarm-activity-confidence"
+                        classList={{
+                            "swarm-activity-confidence--best-effort":
+                                group.confidence === "best_effort",
+                            "swarm-activity-confidence--none":
+                                group.confidence === "none",
+                        }}
+                        title={
+                            group.confidence === "best_effort"
+                                ? "Tracking is best-effort on this platform — descendants that call setsid or register with launchd can escape."
+                                : "No tracker registered — the process list may be empty even if the agent has spawned processes."
+                        }
+                    >
+                        ⚠ {group.confidence === "best_effort" ? "best-effort" : "untracked"}
+                    </span>
+                </Show>
+                <span class="swarm-activity-group-count">
+                    {group.processes.length}{" "}
+                    {group.processes.length === 1 ? "process" : "processes"}
+                </span>
+            </div>
+            <Show when={group.processes.length > 0}>
+                <table class="swarm-activity-table">
+                    <thead>
+                        <tr>
+                            <th>PID</th>
+                            <th>Command</th>
+                            <th>RSS</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <For each={group.processes}>
+                            {(proc) => <SwarmActivityRow proc={proc} />}
+                        </For>
+                    </tbody>
+                </table>
+            </Show>
+        </div>
+    );
+}
+
+function SwarmActivityRow({ proc }: { proc: AgentProcessInfo }): JSX.Element {
+    // Full path is long; show basename in the cell, full path in the
+    // hover title so the user can still read it without scroll.
+    const shortCommand = () => {
+        const c = proc.command || "(unknown)";
+        const slash = Math.max(c.lastIndexOf("/"), c.lastIndexOf("\\"));
+        return slash >= 0 ? c.slice(slash + 1) : c;
+    };
+    const fmtRss = () => {
+        if (proc.rss_bytes === 0) return "—";
+        const mb = proc.rss_bytes / 1024 / 1024;
+        return mb < 1 ? `${(mb * 1024).toFixed(0)} KB` : `${mb.toFixed(1)} MB`;
+    };
+    return (
+        <tr class="swarm-activity-row">
+            <td class="swarm-activity-pid">{proc.pid}</td>
+            <td class="swarm-activity-command" title={proc.command}>
+                {shortCommand()}
+            </td>
+            <td class="swarm-activity-rss">{fmtRss()}</td>
+        </tr>
     );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.324",
+  "version": "0.33.325",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.324",
+      "version": "0.33.325",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.324",
+  "version": "0.33.325",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Second PR in the agent-spawned-process series. Consumes the backend RPCs + events shipped in #497. Adds an **Activity** tab to the swarm pane that shows, grouped per agent block, every OS process the agent has caused to exist on the machine.

Read-only view. Kill buttons, status-line badges, and close-time confirm modals are separate follow-up PRs in the sequence.

## What's in this PR

- **New tab**: `SwarmTab` gains `"activity"` alongside `overview` / `history` / `search`. Default is still overview.
- **`refreshActivity()`**: `AgentTrackedBlocksCommand` → for each block, `AgentProcessListCommand`. Populates a new `activityAtom`.
- **Live refresh**: WPS subscription to `agent:process-added` / `agent:process-exited` triggers refresh on every backend delta.
- **Seed on mount**: first refresh fires in the constructor so the tab isn't empty when first opened.
- **Components**: `SwarmActivity` → `SwarmActivityGroup` → `SwarmActivityRow`. Table per block with PID · command · RSS. Confidence badge (⚠ best-effort / ⚠ untracked) for anything less than `high` — already wired for the upcoming Linux/macOS trackers.
- **RPC wrappers** in `rpc-api.ts`.
- **SCSS** for the tab, including amber/red confidence pills.

## Screenshot expectation

```
┌─ Swarm ───────────────────────────────────────────────────┐
│ Overview · [Activity] · History · Search                   │
├────────────────────────────────────────────────────────────┤
│ TRACKING 2 AGENTS · 4 PROCESSES                            │
│ ┌─────────────────────────────────────────────────────┐  │
│ │ 93e40b11…                                 3 procs  │  │
│ ├─────────────────────────────────────────────────────┤  │
│ │  PID    COMMAND                          RSS       │  │
│ │  4132   claude.exe                       88.1 MB   │  │
│ │  5892   node.exe                         42.3 MB   │  │
│ │  7104   bash.exe                          6.0 MB   │  │
│ └─────────────────────────────────────────────────────┘  │
│ ┌─────────────────────────────────────────────────────┐  │
│ │ a5b6c1d2…  ⚠ best-effort                 1 proc   │  │
│ ├─────────────────────────────────────────────────────┤  │
│ │  PID    COMMAND                          RSS       │  │
│ │  8812   python.exe                      440.1 MB   │  │
│ └─────────────────────────────────────────────────────┘  │
└────────────────────────────────────────────────────────────┘
```

## Test plan

- [ ] Swarm pane `defwidget@swarm` is hidden by default; unhide via "+" menu to access Activity
- [ ] Open an agent pane, run a turn → after ~2s Activity tab shows one group with the CLI process
- [ ] From the agent, run `bash: sleep 60 &` → background bash appears in the same group
- [ ] Close the agent pane → the group disappears on the next refresh (tracker was dropped in `delete_controller`)
- [ ] Confidence pill appears only when less than `high` (visible today only if tracker init fails on Windows)
- [ ] No console errors; RPC calls succeed

## Follow-up PRs (from the spec)

- PR 3: Status-line badge on each agent pane (`⚙ N`)
- PR 4: Kill / kill-tree buttons + close-time confirm modal
- PR 5: Linux `Cgroupv2Tracker`
- PR 6: macOS `ProcessGroupTracker`
- PR 7: Cross-tree diffs (`docker ps`, `schtasks`, `crontab`, `systemctl`)
- PR 8: Loop/cron aggregation

Spec: `agentmux-ai/AGENT_SPAWNED_PROCESSES_SPEC.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)