### PR TITLE
feat(agent-pane): confirm kill-all before closing pane with tracked processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.327"
+version = "0.33.328"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.327"
+version = "0.33.328"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.327"
+version = "0.33.328"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.327"
+version = "0.33.328"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.327"
+version = "0.33.328"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.327"
+version = "0.33.328"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.327"
+version = "0.33.328"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.327"
+version = "0.33.328"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -158,6 +158,49 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // platforms without a real tracker. See `hooks/useProcessCount.ts`.
     const processCount = useProcessCount(model.blockId);
 
+    // Pane-close confirm: when the user closes this pane with tracked
+    // processes still alive, intercept the layout's `onClose` with a
+    // confirm dialog. Accept → `agent.kill-tree` RPC then proceed with
+    // close. Cancel → abort, pane stays open. Zero tracked processes
+    // → original close path, no prompt.
+    //
+    // We wrap `nodeModel.onClose` in place rather than adding a new
+    // ViewModel hook — ViewModel has no `beforeClose` / `canClose`
+    // surface today, and threading one through would touch the layout
+    // + block-frame + pane-actions tree. A local wrapper is enough for
+    // v1 of this feature.
+    onMount(() => {
+        const original = model.nodeModel.onClose;
+        const wrapped = () => {
+            const count = processCount();
+            if (count <= 0) {
+                original?.();
+                return;
+            }
+            const suffix = count === 1 ? "process" : "processes";
+            const ok = window.confirm(
+                `This agent has ${count} ${suffix} still running.\n\n` +
+                `Close and kill them all?`
+            );
+            if (!ok) return;
+            // Kill first, then proceed with layout close. `finally` so
+            // the close still happens even if the kill RPC errors —
+            // we've already committed to closing, and the tracker's
+            // Drop impl in `delete_controller` will nuke what survived.
+            void RpcApi.AgentKillTreeCommand(TabRpcClient, {
+                block_id: model.blockId,
+            }).finally(() => original?.());
+        };
+        model.nodeModel.onClose = wrapped;
+        onCleanup(() => {
+            // Only restore if we're still the wrapper — avoids
+            // clobbering a later wrapper set by someone else.
+            if (model.nodeModel.onClose === wrapped) {
+                model.nodeModel.onClose = original;
+            }
+        });
+    });
+
     // Subscribe to subprocess output and parse into DocumentNodes.
     // `documentVersion` is bumped whenever we mutate the document externally
     // (history load / prepend), causing useAgentStream to rebuild its

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.327",
+  "version": "0.33.328",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.327",
+      "version": "0.33.328",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.327",
+  "version": "0.33.328",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Fifth PR in the process-tracker series. Intercepts the layout's `nodeModel.onClose` on the agent pane: if the tracker reports >0 live processes, a `window.confirm` asks the user whether to kill them. Accept → `agent.kill-tree` then proceed. Cancel → pane stays open. Zero tracked processes → plain close.

## Implementation

Wraps `model.nodeModel.onClose` in `onMount`, restores on `onCleanup`. ViewModel has no `beforeClose` hook today; adding one would touch layout + block-frame + pane-actions. A local wrapper is the minimum surface-area fix for v1.

`finally`-semantics on the kill so the pane still closes if the RPC errors — the tracker's `Drop` in `delete_controller` takes care of anything that survived.

## Version note

`AgentKillTreeCommand` duplicates into `rpc-api.ts` from in-flight PR #500. Identical content, should dedupe cleanly on merge.

## Test plan

- [ ] Idle pane, close with × → closes immediately, no prompt
- [ ] Active turn (agent CLI running) → close asks to kill
- [ ] Click Cancel → pane stays open
- [ ] Click OK → processes die, pane closes
- [ ] From agent: `bash: sleep 300 &` → ⚙ badge ticks up → close → prompt counts correctly
- [ ] Tab-close or window-close → still bypasses confirm; known limitation documented

## Out of scope

- Per-process "keep running" toggles in the modal
- Tab/window close paths (need deeper layout surgery; tracker's Drop still catches the processes, this is UX only)
- Linux `Cgroupv2Tracker` / macOS `ProcessGroupTracker` — separate PRs
- Cross-tree diffs (docker/schtasks/cron) — separate PR
- Loop/cron aggregation — separate PR

Spec: `agentmux-ai/AGENT_SPAWNED_PROCESSES_SPEC.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)