### PR TITLE
feat(forge): re-seed to one definition per CLI (drops AgentX/Y/Z/K/1/2/3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.333"
+version = "0.33.334"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.333"
+version = "0.33.334"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.333"
+version = "0.33.334"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.333"
+version = "0.33.334"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.334"
+version = "0.33.335"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.334"
+version = "0.33.335"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.334"
+version = "0.33.335"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.334"
+version = "0.33.335"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.333"
+version = "0.33.334"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.334"
+version = "0.33.335"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.334"
+version = "0.33.335"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.333"
+version = "0.33.334"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.334"
+version = "0.33.335"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.333"
+version = "0.33.334"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.333"
+version = "0.33.334"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.334"
+version = "0.33.335"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/forge-seed.json
+++ b/agentmux-srv/forge-seed.json
@@ -1,16 +1,18 @@
 {
-  "version": 4,
+  "version": 5,
   "agents": [
     {
-      "id": "agentx",
-      "name": "AgentX",
-      "icon": "🔴",
-      "description": "Primary coding agent",
+      "id": "claude",
+      "name": "Claude",
+      "icon": "✖",
+      "provider": "claude",
+      "agent_type": "host",
+      "description": "Anthropic's coding agent",
       "working_directory": "",
       "shell": "pwsh",
-      "agent_bus_id": "agentx",
+      "agent_bus_id": "claude",
       "content": {
-        "env": "AGENT_NAME=agentx\nAGENTMUX_AGENT_ID=AgentX",
+        "env": "AGENT_NAME=claude\nAGENTMUX_AGENT_ID=Claude",
         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
       },
       "skills": [
@@ -24,15 +26,17 @@
       ]
     },
     {
-      "id": "agenty",
-      "name": "AgentY",
-      "icon": "🟡",
-      "description": "Secondary coding agent",
+      "id": "codex",
+      "name": "Codex",
+      "icon": "✦",
+      "provider": "codex",
+      "agent_type": "host",
+      "description": "OpenAI's coding agent",
       "working_directory": "",
       "shell": "pwsh",
-      "agent_bus_id": "agenty",
+      "agent_bus_id": "codex",
       "content": {
-        "env": "AGENT_NAME=agenty\nAGENTMUX_AGENT_ID=AgentY",
+        "env": "AGENT_NAME=codex\nAGENTMUX_AGENT_ID=Codex",
         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
       },
       "skills": [
@@ -46,15 +50,17 @@
       ]
     },
     {
-      "id": "agentz",
-      "name": "AgentZ",
-      "icon": "🔵",
-      "description": "Tertiary coding agent",
+      "id": "gemini",
+      "name": "Gemini",
+      "icon": "⚡",
+      "provider": "gemini",
+      "agent_type": "host",
+      "description": "Google's coding agent",
       "working_directory": "",
       "shell": "pwsh",
-      "agent_bus_id": "agentz",
+      "agent_bus_id": "gemini",
       "content": {
-        "env": "AGENT_NAME=agentz\nAGENTMUX_AGENT_ID=AgentZ",
+        "env": "AGENT_NAME=gemini\nAGENTMUX_AGENT_ID=Gemini",
         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
       },
       "skills": [
@@ -68,16 +74,17 @@
       ]
     },
     {
-      "id": "agentk",
-      "name": "AgentK",
-      "icon": "🌙",
-      "description": "Kimi Code CLI agent",
-      "working_directory": "",
-      "shell": "pwsh",
-      "agent_bus_id": "agentk",
+      "id": "kimi",
+      "name": "Kimi",
+      "icon": "◈",
       "provider": "kimi",
+      "agent_type": "host",
+      "description": "Moonshot's 262k-context agent",
+      "working_directory": "",
+      "shell": "pwsh",
+      "agent_bus_id": "kimi",
       "content": {
-        "env": "AGENT_NAME=agentk\nAGENTMUX_AGENT_ID=AgentK",
+        "env": "AGENT_NAME=kimi\nAGENTMUX_AGENT_ID=Kimi",
         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
       },
       "skills": [
@@ -91,17 +98,18 @@
       ]
     },
     {
-      "id": "agent1",
-      "name": "Agent1",
-      "icon": "🟢",
-      "description": "Sandboxed coding agent",
-      "working_directory": "/workspace",
-      "shell": "bash",
-      "agent_bus_id": "agent1",
-      "restart_on_crash": true,
+      "id": "pi",
+      "name": "Pi",
+      "icon": "π",
+      "provider": "pi",
+      "agent_type": "host",
+      "description": "Plandex's multi-provider agent",
+      "working_directory": "",
+      "shell": "pwsh",
+      "agent_bus_id": "pi",
       "content": {
-        "env": "AGENT_NAME=agent1\nAGENTMUX_AGENT_ID=Agent1",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\n\n### 2. Dev Tools\nInstall if missing:\n```bash\nnpm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli\n```\n\n### 3. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+        "env": "AGENT_NAME=pi\nAGENTMUX_AGENT_ID=Pi",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
       },
       "skills": [
         {
@@ -109,22 +117,23 @@
           "trigger": "startup",
           "skill_type": "prompt",
           "description": "Re-run tool verification checks and report status table",
-          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
         }
       ]
     },
     {
-      "id": "agent2",
-      "name": "Agent2",
-      "icon": "🟠",
-      "description": "Sandboxed coding agent",
-      "working_directory": "/workspace",
-      "shell": "bash",
-      "agent_bus_id": "agent2",
-      "restart_on_crash": true,
+      "id": "openclaw",
+      "name": "OpenClaw",
+      "icon": "◎",
+      "provider": "openclaw",
+      "agent_type": "host",
+      "description": "ACP orchestration platform",
+      "working_directory": "",
+      "shell": "pwsh",
+      "agent_bus_id": "openclaw",
       "content": {
-        "env": "AGENT_NAME=agent2\nAGENTMUX_AGENT_ID=Agent2",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\n\n### 2. Dev Tools\nInstall if missing:\n```bash\nnpm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli\n```\n\n### 3. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+        "env": "AGENT_NAME=openclaw\nAGENTMUX_AGENT_ID=OpenClaw",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
       },
       "skills": [
         {
@@ -132,30 +141,7 @@
           "trigger": "startup",
           "skill_type": "prompt",
           "description": "Re-run tool verification checks and report status table",
-          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
-        }
-      ]
-    },
-    {
-      "id": "agent3",
-      "name": "Agent3",
-      "icon": "🟣",
-      "description": "Sandboxed coding agent",
-      "working_directory": "/workspace",
-      "shell": "bash",
-      "agent_bus_id": "agent3",
-      "restart_on_crash": true,
-      "content": {
-        "env": "AGENT_NAME=agent3\nAGENTMUX_AGENT_ID=Agent3",
-        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\n\n### 2. Dev Tools\nInstall if missing:\n```bash\nnpm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli\n```\n\n### 3. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
-      },
-      "skills": [
-        {
-          "name": "Startup Verification",
-          "trigger": "startup",
-          "skill_type": "prompt",
-          "description": "Re-run tool verification checks and report status table",
-          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
         }
       ]
     }

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -362,8 +362,13 @@ export class AgentViewModel implements ViewModel {
             envVars["CLAUDE_CODE_EXIT_AFTER_STOP_DELAY"] = "30000";
         }
 
-        // Build config files to write via backend RPC
-        const configFiles = buildConfigFiles(contentMap, skills, agent);
+        // Build config files to write via backend RPC. Pass the
+        // resolved instance name so the injected agentmux MCP server
+        // advertises the same identity the shell / git / pane title
+        // already use — otherwise inter-agent messaging routes on
+        // the definition name while everything else advertises the
+        // instance name (caught by codex on PR #504).
+        const configFiles = buildConfigFiles(contentMap, skills, agent, instanceName);
 
         const oref = WOS.makeORef("block", this.blockId);
         const blockId = this.blockId;
@@ -497,15 +502,20 @@ function resolveCliDir(version: string, providerId: string): string {
 function buildConfigFiles(
     contentMap: Record<string, string>,
     skills: ForgeSkill[] = [],
-    agent?: ForgeAgent
+    agent?: ForgeAgent,
+    instanceName?: string,
 ): AgentConfigFile[] {
     const files: AgentConfigFile[] = [];
 
-    // Template variables for {{}} substitution
+    // Template variables for {{}} substitution. `AGENT` / `AGENT_DISPLAY`
+    // prefer the resolved instance name so templates that reference
+    // the agent identity (CLAUDE.md, skills) match what the shell
+    // and MCP advertise for this run.
     const templateVars: Record<string, string> = {};
     if (agent) {
-        templateVars["AGENT"] = agent.name;
-        templateVars["AGENT_DISPLAY"] = agent.name;
+        const displayName = instanceName || agent.name;
+        templateVars["AGENT"] = displayName;
+        templateVars["AGENT_DISPLAY"] = displayName;
         templateVars["AGENT_SLUG"] = agent.slug || agent.name.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
         templateVars["WORKING_DIR"] = agent.working_directory || "";
         templateVars["AGENT_ID"] = agent.id;
@@ -555,7 +565,7 @@ function buildConfigFiles(
     }
 
     // Build .mcp.json: auto-inject AgentMux MCP + merge user-provided config
-    const mcpConfig = buildMcpConfig(contentMap["mcp"], agent);
+    const mcpConfig = buildMcpConfig(contentMap["mcp"], agent, instanceName);
     if (mcpConfig) {
         files.push({ path: ".mcp.json", content: mcpConfig });
     }
@@ -576,8 +586,16 @@ function expandTemplate(content: string, vars: Record<string, string>): string {
  * Build .mcp.json content with auto-injected AgentMux MCP server.
  * Merges with user-provided MCP config if present.
  */
-function buildMcpConfig(userMcpContent: string | undefined, agent?: ForgeAgent): string | null {
-    // Auto-inject AgentMux MCP server for inter-agent messaging
+function buildMcpConfig(
+    userMcpContent: string | undefined,
+    agent?: ForgeAgent,
+    instanceName?: string,
+): string | null {
+    // Auto-inject AgentMux MCP server for inter-agent messaging.
+    // `AGENTMUX_AGENT_ID` must match the shell's / pane title's
+    // `AGENTMUX_AGENT_ID` (the resolved instance name), otherwise
+    // inter-agent routing targets the definition name while
+    // everything else advertises the instance name.
     const agentMuxServer: Record<string, any> = {
         type: "stdio",
         command: "agentmux-mcp",
@@ -585,7 +603,7 @@ function buildMcpConfig(userMcpContent: string | undefined, agent?: ForgeAgent):
         env: {} as Record<string, string>,
     };
     if (agent) {
-        agentMuxServer.env["AGENTMUX_AGENT_ID"] = agent.name;
+        agentMuxServer.env["AGENTMUX_AGENT_ID"] = instanceName || agent.name;
         if (agent.agent_bus_id) {
             agentMuxServer.env["AGENTMUX_AGENT_BUS_ID"] = agent.agent_bus_id;
         }

--- a/frontend/app/view/agent/defaults/instance-slug.ts
+++ b/frontend/app/view/agent/defaults/instance-slug.ts
@@ -25,20 +25,27 @@ export function slugifyInstanceName(name: string): string {
         .replace(/[^a-z0-9-_]/g, "");
 }
 
-/** Format a Date as `YYYYMMDD-HHMMSS` in the caller's local time. */
+/**
+ * Format a Date as `YYYYMMDD-HHMMSS-mmm` in the caller's local time.
+ * The millisecond suffix makes the stamp unique across realistic
+ * concurrent launches — two clicks in the same millisecond are not
+ * a failure mode we optimise for. Codex flagged sub-second collisions
+ * on PR #504 (https://github.com/agentmuxai/agentmux/pull/504); this
+ * form closes that gap without reaching for UUIDs.
+ */
 export function formatLocalStamp(d: Date): string {
-    const pad = (n: number) => String(n).padStart(2, "0");
+    const pad = (n: number, w = 2) => String(n).padStart(w, "0");
     return (
         `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}` +
-        `-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`
+        `-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}` +
+        `-${pad(d.getMilliseconds(), 3)}`
     );
 }
 
 /**
  * Build the per-instance slug for a given name at the given time.
- * `<slug>-<stamp>` — stable, filesystem-safe, and unique at 1s
- * granularity. Sub-second collisions are resolved by the backend
- * with a `-1`, `-2`, … suffix.
+ * `<slug>-<stamp>` — stable, filesystem-safe, and unique at 1ms
+ * granularity.
  */
 export function buildInstanceSlug(name: string, at: Date = new Date()): string {
     return `${slugifyInstanceName(name)}-${formatLocalStamp(at)}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.333",
+  "version": "0.33.334",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.333",
+      "version": "0.33.334",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.334",
+  "version": "0.33.335",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.334",
+      "version": "0.33.335",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.333",
+  "version": "0.33.334",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.334",
+  "version": "0.33.335",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/gen-seed.js
+++ b/scripts/gen-seed.js
@@ -1,5 +1,19 @@
-// Generates forge-seed.json with proper startup content
-const HOST_STARTUP = `## Verification Round
+// Generates forge-seed.json — one seeded definition per CLI in the
+// catalog (frontend/app/view/agent/defaults/cli-catalog.ts). Each row
+// is a template; a running instance is created when the user picks a
+// card + supplies a name via AgentLaunchModal.
+//
+// See docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md §5.
+//
+// Manifest version 5 (2026-04-23): replaces the AgentX/Y/Z + Agent1/2/3
+// layout with per-CLI definitions. The re-seed engine in
+// `agentmux-srv/src/backend/forge_seed.rs` deletes old seeded rows
+// and inserts the new set on version bump — user customisations to
+// the old rows are lost. This is intentional: the old layout
+// conflated 6 agents into 3 providers, which no longer matches the
+// "one card per CLI" model the picker now shows.
+
+const STARTUP = `## Verification Round
 
 Run each check below. Fix failures before proceeding. Report results in a table.
 
@@ -41,77 +55,108 @@ Check AgentBus connectivity — list available peer agents.
 If all pass: "Verification complete — ready to work."
 If any FAIL: attempt fix. If unfixable, report and ask.`;
 
-const CONTAINER_STARTUP = `## Verification Round
-
-Run each check below. Fix failures before proceeding. Report results in a table.
-
-### 1. Identity
-\`\`\`bash
-gh auth status
-git config user.name && git config user.email
-\`\`\`
-
-### 2. Dev Tools
-Install if missing:
-\`\`\`bash
-npm list -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/file-tools @a5af/reagent-cli
-\`\`\`
-
-### 3. MCP Servers
-Check AgentBus connectivity — list available peer agents.
-
-### Report
-
-| Check | Status | Details |
-|-------|--------|--------|
-| GitHub | OK/FAIL | username |
-| Git Identity | OK/FAIL | name, email |
-| Dev Tools | OK/FAIL | count installed |
-| MCP AgentBus | OK/FAIL | peer count |
-
-If all pass: "Verification complete — ready to work."
-If any FAIL: attempt fix. If unfixable, report and ask.`;
-
 const SKILL = {
     name: "Startup Verification",
     trigger: "startup",
     skill_type: "prompt",
     description: "Re-run tool verification checks and report status table",
-    content: "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+    content:
+        "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible.",
 };
 
-const CONTAINER_SKILL = { ...SKILL, content: SKILL.content.replace(", secrets access,", ",") };
+// Catalog-aligned seed. Keep in lockstep with
+// `frontend/app/view/agent/defaults/cli-catalog.ts`.
+// `working_directory` intentionally empty: `agent-model.ts` resolves
+// it at launch-time (portable vs installed build) and when a user
+// launches via AgentLaunchModal it's overridden with a fresh
+// `<slug>-<YYYYMMDD-HHMMSS>` path.
+const CLI_DEFS = [
+    {
+        id: "claude",
+        name: "Claude",
+        provider: "claude",
+        icon: "\u2716",                  // ✖
+        description: "Anthropic's coding agent",
+        bus: "claude",
+    },
+    {
+        id: "codex",
+        name: "Codex",
+        provider: "codex",
+        icon: "\u2726",                  // ✦
+        description: "OpenAI's coding agent",
+        bus: "codex",
+    },
+    {
+        id: "gemini",
+        name: "Gemini",
+        provider: "gemini",
+        icon: "\u26A1",                  // ⚡
+        description: "Google's coding agent",
+        bus: "gemini",
+    },
+    {
+        id: "kimi",
+        name: "Kimi",
+        provider: "kimi",
+        icon: "\u25C8",                  // ◈
+        description: "Moonshot's 262k-context agent",
+        bus: "kimi",
+    },
+    {
+        id: "pi",
+        name: "Pi",
+        provider: "pi",
+        icon: "\u03C0",                  // π
+        description: "Plandex's multi-provider agent",
+        bus: "pi",
+    },
+    {
+        id: "openclaw",
+        name: "OpenClaw",
+        provider: "openclaw",
+        icon: "\u25CE",                  // ◎
+        description: "ACP orchestration platform",
+        bus: "openclaw",
+    },
+    // NOTE: GitHub Copilot CLI is documented in the catalog but not
+    // registered in frontend PROVIDERS yet — launching it would fail.
+    // Re-add once `providers/index.ts` has a copilot entry with
+    // launchArgs, controllerType, authCheckCommand, etc.
+];
 
 const manifest = {
-    version: 4,
-    agents: [
-        // working_directory intentionally empty for the default host agents so
-        // agent-model.ts resolves it at launch-time via `agentmuxHome()`. That
-        // picks up the portable data dir on portable builds and `~/.agentmux`
-        // on installed builds. Hardcoding `~/.agentmux/agents/<slug>` here
-        // would defeat portable isolation (PR #475) and leave the literal `~`
-        // in the persisted value, which the backend path-canonicaliser rejects.
-        { id: "agentx", name: "AgentX", icon: "\ud83d\udd34", description: "Primary coding agent", working_directory: "", shell: "pwsh", agent_bus_id: "agentx", content: { env: "AGENT_NAME=agentx\nAGENTMUX_AGENT_ID=AgentX", startup: HOST_STARTUP }, skills: [SKILL] },
-        { id: "agenty", name: "AgentY", icon: "\ud83d\udfe1", description: "Secondary coding agent", working_directory: "", shell: "pwsh", agent_bus_id: "agenty", content: { env: "AGENT_NAME=agenty\nAGENTMUX_AGENT_ID=AgentY", startup: HOST_STARTUP }, skills: [SKILL] },
-        { id: "agentz", name: "AgentZ", icon: "\ud83d\udd35", description: "Tertiary coding agent", working_directory: "", shell: "pwsh", agent_bus_id: "agentz", content: { env: "AGENT_NAME=agentz\nAGENTMUX_AGENT_ID=AgentZ", startup: HOST_STARTUP }, skills: [SKILL] },
-        { id: "agentk", name: "AgentK", icon: "\ud83c\udf19", description: "Kimi Code CLI agent", working_directory: "", shell: "pwsh", agent_bus_id: "agentk", provider: "kimi", content: { env: "AGENT_NAME=agentk\nAGENTMUX_AGENT_ID=AgentK", startup: HOST_STARTUP }, skills: [SKILL] },
-        { id: "agent1", name: "Agent1", icon: "\ud83d\udfe2", description: "Sandboxed coding agent", working_directory: "/workspace", shell: "bash", agent_bus_id: "agent1", restart_on_crash: true, content: { env: "AGENT_NAME=agent1\nAGENTMUX_AGENT_ID=Agent1", startup: CONTAINER_STARTUP }, skills: [CONTAINER_SKILL] },
-        { id: "agent2", name: "Agent2", icon: "\ud83d\udfe0", description: "Sandboxed coding agent", working_directory: "/workspace", shell: "bash", agent_bus_id: "agent2", restart_on_crash: true, content: { env: "AGENT_NAME=agent2\nAGENTMUX_AGENT_ID=Agent2", startup: CONTAINER_STARTUP }, skills: [CONTAINER_SKILL] },
-        { id: "agent3", name: "Agent3", icon: "\ud83d\udfe3", description: "Sandboxed coding agent", working_directory: "/workspace", shell: "bash", agent_bus_id: "agent3", restart_on_crash: true, content: { env: "AGENT_NAME=agent3\nAGENTMUX_AGENT_ID=Agent3", startup: CONTAINER_STARTUP }, skills: [CONTAINER_SKILL] },
-    ]
+    version: 5,
+    agents: CLI_DEFS.map((d) => ({
+        id: d.id,
+        name: d.name,
+        icon: d.icon,
+        provider: d.provider,
+        agent_type: "host",
+        description: d.description,
+        working_directory: "",
+        shell: "pwsh",
+        agent_bus_id: d.bus,
+        content: {
+            env: `AGENT_NAME=${d.id}\nAGENTMUX_AGENT_ID=${d.name}`,
+            startup: STARTUP,
+        },
+        skills: [SKILL],
+    })),
 };
 
-// Write the manifest to `agentmux-srv/forge-seed.json` directly rather
-// than emitting it on stdout. Previously this script did
+// Write the manifest to `agentmux-srv/forge-seed.json` directly
+// rather than emitting it on stdout. Previously this script did
 // `process.stdout.write(...)` and callers redirected via
-// `node gen-seed.js > forge-seed.json`. On Windows PowerShell, stdout
-// redirection transcodes the Node UTF-8 output through the console code
-// page (cp437 / cp1252), corrupting the emoji icons (🔴 → "≡ƒö┤") and
-// em-dashes (— → "ΓÇö"). Git Bash preserves bytes but there was no way
-// to enforce the caller's shell. Writing directly sidesteps the issue.
+// `node gen-seed.js > forge-seed.json`. On Windows PowerShell,
+// stdout redirection transcodes the Node UTF-8 output through the
+// console code page (cp437 / cp1252), corrupting the emoji icons
+// (🔴 → "≡ƒö┤") and em-dashes (— → "ΓÇö"). Git Bash preserves bytes
+// but there was no way to enforce the caller's shell. Writing
+// directly sidesteps the issue.
 //
-// Kept the stdout emit too for callers that pipe elsewhere (e.g. diff
-// tools); gated behind `--stdout`.
+// Kept the stdout emit too for callers that pipe elsewhere (e.g.
+// diff tools); gated behind `--stdout`.
 import { writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";


### PR DESCRIPTION
## Summary
- Bumps forge-seed manifest \`version\` 4 → 5
- Replaces the legacy AgentX/Y/Z + Agent1/2/3 + AgentK layout with six provider-aligned definitions: \`claude\`, \`codex\`, \`gemini\`, \`kimi\`, \`pi\`, \`openclaw\`
- Each new row has an explicit \`provider\` field matching its card in the CLI catalog from discussion #493

## Context
Follow-up to PR #504. With the new definition-modal flow, each card *is* one CLI — so shipping 3 rows for claude + 3 for containers no longer fits. This seed migration makes the DB match the UI model.

The re-seed engine in \`agentmux-srv/src/backend/forge_seed.rs\` already handles the delta: on next startup it finds the old IDs missing from the manifest and the new IDs missing from the DB, deletes the former (all were \`is_seeded=1\`), and inserts the latter. User-created rows are untouched.

### Provider coverage

| provider | displayName | icon |
|----------|-------------|------|
| claude   | Claude Code | ✖ |
| codex    | Codex CLI   | ✦ |
| gemini   | Gemini CLI  | ⚡ |
| kimi     | Kimi Code   | ◈ |
| pi       | Pi          | π |
| openclaw | OpenClaw    | ◎ |

**Copilot** is in the frontend catalog (from discussion #493 research) but not yet in \`providers/index.ts\`. Launching it would crash, so the seed drops it. Follow-up PR will add the provider binding (cliCommand, launchArgs, authCheckCommand, controllerType) and restore the Copilot row.

### User impact

- Any existing panes running instances of AgentX/Y/Z/K/1/2/3 keep their process alive but the forge row is gone. Closing and re-launching picks from the new card set.
- Non-seeded rows (user-created) are preserved.
- Portable builds copy forge-seed.json into the embedded binary, so the migration runs on the next portable launch.

## Test plan
- [ ] Fresh install (\`~/.agentmux\` empty): agent picker shows 6 cards, one per provider
- [ ] Existing install with old seed: on next launch, old rows removed, 6 new rows inserted; picker reflects
- [ ] Each card can be clicked, modal opens, launch succeeds (all 6 providers registered in \`providers/index.ts\`)
- [ ] Forge pane shows the 6 new definitions with correct provider/icon/description
- [ ] User-customised rows from before are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)