### PR TITLE
feat(providers): add GitHub Copilot CLI + restore to seed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.335"
+version = "0.33.336"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.335"
+version = "0.33.336"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.335"
+version = "0.33.336"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.335"
+version = "0.33.336"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.336"
+version = "0.33.337"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.336"
+version = "0.33.337"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.336"
+version = "0.33.337"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.336"
+version = "0.33.337"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.335"
+version = "0.33.336"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.336"
+version = "0.33.337"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.335"
+version = "0.33.336"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.336"
+version = "0.33.337"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.335"
+version = "0.33.336"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.336"
+version = "0.33.337"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.335"
+version = "0.33.336"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.336"
+version = "0.33.337"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/forge-seed.json
+++ b/agentmux-srv/forge-seed.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "agents": [
     {
       "id": "claude",
@@ -133,6 +133,30 @@
       "agent_bus_id": "openclaw",
       "content": {
         "env": "AGENT_NAME=openclaw\nAGENTMUX_AGENT_ID=OpenClaw",
+        "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
+      },
+      "skills": [
+        {
+          "name": "Startup Verification",
+          "trigger": "startup",
+          "skill_type": "prompt",
+          "description": "Re-run tool verification checks and report status table",
+          "content": "Run the verification round from your startup instructions. Check identity (gh, git), dev-tools (@a5af/* packages — install if missing), secrets access, and MCP servers. Report a status table with OK/FAIL for each check. Fix any failures automatically if possible."
+        }
+      ]
+    },
+    {
+      "id": "copilot",
+      "name": "Copilot",
+      "icon": "⛶",
+      "provider": "copilot",
+      "agent_type": "host",
+      "description": "Microsoft's coding agent",
+      "working_directory": "",
+      "shell": "pwsh",
+      "agent_bus_id": "copilot",
+      "content": {
+        "env": "AGENT_NAME=copilot\nAGENTMUX_AGENT_ID=Copilot",
         "startup": "## Verification Round\n\nRun each check below. Fix failures before proceeding. Report results in a table.\n\n### 1. Identity\n```bash\ngh auth status\ngit config user.name && git config user.email\n```\nIf `gh auth status` fails, run `gh auth login`.\n\n### 2. Dev Tools\nInstall if missing, then verify:\n```bash\nnpm list -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health 2>/dev/null | grep '@a5af/' || npm install -g @a5af/secrets @a5af/deploy-cli @a5af/database-cli @a5af/api-testing @a5af/file-tools @a5af/e2e-cli @a5af/reagent-cli @a5af/workspace-health\n```\nVerify key tools:\n```bash\nsecrets --version && deploy --version && reagent --version\n```\n\n### 3. Secrets Access\n```bash\nsecrets health services/infra services/prod\n```\n\n### 4. MCP Servers\nCheck AgentBus connectivity — list available peer agents.\n\n### Report\n\n| Check | Status | Details |\n|-------|--------|--------|\n| GitHub | OK/FAIL | username |\n| Git Identity | OK/FAIL | name, email |\n| Dev Tools | OK/FAIL | count installed |\n| Secrets | OK/FAIL | accessible secrets |\n| MCP AgentBus | OK/FAIL | peer count |\n\nIf all pass: \"Verification complete — ready to work.\"\nIf any FAIL: attempt fix. If unfixable, report and ask."
       },
       "skills": [

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -245,6 +245,30 @@ static PI: ProviderConfig = ProviderConfig {
     docs_url: "https://github.com/badlogic/pi-mono",
 };
 
+// GitHub Copilot CLI — Microsoft's coding agent. Runs in ACP mode via
+// `--acp` so the existing ACP controller drives it. Non-interactive
+// `-p`/`--prompt` doesn't accept stdin prompts (github/copilot-cli#96,
+// #1046), hence ACP.
+static COPILOT: ProviderConfig = ProviderConfig {
+    id: "copilot",
+    display_name: "GitHub Copilot CLI",
+    cli_command: "copilot",
+    controller_type: ControllerType::Acp,
+    launch_args: &["--acp"],
+    persistent_launch_args: None,
+    resume_flag: None,
+    session_id_field: "sessionId",
+    styled_output_format: "acp",
+    auth_config_dir_env_var: "COPILOT_HOME",
+    auth_dir_name: "copilot",
+    auth_extra_env: &[],
+    unset_env: &[],
+    npm_package: "@github/copilot",
+    pinned_version: "latest",
+    icon: "github",
+    docs_url: "https://docs.github.com/copilot/concepts/agents/about-copilot-cli",
+};
+
 // ─── Static registry ─────────────────────────────────────────────────────────
 
 static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = LazyLock::new(|| {
@@ -255,6 +279,7 @@ static REGISTRY: LazyLock<HashMap<&'static str, &'static ProviderConfig>> = Lazy
     m.insert(KIMI.id, &KIMI);
     m.insert(OPENCLAW.id, &OPENCLAW);
     m.insert(PI.id, &PI);
+    m.insert(COPILOT.id, &COPILOT);
     m
 });
 
@@ -269,6 +294,9 @@ static ALIASES: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(||
     m.insert("kimi_code", "kimi");
     m.insert("openclaw-cli", "openclaw");
     m.insert("open-claw", "openclaw");
+    m.insert("copilot-cli", "copilot");
+    m.insert("github-copilot", "copilot");
+    m.insert("copilot_cli", "copilot");
     m
 });
 
@@ -306,7 +334,7 @@ pub fn get_provider(id: &str) -> Option<&'static ProviderConfig> {
 /// Return an iterator over all registered providers in insertion order.
 pub fn get_provider_list() -> impl Iterator<Item = &'static ProviderConfig> {
     // Stable canonical order matches the TypeScript PROVIDERS object order.
-    static ORDER: &[&str] = &["claude", "codex", "gemini", "kimi", "openclaw", "pi"];
+    static ORDER: &[&str] = &["claude", "codex", "gemini", "kimi", "openclaw", "pi", "copilot"];
     ORDER.iter().filter_map(|id| REGISTRY.get(*id).copied())
 }
 

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -175,6 +175,38 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "session_id",
         controllerType: "subprocess",
     },
+    // GitHub Copilot CLI — Microsoft's coding agent.
+    // Runs in ACP mode (`--acp` flag) so the existing ACP controller
+    // can drive it the same way it drives Pi and OpenClaw. The CLI's
+    // `-p`/`--prompt` non-interactive mode doesn't accept stdin for
+    // the prompt yet (github/copilot-cli#96, #1046), so ACP is the
+    // only path that composes with our existing subprocess+stdin
+    // controller model. Documentation and CLI reference come from
+    // discussion #493 (research-cli-context-files-2026-04-22).
+    copilot: {
+        id: "copilot",
+        displayName: "GitHub Copilot CLI",
+        cliCommand: "copilot",
+        defaultArgs: [],
+        styledArgs: ["--acp"],
+        outputFormat: "acp",
+        styledOutputFormat: "acp",
+        authType: "oauth",
+        authCheckCommand: ["auth", "status"],
+        authLoginCommand: ["auth", "login"],
+        npmPackage: "@github/copilot",
+        pinnedVersion: "latest",
+        docsUrl: "https://docs.github.com/copilot/concepts/agents/about-copilot-cli",
+        windowsInstallCommand: "npm install -g @github/copilot",
+        unixInstallCommand: "npm install -g @github/copilot",
+        icon: "github",
+        authConfigDirEnvVar: "COPILOT_HOME",
+        authDirName: "copilot",
+        launchArgs: ["--acp"],
+        resumeFlag: null,
+        sessionIdField: "sessionId",
+        controllerType: "acp",
+    },
     // Pi — the lightweight coding agent that powers OpenClaw.
     // Standalone CLI, no gateway required. Pure coding agent with read/write/bash/edit tools.
     // Ideal when users want a fast, self-contained coding agent without the full OpenClaw stack.
@@ -214,6 +246,9 @@ const PROVIDER_ALIASES: Record<string, string> = {
     "kimi_code": "kimi",
     "openclaw-cli": "openclaw",
     "open-claw": "openclaw",
+    "copilot-cli": "copilot",
+    "github-copilot": "copilot",
+    "copilot_cli": "copilot",
 };
 
 export function resolveProviderAlias(id: string): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.336",
+  "version": "0.33.337",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.336",
+      "version": "0.33.337",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.335",
+  "version": "0.33.336",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.335",
+      "version": "0.33.336",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.335",
+  "version": "0.33.336",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.336",
+  "version": "0.33.337",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/gen-seed.js
+++ b/scripts/gen-seed.js
@@ -119,14 +119,18 @@ const CLI_DEFS = [
         description: "ACP orchestration platform",
         bus: "openclaw",
     },
-    // NOTE: GitHub Copilot CLI is documented in the catalog but not
-    // registered in frontend PROVIDERS yet — launching it would fail.
-    // Re-add once `providers/index.ts` has a copilot entry with
-    // launchArgs, controllerType, authCheckCommand, etc.
+    {
+        id: "copilot",
+        name: "Copilot",
+        provider: "copilot",
+        icon: "\u26F6",                  // ⛶
+        description: "Microsoft's coding agent",
+        bus: "copilot",
+    },
 ];
 
 const manifest = {
-    version: 5,
+    version: 6,
     agents: CLI_DEFS.map((d) => ({
         id: d.id,
         name: d.name,


### PR DESCRIPTION
## Summary
- Registers the \`copilot\` provider in \`frontend/app/view/agent/providers/index.ts\`
- Re-adds the Copilot definition to \`forge-seed.json\` (manifest v5 → v6); all 7 CLI catalog entries now have backing definitions
- Provider uses ACP mode (\`--acp\` flag) so the existing ACP controller (already serving Pi + OpenClaw) drives it — same protocol surface, same output parsing

## Context
Follow-up to PR #505 (seed migration), which intentionally dropped Copilot because no provider binding existed yet. Now it's back.

### Why ACP, not \`-p\`
GitHub Copilot CLI's non-interactive \`-p\`/\`--prompt\` mode doesn't accept prompts via stdin — see [github/copilot-cli#96](https://github.com/github/copilot-cli/issues/96) and [#1046](https://github.com/github/copilot-cli/issues/1046). Our subprocess controller writes the user message to the CLI's stdin for every turn, so that path doesn't compose. \`--acp\` runs Copilot as an Agent Client Protocol JSON-RPC server over stdio — the exact contract our ACP controller already understands for Pi and OpenClaw.

### Runtime details
| Field | Value |
|-------|-------|
| CLI command | \`copilot\` |
| Install | \`npm install -g @github/copilot\` |
| Controller | \`acp\` |
| Launch args | \`--acp\` |
| Auth check | \`copilot auth status\` |
| Auth login | \`copilot auth login\` |
| Config dir env | \`COPILOT_HOME\` |
| Docs | https://docs.github.com/copilot/concepts/agents/about-copilot-cli |

Aliases added: \`copilot-cli\`, \`github-copilot\`, \`copilot_cli\`.

## Test plan
- [ ] Agent picker shows 7 cards (claude, codex, gemini, kimi, pi, openclaw, copilot)
- [ ] Copilot card opens the Launch modal on click
- [ ] With Copilot CLI installed and authed, Launch succeeds and the ACP controller connects
- [ ] With Copilot CLI not installed, the existing Node.js / CLI detection shows an install prompt
- [ ] Type check clean

## Follow-up
- Validate against the live Copilot CLI end-to-end (the ACP protocol details differ between implementations; if Copilot's ACP surface diverges from the Zed/Pi spec we already handle, add copilot-specific hooks in the ACP controller)
- Add a Copilot-specific icon glyph to replace the generic \`github\` key once the icon system has one

🤖 Generated with [Claude Code](https://claude.com/claude-code)