### PR TITLE
feat(design-system): Phase 1 — additive token families + mixin library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.338"
+version = "0.33.339"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.338"
+version = "0.33.339"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.338"
+version = "0.33.339"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.338"
+version = "0.33.339"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.338"
+version = "0.33.339"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.338"
+version = "0.33.339"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.338"
+version = "0.33.339"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.338"
+version = "0.33.339"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/mixins.scss
+++ b/frontend/app/mixins.scss
@@ -64,3 +64,79 @@
         }
     }
 }
+
+// ─── Design-System Phase 1 — layout + accessibility helpers ──────────────
+// Introduced by SPEC_DESIGN_SYSTEM_2026_04_23. Keep each mixin one-purpose
+// and grep-friendly; complex multi-property bundles belong in component
+// SCSS, not here. See the spec for the rationale behind each helper.
+
+/// Center children both axes. Shortcut for the `display: flex;
+/// align-items: center; justify-content: center;` triple that recurs
+/// hundreds of times across the frontend.
+@mixin flex-center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/// Vertical flex column with no implicit spacing. Pair with
+/// `gap: var(--space-N)` at the call site.
+@mixin flex-col {
+    display: flex;
+    flex-direction: column;
+}
+
+/// Fill the positioned ancestor. Equivalent to `position: absolute;
+/// top: 0; right: 0; bottom: 0; left: 0;`. Useful for overlays.
+@mixin abs-fill {
+    position: absolute;
+    inset: 0;
+}
+
+/// Multi-line clamp with ellipsis. `$n` is the number of lines.
+@mixin truncate-lines($n) {
+    display: -webkit-box;
+    -webkit-line-clamp: $n;
+    -webkit-box-orient: vertical;
+    line-clamp: $n;
+    overflow: hidden;
+}
+
+/// Accessible focus ring. Use on `&:focus-visible` for interactive
+/// elements; theme-aware via `--shadow-focus-ring`.
+@mixin focus-ring {
+    outline: none;
+    box-shadow: var(--shadow-focus-ring);
+}
+
+/// Media queries keyed off a minimum / maximum width. Pass a token
+/// value or literal — we don't ship canonical breakpoints yet since
+/// the app has effectively none; this is infrastructure for when we do.
+@mixin media-up($w) {
+    @media (min-width: #{$w}) { @content; }
+}
+
+@mixin media-down($w) {
+    @media (max-width: calc(#{$w} - 1px)) { @content; }
+}
+
+/// Respect user's `prefers-reduced-motion` setting. Wrap any non-
+/// essential animation in this so motion-sensitive users opt out.
+@mixin respect-reduced-motion {
+    @media (prefers-reduced-motion: reduce) {
+        @content;
+    }
+}
+
+/// Visually hidden but still read by assistive tech. Standard pattern.
+@mixin sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -161,4 +161,95 @@
     --button-red-outlined-color: #ff3c3c;
     --button-yellow-bg: #c4a000;
     --button-yellow-hover-bg: #fce94f;
+
+    // ─── Design-System Phase 1 — additive primitive tokens ───────────────
+    // Introduced by SPEC_DESIGN_SYSTEM_2026_04_23. These tokens are new
+    // names; existing semantic tokens above are unchanged. Component SCSS
+    // migrates to these families over subsequent PRs — the tokens are
+    // defined now so mixins and new components can adopt them immediately.
+
+    // Spacing scale — 4-px rhythm. Use for padding, margin, gap.
+    --space-0:   0;
+    --space-0-5: 2px;
+    --space-1:   4px;
+    --space-1-5: 6px;
+    --space-2:   8px;
+    --space-3:   12px;
+    --space-4:   16px;
+    --space-5:   20px;
+    --space-6:   24px;
+    --space-8:   32px;
+    --space-10:  40px;
+    --space-12:  48px;
+    --space-16:  64px;
+
+    // Typography scale — size + weight + leading as independent tokens
+    // plus composite role tokens for common text patterns.
+    --text-xs:   11px;
+    --text-sm:   12px;
+    --text-base: 13px;
+    --text-md:   14px;
+    --text-lg:   16px;
+    --text-xl:   18px;
+    --text-2xl:  22px;
+    --text-3xl:  28px;
+
+    --font-weight-normal: 400;
+    --font-weight-medium: 500;
+    --font-weight-bold:   700;
+
+    --leading-tight:  1.2;
+    --leading-normal: 1.45;
+    --leading-loose:  1.65;
+
+    --font-sans: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --font-mono: "Hack", "JetBrains Mono", "Fira Code", "Consolas", monospace;
+
+    // Composite text roles (use when a component just wants "body text"
+    // without picking a specific size/weight/leading combo).
+    --text-body:    var(--font-weight-normal) var(--text-md)   / var(--leading-normal) var(--font-sans);
+    --text-caption: var(--font-weight-normal) var(--text-xs)   / var(--leading-tight)  var(--font-sans);
+    --text-code:    var(--font-weight-normal) var(--text-sm)   / var(--leading-normal) var(--font-mono);
+    --text-heading: var(--font-weight-bold)   var(--text-xl)   / var(--leading-tight)  var(--font-sans);
+    --text-title:   var(--font-weight-bold)   var(--text-2xl)  / var(--leading-tight)  var(--font-sans);
+
+    // Radius scale — chips → modals → pills.
+    --radius-sm:   3px;
+    --radius-md:   6px;
+    --radius-lg:   10px;
+    --radius-xl:   16px;
+    --radius-full: 9999px;
+
+    // Shadow scale. `--shadow-modal` is explicitly named so modal specs
+    // have a role token to consume without hard-coding alpha values.
+    --shadow-sm:    0 1px 2px rgba(0, 0, 0, 0.15);
+    --shadow-md:    0 4px 8px rgba(0, 0, 0, 0.25);
+    --shadow-lg:    0 12px 24px rgba(0, 0, 0, 0.35);
+    --shadow-modal: 0 24px 48px rgba(0, 0, 0, 0.45);
+    --shadow-focus-ring: 0 0 0 2px var(--accent-color);
+
+    // Motion — easing + duration pre-composed so components just
+    // write `transition: transform var(--motion-base);`.
+    --motion-fast:   100ms cubic-bezier(0.2, 1, 0.3, 1);
+    --motion-base:   160ms cubic-bezier(0.2, 1, 0.3, 1);
+    --motion-slow:   280ms cubic-bezier(0.2, 1, 0.3, 1);
+    --motion-spring: 400ms cubic-bezier(0.2, 0.9, 0.2, 1.2);
+
+    // Z-index hierarchy (canonical source — SPEC_DESIGN_SYSTEM §5.3).
+    // Naming is aspirational; existing `--zindex-*` tokens higher in
+    // this file stay valid and will be re-pointed or retired in a
+    // follow-up migration PR. New components must consume these.
+    --z-base:          0;
+    --z-layout-behind: 1;
+    --z-layout-above:  2;
+    --z-node-strip:    3;
+    --z-pane-overlay:  4;
+    --z-xterm-overlay: 5;
+    --z-drag-overlay:  1000;
+    --z-flash-error:   7000;
+    --z-typeahead:     8000;
+    --z-popover:       8500;
+    --z-modal:         9000;
+    --z-flyout-menu:   9500;
+    --z-context-menu:  10000;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.338",
+  "version": "0.33.339",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.338",
+      "version": "0.33.339",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.338",
+  "version": "0.33.339",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Introduces the non-breaking foundation from [SPEC_DESIGN_SYSTEM_2026_04_23](../blob/agenta/design-system-phase-1/docs/specs/SPEC_DESIGN_SYSTEM_2026_04_23.md) Phase 1
- **Zero existing tokens renamed, removed, or repointed** — components are untouched
- Adds new token families: spacing scale, typography scale, radius scale, shadow scale, motion, canonical z-index hierarchy
- Adds layout + accessibility mixins (flex-center, abs-fill, truncate-lines, focus-ring, media-up/down, respect-reduced-motion, sr-only)

## Rationale
Per the spec audit: the frontend has 125 design tokens but ~400 raw color values, no spacing scale, no typography scale, and 20 z-index tokens that are only partially adopted. Phase 1 defines the new names that subsequent migration PRs (Phases 3–5) consume. Landing the additions first lets both the design-system migration and the robust-modal spec proceed against a stable token surface.

### Token inventory added
| Family | Range | Examples |
|---|---|---|
| Spacing | \`--space-0\` → \`--space-16\` (4-px rhythm) | \`--space-2: 8px\` |
| Text size | \`--text-xs\` → \`--text-3xl\` | \`--text-md: 14px\` |
| Font weight | normal / medium / bold | \`--font-weight-medium: 500\` |
| Line-height | tight / normal / loose | \`--leading-normal: 1.45\` |
| Font family | sans / mono | \`--font-sans\` (Inter fallbacks) |
| Composite text roles | body / caption / code / heading / title | \`--text-body\` |
| Radius | sm → full | \`--radius-md: 6px\` |
| Shadow | sm / md / lg / modal + focus-ring | \`--shadow-modal\` |
| Motion | fast / base / slow / spring | \`--motion-base\` |
| Z-index | canonical hierarchy | \`--z-modal: 9000\` |

### Mixins added
\`flex-center\`, \`flex-col\`, \`abs-fill\`, \`truncate-lines(\$n)\`, \`focus-ring\`, \`media-up(\$w)\`, \`media-down(\$w)\`, \`respect-reduced-motion\`, \`sr-only\`.

## Sequencing
This PR unblocks:
- **SPEC_ROBUST_MODAL_SYSTEM_2026_04_23** — the new Modal primitive consumes \`--z-modal\`, \`--shadow-modal\`, \`--radius-lg\`, \`--motion-fast\` directly.
- **SPEC_DESIGN_SYSTEM_2026_04_23 Phase 3–5** — per-pane migration PRs progressively replace raw literals with tokens, shrinking \`.stylelintignore\` each round.

## Test plan
- [ ] Frontend builds with no SCSS errors (\`task build:frontend\`)
- [ ] Existing UI renders identically to pre-PR (nothing consumes the new tokens yet)
- [ ] New tokens are visible in DevTools computed-style \`:root\` declarations

## Follow-up PRs (per spec)
- **Phase 1 PR 4:** stylelint config + pre-commit hook
- **Phase 2 PR 5:** migrate hard-coded \`z-index: N\` to variables
- **Phase 3:** per-pane raw-color → semantic-token migration
- **Phase 4:** per-pane raw-spacing → spacing-scale migration
- **Phase 5:** mega-file decomposition (\`agent-view.scss\` → per-subcomponent SCSS)
- **Phase 6:** light theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)