### PR TITLE
feat(agent-pane): zoom controls + polish to definition cards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.340"
+version = "0.33.341"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.340"
+version = "0.33.341"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.340"
+version = "0.33.341"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.340"
+version = "0.33.341"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.340"
+version = "0.33.341"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.340"
+version = "0.33.341"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.340"
+version = "0.33.341"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.340"
+version = "0.33.341"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -591,9 +591,19 @@
         gap: 8px;
         flex: 1;
         overflow-y: auto;
+        // Cap list width so individual cards don't stretch to an
+        // awkwardly wide pane. The flex:1 info column inside each
+        // card expands to fill the card, which left a large gap
+        // between the title text and the action buttons on wide
+        // layouts. `max-width` + `align-self: center` keeps cards
+        // readable at narrow and wide pane widths alike.
+        max-width: 520px;
+        width: 100%;
+        align-self: center;
     }
 
     .agent-card {
+        position: relative;                // anchor for absolutely-positioned actions
         display: flex;
         align-items: center;
         gap: 12px;
@@ -641,12 +651,21 @@
             cursor: not-allowed;
         }
 
+        // Actions float in the top-left corner of the card so the
+        // icon + title + caption take the full horizontal width.
+        // Absolute positioning keeps them out of the flex row that
+        // lays out icon + info — no reserved gutter, no ellipsis
+        // truncation halfway through long titles. Hidden by default
+        // so the card reads clean; hover/focus reveals them.
         .agent-card-actions {
+            position: absolute;
+            top: 6px;
+            left: 6px;
             display: flex;
             gap: 4px;
-            margin-left: auto;
             opacity: 0;
             transition: opacity 0.15s;
+            z-index: 1;
         }
 
         &:hover .agent-card-actions,
@@ -662,7 +681,9 @@
             justify-content: center;
             padding: 0;
             border: 1px solid var(--border-color);
-            background: color-mix(in srgb, var(--main-text-color) 5%, transparent);
+            // Fully opaque background so the icon/text behind the
+            // absolutely-positioned actions doesn't bleed through.
+            background: var(--main-bg-color);
             border-radius: 4px;
             color: var(--main-text-color);
             font-size: 13px;
@@ -671,7 +692,7 @@
 
             &:hover:not(:disabled) {
                 border-color: var(--accent-color);
-                background: color-mix(in srgb, var(--accent-color) 15%, transparent);
+                background: color-mix(in srgb, var(--accent-color) 15%, var(--main-bg-color));
             }
 
             &:disabled {
@@ -730,31 +751,12 @@
         }
 
         .agent-card-caption {
-            display: flex;
-            align-items: center;
-            gap: 6px;
             font-size: 11px;
-            color: var(--secondary-text-color);
-            min-width: 0;
-        }
-
-        .agent-card-cli-name {
             font-weight: 500;
+            color: var(--secondary-text-color);
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
-        }
-
-        .agent-card-context-badge {
-            flex-shrink: 0;
-            font-family: var(--termfontfamily, monospace);
-            font-size: 10px;
-            color: color-mix(in srgb, var(--accent-color) 85%, var(--main-text-color));
-            background: color-mix(in srgb, var(--accent-color) 12%, transparent);
-            border: 1px solid color-mix(in srgb, var(--accent-color) 30%, transparent);
-            border-radius: 3px;
-            padding: 1px 5px;
-            line-height: 1.2;
         }
 
         // Inline rename row — replaces the name span while editing

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -35,7 +35,7 @@ import { BookmarksPanel } from "./components/BookmarksPanel";
 import { SessionDigestBanner } from "./components/SessionDigestBanner";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { createBlock, getApi } from "@/app/store/global";
+import { createBlock, getApi, WOS } from "@/app/store/global";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { parseAgentAccounts, loadAccounts } from "@/app/view/identity/identity-model";
 import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";
@@ -337,12 +337,77 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         },
     });
 
-    // Per-pane zoom: read term:zoom from block meta (same key as terminal panes)
+    // Per-pane zoom: read term:zoom from block meta (same key as terminal panes).
     const zoomFactor = createMemo(() => {
         const meta = block()?.meta;
         const z = meta?.["term:zoom"];
         if (z == null || typeof z !== "number" || isNaN(z)) return 1.0;
         return Math.max(0.5, Math.min(2.0, z));
+    });
+
+    // Persist a zoom change to block meta. Null when back at 1.0 so
+    // the key round-trips clean instead of persisting a default.
+    const setZoom = (next: number): void => {
+        const clamped = Math.max(0.5, Math.min(2.0, Math.round(next * 100) / 100));
+        void RpcApi.SetMetaCommand(TabRpcClient, {
+            oref: WOS.makeORef("block", model.blockId),
+            meta: { "term:zoom": clamped === 1.0 ? null : clamped },
+        });
+    };
+
+    let rootRef: HTMLDivElement | undefined;
+
+    // Ctrl+Wheel to zoom — capture phase on the root so we intercept
+    // before child scroll handlers (AgentDocumentView's scrollable
+    // region) and before CEF's native page zoom. Same pattern as
+    // `term.tsx`.
+    onMount(() => {
+        if (!rootRef) return;
+        const el = rootRef;
+        const handleCtrlWheel = (ev: WheelEvent) => {
+            if (!ev.ctrlKey) return;
+            ev.preventDefault();
+            ev.stopPropagation();
+            const STEP = 0.1;
+            const delta = ev.deltaY > 0 ? -STEP : STEP;
+            setZoom(zoomFactor() + delta);
+        };
+        el.addEventListener("wheel", handleCtrlWheel, { passive: false, capture: true });
+        onCleanup(() => el.removeEventListener("wheel", handleCtrlWheel, { capture: true }));
+    });
+
+    // Ctrl+Plus / Ctrl+Minus / Ctrl+0 for keyboard zoom. Attached to
+    // `document` in capture phase with a containment check against
+    // `rootRef`, so:
+    //   - it fires regardless of which descendant (textarea, doc view,
+    //     etc.) currently has focus;
+    //   - it only fires for this pane (multiple agent panes each
+    //     zoom independently);
+    //   - it wins over a child that might call stopPropagation on
+    //     Ctrl+±.
+    onMount(() => {
+        if (!rootRef) return;
+        const el = rootRef;
+        const handleKey = (ev: KeyboardEvent) => {
+            if (!ev.ctrlKey || ev.altKey || ev.metaKey) return;
+            if (!(ev.target instanceof Node) || !el.contains(ev.target)) return;
+            const STEP = 0.1;
+            if (ev.key === "+" || ev.key === "=") {
+                ev.preventDefault();
+                ev.stopPropagation();
+                setZoom(zoomFactor() + STEP);
+            } else if (ev.key === "-" || ev.key === "_") {
+                ev.preventDefault();
+                ev.stopPropagation();
+                setZoom(zoomFactor() - STEP);
+            } else if (ev.key === "0") {
+                ev.preventDefault();
+                ev.stopPropagation();
+                setZoom(1.0);
+            }
+        };
+        document.addEventListener("keydown", handleKey, { capture: true });
+        onCleanup(() => document.removeEventListener("keydown", handleKey, { capture: true }));
     });
 
     // Handle subagent link click — open a subagent pane
@@ -377,9 +442,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     return (
         <div
+            ref={rootRef}
             class="agent-view agent-view--presentation"
             style={{ zoom: zoomFactor() }}
             onContextMenu={handleContextMenu}
+            tabIndex={-1}
         >
             {/* Pane title + back button now live in the block frame header,
                 driven by AgentViewModel.viewName / viewIcon / endIconButtons.

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -38,7 +38,6 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
     const icon = () => props.agent.icon || catalog()?.icon || "•";
     const title = () => catalog()?.blurb || props.agent.description || props.agent.name;
     const caption = () => catalog()?.displayName || props.agent.name;
-    const contextBadge = () => catalog()?.primaryContextFile ?? "";
     const popoverText = () => catalog()?.popoverMarkdown ?? props.agent.description ?? "";
 
     const stopAndRun = (fn: () => void) => (e: MouseEvent) => {
@@ -72,14 +71,7 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
             <span class="agent-card-icon">{icon()}</span>
             <span class="agent-card-info">
                 <span class="agent-card-title">{title()}</span>
-                <span class="agent-card-caption">
-                    <span class="agent-card-cli-name">{caption()}</span>
-                    <Show when={contextBadge()}>
-                        <span class="agent-card-context-badge" title={`Reads ${contextBadge()} at startup`}>
-                            {contextBadge()}
-                        </span>
-                    </Show>
-                </span>
+                <span class="agent-card-caption">{caption()}</span>
             </span>
             <div class="agent-card-actions">
                 <Show when={popoverText()}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.340",
+  "version": "0.33.341",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.340",
+      "version": "0.33.341",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.340",
+  "version": "0.33.341",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Adds per-pane zoom to the agent pane (Ctrl + wheel / Ctrl + +/-/0), mirroring the terminal pane's \`term:zoom\` block-meta key
- Definition-card layout polish: width-capped picker, opaque action buttons in top-left, primary-context-file badge removed (redundant with the \`ⓘ\` popover)

## Context
Collected iteration work from dev-loop sessions, unrelated to the design-system or seed migration — tracking as its own small PR.

### Zoom
- \`zoomFactor\` memo in \`agent-view.tsx\` already existed but nothing wrote to \`term:zoom\`. Adds the write path:
  - **Ctrl + Wheel** — capture phase on root element, intercepts before document-view scroll + CEF page zoom
  - **Ctrl + +/=** zoom in, **Ctrl + −/_** zoom out, **Ctrl + 0** reset
  - Keyboard handler attached to \`document\` with \`contains(event.target)\` check against the root ref → fires regardless of which descendant owns focus, scoped per-pane
- Clamped 0.5× … 2.0×; 1.0× writes \`null\` so the meta key round-trips clean

### Card polish
- Picker list capped at 520 px with \`align-self: center\` (was stretching to the full pane width on wide layouts)
- Action buttons (\`ⓘ\` \`⚙\` \`🗑\`) moved to absolute top-left so icon + title + caption row takes full width; still fade in on hover/focus
- Button background flipped to opaque \`var(--main-bg-color)\` so the underlying icon/text doesn't bleed through
- Removed the context-file badge (\`CLAUDE.md\` / \`AGENTS.md\` / etc.) — noise; same info lives in the \`ⓘ\` popover already

## Test plan
- [ ] Ctrl + wheel on a definition card zooms the agent pane
- [ ] Ctrl + +/-/0 works from any focused element inside the pane
- [ ] Zoom persists across pane close/reopen (block-meta write)
- [ ] Picker cards no longer stretch to a wide pane's full width
- [ ] Action buttons (ⓘ ⚙ 🗑) appear on hover in the top-left; opaque backgrounds
- [ ] No context-file badge visible
- [ ] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)