### PR TITLE
feat(design-system): Phase 2 — migrate global z-index literals to tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.341"
+version = "0.33.342"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.341"
+version = "0.33.342"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.341"
+version = "0.33.342"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.341"
+version = "0.33.342"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.341"
+version = "0.33.342"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.341"
+version = "0.33.342"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.341"
+version = "0.33.342"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.341"
+version = "0.33.342"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/drag/drag-overlay.scss
+++ b/frontend/app/drag/drag-overlay.scss
@@ -4,7 +4,10 @@
 .cross-drag-overlay {
     position: fixed;
     inset: 0;
-    z-index: 9999;
+    // Intentionally below modals/popovers — if a drag lands while a
+    // modal is open, the modal keeps focus. Matches the z-index
+    // hierarchy in SPEC_DESIGN_SYSTEM §5.3.
+    z-index: var(--z-drag-overlay);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/frontend/app/element/flyoutmenu.scss
+++ b/frontend/app/element/flyoutmenu.scss
@@ -5,7 +5,7 @@
 
 .menu {
     position: absolute;
-    z-index: 1000;
+    z-index: var(--z-flyout-menu);
     display: flex;
     max-width: 400px;
     min-width: 125px;

--- a/frontend/app/element/popover.scss
+++ b/frontend/app/element/popover.scss
@@ -5,7 +5,7 @@
     min-width: 100px;
     min-height: 150px;
     position: absolute;
-    z-index: 1000; // TODO: put this in theme.scss
+    z-index: var(--z-popover);
     display: flex;
     padding: 2px;
     gap: 1px;

--- a/frontend/app/element/zoomindicator.scss
+++ b/frontend/app/element/zoomindicator.scss
@@ -6,7 +6,9 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    z-index: 10000;
+    // Sits in the context-menu slot so the zoom-level toast always
+    // paints above every other overlay (modals, popovers, flyouts).
+    z-index: var(--z-context-menu);
     pointer-events: none;
 
     animation: zoom-fade-in-out 1.5s ease-out;

--- a/frontend/app/modals/command-palette.scss
+++ b/frontend/app/modals/command-palette.scss
@@ -5,7 +5,9 @@
     position: fixed;
     inset: 0;
     background: rgba(0, 0, 0, 0.45);
-    z-index: 900;
+    // Command palette is a modal — lives in the modal slot.
+    // Backdrop + container are siblings; DOM order controls paint.
+    z-index: var(--z-modal);
 }
 
 .command-palette-container {
@@ -19,7 +21,7 @@
     border: 1px solid var(--border-color, #444);
     border-radius: 8px;
     box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
-    z-index: 901;
+    z-index: var(--z-modal);
     display: flex;
     flex-direction: column;
     overflow: hidden;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.341",
+  "version": "0.33.342",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.341",
+      "version": "0.33.342",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.341",
+  "version": "0.33.342",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Implements [SPEC_DESIGN_SYSTEM_2026_04_23 §5.3](../blob/main/docs/specs/SPEC_DESIGN_SYSTEM_2026_04_23.md) Phase 2
- Tokenizes 5 global-overlay \`z-index\` literals using the \`--z-*\` hierarchy added in PR #507
- Intentionally leaves local stacking-context values alone (they're already correct and don't compete for a shared slot)

## Context
Phase 2 unblocks the robust-modal spec (which needs \`--z-modal\` consumed) and fixes the observed paint-order issues flagged in the audit (flyout beating modal, popover below everything, drag overlay covering modals).

### Migrated

| File | From | To | Net effect |
|------|------|----|------------|
| \`element/flyoutmenu.scss\` | \`1000\` | \`var(--z-flyout-menu)\` (9500) | flyout now paints above modals |
| \`element/popover.scss\` | \`1000\` (had TODO) | \`var(--z-popover)\` (8500) | popover paints above typeahead, below modals |
| \`element/zoomindicator.scss\` | \`10000\` | \`var(--z-context-menu)\` (10000) | value-preserving rename |
| \`drag/drag-overlay.scss\` | \`9999\` | \`var(--z-drag-overlay)\` (1000) | cross-app drag now below modals/popovers (spec intent) |
| \`modals/command-palette.scss\` | \`900\` / \`901\` | \`var(--z-modal)\` / same | joins modal slot; DOM order controls paint between backdrop + container siblings |

### Deferred

Local stacking-context values stay raw (not global competitors):
- \`block.scss:50\` (pane mask stacking context)
- \`blockstats.scss:5\` (matches existing \`--zindex-xterm-viewport-overlay\`, local)
- \`tab.scss:1\`, \`agent-view.scss:2/6/10/20/50/100/200\`, \`subagent-view.scss:10\`, \`term.scss:10\`, \`identity-view.scss:100\`
- \`window/action-widgets.scss:9999\` (unclear semantics; audit before migrating)

## Net user-visible changes
- **Drag overlay** no longer paints over open modals or popovers (previously was 9999, dominated everything). Matches spec intent: modal keeps focus during a cross-app drag, popovers stay readable.
- **Command palette** wins over popovers and sits at the modal level, consistent with its modal semantics.
- **Flyout menus** still beat everything except the zoom indicator (context-menu slot).

## Test plan
- [ ] Open a flyout menu while a modal is visible — flyout still paints above modal? Spec says yes; \`--z-flyout-menu\` (9500) > \`--z-modal\` (9000)
- [ ] Open a popover (hover an ⓘ); it should paint above any typeahead but below modals
- [ ] Start a cross-app drag while the command palette is open — palette stays on top (both at 9000, palette rendered later)
- [ ] Zoom toast still appears above everything
- [ ] No visual regression in normal pane layouts
- [ ] Type check / SCSS compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)