### PR TITLE
feat(element): add Modal v2 primitive (accessible, multi-window, stackable)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.342"
+version = "0.33.343"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.342"
+version = "0.33.343"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.342"
+version = "0.33.343"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.342"
+version = "0.33.343"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.342"
+version = "0.33.343"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.342"
+version = "0.33.343"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.342"
+version = "0.33.343"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.342"
+version = "0.33.343"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/element/modal-v2.scss
+++ b/frontend/app/element/modal-v2.scss
@@ -1,0 +1,121 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Modal v2 — accessible + animated.
+// Consumes design tokens from `theme.scss` (SPEC_DESIGN_SYSTEM_2026_04_23).
+
+@use "../mixins.scss";
+
+.modal-root {
+    position: fixed;
+    inset: 0;
+    z-index: var(--z-modal);
+    display: grid;
+    place-items: center;
+    padding: var(--space-6);
+
+    // The root itself is focusable as a last-resort target (when the
+    // panel has no focusable children, `firstFocusable(panelRef)`
+    // returns null and we fall back to panelRef. panelRef has
+    // tabindex=-1 so this still works without adding to the tab order).
+    &:focus-visible {
+        outline: none;
+    }
+}
+
+.modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    animation: modal-fade-in 120ms ease-out;
+}
+
+.modal-panel {
+    position: relative;
+    max-width: 100%;
+    max-height: calc(100vh - #{2 * 24px});  // 2 × --space-6 literal; avoid var() in calc mult
+    overflow: auto;
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-modal);
+    animation: modal-pop-in 140ms cubic-bezier(0.2, 1, 0.3, 1);
+
+    // Focus ring when the panel itself is the focus target (only
+    // happens when there are no focusable descendants).
+    &:focus-visible {
+        box-shadow: var(--shadow-modal), var(--shadow-focus-ring);
+        outline: none;
+    }
+
+    &[data-size="sm"]  { width: 360px; }
+    &[data-size="md"]  { width: 520px; }
+    &[data-size="lg"]  { width: 720px; }
+    &[data-size="xl"]  { width: 960px; }
+    &[data-size="fit"] { width: auto; }
+}
+
+.modal-focus-sentinel {
+    // A visually-hidden but focusable element. Bookends the panel so
+    // Tab and Shift+Tab wrap within the dialog instead of escaping.
+    @include mixins.sr-only;
+}
+
+// ── Panel subcomponents ──────────────────────────────────────────────────────
+
+.modal-panel-header {
+    padding: var(--space-4) var(--space-5) var(--space-2);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-panel-title {
+    margin: 0;
+    font-size: var(--text-xl);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--leading-tight);
+    color: var(--main-text-color);
+}
+
+.modal-panel-description {
+    margin: var(--space-1) 0 0;
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    line-height: var(--leading-normal);
+}
+
+.modal-panel-body {
+    padding: var(--space-4) var(--space-5);
+    font-size: var(--text-md);
+    line-height: var(--leading-normal);
+}
+
+.modal-panel-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-5);
+    border-top: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--main-text-color) 2%, transparent);
+}
+
+// ── Animations ───────────────────────────────────────────────────────────────
+
+@keyframes modal-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@keyframes modal-pop-in {
+    from { opacity: 0; transform: scale(0.96) translateY(4px); }
+    to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@include mixins.respect-reduced-motion {
+    .modal-backdrop,
+    .modal-panel {
+        animation: none;
+    }
+}

--- a/frontend/app/element/modal-v2.tsx
+++ b/frontend/app/element/modal-v2.tsx
@@ -26,18 +26,28 @@
  */
 
 import {
+    createContext,
     createEffect,
     createSignal,
     createUniqueId,
     JSX,
     onCleanup,
-    onMount,
     Show,
+    useContext,
     type Component,
 } from "solid-js";
 import { Portal } from "solid-js/web";
 
 import "./modal-v2.scss";
+
+// ── Context ──────────────────────────────────────────────────────────────────
+// Shares the Modal's auto-generated title id with a nested ModalHeader
+// so `aria-labelledby` on the dialog root resolves to the heading that
+// ModalHeader actually renders. Without this context the two sides
+// generate independent ids via `createUniqueId()` and never match,
+// breaking the labelling contract.
+
+const ModalTitleIdContext = createContext<string | undefined>(undefined);
 
 // ── Modal stack ──────────────────────────────────────────────────────────────
 // Module-level so multiple Modal instances share it. ESC and backdrop
@@ -120,6 +130,10 @@ export const Modal: Component<ModalProps> = (props) => {
     let previousFocus: HTMLElement | null = null;
     let inertSiblings: HTMLElement[] = [];
     let previousBodyOverflow = "";
+    // Store the document we opened in so `closeModal` restores state
+    // on the same body — `resolveMountDocument()` at close time could
+    // point at a different window if focus moved across CEF windows.
+    let mountDoc: Document | null = null;
 
     const [mounted, setMounted] = createSignal(false);
 
@@ -139,17 +153,19 @@ export const Modal: Component<ModalProps> = (props) => {
     const openModal = (): void => {
         previousFocus = (document.activeElement as HTMLElement) ?? null;
 
-        // Lock body scroll on the originating document.
-        const doc = resolveMountDocument();
-        previousBodyOverflow = doc.body.style.overflow;
-        doc.body.style.overflow = "hidden";
+        // Lock body scroll on the originating document. Cache the
+        // document so closeModal restores state on the same body
+        // even if focus moved to a different CEF window meanwhile.
+        mountDoc = resolveMountDocument();
+        previousBodyOverflow = mountDoc.body.style.overflow;
+        mountDoc.body.style.overflow = "hidden";
 
         // Inert background siblings so assistive tech + keyboard
         // focus can't escape. Skip if `inert` isn't supported
         // (older CEF versions) — focus trap still handles keyboard.
         inertSiblings = [];
         if ("inert" in HTMLElement.prototype) {
-            for (const child of Array.from(doc.body.children) as HTMLElement[]) {
+            for (const child of Array.from(mountDoc.body.children) as HTMLElement[]) {
                 // The Portal mount target is doc.body, so the modal-root
                 // becomes a body child after mount. We inert everything
                 // else and rely on the modal's own focus trap.
@@ -188,9 +204,11 @@ export const Modal: Component<ModalProps> = (props) => {
         for (const el of inertSiblings) el.removeAttribute("inert");
         inertSiblings = [];
 
-        // Restore body scroll.
-        const doc = resolveMountDocument();
-        doc.body.style.overflow = previousBodyOverflow;
+        // Restore body scroll on the same document we locked. Falling
+        // back to `document` if mountDoc was never set is a defensive
+        // no-op — openModal should have set it before this ran.
+        (mountDoc ?? document).body.style.overflow = previousBodyOverflow;
+        mountDoc = null;
 
         setMounted(false);
 
@@ -240,41 +258,54 @@ export const Modal: Component<ModalProps> = (props) => {
         (firstFocusable(panelRef) ?? panelRef).focus();
     };
 
+    // ARIA labelling precedence: only one of aria-label / aria-labelledby
+    // should be set. `aria-labelledby` wins over `aria-label` per the ARIA
+    // spec, so sending both would ignore the caller's explicit `ariaLabel`
+    // prop. Fall through in order: explicit labelledby → explicit label →
+    // auto-wired via the ModalHeader's context-shared id.
+    const labelledById = (): string | undefined => {
+        if (props.ariaLabelledBy) return props.ariaLabelledBy;
+        if (props.ariaLabel) return undefined; // label wins when no labelledby
+        return defaultTitleId;
+    };
+
     return (
         <Show when={mounted()}>
             <Portal mount={resolveMountDocument().body}>
-                <div
-                    class="modal-root"
-                    role="dialog"
-                    aria-modal="true"
-                    aria-label={props.ariaLabel}
-                    aria-labelledby={props.ariaLabelledBy ?? defaultTitleId}
-                    aria-describedby={props.ariaDescribedBy}
-                    tabIndex={-1}
-                    onKeyDown={handleKeyDown}
-                >
-                    <div class="modal-backdrop" onClick={handleBackdropClick} />
-                    <span
-                        class="modal-focus-sentinel"
-                        tabindex="0"
-                        aria-hidden="true"
-                        onFocus={onSentinelStartFocus}
-                    />
+                <ModalTitleIdContext.Provider value={defaultTitleId}>
                     <div
-                        ref={panelRef}
-                        class="modal-panel"
-                        data-size={props.size ?? "md"}
+                        class="modal-root"
+                        role="dialog"
+                        aria-modal="true"
+                        aria-label={props.ariaLabelledBy ? undefined : props.ariaLabel}
+                        aria-labelledby={labelledById()}
+                        aria-describedby={props.ariaDescribedBy}
                         tabIndex={-1}
+                        onKeyDown={handleKeyDown}
                     >
-                        {props.children}
+                        <div class="modal-backdrop" onClick={handleBackdropClick} />
+                        <span
+                            class="modal-focus-sentinel"
+                            tabindex="0"
+                            aria-hidden="true"
+                            onFocus={onSentinelStartFocus}
+                        />
+                        <div
+                            ref={panelRef}
+                            class="modal-panel"
+                            data-size={props.size ?? "md"}
+                            tabIndex={-1}
+                        >
+                            {props.children}
+                        </div>
+                        <span
+                            class="modal-focus-sentinel"
+                            tabindex="0"
+                            aria-hidden="true"
+                            onFocus={onSentinelEndFocus}
+                        />
                     </div>
-                    <span
-                        class="modal-focus-sentinel"
-                        tabindex="0"
-                        aria-hidden="true"
-                        onFocus={onSentinelEndFocus}
-                    />
-                </div>
+                </ModalTitleIdContext.Provider>
             </Portal>
         </Show>
     );
@@ -290,10 +321,15 @@ export interface ModalHeaderProps {
 }
 
 export const ModalHeader: Component<ModalHeaderProps> = (props) => {
+    // When rendered inside a <Modal>, inherit the title id the Modal
+    // wired into `aria-labelledby`. When used standalone, fall back
+    // to a freshly-generated id so we still get a valid element id.
+    const contextTitleId = useContext(ModalTitleIdContext);
     const fallbackId = createUniqueId();
+    const resolvedId = () => props.id ?? contextTitleId ?? fallbackId;
     return (
         <header class="modal-panel-header">
-            <h2 class="modal-panel-title" id={props.id ?? fallbackId}>
+            <h2 class="modal-panel-title" id={resolvedId()}>
                 {props.title}
             </h2>
             <Show when={props.description}>

--- a/frontend/app/element/modal-v2.tsx
+++ b/frontend/app/element/modal-v2.tsx
@@ -71,6 +71,52 @@ const remove = (id: string): void => {
     if (idx >= 0) stack.splice(idx, 1);
 };
 
+// ── Per-document scroll + inert lock ────────────────────────────────────────
+// Reference-counted so stacked modals (or modals closing out of order)
+// don't release the lock prematurely. Codex flagged the unconditional
+// release on PR #511; the shared state below handles stacking cleanly.
+
+interface DocumentLockState {
+    openCount: number;
+    previousOverflow: string;
+    inertSiblings: HTMLElement[];
+}
+
+const docLocks = new WeakMap<Document, DocumentLockState>();
+
+function acquireDocumentLock(doc: Document): void {
+    const existing = docLocks.get(doc);
+    if (existing) {
+        existing.openCount++;
+        return;
+    }
+    const state: DocumentLockState = {
+        openCount: 1,
+        previousOverflow: doc.body.style.overflow,
+        inertSiblings: [],
+    };
+    doc.body.style.overflow = "hidden";
+    if ("inert" in HTMLElement.prototype) {
+        for (const child of Array.from(doc.body.children) as HTMLElement[]) {
+            if (!child.classList.contains("modal-root") && !child.hasAttribute("inert")) {
+                child.setAttribute("inert", "");
+                state.inertSiblings.push(child);
+            }
+        }
+    }
+    docLocks.set(doc, state);
+}
+
+function releaseDocumentLock(doc: Document): void {
+    const state = docLocks.get(doc);
+    if (!state) return;
+    state.openCount--;
+    if (state.openCount > 0) return;
+    for (const el of state.inertSiblings) el.removeAttribute("inert");
+    doc.body.style.overflow = state.previousOverflow;
+    docLocks.delete(doc);
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 const FOCUSABLE_SELECTOR = [
@@ -128,11 +174,11 @@ export const Modal: Component<ModalProps> = (props) => {
 
     let panelRef: HTMLDivElement | undefined;
     let previousFocus: HTMLElement | null = null;
-    let inertSiblings: HTMLElement[] = [];
-    let previousBodyOverflow = "";
-    // Store the document we opened in so `closeModal` restores state
-    // on the same body — `resolveMountDocument()` at close time could
-    // point at a different window if focus moved across CEF windows.
+    // Cache the document we acquired the lock on so release targets the
+    // same body, even if focus moved across CEF windows meanwhile.
+    // Per-doc scroll + inert state lives in the shared `docLocks` map
+    // (reference-counted — handles stacked / out-of-order closes
+    // correctly; see Codex P1 on PR #511).
     let mountDoc: Document | null = null;
 
     const [mounted, setMounted] = createSignal(false);
@@ -153,30 +199,12 @@ export const Modal: Component<ModalProps> = (props) => {
     const openModal = (): void => {
         previousFocus = (document.activeElement as HTMLElement) ?? null;
 
-        // Lock body scroll on the originating document. Cache the
-        // document so closeModal restores state on the same body
-        // even if focus moved to a different CEF window meanwhile.
+        // Acquire the per-document scroll + inert lock. Reference-
+        // counted: the first modal in a document performs the actual
+        // lock; later modals just bump the count so the lock stays
+        // active until the *last* modal closes.
         mountDoc = resolveMountDocument();
-        previousBodyOverflow = mountDoc.body.style.overflow;
-        mountDoc.body.style.overflow = "hidden";
-
-        // Inert background siblings so assistive tech + keyboard
-        // focus can't escape. Skip if `inert` isn't supported
-        // (older CEF versions) — focus trap still handles keyboard.
-        inertSiblings = [];
-        if ("inert" in HTMLElement.prototype) {
-            for (const child of Array.from(mountDoc.body.children) as HTMLElement[]) {
-                // The Portal mount target is doc.body, so the modal-root
-                // becomes a body child after mount. We inert everything
-                // else and rely on the modal's own focus trap.
-                if (!child.classList.contains("modal-root")) {
-                    if (!child.hasAttribute("inert")) {
-                        child.setAttribute("inert", "");
-                        inertSiblings.push(child);
-                    }
-                }
-            }
-        }
+        acquireDocumentLock(mountDoc);
 
         // Register in the stack so ESC / backdrop dispatch to topmost.
         push({ id, close: props.onClose });
@@ -200,14 +228,11 @@ export const Modal: Component<ModalProps> = (props) => {
     const closeModal = (): void => {
         remove(id);
 
-        // Restore inert attribute on siblings.
-        for (const el of inertSiblings) el.removeAttribute("inert");
-        inertSiblings = [];
-
-        // Restore body scroll on the same document we locked. Falling
-        // back to `document` if mountDoc was never set is a defensive
-        // no-op — openModal should have set it before this ran.
-        (mountDoc ?? document).body.style.overflow = previousBodyOverflow;
+        // Release the per-document lock. If this was the last modal
+        // in its document, the lock's cleanup also restores scroll
+        // and clears inert. Lower modals in a stack don't release
+        // the lock until they're gone too.
+        if (mountDoc) releaseDocumentLock(mountDoc);
         mountDoc = null;
 
         setMounted(false);

--- a/frontend/app/element/modal-v2.tsx
+++ b/frontend/app/element/modal-v2.tsx
@@ -1,0 +1,312 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Modal v2 — accessible, multi-window-aware, stackable.
+ *
+ * Implements PR 1 of SPEC_ROBUST_MODAL_SYSTEM_2026_04_23. Retires
+ * `element/modal.tsx` and the `modals/` wrapper once callers migrate
+ * (see spec §6 PRs 3–5).
+ *
+ * Behaviour:
+ * - `role="dialog"` + `aria-modal="true"` + generated `aria-labelledby`.
+ * - Portal mounts into the originating window's document (multi-window
+ *   aware via `document.activeElement?.ownerDocument`).
+ * - Body scroll locked while any modal is open.
+ * - Background siblings of the modal root receive `inert` so screen
+ *   readers and keyboard focus don't escape.
+ * - Focus saved on open, restored on close. Trap via sentinel spans.
+ * - ESC closes topmost; modal stack coordinates stacking.
+ * - Backdrop click closes (opt-out via `closeOnBackdropClick={false}`).
+ * - Animations honour `prefers-reduced-motion`.
+ *
+ * Consumes design tokens from `theme.scss`:
+ *   --z-modal, --shadow-modal, --shadow-focus-ring, --radius-lg,
+ *   --motion-fast, --motion-base, --space-*
+ */
+
+import {
+    createEffect,
+    createSignal,
+    createUniqueId,
+    JSX,
+    onCleanup,
+    onMount,
+    Show,
+    type Component,
+} from "solid-js";
+import { Portal } from "solid-js/web";
+
+import "./modal-v2.scss";
+
+// ── Modal stack ──────────────────────────────────────────────────────────────
+// Module-level so multiple Modal instances share it. ESC and backdrop
+// dispatch only to the topmost entry.
+
+interface StackEntry {
+    id: string;
+    close: () => void;
+}
+
+const stack: StackEntry[] = [];
+
+const topmost = (): StackEntry | undefined => stack[stack.length - 1];
+
+const push = (entry: StackEntry): void => {
+    stack.push(entry);
+};
+
+const remove = (id: string): void => {
+    const idx = stack.findIndex((e) => e.id === id);
+    if (idx >= 0) stack.splice(idx, 1);
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const FOCUSABLE_SELECTOR = [
+    "input:not([disabled])",
+    "textarea:not([disabled])",
+    "select:not([disabled])",
+    "button:not([disabled])",
+    "a[href]",
+    "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+function firstFocusable(root: HTMLElement): HTMLElement | null {
+    return root.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+}
+
+function lastFocusable(root: HTMLElement): HTMLElement | null {
+    const nodes = root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    return nodes.length ? nodes[nodes.length - 1] : null;
+}
+
+/**
+ * Resolve the document the modal should mount into. Uses the
+ * currently focused element's `ownerDocument` so a modal opened
+ * from a click in the N-th CEF window mounts into that window's
+ * DOM, not the main window's.
+ */
+function resolveMountDocument(): Document {
+    const active = typeof document !== "undefined" ? document.activeElement : null;
+    return active?.ownerDocument ?? document;
+}
+
+// ── Modal ────────────────────────────────────────────────────────────────────
+
+export interface ModalProps {
+    open: boolean;
+    onClose: () => void;
+    /** Backdrop click closes. Default `true`. */
+    closeOnBackdropClick?: boolean;
+    /** ESC closes. Default `true`. */
+    closeOnEscape?: boolean;
+    /** Width preset. `fit` = auto. Default `md`. */
+    size?: "sm" | "md" | "lg" | "xl" | "fit";
+    /** Override aria-labelledby. By default resolves from a nested ModalHeader. */
+    ariaLabel?: string;
+    ariaLabelledBy?: string;
+    ariaDescribedBy?: string;
+    /** Element (or accessor) to focus on open. Defaults to the first focusable. */
+    initialFocus?: HTMLElement | (() => HTMLElement | null);
+    children: JSX.Element;
+}
+
+export const Modal: Component<ModalProps> = (props) => {
+    const id = createUniqueId();
+    const defaultTitleId = `modal-title-${id}`;
+
+    let panelRef: HTMLDivElement | undefined;
+    let previousFocus: HTMLElement | null = null;
+    let inertSiblings: HTMLElement[] = [];
+    let previousBodyOverflow = "";
+
+    const [mounted, setMounted] = createSignal(false);
+
+    // Track `open` changes to run the open/close lifecycle.
+    createEffect(() => {
+        if (props.open && !mounted()) {
+            openModal();
+        } else if (!props.open && mounted()) {
+            closeModal();
+        }
+    });
+
+    onCleanup(() => {
+        if (mounted()) closeModal();
+    });
+
+    const openModal = (): void => {
+        previousFocus = (document.activeElement as HTMLElement) ?? null;
+
+        // Lock body scroll on the originating document.
+        const doc = resolveMountDocument();
+        previousBodyOverflow = doc.body.style.overflow;
+        doc.body.style.overflow = "hidden";
+
+        // Inert background siblings so assistive tech + keyboard
+        // focus can't escape. Skip if `inert` isn't supported
+        // (older CEF versions) — focus trap still handles keyboard.
+        inertSiblings = [];
+        if ("inert" in HTMLElement.prototype) {
+            for (const child of Array.from(doc.body.children) as HTMLElement[]) {
+                // The Portal mount target is doc.body, so the modal-root
+                // becomes a body child after mount. We inert everything
+                // else and rely on the modal's own focus trap.
+                if (!child.classList.contains("modal-root")) {
+                    if (!child.hasAttribute("inert")) {
+                        child.setAttribute("inert", "");
+                        inertSiblings.push(child);
+                    }
+                }
+            }
+        }
+
+        // Register in the stack so ESC / backdrop dispatch to topmost.
+        push({ id, close: props.onClose });
+
+        setMounted(true);
+
+        // Focus resolution — next frame so the Portal has rendered.
+        requestAnimationFrame(() => {
+            if (!panelRef) return;
+            let target: HTMLElement | null = null;
+            if (typeof props.initialFocus === "function") {
+                target = props.initialFocus();
+            } else if (props.initialFocus) {
+                target = props.initialFocus;
+            }
+            if (!target) target = firstFocusable(panelRef);
+            (target ?? panelRef).focus();
+        });
+    };
+
+    const closeModal = (): void => {
+        remove(id);
+
+        // Restore inert attribute on siblings.
+        for (const el of inertSiblings) el.removeAttribute("inert");
+        inertSiblings = [];
+
+        // Restore body scroll.
+        const doc = resolveMountDocument();
+        doc.body.style.overflow = previousBodyOverflow;
+
+        setMounted(false);
+
+        // Restore focus on the next tick so Solid's cleanup has finished
+        // and the previously-focused element isn't immediately moved by
+        // an unrelated reactive update.
+        queueMicrotask(() => {
+            if (previousFocus && previousFocus.isConnected && typeof previousFocus.focus === "function") {
+                previousFocus.focus();
+            }
+            previousFocus = null;
+        });
+    };
+
+    // Key + backdrop handling. ESC only fires on the topmost — modals
+    // lower in the stack stay open.
+    const handleKeyDown = (ev: KeyboardEvent): void => {
+        if (ev.key !== "Escape") return;
+        if (props.closeOnEscape === false) return;
+        if (topmost()?.id !== id) return;
+        ev.preventDefault();
+        ev.stopPropagation();
+        props.onClose();
+    };
+
+    const handleBackdropClick = (ev: MouseEvent): void => {
+        if (props.closeOnBackdropClick === false) return;
+        if (topmost()?.id !== id) return;
+        // Only the backdrop itself should close — clicks inside the
+        // panel bubble through but the panel is a sibling, not a child
+        // of the backdrop, so `target === backdrop` is the simplest test.
+        if (ev.target === ev.currentTarget) {
+            props.onClose();
+        }
+    };
+
+    // Sentinel focus trap. Focusing a sentinel bounces focus to the
+    // opposite end of the panel so Tab and Shift+Tab both wrap inside
+    // the dialog without escaping into the page behind.
+    const onSentinelStartFocus = (): void => {
+        if (!panelRef) return;
+        (lastFocusable(panelRef) ?? panelRef).focus();
+    };
+
+    const onSentinelEndFocus = (): void => {
+        if (!panelRef) return;
+        (firstFocusable(panelRef) ?? panelRef).focus();
+    };
+
+    return (
+        <Show when={mounted()}>
+            <Portal mount={resolveMountDocument().body}>
+                <div
+                    class="modal-root"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-label={props.ariaLabel}
+                    aria-labelledby={props.ariaLabelledBy ?? defaultTitleId}
+                    aria-describedby={props.ariaDescribedBy}
+                    tabIndex={-1}
+                    onKeyDown={handleKeyDown}
+                >
+                    <div class="modal-backdrop" onClick={handleBackdropClick} />
+                    <span
+                        class="modal-focus-sentinel"
+                        tabindex="0"
+                        aria-hidden="true"
+                        onFocus={onSentinelStartFocus}
+                    />
+                    <div
+                        ref={panelRef}
+                        class="modal-panel"
+                        data-size={props.size ?? "md"}
+                        tabIndex={-1}
+                    >
+                        {props.children}
+                    </div>
+                    <span
+                        class="modal-focus-sentinel"
+                        tabindex="0"
+                        aria-hidden="true"
+                        onFocus={onSentinelEndFocus}
+                    />
+                </div>
+            </Portal>
+        </Show>
+    );
+};
+
+// ── Subcomponents ────────────────────────────────────────────────────────────
+
+export interface ModalHeaderProps {
+    title: string;
+    description?: string;
+    /** Override id (rarely needed — Modal auto-wires `aria-labelledby`). */
+    id?: string;
+}
+
+export const ModalHeader: Component<ModalHeaderProps> = (props) => {
+    const fallbackId = createUniqueId();
+    return (
+        <header class="modal-panel-header">
+            <h2 class="modal-panel-title" id={props.id ?? fallbackId}>
+                {props.title}
+            </h2>
+            <Show when={props.description}>
+                <p class="modal-panel-description">{props.description}</p>
+            </Show>
+        </header>
+    );
+};
+
+export const ModalBody: Component<{ children: JSX.Element; class?: string }> = (props) => (
+    <div class={`modal-panel-body ${props.class ?? ""}`}>{props.children}</div>
+);
+
+export const ModalFooter: Component<{ children: JSX.Element; class?: string }> = (props) => (
+    <footer class={`modal-panel-footer ${props.class ?? ""}`}>{props.children}</footer>
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.342",
+  "version": "0.33.343",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.342",
+      "version": "0.33.343",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.342",
+  "version": "0.33.343",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Adds \`frontend/app/element/modal-v2.tsx\` + \`.scss\` — the new primitive per [SPEC_ROBUST_MODAL_SYSTEM_2026_04_23](../blob/main/docs/specs/SPEC_ROBUST_MODAL_SYSTEM_2026_04_23.md)
- **Zero callers migrated.** The existing \`element/modal.tsx\` and \`modals/Modal\` stay intact; consumers port one at a time in subsequent PRs

## Context
First PR of the modal-system series. Builds directly on design-system Phase 1 (PR #507) tokens + mixins and Phase 2 (PR #510, in review) z-index rewire. Once the primitive lands, migration PRs port each consumer (\`AgentLaunchModal\`, \`ImportPreviewModal\`, \`CommandPaletteModal\`, etc.) one at a time.

### API
\`\`\`
<Modal open={open()} onClose={() => setOpen(false)} size="md">
    <ModalHeader title="Launch Claude Code" description="…" />
    <ModalBody>…</ModalBody>
    <ModalFooter>…</ModalFooter>
</Modal>
\`\`\`

### Built-in behaviour
| Feature | How |
|---|---|
| \`role="dialog"\` + \`aria-modal="true"\` | set on the root |
| \`aria-labelledby\` | auto-wired to nested \`<ModalHeader>\`; override via prop |
| Multi-window Portal routing | \`document.activeElement?.ownerDocument\` — mounts in the originating CEF window |
| Focus save/restore | \`queueMicrotask\` on close so Solid's cleanup flushes before restoration |
| Focus trap | two \`tabindex="0"\` sentinel spans bracket the panel |
| Background \`inert\` | every \`<body>\` child except \`.modal-root\` (if runtime supports) |
| Scroll lock | \`body.style.overflow = "hidden"\` |
| ESC / backdrop close | only the topmost stack entry fires |
| Stack | module-level array; push on open, remove on close |
| Animations | 120ms fade-in backdrop + 140ms pop-in panel; suppressed under \`prefers-reduced-motion\` |

### Tokens consumed (all from PR #507)
\`--z-modal\`, \`--shadow-modal\`, \`--shadow-focus-ring\`, \`--radius-lg\`, \`--space-*\`, \`--text-*\`, \`--font-weight-*\`, \`--leading-*\`, \`--motion-*\`.

## Test plan
- [ ] Type check clean
- [ ] No consumers migrated — existing modals unchanged
- [ ] Build produces the new \`.scss\` output (Vite)
- [ ] Follow-up: smoke-test the new primitive by migrating \`AgentLaunchModal\` (next PR)

## Next in series
- **Migrate \`AgentLaunchModal\`** — first real consumer; validates API
- **Migrate \`ImportPreviewModal\`, \`AboutModal\`, \`MessageModal\`, \`UserInputModal\`** — bulk migration, each is thin
- **Migrate \`CommandPaletteModal\` + \`TypeAheadModal\`** — more invasive (keybinding disabling, block-ref mounting)
- **Retire \`element/modal.tsx\` and stale \`modals/Modal\` wrappers**
- **ConfirmModal preset** — destructive-action focus on Cancel by default
- **Polish + docs**

🤖 Generated with [Claude Code](https://claude.com/claude-code)