### PR TITLE
feat(agent-pane): migrate AgentLaunchModal to modal-v2 primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.343"
+version = "0.33.344"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.343"
+version = "0.33.344"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.343"
+version = "0.33.344"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.343"
+version = "0.33.344"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.343"
+version = "0.33.344"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.343"
+version = "0.33.344"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.343"
+version = "0.33.344"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.343"
+version = "0.33.344"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -12,7 +12,7 @@
 
 import { createMemo, createSignal, Show, type JSX } from "solid-js";
 import { Button } from "@/element/button";
-import { Modal, ModalContent, ModalFooter, ModalHeader } from "@/element/modal";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal-v2";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { buildInstanceSlug, slugifyInstanceName } from "../defaults/instance-slug";
 
@@ -82,20 +82,26 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
         // Success: parent closes the modal so we leave submitting true.
     };
 
+    // Modal v2 handles ESC (topmost-aware), backdrop click, focus
+    // trap, focus restoration, and scroll lock. We only need to add
+    // Enter-to-submit since the modal doesn't prescribe form semantics.
     const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === "Enter" && canSubmit()) {
             e.preventDefault();
             void handleSubmit();
-        } else if (e.key === "Escape") {
-            e.preventDefault();
-            props.onCancel();
         }
     };
 
     return (
-        <Modal onClickOut={() => { if (!submitting()) props.onCancel(); }}>
+        <Modal
+            open={true}
+            onClose={() => { if (!submitting()) props.onCancel(); }}
+            closeOnBackdropClick={!submitting()}
+            closeOnEscape={!submitting()}
+            size="md"
+        >
             <ModalHeader title={`Launch ${displayName()}`} />
-            <ModalContent>
+            <ModalBody>
                 <div class="agent-launch-modal-body" onKeyDown={handleKeyDown}>
                     <Show when={catalog()}>
                         <p class="agent-launch-modal-blurb">
@@ -113,7 +119,6 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
                             value={name()}
                             onInput={(e) => setName(e.currentTarget.value)}
                             disabled={submitting()}
-                            ref={(el) => setTimeout(() => el?.focus(), 0)}
                             aria-label="Instance name"
                         />
                         <span class="agent-launch-modal-hint">
@@ -189,7 +194,7 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
                         <div class="agent-launch-modal-error">{error()}</div>
                     </Show>
                 </div>
-            </ModalContent>
+            </ModalBody>
             <ModalFooter>
                 <Button onClick={props.onCancel} disabled={submitting()}>
                     Cancel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.343",
+  "version": "0.33.344",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.343",
+      "version": "0.33.344",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.343",
+  "version": "0.33.344",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- First consumer migrated to \`element/modal-v2\` (added in PR #511)
- Validates the new API against a real caller
- Zero visual regression intended; gains accessibility + focus management for free

## Context
Implements the \"migrate AgentLaunchModal\" step of [SPEC_ROBUST_MODAL_SYSTEM §6](../blob/main/docs/specs/SPEC_ROBUST_MODAL_SYSTEM_2026_04_23.md). Four more caller migrations follow (ImportPreviewModal, AboutModal, MessageModal, UserInputModal), then CommandPaletteModal + TypeAheadModal (which have trickier semantics), and finally retire \`element/modal.tsx\`.

### Diff
- Import swap: \`@/element/modal\` → \`@/element/modal-v2\` (+ \`ModalContent\` → \`ModalBody\` rename)
- \`<Modal onClickOut=...>\` → \`<Modal open={true} onClose={...} closeOnBackdropClick closeOnEscape size=\"md\">\`. While \`submitting\`, both close paths disable so the in-flight launch can't be accidentally aborted
- Removed the custom Escape handler and the manual focus timer on the name input — modal-v2 handles both natively (topmost-aware ESC + auto-focus-first-focusable after Portal mount)
- Kept the Enter-to-submit handler (form-specific, not modal-level)

### Inherited from modal-v2 with no extra wiring
- \`role=\"dialog\"\` + \`aria-modal=\"true\"\` + auto-wired \`aria-labelledby\` to the ModalHeader title
- Focus trap (Tab/Shift+Tab wrap inside panel)
- Focus save/restore (previous element regains focus on close)
- Background \`inert\` + body scroll lock (reference-counted for stacked-modal correctness)
- Backdrop blur + fade-in + pop-in animation, \`prefers-reduced-motion\` respected
- Multi-window Portal routing via \`document.activeElement?.ownerDocument\`

## Test plan
- [ ] Click a definition card in the agent picker → modal opens, name input gets focus
- [ ] Tab/Shift+Tab wrap inside the dialog (don't escape to the page behind)
- [ ] Backdrop click closes (unless submitting)
- [ ] ESC closes (unless submitting)
- [ ] Enter submits when name valid
- [ ] Closing returns focus to the clicked card
- [ ] No scroll on body while modal is open
- [ ] Screen reader announces \"dialog — Launch Claude Code\"

## Follow-ups
- Migrate ImportPreviewModal (next PR)
- Migrate AboutModal, MessageModal, UserInputModal (bulk)
- Migrate CommandPaletteModal, TypeAheadModal (more invasive)
- Retire \`element/modal.tsx\`
- Add ConfirmModal preset for destructive actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)