### PR TITLE
feat(agent-pane): migrate ImportPreviewModal to modal-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.344"
+version = "0.33.345"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.344"
+version = "0.33.345"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.344"
+version = "0.33.345"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.344"
+version = "0.33.345"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.344"
+version = "0.33.345"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.344"
+version = "0.33.345"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.344"
+version = "0.33.345"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.344"
+version = "0.33.345"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -2583,70 +2583,6 @@
         }
     }
 
-    // === Import Preview Modal ===
-    // Outer chrome (overlay / panel / header / footer / buttons) is
-    // now provided by `element/modal-v2`. Only the inner content
-    // styles for the list + summary remain here.
-    .agent-import-count {
-        font-size: 12px;
-        color: var(--secondary-text-color);
-        margin-bottom: 8px;
-    }
-
-    .agent-import-list {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        margin-bottom: 10px;
-    }
-
-    .agent-import-row {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 12px;
-        color: var(--main-text-color);
-        padding: 2px 0;
-
-        &.agent-import-row-skip {
-            opacity: 0.5;
-        }
-
-        .agent-import-row-status {
-            width: 16px;
-            text-align: center;
-            flex-shrink: 0;
-        }
-
-        .agent-import-row-icon {
-            flex-shrink: 0;
-        }
-
-        .agent-import-row-name {
-            font-weight: 500;
-        }
-
-        .agent-import-row-desc,
-        .agent-import-row-skip-label {
-            color: var(--secondary-text-color);
-            font-size: 11px;
-        }
-    }
-
-    .agent-import-summary {
-        font-size: 12px;
-        color: var(--secondary-text-color);
-        border-top: 1px solid var(--border-color);
-        padding-top: 8px;
-    }
-
-    .agent-import-result {
-        font-size: 13px;
-        color: var(--main-text-color);
-        text-align: center;
-        padding: 20px 0;
-    }
-
     // === Setup Wizard ===
     .setup-wizard {
         display: flex;
@@ -3965,4 +3901,70 @@
     padding: 6px 8px;
     background: color-mix(in srgb, var(--error-color, #e06c75) 10%, transparent);
     border-radius: 3px;
+}
+
+// ── Import Preview Modal ─────────────────────────────────────────────────────
+// Inner content styles for the Modal v2-rendered import preview. Kept
+// at top level because modal-v2 portals to `document.body`, so
+// selectors nested inside `.agent-view` never match (caught by reagent
+// on PR #513).
+
+.agent-import-count {
+    font-size: 12px;
+    color: var(--secondary-text-color);
+    margin-bottom: 8px;
+}
+
+.agent-import-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 10px;
+}
+
+.agent-import-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--main-text-color);
+    padding: 2px 0;
+
+    &.agent-import-row-skip {
+        opacity: 0.5;
+    }
+
+    .agent-import-row-status {
+        width: 16px;
+        text-align: center;
+        flex-shrink: 0;
+    }
+
+    .agent-import-row-icon {
+        flex-shrink: 0;
+    }
+
+    .agent-import-row-name {
+        font-weight: 500;
+    }
+
+    .agent-import-row-desc,
+    .agent-import-row-skip-label {
+        color: var(--secondary-text-color);
+        font-size: 11px;
+    }
+}
+
+.agent-import-summary {
+    font-size: 12px;
+    color: var(--secondary-text-color);
+    border-top: 1px solid var(--border-color);
+    padding-top: 8px;
+}
+
+.agent-import-result {
+    font-size: 13px;
+    color: var(--main-text-color);
+    text-align: center;
+    padding: 20px 0;
 }

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -2584,145 +2584,67 @@
     }
 
     // === Import Preview Modal ===
-    .agent-import-overlay {
-        position: absolute;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.5);
+    // Outer chrome (overlay / panel / header / footer / buttons) is
+    // now provided by `element/modal-v2`. Only the inner content
+    // styles for the list + summary remain here.
+    .agent-import-count {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+        margin-bottom: 8px;
+    }
+
+    .agent-import-list {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: 10px;
+    }
+
+    .agent-import-row {
         display: flex;
         align-items: center;
-        justify-content: center;
-        z-index: 200;
+        gap: 6px;
+        font-size: 12px;
+        color: var(--main-text-color);
+        padding: 2px 0;
 
-        .agent-import-modal {
-            background: var(--main-bg-color);
-            border: 1px solid var(--border-color);
-            border-radius: 8px;
-            width: 420px;
-            max-width: 90vw;
-            max-height: 70vh;
-            display: flex;
-            flex-direction: column;
-            overflow: hidden;
-
-            .agent-import-modal-header {
-                padding: 12px 16px;
-                border-bottom: 1px solid var(--border-color);
-                font-size: 14px;
-                font-weight: 600;
-                color: var(--main-text-color);
-                flex-shrink: 0;
-            }
-
-            .agent-import-modal-body {
-                padding: 12px 16px;
-                overflow-y: auto;
-                flex: 1;
-
-                .agent-import-count {
-                    font-size: 12px;
-                    color: var(--secondary-text-color);
-                    margin-bottom: 8px;
-                }
-
-                .agent-import-list {
-                    display: flex;
-                    flex-direction: column;
-                    gap: 4px;
-                    margin-bottom: 10px;
-
-                    .agent-import-row {
-                        display: flex;
-                        align-items: center;
-                        gap: 6px;
-                        font-size: 12px;
-                        color: var(--main-text-color);
-                        padding: 2px 0;
-
-                        &.agent-import-row-skip {
-                            opacity: 0.5;
-                        }
-
-                        .agent-import-row-status {
-                            width: 16px;
-                            text-align: center;
-                            flex-shrink: 0;
-                        }
-
-                        .agent-import-row-icon {
-                            flex-shrink: 0;
-                        }
-
-                        .agent-import-row-name {
-                            font-weight: 500;
-                        }
-
-                        .agent-import-row-desc,
-                        .agent-import-row-skip-label {
-                            color: var(--secondary-text-color);
-                            font-size: 11px;
-                        }
-                    }
-                }
-
-                .agent-import-summary {
-                    font-size: 12px;
-                    color: var(--secondary-text-color);
-                    border-top: 1px solid var(--border-color);
-                    padding-top: 8px;
-                }
-
-                .agent-import-result {
-                    font-size: 13px;
-                    color: var(--main-text-color);
-                    text-align: center;
-                    padding: 20px 0;
-                }
-            }
-
-            .agent-import-modal-footer {
-                display: flex;
-                justify-content: flex-end;
-                gap: 8px;
-                padding: 10px 16px;
-                border-top: 1px solid var(--border-color);
-                flex-shrink: 0;
-
-                .agent-import-btn {
-                    height: 28px;
-                    padding: 0 14px;
-                    font-size: 12px;
-                    border-radius: 4px;
-                    cursor: pointer;
-                    border: 1px solid var(--border-color);
-                    transition: background 0.1s, color 0.1s;
-
-                    &.agent-import-btn-cancel {
-                        background: transparent;
-                        color: var(--secondary-text-color);
-
-                        &:hover {
-                            background: color-mix(in srgb, var(--main-text-color) 8%, transparent);
-                            color: var(--main-text-color);
-                        }
-                    }
-
-                    &.agent-import-btn-confirm {
-                        background: color-mix(in srgb, var(--main-text-color) 12%, transparent);
-                        color: var(--main-text-color);
-
-                        &:hover {
-                            background: color-mix(in srgb, var(--main-text-color) 20%, transparent);
-                        }
-
-                        &.agent-action-btn-disabled {
-                            opacity: 0.4;
-                            cursor: default;
-                            pointer-events: none;
-                        }
-                    }
-                }
-            }
+        &.agent-import-row-skip {
+            opacity: 0.5;
         }
+
+        .agent-import-row-status {
+            width: 16px;
+            text-align: center;
+            flex-shrink: 0;
+        }
+
+        .agent-import-row-icon {
+            flex-shrink: 0;
+        }
+
+        .agent-import-row-name {
+            font-weight: 500;
+        }
+
+        .agent-import-row-desc,
+        .agent-import-row-skip-label {
+            color: var(--secondary-text-color);
+            font-size: 11px;
+        }
+    }
+
+    .agent-import-summary {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+        border-top: 1px solid var(--border-color);
+        padding-top: 8px;
+    }
+
+    .agent-import-result {
+        font-size: 13px;
+        color: var(--main-text-color);
+        text-align: center;
+        padding: 20px 0;
     }
 
     // === Setup Wizard ===

--- a/frontend/app/view/agent/components/ImportPreviewModal.tsx
+++ b/frontend/app/view/agent/components/ImportPreviewModal.tsx
@@ -4,6 +4,8 @@
 import { createEffect, createMemo, createSignal, For, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { Button } from "@/element/button";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal-v2";
 
 interface ImportPreviewModalProps {
     payload: ExportForgeAgentsResult | null;
@@ -72,67 +74,66 @@ export const ImportPreviewModal = (props: ImportPreviewModalProps): JSX.Element 
         }
     }
 
-    function handleBackdropClick(e: MouseEvent) {
-        if (e.target === e.currentTarget) props.onClose();
-    }
-
     return (
         <Show when={props.payload != null}>
-            <div class="agent-import-overlay" onClick={handleBackdropClick}>
-                <div class="agent-import-modal">
-                    <div class="agent-import-modal-header">Import Agents</div>
-                    <div class="agent-import-modal-body">
-                        <Show
-                            when={resultMsg() == null}
-                            fallback={<div class="agent-import-result">{resultMsg()}</div>}
-                        >
-                            <div class="agent-import-count">
-                                Found {agentRows().length} agent{agentRows().length !== 1 ? "s" : ""} in file:
-                            </div>
-                            <div class="agent-import-list">
-                                <For each={agentRows()}>
-                                    {(row) => (
-                                        <div classList={{
-                                            "agent-import-row": true,
-                                            "agent-import-row-skip": row.skip,
-                                        }}>
-                                            <span class="agent-import-row-status">
-                                                {row.skip ? "⏭" : "✓"}
-                                            </span>
-                                            <span class="agent-import-row-icon">{row.agent.icon}</span>
-                                            <span class="agent-import-row-name">{row.agent.name}</span>
-                                            <Show when={row.agent.description}>
-                                                <span class="agent-import-row-desc"> — {row.agent.description}</span>
-                                            </Show>
-                                            <Show when={row.skip}>
-                                                <span class="agent-import-row-skip-label"> (already exists)</span>
-                                            </Show>
-                                        </div>
-                                    )}
-                                </For>
-                            </div>
-                            <div class="agent-import-summary">
-                                {toImportCount()} will be imported
-                                <Show when={skipCount() > 0}>
-                                    {" "}&middot; {skipCount()} will be skipped
-                                </Show>
-                            </div>
-                        </Show>
-                    </div>
-                    <div class="agent-import-modal-footer">
-                        <button class="agent-import-btn agent-import-btn-cancel" onClick={props.onClose}>
-                            Cancel
-                        </button>
-                        <button
-                            class="agent-import-btn agent-import-btn-confirm"
-                            classList={{ "agent-action-btn-disabled": importing() || toImportCount() === 0 }}
-                            onClick={handleConfirm}
-                        >
-                            {importing() ? "Importing…" : `Import ${toImportCount()} Agent${toImportCount() !== 1 ? "s" : ""}`}
-                        </button>
-                    </div>
-                </div>
-            </div>
+            <Modal
+                open={true}
+                onClose={() => { if (!importing()) props.onClose(); }}
+                closeOnBackdropClick={!importing()}
+                closeOnEscape={!importing()}
+                size="md"
+            >
+                <ModalHeader title="Import Agents" />
+                <ModalBody>
+                    <Show
+                        when={resultMsg() == null}
+                        fallback={<div class="agent-import-result">{resultMsg()}</div>}
+                    >
+                        <div class="agent-import-count">
+                            Found {agentRows().length} agent{agentRows().length !== 1 ? "s" : ""} in file:
+                        </div>
+                        <div class="agent-import-list">
+                            <For each={agentRows()}>
+                                {(row) => (
+                                    <div classList={{
+                                        "agent-import-row": true,
+                                        "agent-import-row-skip": row.skip,
+                                    }}>
+                                        <span class="agent-import-row-status">
+                                            {row.skip ? "⏭" : "✓"}
+                                        </span>
+                                        <span class="agent-import-row-icon">{row.agent.icon}</span>
+                                        <span class="agent-import-row-name">{row.agent.name}</span>
+                                        <Show when={row.agent.description}>
+                                            <span class="agent-import-row-desc"> — {row.agent.description}</span>
+                                        </Show>
+                                        <Show when={row.skip}>
+                                            <span class="agent-import-row-skip-label"> (already exists)</span>
+                                        </Show>
+                                    </div>
+                                )}
+                            </For>
+                        </div>
+                        <div class="agent-import-summary">
+                            {toImportCount()} will be imported
+                            <Show when={skipCount() > 0}>
+                                {" "}&middot; {skipCount()} will be skipped
+                            </Show>
+                        </div>
+                    </Show>
+                </ModalBody>
+                <ModalFooter>
+                    <Button onClick={props.onClose} disabled={importing()}>
+                        Cancel
+                    </Button>
+                    <Button
+                        onClick={handleConfirm}
+                        disabled={importing() || toImportCount() === 0}
+                    >
+                        {importing() ? "Importing…" : `Import ${toImportCount()} Agent${toImportCount() !== 1 ? "s" : ""}`}
+                    </Button>
+                </ModalFooter>
+            </Modal>
         </Show>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.344",
+  "version": "0.33.345",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.344",
+      "version": "0.33.345",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.344",
+  "version": "0.33.345",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Second modal-v2 consumer migration after #512 (AgentLaunchModal)
- Replaces hand-rolled \`.agent-import-overlay\` / \`.agent-import-modal\` chrome with the Modal v2 primitive
- Nets **−77 LoC** (removes duplicated overlay, panel, header, footer, and button styling that now comes from modal-v2)

## Context
Per [SPEC_ROBUST_MODAL_SYSTEM §6](../blob/main/docs/specs/SPEC_ROBUST_MODAL_SYSTEM_2026_04_23.md) — continuing the migration series. Three more callers to port (\`AboutModal\`, \`MessageModal\`, \`UserInputModal\`) then the trickier \`CommandPaletteModal\` + \`TypeAheadModal\`, then retire the old \`element/modal.tsx\`.

### Inherited from modal-v2 (no new wiring)
- \`role=\"dialog\"\` + \`aria-modal=\"true\"\` + auto-wired \`aria-labelledby\`
- Focus trap + focus save/restore
- Background \`inert\` + body scroll lock (reference-counted for stacking)
- Backdrop blur + fade/pop animations (respects \`prefers-reduced-motion\`)
- Multi-window Portal routing via \`ownerDocument\`

### Preserved behaviour
- ESC + backdrop-click disabled while \`importing\` — in-flight import cannot be accidentally aborted
- Auto-close 1.5s after a successful import

### Removed
- \`.agent-import-overlay\` with \`z-index: 200\` + rgba backdrop
- \`.agent-import-modal\` chrome + the header / body / footer divs
- \`.agent-import-btn\`, \`.agent-import-btn-cancel\`, \`.agent-import-btn-confirm\` → replaced by the shared \`Button\` component in \`ModalFooter\`
- Manual \`handleBackdropClick\` function

### Kept
Inner content classes unchanged: \`.agent-import-count\`, \`.agent-import-list\`, \`.agent-import-row*\`, \`.agent-import-summary\`, \`.agent-import-result\` — un-nested since they no longer live under an overlay wrapper.

## Test plan
- [ ] Click Import in the agent picker's action bar, pick a JSON file → preview modal opens with list
- [ ] Focus starts on a focusable element inside the modal; Tab wraps
- [ ] Backdrop click / ESC close cleanly before import starts
- [ ] Clicking Import disables ESC + backdrop while importing
- [ ] Success shows result text for ~1.5s then auto-closes
- [ ] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)