### PR TITLE
feat(modals): migrate AboutModal to modal-v2 primitive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.345"
+version = "0.33.346"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.345"
+version = "0.33.346"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.345"
+version = "0.33.346"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.345"
+version = "0.33.346"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.345"
+version = "0.33.346"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.345"
+version = "0.33.346"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.345"
+version = "0.33.346"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.345"
+version = "0.33.346"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/modals/about.tsx
+++ b/frontend/app/modals/about.tsx
@@ -3,7 +3,7 @@
 
 import logoUrl from "@/app/asset/logo.svg?url";
 import { modalsModel } from "@/app/store/modalmodel";
-import { Modal } from "./modal";
+import { Modal, ModalBody } from "@/element/modal-v2";
 
 import { isDev } from "@/util/isdev";
 import { getApi } from "../store/global";
@@ -16,53 +16,60 @@ const AboutModal = ({}: AboutModalProps) => {
     const updaterChannel = getApi().getUpdaterChannel();
 
     return (
-        <Modal class="pb-[34px]" onClose={() => modalsModel.popModal()}>
-            <div class="flex flex-col gap-[26px] w-full">
-                <div class="flex flex-col items-center justify-center gap-4 self-stretch w-full text-center">
-                    <img src={logoUrl} style={{ height: "48px" }} />
-                    <div class="text-[25px]">AgentMux</div>
-                    <div class="leading-5">
-                        Open-Source Agentic Workflow Environment
+        <Modal
+            open={true}
+            onClose={() => modalsModel.popModal()}
+            size="md"
+            ariaLabel="About AgentMux"
+        >
+            <ModalBody>
+                <div class="flex flex-col gap-[26px] w-full pb-[34px]">
+                    <div class="flex flex-col items-center justify-center gap-4 self-stretch w-full text-center">
+                        <img src={logoUrl} style={{ height: "48px" }} />
+                        <div class="text-[25px]">AgentMux</div>
+                        <div class="leading-5">
+                            Open-Source Agentic Workflow Environment
+                            <br />
+                            Built for Seamless AI Agent Collaboration
+                        </div>
+                    </div>
+                    <div class="items-center gap-4 self-stretch w-full text-center">
+                        Client Version {details.version} ({isDev() ? "dev-" : ""}
+                        {details.buildTime})
                         <br />
-                        Built for Seamless AI Agent Collaboration
+                        Update Channel: {updaterChannel}
+                    </div>
+                    <div class="flex items-start gap-[10px] self-stretch w-full text-center">
+                        <a
+                            href="https://github.com/agentmuxai/agentmux?ref=about"
+                            target="_blank"
+                            rel="noopener"
+                            class="inline-flex items-center px-4 py-2 rounded border border-border hover:bg-hoverbg transition-colors duration-200"
+                        >
+                            <i class="fa-brands fa-github mr-2"></i>Github
+                        </a>
+                        <a
+                            href="https://agentmux.ai?ref=about"
+                            target="_blank"
+                            rel="noopener"
+                            class="inline-flex items-center px-4 py-2 rounded border border-border hover:bg-hoverbg transition-colors duration-200"
+                        >
+                            <i class="fa-sharp fa-light fa-globe mr-2"></i>Website
+                        </a>
+                        <a
+                            href="https://github.com/agentmuxai/agentmux/blob/main/ACKNOWLEDGEMENTS.md"
+                            target="_blank"
+                            rel="noopener"
+                            class="inline-flex items-center px-4 py-2 rounded border border-border hover:bg-hoverbg transition-colors duration-200"
+                        >
+                            <i class="fa-sharp fa-light fa-heart mr-2"></i>Acknowledgements
+                        </a>
+                    </div>
+                    <div class="items-center gap-4 self-stretch w-full text-center">
+                        &copy; {currentDate.getFullYear()} AgentMux Corp
                     </div>
                 </div>
-                <div class="items-center gap-4 self-stretch w-full text-center">
-                    Client Version {details.version} ({isDev() ? "dev-" : ""}
-                    {details.buildTime})
-                    <br />
-                    Update Channel: {updaterChannel}
-                </div>
-                <div class="flex items-start gap-[10px] self-stretch w-full text-center">
-                    <a
-                        href="https://github.com/agentmuxai/agentmux?ref=about"
-                        target="_blank"
-                        rel="noopener"
-                        class="inline-flex items-center px-4 py-2 rounded border border-border hover:bg-hoverbg transition-colors duration-200"
-                    >
-                        <i class="fa-brands fa-github mr-2"></i>Github
-                    </a>
-                    <a
-                        href="https://agentmux.ai?ref=about"
-                        target="_blank"
-                        rel="noopener"
-                        class="inline-flex items-center px-4 py-2 rounded border border-border hover:bg-hoverbg transition-colors duration-200"
-                    >
-                        <i class="fa-sharp fa-light fa-globe mr-2"></i>Website
-                    </a>
-                    <a
-                        href="https://github.com/agentmuxai/agentmux/blob/main/ACKNOWLEDGEMENTS.md"
-                        target="_blank"
-                        rel="noopener"
-                        class="inline-flex items-center px-4 py-2 rounded border border-border hover:bg-hoverbg transition-colors duration-200"
-                    >
-                        <i class="fa-sharp fa-light fa-heart mr-2"></i>Acknowledgements
-                    </a>
-                </div>
-                <div class="items-center gap-4 self-stretch w-full text-center">
-                    &copy; {currentDate.getFullYear()} AgentMux Corp
-                </div>
-            </div>
+            </ModalBody>
         </Modal>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.345",
+  "version": "0.33.346",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.345",
+      "version": "0.33.346",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.345",
+  "version": "0.33.346",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Third modal-v2 consumer migration (after #512 AgentLaunchModal, #513 ImportPreviewModal)
- First caller migrated away from the \`modals/Modal\` wrapper (distinct from \`element/modal\` — this is the other primitive)

## Context
Per [SPEC_ROBUST_MODAL_SYSTEM §6](../blob/main/docs/specs/SPEC_ROBUST_MODAL_SYSTEM_2026_04_23.md) migration series.

### Diff
- Import swap: \`@/app/modals/modal\` → \`@/element/modal-v2\`
- \`<Modal class=\"pb-[34px]\" onClose={...}>\` → \`<Modal open={true} onClose={...} size=\"md\" ariaLabel=\"About AgentMux\">\`
- No \`ModalHeader\` (About has no title bar) → set \`ariaLabel\` so screen readers get a name
- Custom \`pb-[34px]\` Tailwind padding moved onto the inner flex column since modal-v2 doesn't expose a panel-class prop
- Content wrapped in \`<ModalBody>\`

### Known regression
The old \`modals/Modal\` rendered an X close button in the top-right corner. Modal-v2 doesn't yet. Users dismiss About via ESC or backdrop click. Will restore as a \`showCloseButton\` prop on modal-v2 in a follow-up — intentional to keep migration diffs tight.

### Inherited from modal-v2
- \`role=\"dialog\"\` + \`aria-modal=\"true\"\` + \`aria-label\`
- Focus trap + save/restore
- Background \`inert\` + reference-counted scroll lock
- Backdrop blur + animations (respects \`prefers-reduced-motion\`)
- Multi-window Portal routing via \`ownerDocument\`

## Test plan
- [ ] Open About (from menu or keyboard) → modal appears with backdrop blur
- [ ] Content (logo, version, links, copyright) all render styled correctly
- [ ] ESC closes
- [ ] Backdrop click closes
- [ ] Focus returns to the trigger after close

## Next in series
- Migrate MessageModal (very thin — ~20 lines)
- Migrate UserInputModal
- Migrate CommandPaletteModal + TypeAheadModal
- Add \`showCloseButton\` prop to modal-v2 and restore X on About
- Retire \`element/modal.tsx\` + \`modals/Modal\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)