### PR TITLE
feat(modals): migrate MessageModal to modal-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.346"
+version = "0.33.347"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.346"
+version = "0.33.347"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.346"
+version = "0.33.347"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.346"
+version = "0.33.347"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.346"
+version = "0.33.347"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.346"
+version = "0.33.347"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.346"
+version = "0.33.347"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.346"
+version = "0.33.347"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/modals/messagemodal.scss
+++ b/frontend/app/modals/messagemodal.scss
@@ -1,6 +1,0 @@
-// Copyright 2024-2026, AgentMux Corp.
-// SPDX-License-Identifier: Apache-2.0
-
-.message-modal {
-    min-width: 400px;
-}

--- a/frontend/app/modals/messagemodal.tsx
+++ b/frontend/app/modals/messagemodal.tsx
@@ -1,11 +1,11 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Modal } from "@/app/modals/modal";
+import { Button } from "@/element/button";
+import { Modal, ModalBody, ModalFooter } from "@/element/modal-v2";
 import { modalsModel } from "@/app/store/modalmodel";
 
 import type { JSX } from "solid-js";
-import "./messagemodal.scss";
 
 const MessageModal = ({ children }: { children: JSX.Element }) => {
     function closeModal() {
@@ -13,8 +13,11 @@ const MessageModal = ({ children }: { children: JSX.Element }) => {
     }
 
     return (
-        <Modal class="message-modal" onOk={() => closeModal()} onClose={() => closeModal()}>
-            {children}
+        <Modal open={true} onClose={closeModal} size="md" ariaLabel="Message">
+            <ModalBody>{children}</ModalBody>
+            <ModalFooter>
+                <Button onClick={closeModal}>Ok</Button>
+            </ModalFooter>
         </Modal>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.346",
+  "version": "0.33.347",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.346",
+      "version": "0.33.347",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.346",
+  "version": "0.33.347",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Fourth modal-v2 consumer migration (after #512, #513, #514)
- MessageModal is ~24 lines; trivially small port
- Deletes \`messagemodal.scss\` (only contained \`min-width: 400px\`, now subsumed by modal-v2's \`size=\"md\"\` = 520px)

## Context
Per [SPEC_ROBUST_MODAL_SYSTEM §6](../blob/main/docs/specs/SPEC_ROBUST_MODAL_SYSTEM_2026_04_23.md) migration series.

### Diff
- Import swap: \`@/app/modals/modal\` → \`@/element/modal-v2\`
- \`<Modal onOk={...}>\` (implicit footer button) → explicit \`<ModalFooter><Button onClick={closeModal}>Ok</Button></ModalFooter>\`
- \`ariaLabel=\"Message\"\` since there's no header
- Removed the \`messagemodal.scss\` import + file

### Inherited from modal-v2
- role=dialog / aria-modal / focus trap / scroll lock / inert
- Backdrop blur + animations
- Multi-window Portal routing
- ESC + backdrop click both fire \`onClose\`

## Test plan
- [ ] Any code path that calls \`modalsModel.pushModal(MessageModal, ...)\` opens a dialog with backdrop blur
- [ ] Children render inside the body styled correctly
- [ ] Ok button closes; ESC closes; backdrop click closes
- [ ] Focus returns to the trigger after close

🤖 Generated with [Claude Code](https://claude.com/claude-code)