### PR TITLE
feat(modals): migrate UserInputModal to modal-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.347"
+version = "0.33.348"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.347"
+version = "0.33.348"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.347"
+version = "0.33.348"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.347"
+version = "0.33.348"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.347"
+version = "0.33.348"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.347"
+version = "0.33.348"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.347"
+version = "0.33.348"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.347"
+version = "0.33.348"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/modals/userinputmodal.scss
+++ b/frontend/app/modals/userinputmodal.scss
@@ -1,11 +1,9 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-.userinput-header {
-    font-weight: bold;
-    color: var(--main-text-color);
-    padding-bottom: 10px;
-}
+// `.userinput-header` was replaced by `<ModalHeader>` from modal-v2
+// during the migration — the bold + text-color styling comes from
+// the modal's own `.modal-panel-title` rule.
 
 .userinput-body {
     display: flex;

--- a/frontend/app/modals/userinputmodal.scss
+++ b/frontend/app/modals/userinputmodal.scss
@@ -1,10 +1,6 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// `.userinput-header` was replaced by `<ModalHeader>` from modal-v2
-// during the migration — the bold + text-color styling comes from
-// the modal's own `.modal-panel-title` rule.
-
 .userinput-body {
     display: flex;
     flex-direction: column;

--- a/frontend/app/modals/userinputmodal.tsx
+++ b/frontend/app/modals/userinputmodal.tsx
@@ -72,19 +72,26 @@ const UserInputModal = (userInputRequest: UserInputRequest) => {
     };
 
     // Countdown timer using setInterval — fires an err response when it
-    // hits zero. Cleanup on unmount so a cancel/submit stops the tick.
+    // hits zero. Cleanup on unmount so a cancel/submit stops the tick
+    // AND clears the pending 300ms-delayed err-response so dismissing
+    // within that window doesn't double-fire handleSendErrResponse
+    // against a stale request (would pop a sibling modal).
     let intervalId: ReturnType<typeof setInterval>;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
     intervalId = setInterval(() => {
         setCountdown((prev) => {
             if (prev <= 1) {
                 clearInterval(intervalId);
-                setTimeout(() => handleSendErrResponse(), 300);
+                timeoutId = setTimeout(() => handleSendErrResponse(), 300);
                 return 0;
             }
             return prev - 1;
         });
     }, 1000);
-    onCleanup(() => clearInterval(intervalId));
+    onCleanup(() => {
+        clearInterval(intervalId);
+        if (timeoutId !== null) clearTimeout(timeoutId);
+    });
 
     const queryText = (): JSX.Element => {
         if (userInputRequest.markdown) {

--- a/frontend/app/modals/userinputmodal.tsx
+++ b/frontend/app/modals/userinputmodal.tsx
@@ -1,12 +1,13 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Modal } from "@/app/modals/modal";
+import { Button } from "@/element/button";
 import { Markdown } from "@/element/markdown";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal-v2";
 import { modalsModel } from "@/store/modalmodel";
 import * as keyutil from "@/util/keyutil";
 import { fireAndForget } from "@/util/util";
-import { createSignal, Show, type JSX } from "solid-js";
+import { createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { UserInputService } from "../store/services";
 import "./userinputmodal.scss";
 
@@ -62,31 +63,28 @@ const UserInputModal = (userInputRequest: UserInputRequest) => {
     };
 
     const handleKeyDown = (waveEvent: WaveKeyboardEvent): boolean => {
-        if (keyutil.checkKeyPressed(waveEvent, "Escape")) {
-            handleSendErrResponse();
-            return;
-        }
+        // Enter submits; ESC is handled by modal-v2's closeOnEscape
+        // which calls our onClose → handleSendErrResponse.
         if (keyutil.checkKeyPressed(waveEvent, "Enter")) {
             handleSubmit();
             return true;
         }
     };
 
-    // Countdown timer using setInterval
+    // Countdown timer using setInterval — fires an err response when it
+    // hits zero. Cleanup on unmount so a cancel/submit stops the tick.
     let intervalId: ReturnType<typeof setInterval>;
-    const startCountdown = () => {
-        intervalId = setInterval(() => {
-            setCountdown((prev) => {
-                if (prev <= 1) {
-                    clearInterval(intervalId);
-                    setTimeout(() => handleSendErrResponse(), 300);
-                    return 0;
-                }
-                return prev - 1;
-            });
-        }, 1000);
-    };
-    startCountdown();
+    intervalId = setInterval(() => {
+        setCountdown((prev) => {
+            if (prev <= 1) {
+                clearInterval(intervalId);
+                setTimeout(() => handleSendErrResponse(), 300);
+                return 0;
+            }
+            return prev - 1;
+        });
+    }, 1000);
+    onCleanup(() => clearInterval(intervalId));
 
     const queryText = (): JSX.Element => {
         if (userInputRequest.markdown) {
@@ -144,18 +142,26 @@ const UserInputModal = (userInputRequest: UserInputRequest) => {
 
     return (
         <Modal
-            onOk={() => handleSubmit()}
-            onCancel={() => handleNegativeResponse()}
-            onClose={() => handleSendErrResponse()}
-            okLabel={userInputRequest.oklabel}
-            cancelLabel={userInputRequest.cancellabel}
+            open={true}
+            onClose={handleSendErrResponse}
+            size="md"
         >
-            <div class="userinput-header">{userInputRequest.title + ` (${countdown()}s)`}</div>
-            <div class="userinput-body">
-                {queryText()}
-                {inputBox()}
-                {optionalCheckbox()}
-            </div>
+            <ModalHeader title={`${userInputRequest.title} (${countdown()}s)`} />
+            <ModalBody>
+                <div class="userinput-body">
+                    {queryText()}
+                    {inputBox()}
+                    {optionalCheckbox()}
+                </div>
+            </ModalBody>
+            <ModalFooter>
+                <Button onClick={handleNegativeResponse}>
+                    {userInputRequest.cancellabel ?? "Cancel"}
+                </Button>
+                <Button onClick={handleSubmit}>
+                    {userInputRequest.oklabel ?? "Ok"}
+                </Button>
+            </ModalFooter>
         </Modal>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.347",
+  "version": "0.33.348",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.347",
+      "version": "0.33.348",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.347",
+  "version": "0.33.348",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Fifth modal-v2 consumer migration (after #512–#515)
- UserInputModal is the heaviest of the \`modals/Modal\` consumers — countdown timer, text/confirm branching, optional checkbox, Enter/Esc semantics

## Context
Per [SPEC_ROBUST_MODAL_SYSTEM §6](../blob/main/docs/specs/SPEC_ROBUST_MODAL_SYSTEM_2026_04_23.md) migration series.

### Diff
- Import swap: \`@/app/modals/modal\` → \`@/element/modal-v2\` (+ \`Button\` import)
- Old \`onOk\` / \`onCancel\` / \`onClose\` (three separate handlers on the old primitive) → explicit \`<ModalFooter>\` with Cancel + Ok buttons, plus \`onClose={handleSendErrResponse}\` on Modal for the ESC / backdrop / countdown-timeout paths (all three want the same \"canceled by user\" err response)
- \`.userinput-header <div>\` → \`<ModalHeader>\` since modal-v2's own \`.modal-panel-title\` rule supplies the bold + color the old div had. SCSS rule removed.
- Dropped the inline ESC-key check in \`handleKeyDown\` — modal-v2's \`closeOnEscape\` (default on) routes ESC to our \`onClose\`
- Countdown interval now uses \`onCleanup\` to clear on unmount, preventing the 300ms-delayed err-response from firing against a stale request if the user dismisses first

### Preserved behaviour
- Enter submits (via remaining keydown handler)
- Countdown title with live seconds remaining
- autofocus on the input field
- Text vs confirm response-type branching
- Optional checkbox

### Inherited from modal-v2
- \`role=\"dialog\"\` + \`aria-modal=\"true\"\` + auto-wired \`aria-labelledby\` to the header title
- Focus trap + save/restore
- Background \`inert\` + scroll lock (reference-counted)
- Backdrop blur + animations
- Multi-window Portal routing

## Test plan
- [ ] Text input flow: opens with input focused; Enter submits; Cancel / ESC / backdrop all send err-response; countdown decrements each second
- [ ] Confirm flow: opens without input; Ok sends confirm=true; Cancel sends confirm=false; ESC / backdrop / countdown timeout send err-response
- [ ] Checkbox flow: \`checkboxmsg\` non-empty renders checkbox; state included in the response
- [ ] Markdown query text: markdown flag renders via \`<Markdown>\` component
- [ ] Type check clean

## Remaining migrations
- CommandPaletteModal (keybinding disable during open)
- TypeAheadModal (block-ref mount target)
- ConnTypeAheadModal
- Add \`showCloseButton\` prop to modal-v2 + restore X on About
- Retire \`element/modal.tsx\` + \`modals/Modal\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)