### PR TITLE
feat(modals): migrate CommandPaletteModal to modal-v2 + add placement/panelClass props

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.348"
+version = "0.33.349"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.348"
+version = "0.33.349"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.348"
+version = "0.33.349"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.348"
+version = "0.33.349"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.348"
+version = "0.33.349"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.348"
+version = "0.33.349"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.348"
+version = "0.33.349"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.348"
+version = "0.33.349"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/element/modal-v2.scss
+++ b/frontend/app/element/modal-v2.scss
@@ -14,6 +14,13 @@
     place-items: center;
     padding: var(--space-6);
 
+    // Top-anchored placement for command-palette-style surfaces that
+    // drop from the top of the viewport.
+    &[data-placement="top"] {
+        align-items: start;
+        padding-top: 15vh;
+    }
+
     // The root itself is focusable as a last-resort target (when the
     // panel has no focusable children, `firstFocusable(panelRef)`
     // returns null and we fall back to panelRef. panelRef has

--- a/frontend/app/element/modal-v2.tsx
+++ b/frontend/app/element/modal-v2.tsx
@@ -159,6 +159,14 @@ export interface ModalProps {
     closeOnEscape?: boolean;
     /** Width preset. `fit` = auto. Default `md`. */
     size?: "sm" | "md" | "lg" | "xl" | "fit";
+    /** Vertical placement of the panel. `center` (default) centers
+     *  with the grid; `top` anchors near the top of the viewport —
+     *  matches command-palette-style surfaces that drop down from
+     *  the top of the screen. */
+    placement?: "center" | "top";
+    /** Optional extra class on the panel — lets a caller apply
+     *  component-specific layout without sidestepping the primitive. */
+    panelClass?: string;
     /** Override aria-labelledby. By default resolves from a nested ModalHeader. */
     ariaLabel?: string;
     ariaLabelledBy?: string;
@@ -300,6 +308,7 @@ export const Modal: Component<ModalProps> = (props) => {
                 <ModalTitleIdContext.Provider value={defaultTitleId}>
                     <div
                         class="modal-root"
+                        data-placement={props.placement ?? "center"}
                         role="dialog"
                         aria-modal="true"
                         aria-label={props.ariaLabelledBy ? undefined : props.ariaLabel}
@@ -317,7 +326,7 @@ export const Modal: Component<ModalProps> = (props) => {
                         />
                         <div
                             ref={panelRef}
-                            class="modal-panel"
+                            class={`modal-panel ${props.panelClass ?? ""}`}
                             data-size={props.size ?? "md"}
                             tabIndex={-1}
                         >

--- a/frontend/app/modals/command-palette.scss
+++ b/frontend/app/modals/command-palette.scss
@@ -1,33 +1,27 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Command-palette specific styles. Outer chrome (backdrop, z-index,
+// scroll lock, inert) is provided by modal-v2; this file only styles
+// the panel sizing + inner search row + result list.
 
-.command-palette-backdrop {
-    position: fixed;
-    inset: 0;
-    background: rgba(0, 0, 0, 0.45);
-    // Command palette is a modal — lives in the modal slot.
-    // Backdrop + container are siblings; DOM order controls paint.
-    z-index: var(--z-modal);
+// Override modal-v2's default panel width for the palette. Applied
+// via the `panelClass="command-palette-panel"` prop passed to Modal.
+.modal-panel.command-palette-panel {
+    width: 560px;
+    max-width: 92vw;
+    max-height: 480px;
+    padding: 0;
+    // Panel content manages its own scrolling in the list area, so
+    // let overflow fall through.
+    overflow: hidden;
 }
 
 .command-palette-container {
-    position: fixed;
-    top: 20%;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 560px;
-    max-height: 480px;
-    background: var(--modal-bg-color, #1e1e1e);
-    border: 1px solid var(--border-color, #444);
-    border-radius: 8px;
-    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
-    z-index: var(--z-modal);
     display: flex;
     flex-direction: column;
-    overflow: hidden;
-
-    // Ensure command palette is above all other content
-    isolation: isolate;
+    height: 100%;
+    max-height: inherit;
 }
 
 .command-palette-input-row {

--- a/frontend/app/modals/command-palette.tsx
+++ b/frontend/app/modals/command-palette.tsx
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Command palette modal — opened via Ctrl+P, lists all registered commands.
+// Migrated to the shared `element/modal-v2` primitive; the palette's
+// specific chrome (search row + scroll list) lives in the panel body.
 
 import { commandRegistry, type CommandEntry } from "@/app/store/command-registry";
 import { modalsModel } from "@/app/store/modalmodel";
 import { disableGlobalKeybindings, enableGlobalKeybindings } from "@/app/store/keymodel";
+import { Modal } from "@/element/modal-v2";
 import { createMemo, createSignal, For, onCleanup, onMount, type JSX } from "solid-js";
-import { Portal } from "solid-js/web";
 import "./command-palette.scss";
 
 const CATEGORY_ORDER: string[] = ["Open", "Split", "Window", "Tab", "Pane", "Dev"];
@@ -49,7 +51,10 @@ const CommandPaletteModal = (): JSX.Element => {
 
     onMount(() => {
         disableGlobalKeybindings();
-        inputRef?.focus();
+        // Modal-v2 will focus the first focusable after Portal mount
+        // (the search input). Keep a defensive explicit focus() in case
+        // the order of focusable elements ever changes.
+        queueMicrotask(() => inputRef?.focus());
     });
 
     onCleanup(() => {
@@ -72,13 +77,9 @@ const CommandPaletteModal = (): JSX.Element => {
         }, 0);
     }
 
+    // Arrow keys + Enter are palette-specific navigation. ESC and
+    // backdrop close are handled by modal-v2 → `onClose`.
     function handleKeyDown(e: KeyboardEvent) {
-        if (e.key === "Escape") {
-            e.preventDefault();
-            e.stopPropagation();
-            close();
-            return;
-        }
         if (e.key === "ArrowDown") {
             e.preventDefault();
             setSelectedIdx((i) => Math.min(i + 1, filtered().length - 1));
@@ -102,8 +103,13 @@ const CommandPaletteModal = (): JSX.Element => {
     }
 
     return (
-        <Portal mount={document.getElementById("main") ?? document.body}>
-            <div class="command-palette-backdrop" onClick={close} />
+        <Modal
+            open={true}
+            onClose={close}
+            placement="top"
+            panelClass="command-palette-panel"
+            ariaLabel="Command palette"
+        >
             <div class="command-palette-container" onKeyDown={handleKeyDown}>
                 <div class="command-palette-input-row">
                     <i class="fa-sharp fa-solid fa-magnifying-glass command-palette-search-icon" />
@@ -146,7 +152,7 @@ const CommandPaletteModal = (): JSX.Element => {
                     )}
                 </div>
             </div>
-        </Portal>
+        </Modal>
     );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.348",
+  "version": "0.33.349",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.348",
+      "version": "0.33.349",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.348",
+  "version": "0.33.349",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Sixth modal-v2 consumer migration. Command palette was the last modal using a custom Portal implementation
- Along the way: two small additive props on modal-v2 (\`placement\` + \`panelClass\`) to handle non-centered surfaces
- Net LoC: −0 or thereabouts; complexity moves out of the consumer and into the shared primitive

## Context
Per [SPEC_ROBUST_MODAL_SYSTEM §6](../blob/main/docs/specs/SPEC_ROBUST_MODAL_SYSTEM_2026_04_23.md) migration series.

### New modal-v2 props
1. **\`placement?: \"center\" | \"top\"\`** — sets the root grid's vertical alignment. \`top\` (15vh padding-top + \`align-items: start\`) matches the command-palette / quick-open pattern that drops from the top of the viewport.
2. **\`panelClass?: string\`** — appends a custom class to \`.modal-panel\` so consumers can override width / padding / overflow without sidestepping the primitive.

### CommandPaletteModal diff
- Drops its own Portal, backdrop div, and hand-rolled z-index wiring
- Drops inline ESC handler (modal-v2 → \`onClose\` handles it)
- Arrow keys + Enter navigation stay (palette-specific, not modal-level)
- Width / max-height / chrome applied via \`.command-palette-panel\` referenced from \`panelClass\`
- \`disableGlobalKeybindings\` / \`enableGlobalKeybindings\` stay (app-wide keybinding scope, not modal-level)

### Inherited from modal-v2
- role=dialog / aria-modal / aria-label=\"Command palette\"
- Focus trap + save/restore
- Background inert + reference-counted scroll lock (multi-window)
- Backdrop blur + animations (respects \`prefers-reduced-motion\`)

## Test plan
- [ ] Ctrl+P opens palette; input focused
- [ ] Arrow keys navigate results; Enter executes
- [ ] ESC closes; clicking backdrop closes
- [ ] Type filter narrows list; click selects
- [ ] Focus returns to the trigger after execute/close
- [ ] Global keybindings re-enable on close

## Remaining migrations
- TypeAheadModal (block-ref mount target — will likely need a \`mountTarget\` prop on modal-v2)
- ConnTypeAheadModal (similar to TypeAheadModal)
- Add \`showCloseButton\` prop to modal-v2 + restore X on About
- Retire \`element/modal.tsx\` + \`modals/Modal\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)