### PR TITLE
feat(agent-pane): use ConfirmModal for definition delete confirmation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.352"
+version = "0.33.353"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.352"
+version = "0.33.353"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.352"
+version = "0.33.353"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.352"
+version = "0.33.353"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.352"
+version = "0.33.353"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.352"
+version = "0.33.353"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.352"
+version = "0.33.353"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.352"
+version = "0.33.353"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -3968,3 +3968,15 @@
     text-align: center;
     padding: 20px 0;
 }
+
+// Error line shown inside the delete-confirm modal when the RPC fails.
+// Top level (not under .agent-view) because the ConfirmModal portals
+// to document.body.
+.agent-picker-delete-error {
+    margin-top: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    font-size: var(--text-sm);
+    color: var(--error-color);
+    background: color-mix(in srgb, var(--error-color) 10%, transparent);
+    border-radius: var(--radius-sm);
+}

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -19,6 +19,7 @@ import { AgentCard } from "./AgentCard";
 import { AgentCardSettingsPanel } from "./AgentCardSettingsPanel";
 import { AgentActionBar } from "./AgentActionBar";
 import { AgentLaunchModal, type LaunchOverrides } from "./AgentLaunchModal";
+import { ConfirmModal } from "@/element/modal-v2";
 
 // ── useForgeAgents hook ───────────────────────────────────────────────────────
 
@@ -67,6 +68,8 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     const [launching, setLaunching] = createSignal<string | null>(null);
     const [nodejsError, setNodejsError] = createSignal<string | null>(null);
     const [launchModalAgent, setLaunchModalAgent] = createSignal<ForgeAgent | null>(null);
+    const [deleteCandidate, setDeleteCandidate] = createSignal<ForgeAgent | null>(null);
+    const [deleteError, setDeleteError] = createSignal<string | null>(null);
     const agents = useForgeAgents();
 
     // Inline Forge-settings panel: which definition is expanded.
@@ -112,20 +115,26 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     };
 
     /**
-     * Delete a Forge definition after confirmation. The backend
-     * `DeleteForgeAgent` RPC removes the row and emits a
+     * Stage a Forge definition for deletion — the actual delete runs
+     * via `handleDeleteConfirm` when the user confirms in the modal.
+     * The backend `DeleteForgeAgent` RPC removes the row and emits a
      * `forgeagents:changed` event, which `useForgeAgents` re-fetches
      * on — so the list updates without manual refresh.
      */
-    const handleDelete = async (agent: ForgeAgent) => {
-        const ok = window.confirm(
-            `Delete definition "${agent.name}"?\n\nThis removes it permanently. Any open panes running instances of it will stay connected until you close them.`
-        );
-        if (!ok) return;
+    const handleDelete = (agent: ForgeAgent) => {
+        setDeleteError(null);
+        setDeleteCandidate(agent);
+    };
+
+    const handleDeleteConfirm = async () => {
+        const agent = deleteCandidate();
+        if (!agent) return;
         try {
             await RpcApi.DeleteForgeAgentCommand(TabRpcClient, { id: agent.id });
+            setDeleteCandidate(null);
         } catch (e: any) {
-            alert(`Delete failed: ${e?.message ?? String(e)}`);
+            setDeleteError(e?.message ?? String(e));
+            // Leave the modal open so the user sees the error.
         }
     };
 
@@ -200,6 +209,28 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         onCancel={() => setLaunchModalAgent(null)}
                         onSubmit={handleLaunchSubmit}
                     />
+                )}
+            </Show>
+            <Show when={deleteCandidate()}>
+                {(agent) => (
+                    <ConfirmModal
+                        open={true}
+                        title={`Delete definition "${agent().name}"?`}
+                        description="This removes it permanently. Any open panes running instances of it will stay connected until you close them."
+                        confirmLabel="Delete"
+                        destructive
+                        onConfirm={handleDeleteConfirm}
+                        onCancel={() => {
+                            setDeleteCandidate(null);
+                            setDeleteError(null);
+                        }}
+                    >
+                        <Show when={deleteError()}>
+                            <div class="agent-picker-delete-error">
+                                Delete failed: {deleteError()}
+                            </div>
+                        </Show>
+                    </ConfirmModal>
                 )}
             </Show>
         </>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.352",
+  "version": "0.33.353",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.352",
+      "version": "0.33.353",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.352",
+  "version": "0.33.353",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- First real consumer of the \`ConfirmModal\` preset added in #520
- Replaces the jarring native \`window.confirm\` + \`alert\` pair with an in-app modal that matches the rest of the UI
- Destructive mode → red confirm button + initial focus on Cancel

## Context
Continuing the modal-v2 migration polish. The delete-definition flow was the most visible remaining \`window.confirm\` in the agent pane (and the agent-picker is a top-level surface many users hit).

### Diff
- \`handleDelete\` split into:
  - Stage-on-click: sets \`deleteCandidate\` signal
  - \`handleDeleteConfirm\`: runs the actual DeleteForgeAgent RPC when the user confirms
- Error state stays inside the modal (inline \`.agent-picker-delete-error\`) instead of popping a separate \`alert()\` — users can retry or cancel without losing context
- Flagged \`destructive\` so the preset flips the confirm button to red and routes initial focus to Cancel

### Inherited from ConfirmModal / modal-v2
- \`role=\"dialog\"\` + \`aria-modal\` + focus trap + scroll lock + inert
- Backdrop blur + animations (\`prefers-reduced-motion\` respected)
- Multi-window Portal routing
- Pending lock during async onConfirm: no double-delete on rapid clicks; ESC / backdrop blocked while in flight

## Test plan
- [ ] Click 🗑 on a definition card → modal appears with agent name in title, Cancel focused
- [ ] ESC / Cancel / backdrop all dismiss without deleting
- [ ] Confirm deletes; modal closes; list refreshes via \`forgeagents:changed\` event
- [ ] Force an error (e.g. disconnect backend): modal stays open with error line; Cancel still works; no sibling alert
- [ ] Second rapid click during in-flight delete is a no-op (pending lock)

## Follow-ups
Three more \`window.confirm\`/\`alert\` callsites worth migrating:
- \`agent-view.tsx\` pane-close-with-tracked-processes
- \`swarm-view.tsx\` kill-all-under-agent
- \`AgentActionBar.tsx\` import-error alerts (these need a MessageModal-style toast rather than ConfirmModal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)