### PR TITLE
feat(modals): migrate remaining window.confirm kill-tree callsites to ConfirmModal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.353"
+version = "0.33.354"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.353"
+version = "0.33.354"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.353"
+version = "0.33.354"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.353"
+version = "0.33.354"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.353"
+version = "0.33.354"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.353"
+version = "0.33.354"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.353"
+version = "0.33.354"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.353"
+version = "0.33.354"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -36,6 +36,7 @@ import { SessionDigestBanner } from "./components/SessionDigestBanner";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { createBlock, getApi, WOS } from "@/app/store/global";
+import { ConfirmModal } from "@/element/modal-v2";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { parseAgentAccounts, loadAccounts } from "@/app/view/identity/identity-model";
 import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";
@@ -158,8 +159,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const processCount = useProcessCount(model.blockId);
 
     // Pane-close confirm: when the user closes this pane with tracked
-    // processes still alive, intercept the layout's `onClose` with a
-    // confirm dialog. Accept → `agent.kill-tree` RPC then proceed with
+    // processes still alive, intercept the layout's `onClose` and raise
+    // a ConfirmModal. Accept → `agent.kill-tree` RPC then proceed with
     // close. Cancel → abort, pane stays open. Zero tracked processes
     // → original close path, no prompt.
     //
@@ -168,6 +169,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // surface today, and threading one through would touch the layout
     // + block-frame + pane-actions tree. A local wrapper is enough for
     // v1 of this feature.
+    const [closeConfirm, setCloseConfirm] = createSignal<{
+        count: number;
+        originalClose: () => void;
+    } | null>(null);
+
     onMount(() => {
         const original = model.nodeModel.onClose;
         const wrapped = () => {
@@ -176,19 +182,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 original?.();
                 return;
             }
-            const suffix = count === 1 ? "process" : "processes";
-            const ok = window.confirm(
-                `This agent has ${count} ${suffix} still running.\n\n` +
-                `Close and kill them all?`
-            );
-            if (!ok) return;
-            // Kill first, then proceed with layout close. `finally` so
-            // the close still happens even if the kill RPC errors —
-            // we've already committed to closing, and the tracker's
-            // Drop impl in `delete_controller` will nuke what survived.
-            void RpcApi.AgentKillTreeCommand(TabRpcClient, {
-                block_id: model.blockId,
-            }).finally(() => original?.());
+            // Stash the original close so the modal can invoke it on
+            // confirm. Not calling original() here keeps the pane open
+            // until the user decides.
+            setCloseConfirm({ count, originalClose: () => original?.() });
         };
         model.nodeModel.onClose = wrapped;
         onCleanup(() => {
@@ -199,6 +196,24 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             }
         });
     });
+
+    const handleCloseConfirmAccept = async () => {
+        const info = closeConfirm();
+        if (!info) return;
+        try {
+            // Kill first, then proceed with layout close. The tracker's
+            // Drop impl in `delete_controller` will nuke what survived
+            // if the RPC errors — we've already committed to closing.
+            await RpcApi.AgentKillTreeCommand(TabRpcClient, {
+                block_id: model.blockId,
+            });
+        } catch {
+            // swallow — close proceeds regardless
+        } finally {
+            setCloseConfirm(null);
+            info.originalClose();
+        }
+    };
 
     // Subscribe to subprocess output and parse into DocumentNodes.
     // `documentVersion` is bumped whenever we mutate the document externally
@@ -591,6 +606,23 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 AgentPicker view only. Once an agent is loaded the user
                 is working in the conversation; the action bar would
                 just take up vertical space. */}
+            <Show when={closeConfirm()}>
+                {(info) => (
+                    <ConfirmModal
+                        open={true}
+                        title="Close pane?"
+                        description={
+                            `This agent has ${info().count} ${
+                                info().count === 1 ? "process" : "processes"
+                            } still running. Close and kill them all?`
+                        }
+                        confirmLabel="Close and kill"
+                        destructive
+                        onConfirm={handleCloseConfirmAccept}
+                        onCancel={() => setCloseConfirm(null)}
+                    />
+                )}
+            </Show>
         </div>
     );
 };

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createSignal, For, Show, type JSX } from "solid-js";
+import { ConfirmModal } from "@/element/modal-v2";
 import type {
     SwarmViewModel,
     ActiveSubagent,
@@ -512,12 +513,14 @@ function SwarmActivity({ model }: { model: SwarmViewModel }): JSX.Element {
 
 function SwarmActivityGroup({ group }: { group: AgentProcessGroup }): JSX.Element {
     const [busy, setBusy] = createSignal(false);
+    const [confirmOpen, setConfirmOpen] = createSignal(false);
 
-    const killTree = async () => {
+    const killTree = () => {
         if (busy()) return;
-        const count = group.processes.length;
-        const suffix = count === 1 ? "process" : "processes";
-        if (!window.confirm(`Kill all ${count} ${suffix} under this agent?`)) return;
+        setConfirmOpen(true);
+    };
+
+    const handleKillConfirm = async () => {
         setBusy(true);
         try {
             await RpcApi.AgentKillTreeCommand(TabRpcClient, { block_id: group.block_id });
@@ -528,6 +531,7 @@ function SwarmActivityGroup({ group }: { group: AgentProcessGroup }): JSX.Elemen
             // Silently tolerate — older backends without the RPC.
         } finally {
             setBusy(false);
+            setConfirmOpen(false);
         }
     };
 
@@ -589,6 +593,21 @@ function SwarmActivityGroup({ group }: { group: AgentProcessGroup }): JSX.Elemen
                         </For>
                     </tbody>
                 </table>
+            </Show>
+            <Show when={confirmOpen()}>
+                <ConfirmModal
+                    open={true}
+                    title="Kill all processes?"
+                    description={
+                        `This will terminate ${group.processes.length} ${
+                            group.processes.length === 1 ? "process" : "processes"
+                        } under this agent.`
+                    }
+                    confirmLabel="Kill all"
+                    destructive
+                    onConfirm={handleKillConfirm}
+                    onCancel={() => setConfirmOpen(false)}
+                />
             </Show>
         </div>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.353",
+  "version": "0.33.354",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.353",
+      "version": "0.33.354",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.353",
+  "version": "0.33.354",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Two more \`window.confirm\` → \`ConfirmModal\` migrations, following the agent-picker delete flow (#521)
- Both flagged \`destructive\` — red confirm button + initial Cancel focus

## Context
Continues the modal-v2 migration polish series. Every remaining kill-tree confirmation in the app now uses the in-app \`ConfirmModal\` preset.

### Migrated
1. **Agent pane close-with-tracked-processes** (\`agent-view.tsx\`)
   - The \`onClose\` wrapper previously blocked on \`window.confirm\`. Now stashes the count + original close callback into a \`closeConfirm\` signal; the ConfirmModal renders at the root of the presentation view.
   - Accept → runs \`AgentKillTreeCommand\` then invokes the original close
   - Cancel → does nothing, pane stays open
   - Modal stays mounted while the pane is alive, so the user isn't rushed

2. **Swarm kill-all per agent** (\`swarm-view.tsx\`)
   - \`killTree\` on \`SwarmActivityGroup\` used to pop \`window.confirm\` synchronously
   - Now sets \`confirmOpen\` and the ConfirmModal handles the decision

### Inherited from ConfirmModal / modal-v2
- role=dialog / aria-modal / focus trap / scroll lock / inert
- Backdrop blur + animations
- Multi-window Portal routing
- Pending lock — rapid click during in-flight kill is a no-op
- ESC / backdrop blocked while pending

## Remaining
Three \`alert()\` calls in \`AgentActionBar.tsx\` handle import/export errors. They're toasts, not confirmations — the correct target is a MessageModal or a dedicated toast surface. Separate PR.

## Test plan
- [ ] Close a pane with running processes → modal appears; ESC / Cancel keeps pane; Confirm kills + closes
- [ ] Swarm kill-all → same flow; modal closes after success; pending lock during RPC
- [ ] Close pane with zero processes → no modal, close happens immediately (unchanged)
- [ ] Type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)