### PR TITLE
feat(agent-pane): replace AgentActionBar alert() calls with modal-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.354"
+version = "0.33.355"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.354"
+version = "0.33.355"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.354"
+version = "0.33.355"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.354"
+version = "0.33.355"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.354"
+version = "0.33.355"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.354"
+version = "0.33.355"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.354"
+version = "0.33.355"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.354"
+version = "0.33.355"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentActionBar.tsx
+++ b/frontend/app/view/agent/components/AgentActionBar.tsx
@@ -1,15 +1,20 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { createSignal, type JSX } from "solid-js";
+import { createSignal, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { Button } from "@/element/button";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal-v2";
 import { ImportPreviewModal } from "./ImportPreviewModal";
 
 export const AgentActionBar = (): JSX.Element => {
     const [importing, setImporting] = createSignal(false);
     const [exporting, setExporting] = createSignal(false);
     const [importPayload, setImportPayload] = createSignal<ExportForgeAgentsResult | null>(null);
+    // Error dialog replaces the four `alert()` callsites — in-app,
+    // styled, focus-managed, matches the rest of the UI.
+    const [errorMsg, setErrorMsg] = createSignal<string | null>(null);
 
     function handleImportClick() {
         if (importing()) return;
@@ -27,17 +32,17 @@ export const AgentActionBar = (): JSX.Element => {
                 try {
                     parsed = JSON.parse(text);
                 } catch {
-                    alert("Invalid file — expected AgentMux export format (JSON parse error)");
+                    setErrorMsg("Invalid file — expected AgentMux export format (JSON parse error)");
                     return;
                 }
                 if (!parsed?.agents || !Array.isArray(parsed.agents)) {
-                    alert("Invalid file — expected AgentMux export format (missing agents array)");
+                    setErrorMsg("Invalid file — expected AgentMux export format (missing agents array)");
                     return;
                 }
                 setImportPayload(parsed);
             } catch (err) {
                 console.error("AgentActionBar: import read error", err);
-                alert("Failed to read file");
+                setErrorMsg("Failed to read file");
             } finally {
                 setImporting(false);
             }
@@ -65,7 +70,7 @@ export const AgentActionBar = (): JSX.Element => {
             URL.revokeObjectURL(url);
         } catch (err) {
             console.error("AgentActionBar: export error", err);
-            alert("Export failed");
+            setErrorMsg("Export failed");
         } finally {
             setExporting(false);
         }
@@ -95,6 +100,20 @@ export const AgentActionBar = (): JSX.Element => {
                 payload={importPayload()}
                 onClose={() => setImportPayload(null)}
             />
+            <Show when={errorMsg()}>
+                <Modal
+                    open={true}
+                    onClose={() => setErrorMsg(null)}
+                    size="sm"
+                    ariaLabel="Error"
+                >
+                    <ModalHeader title="Something went wrong" />
+                    <ModalBody>{errorMsg()}</ModalBody>
+                    <ModalFooter>
+                        <Button onClick={() => setErrorMsg(null)}>Close</Button>
+                    </ModalFooter>
+                </Modal>
+            </Show>
         </>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.354",
+  "version": "0.33.355",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.354",
+      "version": "0.33.355",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.354",
+  "version": "0.33.355",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Replaces the four \`alert()\` calls in \`AgentActionBar\` (import parse failure, missing agents array, read failure, export failure) with a single modal-v2 error dialog
- No remaining \`window.confirm\` or \`alert()\` in the agent / swarm surfaces after this lands

## Context
Final polish in the modal-v2 migration series. These are single-button error notifications, so a plain \`<Modal>\` with ModalHeader / ModalBody / ModalFooter + Close button fits better than \`ConfirmModal\` (which has a destructive-action / Cancel semantic).

### Diff
- Added \`errorMsg\` signal; the four \`alert()\` callsites set it instead of calling the browser alert
- Added \`<Show when={errorMsg()}>\` wrapping a \`<Modal size=\"sm\" ariaLabel=\"Error\">\` with a single Close button that clears the signal

### Inherited from modal-v2
- role=dialog / aria-modal / focus trap / scroll lock / inert
- Backdrop blur + animations (respects \`prefers-reduced-motion\`)
- Multi-window Portal routing
- ESC + backdrop close

## Test plan
- [ ] Import a non-JSON file → error modal \"Invalid file — … JSON parse error\"
- [ ] Import a JSON file missing \`agents\` array → error modal about missing array
- [ ] Force a read failure (e.g. select a locked file) → error modal \"Failed to read file\"
- [ ] Force an export failure (kill backend) → error modal \"Export failed\"
- [ ] Close button dismisses; ESC dismisses; backdrop click dismisses

## Modal-v2 migration series status
- ✅ Primitive (#511) with ARIA, focus, multi-window, stack
- ✅ 6 consumers migrated (#512–#517)
- ✅ Old primitives retired (#518)
- ✅ showCloseButton prop + X on About (#519)
- ✅ ConfirmModal preset (#520)
- ✅ Agent-picker delete → ConfirmModal (#521)
- ✅ Kill-tree confirms (agent close + swarm) → ConfirmModal (#522)
- ✅ AgentActionBar alerts → Modal (this PR)

Remaining opportunity: the \`TypeAheadModal\` / \`ConnTypeAheadModal\` pair are really popover-style dropdowns, not modals; a separate spec would port them to the \`Popover\` primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)