### PR TITLE
feat(swarm): Instances tab — list every launched AgentInstance (PR G)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.357"
+version = "0.33.358"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.357"
+version = "0.33.358"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.357"
+version = "0.33.358"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.357"
+version = "0.33.358"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.357"
+version = "0.33.358"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.357"
+version = "0.33.358"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.357"
+version = "0.33.358"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.357"
+version = "0.33.358"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -234,11 +234,6 @@ export class SwarmViewModel implements ViewModel {
     }
 
     /**
-     * Refresh the Activity tab: list every tracked block, then fetch
-     * each block's process list + confidence level, then set the atom.
-     * Runs serially — block counts are small (a few agents at most).
-     */
-    /**
      * Refresh the Instances tab — list every AgentInstance row in
      * the database. Sorted newest-first since the most recent runs
      * are the most likely target for "open it again". Backend
@@ -253,6 +248,11 @@ export class SwarmViewModel implements ViewModel {
         }
     };
 
+    /**
+     * Refresh the Activity tab: list every tracked block, then fetch
+     * each block's process list + confidence level, then set the atom.
+     * Runs serially — block counts are small (a few agents at most).
+     */
     refreshActivity = async (): Promise<void> => {
         try {
             const { block_ids } = await RpcApi.AgentTrackedBlocksCommand(TabRpcClient, {});

--- a/frontend/app/view/swarm/swarm-model.ts
+++ b/frontend/app/view/swarm/swarm-model.ts
@@ -68,7 +68,7 @@ export interface HistorySession {
     messages: HistoryMessage[];
 }
 
-export type SwarmTab = "overview" | "activity" | "history" | "search";
+export type SwarmTab = "overview" | "activity" | "instances" | "history" | "search";
 
 // ── Activity tab types ──────────────────────────────────────────────────
 // Mirrors `backend::process_tracker::TrackedProcess` + RPC responses
@@ -137,6 +137,13 @@ export class SwarmViewModel implements ViewModel {
     private _activity = createSignal<AgentProcessGroup[]>([]);
     activityAtom: Accessor<AgentProcessGroup[]> = this._activity[0];
     private setActivity: Setter<AgentProcessGroup[]> = this._activity[1];
+
+    // Instances tab — every AgentInstance ever created on this tab.
+    // Surfaces a "where's that agent I started earlier?" answer per
+    // SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23 PR G.
+    private _instances = createSignal<AgentInstance[]>([]);
+    instancesAtom: Accessor<AgentInstance[]> = this._instances[0];
+    private setInstances: Setter<AgentInstance[]> = this._instances[1];
 
     // Search
     private _searchQuery = createSignal<string>("");
@@ -231,6 +238,21 @@ export class SwarmViewModel implements ViewModel {
      * each block's process list + confidence level, then set the atom.
      * Runs serially — block counts are small (a few agents at most).
      */
+    /**
+     * Refresh the Instances tab — list every AgentInstance row in
+     * the database. Sorted newest-first since the most recent runs
+     * are the most likely target for "open it again". Backend
+     * sorts at the SQL layer.
+     */
+    refreshInstances = async (): Promise<void> => {
+        try {
+            const list = await RpcApi.ListAgentInstancesCommand(TabRpcClient, {});
+            this.setInstances(list ?? []);
+        } catch {
+            // Silent fail — older backends without the RPC.
+        }
+    };
+
     refreshActivity = async (): Promise<void> => {
         try {
             const { block_ids } = await RpcApi.AgentTrackedBlocksCommand(TabRpcClient, {});

--- a/frontend/app/view/swarm/swarm-view.scss
+++ b/frontend/app/view/swarm/swarm-view.scss
@@ -751,3 +751,78 @@
     0%, 100% { opacity: 0.6; }
     50% { opacity: 1; }
 }
+
+// ── Instances tab (PR G of SPEC_AGENT_DEFINITIONS_MODAL) ─────────────────
+
+.swarm-instances {
+    padding: var(--space-3);
+    overflow-y: auto;
+    height: 100%;
+}
+
+.swarm-instances-summary {
+    margin-bottom: var(--space-2);
+    font-size: var(--text-xs);
+    color: var(--secondary-text-color);
+}
+
+.swarm-instances-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--text-sm);
+
+    th, td {
+        padding: var(--space-1-5) var(--space-2);
+        text-align: left;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    th {
+        font-size: var(--text-xs);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--secondary-text-color);
+        font-weight: var(--font-weight-medium);
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    tbody tr {
+        border-bottom: 1px solid color-mix(in srgb, var(--border-color) 50%, transparent);
+
+        &:hover {
+            background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+        }
+    }
+}
+
+.swarm-instance-status {
+    display: inline-block;
+    padding: 1px var(--space-1-5);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-xs);
+    font-family: var(--font-mono);
+    text-transform: lowercase;
+
+    &--running {
+        background: color-mix(in srgb, var(--success-color) 18%, transparent);
+        color: var(--success-color);
+    }
+    &--paused {
+        background: color-mix(in srgb, var(--warning-color) 18%, transparent);
+        color: var(--warning-color);
+    }
+    &--stopped {
+        background: color-mix(in srgb, var(--secondary-text-color) 14%, transparent);
+        color: var(--secondary-text-color);
+    }
+    &--crashed {
+        background: color-mix(in srgb, var(--error-color) 18%, transparent);
+        color: var(--error-color);
+    }
+    &--detached {
+        background: color-mix(in srgb, var(--accent-color) 14%, transparent);
+        color: var(--accent-color);
+    }
+}

--- a/frontend/app/view/swarm/swarm-view.tsx
+++ b/frontend/app/view/swarm/swarm-view.tsx
@@ -41,6 +41,15 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
                         Activity
                     </button>
                     <button
+                        class={`swarm-tab ${model.tabAtom() === "instances" ? "active" : ""}`}
+                        onClick={() => {
+                            model.setTab("instances");
+                            void model.refreshInstances();
+                        }}
+                    >
+                        Instances
+                    </button>
+                    <button
                         class={`swarm-tab ${model.tabAtom() === "history" ? "active" : ""}`}
                         onClick={() => {
                             model.setTab("history");
@@ -64,6 +73,9 @@ export function SwarmView(props: ViewComponentProps<SwarmViewModel>): JSX.Elemen
                 </Show>
                 <Show when={model.tabAtom() === "activity"}>
                     <SwarmActivity model={model} />
+                </Show>
+                <Show when={model.tabAtom() === "instances"}>
+                    <SwarmInstances model={model} />
                 </Show>
                 <Show when={model.tabAtom() === "history"}>
                     <SwarmHistory model={model} />
@@ -508,6 +520,98 @@ function SwarmActivity({ model }: { model: SwarmViewModel }): JSX.Element {
                 </For>
             </Show>
         </div>
+    );
+}
+
+// ── Instances Tab ───────────────────────────────────────────────────────
+// Lists every AgentInstance (a launched run of a definition). Click
+// "Open" to bring the pane that started the run back into focus, or
+// to (re-)launch a fresh pane for stopped/crashed instances.
+//
+// Implements PR G of SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.
+
+function SwarmInstances({ model }: { model: SwarmViewModel }): JSX.Element {
+    const instances = () => model.instancesAtom();
+
+    // Newest-first: AgentInstance.created_at is millis since epoch;
+    // a desc sort puts the most recent run on top.
+    const sorted = () =>
+        [...instances()].sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0));
+
+    return (
+        <div class="swarm-instances">
+            <Show when={sorted().length === 0}>
+                <div class="swarm-empty">
+                    No instances yet. Launch an agent from the agent
+                    pane to populate this list.
+                </div>
+            </Show>
+
+            <Show when={sorted().length > 0}>
+                <div class="swarm-instances-summary">
+                    {sorted().length}{" "}
+                    {sorted().length === 1 ? "instance" : "instances"}
+                </div>
+                <table class="swarm-instances-table">
+                    <thead>
+                        <tr>
+                            <th>Status</th>
+                            <th>Definition</th>
+                            <th>Started</th>
+                            <th>Block</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <For each={sorted()}>
+                            {(inst) => <SwarmInstanceRow inst={inst} />}
+                        </For>
+                    </tbody>
+                </table>
+            </Show>
+        </div>
+    );
+}
+
+function SwarmInstanceRow({ inst }: { inst: AgentInstance }): JSX.Element {
+    const fmtAge = (created_at?: number): string => {
+        if (!created_at) return "—";
+        const ageMs = Date.now() - created_at;
+        const ageS = Math.floor(ageMs / 1000);
+        if (ageS < 60) return `${ageS}s ago`;
+        const ageM = Math.floor(ageS / 60);
+        if (ageM < 60) return `${ageM}m ago`;
+        const ageH = Math.floor(ageM / 60);
+        if (ageH < 24) return `${ageH}h ago`;
+        return `${Math.floor(ageH / 24)}d ago`;
+    };
+
+    return (
+        <tr class="swarm-instance-row">
+            <td>
+                <span
+                    class={`swarm-instance-status swarm-instance-status--${inst.status}`}
+                    title={inst.status}
+                >
+                    {inst.status}
+                </span>
+            </td>
+            <td title={inst.definition_id}>{inst.definition_id}</td>
+            <td>{fmtAge(inst.created_at)}</td>
+            <td title={inst.block_id ?? ""}>
+                {inst.block_id ? `${inst.block_id.slice(0, 8)}…` : "—"}
+            </td>
+            <td>
+                {/*
+                    "Open" doesn't yet bring focus to the running pane —
+                    that requires a tab/block focus RPC we don't have
+                    surfaced yet. For now this row is informational so
+                    users can answer "what have I launched?" without
+                    having to scroll through tabs. A `focusBlock(id)`
+                    RPC + button is the natural follow-up.
+                */}
+            </td>
+        </tr>
     );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.357",
+  "version": "0.33.358",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.357",
+      "version": "0.33.358",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.357",
+  "version": "0.33.358",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Implements [PR G of SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23](../blob/main/docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md#7-implementation-plan)
- Adds an **Instances** tab to the swarm pane listing every \`AgentInstance\` row (newest first)
- Surfaces the \"where's that agent I started earlier?\" answer

## Context
Last untouched item in the agent-definitions spec migration plan. Each Launch via the AgentLaunchModal already creates an \`AgentInstance\` row (existing \`CreateAgentInstanceCommand\` plumbing), but until now nothing in the UI exposed that history. The swarm pane's existing tab structure (Overview / Activity / History / Search) is the natural home.

### Changes
- \`SwarmTab\` enum gains \`\"instances\"\`
- \`SwarmViewModel\`:
  - new \`instancesAtom\` + \`setInstances\` signal pair
  - new \`refreshInstances()\` method calling \`RpcApi.ListAgentInstancesCommand\`
- \`SwarmView\` renders the new tab button + \`<SwarmInstances>\`; clicking the tab triggers the refresh
- \`SwarmInstances\` table columns: Status / Definition / Started / Block — sorted newest-first by \`created_at\`
- \`SwarmInstanceRow\`: relative-age formatter (\"3m ago\", \"2h ago\", \"1d ago\"), color-coded status pill via \`swarm-instance-status--{running|paused|stopped|crashed|detached}\`
- All styling consumes the design-system tokens (no raw literals introduced)

### Known scope cut
The \"Open\" action button is intentionally a placeholder column for now — surfacing a \`focusBlock(id)\` RPC + button is the natural follow-up. The list is informational in this PR; users can visually answer \"what have I launched?\" without any extra plumbing. Planned follow-up adds:
- Click-to-focus on the running pane (if block_id still valid)
- Right-click menu: stop / restart / open working dir / delete instance row

## Test plan
- [ ] Swarm pane: Instances tab appears between Activity and History
- [ ] Empty state shows when no instances exist
- [ ] After launching an agent via the AgentLaunchModal, the row appears in the table on tab open
- [ ] Status pill renders correct color for each enum value
- [ ] Age formatter shows \"Ns ago\" within the first minute, \"Nm ago\" / \"Nh ago\" / \"Nd ago\" thereafter
- [ ] Definition + block columns truncate cleanly on narrow swarm widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)