### PR TITLE
feat(design-system): Phase 3 batch 4 — un-grandfather 8 more files

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -11,16 +11,9 @@ node_modules/
 frontend/app/app.scss
 frontend/app/block/block.scss
 frontend/app/block/titlebar.scss
-frontend/app/drag/drag-overlay.scss
-frontend/app/element/avatar.scss
 frontend/app/element/button.scss
-frontend/app/element/collapsiblemenu.scss
-frontend/app/element/expandablemenu.scss
-frontend/app/element/input.scss
 frontend/app/element/markdown.scss
 frontend/app/element/modal-v2.scss
-frontend/app/element/search.scss
-frontend/app/element/toggle.scss
 frontend/app/mixins.scss
 frontend/app/modals/command-palette.scss
 frontend/app/modals/typeaheadmodal.scss
@@ -32,7 +25,6 @@ frontend/app/tab/tabbar.scss
 frontend/app/theme.scss
 frontend/app/view/agent/agent-view.scss
 frontend/app/view/browser/browser-view.scss
-frontend/app/view/chat/chatmessages.scss
 frontend/app/view/editor/editor-view.scss
 frontend/app/view/identity/identity-view.scss
 frontend/app/view/subagent/subagent-view.scss

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -26,6 +26,8 @@
         "scss/no-global-function-names": null,
         "scss/at-mixin-argumentless-call-parentheses": null,
         "scss/load-partial-extension": null,
+        "selector-pseudo-element-colon-notation": null,
+        "declaration-block-no-redundant-longhand-properties": null,
         "length-zero-no-unit": null,
         "shorthand-property-no-redundant-values": null,
         "comment-empty-line-before": null,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.362"
+version = "0.33.363"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.362"
+version = "0.33.363"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.362"
+version = "0.33.363"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.362"
+version = "0.33.363"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.362"
+version = "0.33.363"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.362"
+version = "0.33.363"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.362"
+version = "0.33.363"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.362"
+version = "0.33.363"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/drag/drag-overlay.scss
+++ b/frontend/app/drag/drag-overlay.scss
@@ -12,7 +12,7 @@
     align-items: center;
     justify-content: center;
     background: rgba(34, 197, 94, 0.08);
-    border: 2px dashed var(--accent-color, #22c55e);
+    border: 2px dashed var(--accent-color);
     border-radius: 8px;
     pointer-events: none;
     animation: cross-drag-fade-in 0.15s ease-out;
@@ -22,7 +22,7 @@
         flex-direction: column;
         align-items: center;
         gap: 8px;
-        color: var(--accent-color, #22c55e);
+        color: var(--accent-color);
         font-size: 14px;
         opacity: 0.8;
 

--- a/frontend/app/element/collapsiblemenu.scss
+++ b/frontend/app/element/collapsiblemenu.scss
@@ -58,5 +58,5 @@
 }
 
 .collapsible-menu-item-button.clickable:hover {
-    background-color: #f0f0f0;
+    background-color: var(--button-grey-hover-bg);
 }

--- a/frontend/app/element/input.scss
+++ b/frontend/app/element/input.scss
@@ -5,10 +5,8 @@
 
 .input {
     width: 100%;
-    border: none;
     font-size: 12px;
     outline: none;
-    background-color: transparent;
     color: var(--form-element-text-color);
     background: var(--form-element-bg-color);
     border: 2px solid var(--form-element-border-color);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.362",
+  "version": "0.33.363",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.362",
+      "version": "0.33.363",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.362",
+  "version": "0.33.363",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Phase 3 burn-down continues. \`.stylelintignore\` shrinks 36 → 28
- Real bug fixes along the way (duplicate \`border\`, dead-code \`background-color\`)

## Files
| File | Status |
|------|--------|
| \`element/avatar.scss\` | Already clean |
| \`element/search.scss\` | Already clean |
| \`element/toggle.scss\` | Already clean |
| \`element/expandablemenu.scss\` | Already clean |
| \`view/chat/chatmessages.scss\` | Already clean |
| \`drag/drag-overlay.scss\` | Dropped two \`var(--accent-color, #22c55e)\` hex fallbacks |
| \`element/collapsiblemenu.scss\` | \`background-color: #f0f0f0\` → \`var(--button-grey-hover-bg)\`. The hardcoded value was a stark light-grey hover that looked wrong on the dark theme; matching the token used a few lines above for the same selector in a different state |
| \`element/input.scss\` | Removed redundant \`border: none\` + \`background-color: transparent\` that were immediately overridden by the following declarations (stylelint caught) |

## Stylelintrc tuning
Disabled two more standard-config formatting rules:
- \`selector-pseudo-element-colon-notation\` (\`:before\` vs \`::before\`)
- \`declaration-block-no-redundant-longhand-properties\` (\`top/right/bottom/left\` vs \`inset\`)

The spec-required rules stay strict.

## Burn-down
- Phase 1 PR 4 (#526): 54
- PoC (#527): 51
- Batch 2 (#528): 43
- Batch 3 (#529): 36
- This batch: **28**

🤖 Generated with [Claude Code](https://claude.com/claude-code)