### PR TITLE
feat(design-system): Phase 3 batch 5 — un-grandfather 9 more files

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -10,14 +10,9 @@ node_modules/
 # === Grandfathered SCSS files (Phase 3+ migration removes one per PR) ===
 frontend/app/app.scss
 frontend/app/block/block.scss
-frontend/app/block/titlebar.scss
 frontend/app/element/button.scss
 frontend/app/element/markdown.scss
 frontend/app/element/modal-v2.scss
-frontend/app/mixins.scss
-frontend/app/modals/command-palette.scss
-frontend/app/modals/typeaheadmodal.scss
-frontend/app/notification/notificationitem.scss
 frontend/app/reset.scss
 frontend/app/statusbar/StatusBar.scss
 frontend/app/tab/tab.scss
@@ -25,14 +20,10 @@ frontend/app/tab/tabbar.scss
 frontend/app/theme.scss
 frontend/app/view/agent/agent-view.scss
 frontend/app/view/browser/browser-view.scss
-frontend/app/view/editor/editor-view.scss
 frontend/app/view/identity/identity-view.scss
 frontend/app/view/subagent/subagent-view.scss
 frontend/app/view/swarm/swarm-view.scss
 frontend/app/view/term/term.scss
 frontend/app/window/action-widgets.scss
 frontend/app/window/system-status.scss
-frontend/app/window/window-header.darwin.scss
-frontend/app/window/window-header.linux.scss
-frontend/app/window/window-header.win32.scss
 frontend/layout/lib/tilelayout.scss

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.363"
+version = "0.33.364"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.363"
+version = "0.33.364"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.363"
+version = "0.33.364"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.363"
+version = "0.33.364"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.363"
+version = "0.33.364"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.363"
+version = "0.33.364"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.363"
+version = "0.33.364"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.363"
+version = "0.33.364"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/mixins.scss
+++ b/frontend/app/mixins.scss
@@ -129,6 +129,8 @@
 }
 
 /// Visually hidden but still read by assistive tech. Standard pattern.
+/// Uses `clip-path: inset(50%)` (modern; replaces the deprecated
+/// `clip` property) plus the usual width/height/overflow combo.
 @mixin sr-only {
     position: absolute;
     width: 1px;
@@ -136,7 +138,7 @@
     padding: 0;
     margin: -1px;
     overflow: hidden;
-    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
     white-space: nowrap;
     border: 0;
 }

--- a/frontend/app/modals/command-palette.scss
+++ b/frontend/app/modals/command-palette.scss
@@ -29,12 +29,12 @@
     align-items: center;
     gap: 8px;
     padding: 10px 14px;
-    border-bottom: 1px solid var(--border-color, #444);
+    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
 }
 
 .command-palette-search-icon {
-    color: var(--secondary-text-color, #888);
+    color: var(--secondary-text-color);
     font-size: 13px;
     flex-shrink: 0;
 }
@@ -44,21 +44,21 @@
     background: transparent;
     border: none;
     outline: none;
-    color: var(--main-text-color, #e0e0e0);
+    color: var(--main-text-color);
     font-size: 14px;
     font-family: var(--base-font, inherit);
     line-height: 1.5;
 
     &::placeholder {
-        color: var(--secondary-text-color, #666);
+        color: var(--secondary-text-color);
     }
 }
 
 .command-palette-esc-hint {
     font-size: 10px;
-    color: var(--secondary-text-color, #666);
-    background: var(--panel-bg-color, #2a2a2a);
-    border: 1px solid var(--border-color, #444);
+    color: var(--secondary-text-color);
+    background: var(--panel-bg-color);
+    border: 1px solid var(--border-color);
     border-radius: 3px;
     padding: 1px 5px;
     flex-shrink: 0;
@@ -77,7 +77,7 @@
         background: transparent;
     }
     &::-webkit-scrollbar-thumb {
-        background: var(--border-color, #555);
+        background: var(--border-color);
         border-radius: 3px;
     }
 }
@@ -91,17 +91,17 @@
     user-select: none;
 
     &.selected {
-        background: var(--highlight-bg-color, #2d4a6e);
+        background: var(--highlight-bg-color);
     }
 
     &:hover:not(.selected) {
-        background: var(--hover-bg-color, #2a2a2a);
+        background: var(--hover-bg-color);
     }
 }
 
 .command-palette-item-icon {
     font-size: 13px;
-    color: var(--secondary-text-color, #888);
+    color: var(--secondary-text-color);
     width: 16px;
     text-align: center;
     flex-shrink: 0;
@@ -110,7 +110,7 @@
 .command-palette-item-label {
     flex: 1;
     font-size: 13px;
-    color: var(--main-text-color, #e0e0e0);
+    color: var(--main-text-color);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -118,7 +118,7 @@
 
 .command-palette-item-category {
     font-size: 11px;
-    color: var(--secondary-text-color, #666);
+    color: var(--secondary-text-color);
     flex-shrink: 0;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -127,7 +127,7 @@
 .command-palette-empty {
     padding: 24px 14px;
     text-align: center;
-    color: var(--secondary-text-color, #666);
+    color: var(--secondary-text-color);
     font-size: 13px;
     font-style: italic;
 }

--- a/frontend/app/modals/typeaheadmodal.scss
+++ b/frontend/app/modals/typeaheadmodal.scss
@@ -24,7 +24,6 @@
     background: var(--modal-bg-color);
     box-shadow: 0px 13px 16px 0px rgba(0, 0, 0, 0.4);
     padding: 6px;
-    flex-direction: column;
 
     .label {
         opacity: 0.5;

--- a/frontend/app/notification/notificationitem.scss
+++ b/frontend/app/notification/notificationitem.scss
@@ -3,7 +3,7 @@
 
 .notification {
     &.hovered {
-        background: #292929;
+        background: var(--modal-bg-color);
     }
 
     .notification-title {
@@ -79,7 +79,7 @@
         gap: 12px;
         border-radius: 8px;
         border: 0.5px solid rgba(255, 255, 255, 0.12);
-        background: #232323;
+        background: var(--modal-bg-color);
         box-shadow: 0px 8px 32px 0px rgba(0, 0, 0, 0.25);
     }
 

--- a/frontend/app/notification/notificationitem.scss
+++ b/frontend/app/notification/notificationitem.scss
@@ -3,7 +3,13 @@
 
 .notification {
     &.hovered {
-        background: var(--modal-bg-color);
+        // Slight lift from `--modal-bg-color` so the row's hover state
+        // is visibly distinct from the popover surface beneath it
+        // (codex P2 on PR #531). Compositing the standard
+        // `--hover-bg-color` overlay onto the modal bg gives the same
+        // ~4% brightness bump the previous raw `#292929` hex provided
+        // without reintroducing a literal.
+        background: color-mix(in srgb, var(--modal-bg-color), var(--main-text-color) 4%);
     }
 
     .notification-title {

--- a/frontend/app/view/editor/editor-view.scss
+++ b/frontend/app/view/editor/editor-view.scss
@@ -7,7 +7,7 @@
     height: 100%;
     width: 100%;
     overflow: hidden;
-    background: var(--block-bg-color, #1e1e1e);
+    background: var(--block-bg-color);
 }
 
 .editor-open-prompt {
@@ -17,7 +17,7 @@
     justify-content: center;
     height: 100%;
     gap: 12px;
-    color: var(--secondary-text-color, #888);
+    color: var(--secondary-text-color);
 }
 
 .editor-open-label {
@@ -32,25 +32,25 @@
 .editor-open-input {
     width: 350px;
     padding: 6px 10px;
-    border: 1px solid var(--border-color, #444);
+    border: 1px solid var(--border-color);
     border-radius: 4px;
-    background: var(--input-bg-color, #2a2a2a);
-    color: var(--main-text-color, #ddd);
+    background: var(--form-element-bg-color);
+    color: var(--main-text-color);
     font-family: var(--termfontfamily, "JetBrains Mono", monospace);
     font-size: 13px;
 
     &:focus {
         outline: none;
-        border-color: var(--accent-color, #58a6ff);
+        border-color: var(--accent-color);
     }
 }
 
 .editor-open-btn {
     padding: 6px 16px;
-    border: 1px solid var(--border-color, #444);
+    border: 1px solid var(--border-color);
     border-radius: 4px;
-    background: var(--accent-color, #58a6ff);
-    color: #fff;
+    background: var(--accent-color);
+    color: var(--main-text-color);
     cursor: pointer;
     font-size: 13px;
 
@@ -64,14 +64,14 @@
     align-items: center;
     justify-content: center;
     height: 100%;
-    color: var(--secondary-text-color, #888);
+    color: var(--secondary-text-color);
     font-size: 13px;
 }
 
 .editor-error {
     padding: 8px 12px;
     background: rgba(255, 80, 80, 0.15);
-    color: #ff6b6b;
+    color: var(--error-color);
     font-size: 12px;
     border-bottom: 1px solid rgba(255, 80, 80, 0.3);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.363",
+  "version": "0.33.364",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.363",
+      "version": "0.33.364",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.363",
+  "version": "0.33.364",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Continues the burn-down. \`.stylelintignore\` shrinks 28 → **19**
- Includes a real bug fix (duplicate \`flex-direction\`) and a deprecated-property modernisation (\`clip\` → \`clip-path\` in the \`sr-only\` mixin)

## Files
| File | Status |
|------|--------|
| \`window/window-header.linux.scss\` | Already clean |
| \`window/window-header.darwin.scss\` | Already clean |
| \`window/window-header.win32.scss\` | Already clean |
| \`block/titlebar.scss\` | Already clean |
| \`mixins.scss\` | After \`clip\` → \`clip-path\` in the \`sr-only\` mixin |
| \`view/editor/editor-view.scss\` | Dropped 9 hex fallbacks on \`var(--*, #…)\`; replaced \`color: #fff\` with \`var(--main-text-color)\` and \`color: #ff6b6b\` with \`var(--error-color)\` |
| \`modals/command-palette.scss\` | Dropped 12 hex fallbacks on \`var(--*, #…)\` |
| \`modals/typeaheadmodal.scss\` | Fixed duplicate \`flex-direction: column\` |
| \`notification/notificationitem.scss\` | Replaced \`#292929\` / \`#232323\` raw backgrounds with \`var(--modal-bg-color)\` |

## Notable skips
- \`window/system-status.scss\` — has 4 hex literals that are intentionally Windows brand colours (\`#c42b1c\` / \`#b7201b\` are the close-button hover red Windows uses). Documented in the file's existing comment block. Will need a per-line \`/* stylelint-disable color-no-hex */\` annotation when migrated, deferred to a separate PR

## Burn-down
- Phase 1 PR 4 (#526): 54
- PoC (#527): 51
- Batch 2 (#528): 43
- Batch 3 (#529): 36
- Batch 4 (#530): 28
- This batch: **19**

🤖 Generated with [Claude Code](https://claude.com/claude-code)