### PR TITLE
feat(design-system): Phase 3 batch 8 — un-grandfather 4 mid-size files

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -8,10 +8,6 @@ dist/
 node_modules/
 
 # === Grandfathered SCSS files (Phase 3+ migration removes one per PR) ===
-frontend/app/element/markdown.scss
-frontend/app/statusbar/StatusBar.scss
-frontend/app/tab/tab.scss
 frontend/app/view/agent/agent-view.scss
 frontend/app/view/identity/identity-view.scss
 frontend/app/view/swarm/swarm-view.scss
-frontend/app/view/term/term.scss

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,7 +8,7 @@
             "z-index": [
                 "/^var\\(--z(index)?-/",
                 "/^calc\\(/",
-                "/^-?[0-9]{1,2}$/",
+                "/^[0-9]{1,2}$/",
                 "auto", "unset", "inherit", "initial"
             ]
         },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.366"
+version = "0.33.367"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.366"
+version = "0.33.367"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.366"
+version = "0.33.367"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.366"
+version = "0.33.367"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.366"
+version = "0.33.367"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.366"
+version = "0.33.367"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.366"
+version = "0.33.367"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.366"
+version = "0.33.367"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/element/markdown.scss
+++ b/frontend/app/element/markdown.scss
@@ -1,7 +1,7 @@
 // Copyright 2024-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-@import url("../../../node_modules/highlight.js/scss/github-dark-dimmed.scss");
+@import "../../../node_modules/highlight.js/scss/github-dark-dimmed.scss";
 
 .markdown {
     display: flex;
@@ -24,6 +24,12 @@
             overflow: hidden;
         }
 
+        /* stylelint-disable declaration-no-important --
+           Markdown rendering inserts paragraph/list margins that
+           break the block's visual containment; forcing the first
+           heading and last child to 0 margin is the standard fix
+           and must beat the rehype styles that land at higher
+           specificity. */
         *:last-child {
             margin-bottom: 0 !important;
         }
@@ -31,6 +37,7 @@
         .heading:not(.heading ~ .heading) {
             margin-top: 0 !important;
         }
+        /* stylelint-enable declaration-no-important */
 
         .heading {
             color: var(--main-text-color);
@@ -87,7 +94,7 @@
         }
 
         a {
-            color: #32afff;
+            color: var(--term-bright-blue);
         }
 
         ul {
@@ -118,7 +125,7 @@
             code {
                 line-height: 1.5;
                 white-space: pre-wrap;
-                word-wrap: break-word;
+                overflow-wrap: break-word;
                 overflow: auto;
                 overflow: hidden;
                 background-color: transparent;

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -158,7 +158,7 @@
     position: absolute;
     bottom: calc(100% + 4px);
     left: 0;
-    background: var(--modal-bg-color, #1e1e1e);
+    background: var(--modal-bg-color);
     border: 1px solid var(--border-color);
     border-radius: 4px;
     padding: 8px 10px;
@@ -202,7 +202,9 @@
     width: 100%;
     padding: 4px 8px;
     background: var(--error-color);
-    color: #fff;
+    /* Pure white on red — intentional for the restart button;
+       no semantic token maps to "always white regardless of theme". */
+    color: #fff; /* stylelint-disable-line color-no-hex */
     border: none;
     border-radius: 3px;
     cursor: pointer;

--- a/frontend/app/tab/tab.scss
+++ b/frontend/app/tab/tab.scss
@@ -108,7 +108,10 @@
         cursor: pointer;
         z-index: var(--zindex-tab-name);
         padding: 0;
-        transition: none !important;
+        /* Tab close button must NOT pick up the general `.tab *`
+           transition rule — a transition on the close button causes
+           a visible flicker every time the active tab changes. */
+        transition: none !important; /* stylelint-disable-line declaration-no-important */
     }
 
     .close {
@@ -117,6 +120,11 @@
 
     // Custom tab color — overrides all other backgrounds
     &.tab-colored {
+        /* stylelint-disable declaration-no-important --
+           User-picked tab colour must beat the hover/active/dragging
+           state backgrounds declared further down; without
+           `!important` the later-declared hover selectors win and
+           the custom colour vanishes. */
         .tab-inner {
             background: var(--tab-color) !important;
         }
@@ -124,6 +132,7 @@
             color: rgba(255, 255, 255, 0.95) !important;
             text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
         }
+        /* stylelint-enable declaration-no-important */
         .wave-button {
             color: rgba(255, 255, 255, 0.65);
             &:hover {
@@ -164,7 +173,7 @@ body.nohover .tab.active .close {
     visibility: visible;
 }
 
-@keyframes expandWidthAndFadeIn {
+@keyframes expand-width-and-fade-in {
     from {
         width: var(--initial-tab-width);
         opacity: 0;
@@ -176,7 +185,7 @@ body.nohover .tab.active .close {
 }
 
 .tab.new-tab {
-    animation: expandWidthAndFadeIn 0.1s forwards;
+    animation: expand-width-and-fade-in 0.1s forwards;
 }
 
 // Colored active tab — white accent bar for contrast on any color
@@ -196,7 +205,9 @@ body:not(.nohover) .tab.tab-colored.active:hover {
 body:not(.nohover) .tab.tab-colored:hover,
 body:not(.nohover) .tab.tab-colored.dragging {
     .tab-inner {
-        background: var(--tab-color) !important;
+        /* Same override as the base `.tab-colored` rule above — user
+           tab colour must beat the hover background. */
+        background: var(--tab-color) !important; /* stylelint-disable-line declaration-no-important */
         filter: brightness(1.18);
     }
 }
@@ -208,8 +219,8 @@ body:not(.nohover) .tab.tab-colored.dragging {
     flex-direction: column;
     gap: 6px;
     padding: 8px;
-    background: var(--main-bg-color, #1a1a2e);
-    border: 1px solid var(--border-color, #333);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
     border-radius: 6px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
     user-select: none;
@@ -234,7 +245,7 @@ body:not(.nohover) .tab.tab-colored.dragging {
 .tab-context-actions {
     display: flex;
     gap: 4px;
-    border-top: 1px solid var(--border-color, #333);
+    border-top: 1px solid var(--border-color);
     padding-top: 6px;
 }
 
@@ -242,7 +253,7 @@ body:not(.nohover) .tab.tab-colored.dragging {
     flex: 1;
     padding: 4px 6px;
     background: transparent;
-    border: 1px solid var(--border-color, #333);
+    border: 1px solid var(--border-color);
     border-radius: 4px;
     color: var(--secondary-text-color);
     font-size: 11px;
@@ -255,8 +266,8 @@ body:not(.nohover) .tab.tab-colored.dragging {
     }
 
     &.tab-context-btn-close:hover {
-        border-color: var(--error-color, #e55);
-        color: var(--error-color, #e55);
+        border-color: var(--error-color);
+        color: var(--error-color);
     }
 }
 

--- a/frontend/app/view/term/term.scss
+++ b/frontend/app/view/term/term.scss
@@ -150,7 +150,11 @@
         // WebView2 renders the native textarea caret even at opacity:0
         // when the terminal background is transparent.
         .xterm-helper-textarea {
-            caret-color: transparent !important;
+            /* WebView2 renders the native textarea caret even at
+               opacity:0 when the terminal background is transparent
+               — `!important` is required because xterm's own stylesheet
+               sets `caret-color: black` with matching specificity. */
+            caret-color: transparent !important; /* stylelint-disable-line declaration-no-important */
         }
 
         .xterm-viewport {
@@ -198,6 +202,7 @@
     padding: 2px 6px;
     border-radius: 4px;
     background: rgba(200, 120, 0, 0.75);
-    color: #fff;
+    /* Pure white on the amber warning badge — intentional contrast. */
+    color: #fff; /* stylelint-disable-line color-no-hex */
     opacity: 0.85;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.366",
+  "version": "0.33.367",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.366",
+      "version": "0.33.367",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.366",
+  "version": "0.33.367",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- Burn-down: \`.stylelintignore\` shrinks 7 → **3** (only the three view mega-files remain)
- Addresses codex P2 on #533: z-index regex tightened to disallow negative literals

## Files
| File | Status |
|------|--------|
| \`element/markdown.scss\` | \`#32afff\` → \`var(--term-bright-blue)\`; deprecated \`word-wrap\` → \`overflow-wrap\`; old \`@import url(…)\` → modern \`@import \"…\"\`; \`!important\` margin overrides annotated with \`stylelint-disable\` |
| \`statusbar/StatusBar.scss\` | Dropped hex fallback; pure-white restart-button text annotated |
| \`tab/tab.scss\` | Dropped 3 hex fallbacks; annotated 3 distinct \`!important\` patterns; renamed \`@keyframes expandWidthAndFadeIn\` → \`expand-width-and-fade-in\` (kebab-case) |
| \`view/term/term.scss\` | Annotated \`caret-color: transparent !important\` (WebView2 workaround) + pure-white warning-badge text |

## Codex P2 on #533
\`/^-?[0-9]{1,2}$/\` → \`/^[0-9]{1,2}$/\`. Negative z-index values now require a \`--zindex-*\` token (the canonical \`--zindex-app-background: -1\` is already tokenized, so no raw negatives should appear in component SCSS).

## Burn-down
- PR #526 (initial): 54
- PRs #527–#533: 54 → 7
- This PR: **3**

Remaining:
- \`view/swarm/swarm-view.scss\` (828 lines)
- \`view/identity/identity-view.scss\` (567 lines)
- \`view/agent/agent-view.scss\` (4051 lines — the final boss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)