### PR TITLE
feat(design-system): Phase 3 final boss — agent-view.scss un-grandfathered (burn-down complete)

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -8,4 +8,3 @@ dist/
 node_modules/
 
 # === Grandfathered SCSS files (Phase 3+ migration removes one per PR) ===
-frontend/app/view/agent/agent-view.scss

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.368"
+version = "0.33.369"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.368"
+version = "0.33.369"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.368"
+version = "0.33.369"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.368"
+version = "0.33.369"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.368"
+version = "0.33.369"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.368"
+version = "0.33.369"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.368"
+version = "0.33.369"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.368"
+version = "0.33.369"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -102,7 +102,7 @@
             }
 
             &--active {
-                color: var(--warning-color, #eab308);
+                color: var(--warning-color);
             }
 
             &:disabled,
@@ -124,7 +124,7 @@
         contain: layout style;
 
         &:focus {
-            outline: 1px solid var(--accent-color, #3b82f6);
+            outline: 1px solid var(--accent-color);
             outline-offset: -1px;
         }
     }
@@ -271,7 +271,7 @@
                 white-space: pre-wrap;
                 overflow: visible;
                 text-overflow: clip;
-                word-break: break-word;
+                overflow-wrap: anywhere;
             }
         }
 
@@ -294,14 +294,14 @@
         margin-top: 8px;
         padding: 10px 12px;
         background: var(--panel-bg-color, rgba(74, 158, 255, 0.08));
-        border: 1px solid var(--accent-color, #4a9eff);
+        border: 1px solid var(--accent-color);
         border-radius: 6px;
         box-shadow: 0 0 12px rgba(74, 158, 255, 0.15);
     }
 
     .agent-auth-url-label {
         font-size: 11px;
-        color: #8cc8ff;
+        color: var(--accent-color);
         margin-bottom: 6px;
         font-weight: 600;
         letter-spacing: 0.3px;
@@ -325,7 +325,7 @@
     .agent-auth-url-text {
         flex: 1;
         word-break: break-all;
-        color: #8cc8ff;
+        color: var(--accent-color);
         font-size: 11px;
         font-family: var(--fixed-font, monospace);
         user-select: text;
@@ -340,8 +340,8 @@
         padding: 4px 12px;
         font-size: 10px;
         font-weight: 600;
-        background: #4a9eff;
-        color: #fff;
+        background: var(--accent-color);
+        color: #fff; /* stylelint-disable-line color-no-hex */
         border: none;
         border-radius: 3px;
         cursor: pointer;
@@ -350,7 +350,7 @@
         box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
 
         &:hover {
-            background: #6bb0ff;
+            background: color-mix(in srgb, var(--accent-color), white 15%);
         }
 
         &:active {
@@ -376,7 +376,7 @@
             outline: none;
 
             &:focus {
-                border-color: #4a9eff;
+                border-color: var(--accent-color);
             }
 
             &::placeholder {
@@ -388,7 +388,7 @@
             position: static;
             transform: none;
             opacity: 1;
-            &:hover { background: #6bb0ff; }
+            &:hover { background: color-mix(in srgb, var(--accent-color), white 15%); }
             &:disabled { opacity: 0.4; cursor: default; }
         }
     }
@@ -396,7 +396,7 @@
     .agent-auth-paste-result {
         margin-top: 5px;
         font-size: 10px;
-        color: #8cc8ff;
+        color: var(--accent-color);
         opacity: 0.8;
     }
 
@@ -413,15 +413,15 @@
         padding: 5px 18px;
         font-size: 12px;
         font-family: inherit;
-        background: var(--accent-color, #4a9eff);
-        color: #fff;
+        background: var(--accent-color);
+        color: #fff; /* stylelint-disable-line color-no-hex */
         border: none;
         border-radius: 4px;
         cursor: pointer;
         &:hover { opacity: 0.85; }
         &:active { opacity: 0.7; }
         &--cancel {
-            background: var(--secondary-text-color, #888);
+            background: var(--secondary-text-color);
         }
     }
 
@@ -538,7 +538,7 @@
 
     .agent-focused-rename-error {
         font-size: 12px;
-        color: var(--error-color, #e55);
+        color: var(--error-color);
     }
 
     .agent-focused-rename-actions {
@@ -566,9 +566,9 @@
         }
 
         &--confirm {
-            background: var(--accent-color, #4a9eff);
-            border-color: var(--accent-color, #4a9eff);
-            color: #fff;
+            background: var(--accent-color);
+            border-color: var(--accent-color);
+            color: #fff; /* stylelint-disable-line color-no-hex */
 
             &:hover:not(:disabled) {
                 filter: brightness(1.1);
@@ -780,7 +780,7 @@
             outline: none;
 
             &.agent-card-rename-input--error {
-                border-color: var(--error-color, #e55);
+                border-color: var(--error-color);
             }
         }
 
@@ -805,15 +805,15 @@
             }
 
             &--confirm:hover {
-                color: var(--success-color, #4c8);
-                border-color: var(--success-color, #4c8);
-                background: color-mix(in srgb, var(--success-color, #4c8) 15%, transparent);
+                color: var(--success-color);
+                border-color: var(--success-color);
+                background: color-mix(in srgb, var(--success-color) 15%, transparent);
             }
 
             &--cancel:hover {
-                color: var(--error-color, #e55);
-                border-color: var(--error-color, #e55);
-                background: color-mix(in srgb, var(--error-color, #e55) 15%, transparent);
+                color: var(--error-color);
+                border-color: var(--error-color);
+                background: color-mix(in srgb, var(--error-color) 15%, transparent);
             }
         }
 
@@ -931,7 +931,7 @@
 
         .nodejs-notice-icon {
             font-size: 18px;
-            color: #f59e0b;
+            color: var(--warning-color);
             flex-shrink: 0;
             padding-top: 2px;
         }
@@ -1041,7 +1041,7 @@
         font-family: var(--fixed-font, monospace);
 
         &.agent-status-line--loading {
-            color: #8cc8ff;
+            color: var(--accent-color);
             opacity: 1;
             width: 100%;
 
@@ -1109,7 +1109,7 @@
         width: 7px;
         height: 7px;
         border-radius: 50%;
-        background: #8cc8ff;
+        background: var(--accent-color);
         flex-shrink: 0;
         animation: agent-pulse 1.2s ease-in-out infinite;
         // Subtle halo that breathes with the pulse — gives the dot
@@ -1164,8 +1164,8 @@
     .slash-picker {
         display: flex;
         flex-direction: column;
-        background: color-mix(in srgb, var(--accent-color, #4a9eff) 8%, var(--main-bg-color));
-        border-top: 1px solid color-mix(in srgb, var(--accent-color, #4a9eff) 40%, var(--border-color));
+        background: color-mix(in srgb, var(--accent-color) 8%, var(--main-bg-color));
+        border-top: 1px solid color-mix(in srgb, var(--accent-color) 40%, var(--border-color));
         border-bottom: 1px solid var(--border-color);
         font-size: 12px;
         max-height: 240px;
@@ -1198,7 +1198,7 @@
         color: var(--main-text-color);
 
         &--selected {
-            background: color-mix(in srgb, var(--accent-color, #4a9eff) 22%, transparent);
+            background: color-mix(in srgb, var(--accent-color) 22%, transparent);
         }
     }
 
@@ -1207,7 +1207,7 @@
         width: 10px;
         text-align: center;
         font-size: 9px;
-        color: var(--accent-color, #4a9eff);
+        color: var(--accent-color);
     }
 
     .slash-picker__label {
@@ -1244,7 +1244,7 @@
         max-height: 220px;
         overflow-y: auto;
         background: var(--main-bg-color);
-        border: 1px solid color-mix(in srgb, var(--accent-color, #4a9eff) 50%, var(--border-color));
+        border: 1px solid color-mix(in srgb, var(--accent-color) 50%, var(--border-color));
         border-radius: 3px;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
         z-index: 50;
@@ -1263,14 +1263,14 @@
         color: var(--main-text-color);
 
         &--selected {
-            background: color-mix(in srgb, var(--accent-color, #4a9eff) 22%, transparent);
+            background: color-mix(in srgb, var(--accent-color) 22%, transparent);
         }
     }
 
     .slash-autocomplete__name {
         flex-shrink: 0;
         font-weight: 500;
-        color: var(--accent-color, #4a9eff);
+        color: var(--accent-color);
         min-width: 110px;
         font-family: var(--monospace-font, monospace);
     }
@@ -1298,8 +1298,8 @@
     .slash-help {
         display: flex;
         flex-direction: column;
-        background: color-mix(in srgb, var(--accent-color, #4a9eff) 6%, var(--main-bg-color));
-        border-top: 1px solid color-mix(in srgb, var(--accent-color, #4a9eff) 40%, var(--border-color));
+        background: color-mix(in srgb, var(--accent-color) 6%, var(--main-bg-color));
+        border-top: 1px solid color-mix(in srgb, var(--accent-color) 40%, var(--border-color));
         border-bottom: 1px solid var(--border-color);
         font-size: 12px;
         max-height: 360px;
@@ -1339,9 +1339,9 @@
         transition: background 0.1s, color 0.1s, border-color 0.1s;
 
         &:hover {
-            background: color-mix(in srgb, var(--error-color, #f87171) 15%, transparent);
-            border-color: color-mix(in srgb, var(--error-color, #f87171) 40%, transparent);
-            color: var(--error-color, #f87171);
+            background: color-mix(in srgb, var(--error-color) 15%, transparent);
+            border-color: color-mix(in srgb, var(--error-color) 40%, transparent);
+            color: var(--error-color);
         }
     }
 
@@ -1377,14 +1377,14 @@
 
         &:hover,
         &:focus {
-            background: color-mix(in srgb, var(--accent-color, #4a9eff) 18%, transparent);
+            background: color-mix(in srgb, var(--accent-color) 18%, transparent);
             outline: none;
         }
     }
 
     .slash-help__name {
         font-weight: 500;
-        color: var(--accent-color, #4a9eff);
+        color: var(--accent-color);
         font-family: var(--monospace-font, monospace);
     }
 
@@ -1426,8 +1426,8 @@
         justify-content: space-between;
         gap: 8px;
         padding: 4px 8px;
-        background: color-mix(in srgb, var(--accent-color, #3b82f6) 14%, transparent);
-        border-bottom: 1px solid color-mix(in srgb, var(--accent-color, #3b82f6) 30%, transparent);
+        background: color-mix(in srgb, var(--accent-color) 14%, transparent);
+        border-bottom: 1px solid color-mix(in srgb, var(--accent-color) 30%, transparent);
         font-size: 11px;
         color: var(--main-text-color);
 
@@ -1443,8 +1443,8 @@
         justify-content: space-between;
         gap: 8px;
         padding: 4px 8px;
-        background: color-mix(in srgb, var(--warning-color, #eab308) 14%, transparent);
-        border-bottom: 1px solid color-mix(in srgb, var(--warning-color, #eab308) 30%, transparent);
+        background: color-mix(in srgb, var(--warning-color) 14%, transparent);
+        border-bottom: 1px solid color-mix(in srgb, var(--warning-color) 30%, transparent);
         font-size: 11px;
         color: var(--main-text-color);
 
@@ -1482,7 +1482,7 @@
     }
 
     .agent-control-nondefault {
-        color: var(--warning-color, #eab308);
+        color: var(--warning-color);
         font-weight: 700;
     }
 
@@ -1537,7 +1537,7 @@
         margin: 0;
         padding: 1px 0;
         white-space: pre-wrap;
-        word-break: break-word;
+        overflow-wrap: anywhere;
         font-size: var(--termfontsize, 13px);
         line-height: 1.3;
         color: var(--main-text-color);
@@ -1658,17 +1658,16 @@
         // When pinned open, the click-to-pin state gets a subtle accent
         // on the left border so users can tell they've stuck a block open.
         &.pinned {
-            border-left: 2px solid var(--accent-color, #a78bfa);
+            border-left: 2px solid var(--accent-color);
         }
 
         // Status icon color variants for the collapsed row
-        &.success .agent-tool-status-icon { color: var(--success-color, #22c55e); }
-        &.failed  .agent-tool-status-icon { color: var(--error-color, #ef4444); }
-        &.running .agent-tool-status-icon { color: var(--warning-color, #eab308); }
+        &.success .agent-tool-status-icon { color: var(--success-color); }
+        &.failed  .agent-tool-status-icon { color: var(--error-color); }
+        &.running .agent-tool-status-icon { color: var(--warning-color); }
 
         .agent-tool-content {
             padding: 0 4px 4px 16px;
-            cursor: default;
             user-select: text;
             cursor: text;
         }
@@ -1695,7 +1694,7 @@
             background: none;
             border: 1px solid var(--border-color);
             border-radius: 3px;
-            color: var(--accent-color, #a78bfa);
+            color: var(--accent-color);
             cursor: pointer;
             font-size: 13px;
             padding: 1px 6px;
@@ -1703,8 +1702,8 @@
             flex-shrink: 0;
 
             &:hover {
-                background: var(--accent-color, #a78bfa);
-                color: #fff;
+                background: var(--accent-color);
+                color: #fff; /* stylelint-disable-line color-no-hex */
             }
         }
 
@@ -1718,7 +1717,7 @@
             .agent-tool-agent-result {
                 font-size: 12px;
                 white-space: pre-wrap;
-                word-break: break-word;
+                overflow-wrap: anywhere;
                 max-height: 200px;
                 overflow-y: auto;
             }
@@ -1765,7 +1764,7 @@
         // Shiki adds background-color on the <pre> via inline style — remove it
         // so our themed background (from the parent container) wins.
         &[style*="background"] {
-            background: transparent !important;
+            background: transparent !important; /* stylelint-disable-line declaration-no-important */
         }
     }
 
@@ -1787,12 +1786,12 @@
         // Plain-render diff classes (used before Shiki resolves and as fallback)
         .agent-diff-add {
             background: color-mix(in srgb, green 15%, transparent);
-            color: #a0ffa0;
+            color: var(--success-color);
         }
 
         .agent-diff-del {
             background: color-mix(in srgb, red 15%, transparent);
-            color: #ffa0a0;
+            color: var(--error-color);
         }
 
         .agent-diff-hunk {
@@ -2085,7 +2084,7 @@
             pre {
                 margin: 0;
                 white-space: pre-wrap;
-                word-break: break-word;
+                overflow-wrap: anywhere;
             }
         }
 
@@ -2144,7 +2143,7 @@
             margin: 0;
             // Shiki <pre> override: ensure our bg wins
             &[style*="background"] {
-                background: var(--main-bg-color) !important;
+                background: var(--main-bg-color) !important; /* stylelint-disable-line declaration-no-important */
             }
         }
     }
@@ -2238,7 +2237,7 @@
             margin: 4px 0 0 0;
             font-size: 11px;
             white-space: pre-wrap;
-            word-break: break-word;
+            overflow-wrap: anywhere;
         }
     }
 
@@ -2453,7 +2452,7 @@
             pre {
                 margin: 0;
                 white-space: pre-wrap;
-                word-break: break-word;
+                overflow-wrap: anywhere;
                 color: color-mix(in srgb, var(--main-text-color) 80%, transparent);
             }
         }
@@ -2956,7 +2955,9 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        z-index: 100;
+        // Pane-level auth modal — sits in the element-modal slot so
+        // it covers the agent doc + composer beneath it.
+        z-index: var(--zindex-elem-modal);
 
         .agent-auth-overlay-content {
             display: flex;
@@ -3219,7 +3220,7 @@
 
     // Subtle left-border highlight on bookmarked nodes.
     .agent-node-bookmarked {
-        border-left: 2px solid var(--warning-color, #eab308) !important;
+        border-left: 2px solid var(--warning-color) !important; /* stylelint-disable-line declaration-no-important */
         padding-left: 2px;
         position: relative;
     }
@@ -3228,7 +3229,7 @@
     .agent-bookmarks-panel {
         flex-shrink: 0;
         border-bottom: 1px solid var(--border-color);
-        background: color-mix(in srgb, var(--warning-color, #eab308) 4%, var(--main-bg-color));
+        background: color-mix(in srgb, var(--warning-color) 4%, var(--main-bg-color));
         font-size: 12px;
         max-height: 220px;
         display: flex;
@@ -3243,11 +3244,11 @@
         cursor: pointer;
         user-select: none;
         border-bottom: 1px solid var(--border-color);
-        background: color-mix(in srgb, var(--warning-color, #eab308) 6%, var(--main-bg-color));
+        background: color-mix(in srgb, var(--warning-color) 6%, var(--main-bg-color));
         flex-shrink: 0;
 
         &:hover {
-            background: color-mix(in srgb, var(--warning-color, #eab308) 10%, var(--main-bg-color));
+            background: color-mix(in srgb, var(--warning-color) 10%, var(--main-bg-color));
         }
     }
 
@@ -3370,7 +3371,7 @@
         }
 
         &:hover {
-            opacity: 1 !important;
+            opacity: 1 !important; /* stylelint-disable-line declaration-no-important */
             color: var(--error-color);
         }
     }
@@ -3394,7 +3395,7 @@
         align-items: center;
         gap: 4px;
         padding: 4px 8px;
-        background: color-mix(in srgb, var(--accent-color, #4a9eff) 6%, var(--main-bg-color));
+        background: color-mix(in srgb, var(--accent-color) 6%, var(--main-bg-color));
         border-bottom: 1px solid var(--border-color);
         // Sticky so it stays visible while the document scrolls beneath it
         position: sticky;
@@ -3416,7 +3417,7 @@
         transition: border-color 0.15s;
 
         &:focus {
-            border-color: var(--accent-color, #4a9eff);
+            border-color: var(--accent-color);
         }
 
         &::placeholder {
@@ -3453,7 +3454,7 @@
         transition: background 0.1s, color 0.1s, border-color 0.1s;
 
         &:hover {
-            background: color-mix(in srgb, var(--accent-color, #4a9eff) 15%, transparent);
+            background: color-mix(in srgb, var(--accent-color) 15%, transparent);
             border-color: var(--border-color);
             color: var(--main-text-color);
         }
@@ -3463,9 +3464,9 @@
             margin-left: 2px;
 
             &:hover {
-                background: color-mix(in srgb, var(--error-color, #f87171) 15%, transparent);
-                border-color: color-mix(in srgb, var(--error-color, #f87171) 40%, transparent);
-                color: var(--error-color, #f87171);
+                background: color-mix(in srgb, var(--error-color) 15%, transparent);
+                border-color: color-mix(in srgb, var(--error-color) 40%, transparent);
+                color: var(--error-color);
             }
         }
     }
@@ -3474,9 +3475,9 @@
 
     .agent-node-search-match {
         // Subtle accent-tinted background to flag the matched node
-        background: color-mix(in srgb, var(--accent-color, #4a9eff) 10%, transparent) !important;
+        background: color-mix(in srgb, var(--accent-color) 10%, transparent) !important; /* stylelint-disable-line declaration-no-important */
         // Left border acts as a gutter indicator
-        border-left: 3px solid var(--accent-color, #4a9eff) !important;
+        border-left: 3px solid var(--accent-color) !important; /* stylelint-disable-line declaration-no-important */
         border-radius: 2px;
         // Small padding-left offset to compensate for the border
         padding-left: 4px;
@@ -3487,10 +3488,10 @@
 
     @keyframes search-match-flash {
         from {
-            background: color-mix(in srgb, var(--accent-color, #4a9eff) 28%, transparent);
+            background: color-mix(in srgb, var(--accent-color) 28%, transparent);
         }
         to {
-            background: color-mix(in srgb, var(--accent-color, #4a9eff) 10%, transparent);
+            background: color-mix(in srgb, var(--accent-color) 10%, transparent);
         }
     }
 
@@ -3499,8 +3500,8 @@
     .agent-session-digest {
         margin: 4px 0 2px;
         padding: 6px 8px;
-        background: color-mix(in srgb, var(--accent-color, #4a9eff) 8%, transparent);
-        border: 1px solid var(--accent-color, #4a9eff);
+        background: color-mix(in srgb, var(--accent-color) 8%, transparent);
+        border: 1px solid var(--accent-color);
         border-radius: 4px;
         font-size: 12px;
         flex-shrink: 0;
@@ -3516,7 +3517,7 @@
 
     .agent-session-digest-title {
         flex: 1;
-        color: var(--accent-color, #4a9eff);
+        color: var(--accent-color);
         font-size: 12px;
     }
 
@@ -3542,7 +3543,7 @@
 
         &:hover:not(:disabled) {
             opacity: 1;
-            background: color-mix(in srgb, var(--accent-color, #4a9eff) 15%, transparent);
+            background: color-mix(in srgb, var(--accent-color) 15%, transparent);
         }
 
         &:disabled {
@@ -3552,8 +3553,8 @@
     }
 
     .agent-session-digest-dismiss:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--error-color, #f87171) 15%, transparent);
-        color: var(--error-color, #f87171);
+        background: color-mix(in srgb, var(--error-color) 15%, transparent);
+        color: var(--error-color);
     }
 
     .agent-session-digest-body {
@@ -3584,7 +3585,10 @@
 // rather than nested inside .agent-view because SolidJS <Portal> mounts to
 // document.body by default.
 .agent-tool-content--portal {
-    z-index: 200;
+    // Tool overlay portals to body and floats above the page tree;
+    // typeahead's slot is the right precedent (anchor-positioned
+    // overlays that aren't full modals).
+    z-index: var(--zindex-typeahead-modal);
     background: var(--main-bg-color);
     border: 1px solid var(--border-color);
     border-radius: 0 0 3px 3px;
@@ -3648,7 +3652,7 @@
     border-radius: 3px;
 
     &:hover {
-        background: color-mix(in srgb, var(--highlight-bg-color, #ffffff10) 50%, transparent);
+        background: color-mix(in srgb, var(--highlight-bg-color) 50%, transparent);
     }
 }
 
@@ -3710,7 +3714,7 @@
     cursor: pointer;
 
     &:focus {
-        outline: 1px solid var(--accent-color, #4a90e2);
+        outline: 1px solid var(--accent-color);
         outline-offset: 1px;
     }
 
@@ -3732,7 +3736,7 @@
     white-space: nowrap;
 
     &:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--highlight-bg-color, #ffffff15) 60%, transparent);
+        background: color-mix(in srgb, var(--highlight-bg-color) 60%, transparent);
         color: var(--main-text-color);
     }
 
@@ -3744,20 +3748,20 @@
 
 .agent-identity-unassign-btn {
     padding: 2px 6px;
-    border-color: color-mix(in srgb, var(--error-color, #e06c75) 50%, transparent);
-    color: color-mix(in srgb, var(--error-color, #e06c75) 70%, transparent);
+    border-color: color-mix(in srgb, var(--error-color) 50%, transparent);
+    color: color-mix(in srgb, var(--error-color) 70%, transparent);
 
     &:hover:not(:disabled) {
-        background: color-mix(in srgb, var(--error-color, #e06c75) 15%, transparent);
-        color: var(--error-color, #e06c75);
+        background: color-mix(in srgb, var(--error-color) 15%, transparent);
+        color: var(--error-color);
     }
 }
 
 .agent-identity-error {
     font-size: 11px;
-    color: var(--error-color, #e06c75);
+    color: var(--error-color);
     padding: 4px 6px;
-    background: color-mix(in srgb, var(--error-color, #e06c75) 10%, transparent);
+    background: color-mix(in srgb, var(--error-color) 10%, transparent);
     border-radius: 3px;
 }
 
@@ -3897,9 +3901,9 @@
 
 .agent-launch-modal-error {
     font-size: 12px;
-    color: var(--error-color, #e06c75);
+    color: var(--error-color);
     padding: 6px 8px;
-    background: color-mix(in srgb, var(--error-color, #e06c75) 10%, transparent);
+    background: color-mix(in srgb, var(--error-color) 10%, transparent);
     border-radius: 3px;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.368",
+  "version": "0.33.369",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.368",
+      "version": "0.33.369",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.368",
+  "version": "0.33.369",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary
- The 4051-line \`agent-view.scss\` is the last file in \`.stylelintignore\`
- After this merges, **every component SCSS file in the codebase is enforced** by the spec rules — design-system Phase 3 burn-down complete

## Changes
| Category | Before | After |
|----------|--------|-------|
| Hex literals | 90 | 4 (all \`#fff\` annotated) |
| Raw \`z-index\` ≥ 100 | 2 | 0 (both tokenised) |
| \`!important\` | 6 | 0 unjustified (all 6 annotated with reasons) |

## Migration detail
- Bulk-dropped 86 hex fallbacks on \`var(--token, #...)\` patterns
- Migrated raw colours to semantic tokens:
  - \`#8cc8ff\` (loading-dot blue, several uses) → \`var(--accent-color)\`
  - \`#4a9eff\` (action button) → \`var(--accent-color)\`
  - \`#6bb0ff\` (hover lightener) → \`color-mix(in srgb, var(--accent-color), white 15%)\`
  - \`#f59e0b\` (amber) → \`var(--warning-color)\`
  - \`#a0ffa0\` (diff add) → \`var(--success-color)\`
  - \`#ffa0a0\` (diff remove) → \`var(--error-color)\`
- 4 × \`#fff\` (intentional white on accent/error buttons) → \`stylelint-disable-line color-no-hex\`
- \`z-index: 100\` (auth overlay) → \`var(--zindex-elem-modal)\`
- \`z-index: 200\` (portal-rendered tool overlay) → \`var(--zindex-typeahead-modal)\`
- All 6 \`!important\` instances annotated with \`stylelint-disable-line declaration-no-important\` (each retained for documented specificity reasons)
- 2 deprecated \`word-break: break-word\` → modern \`overflow-wrap: anywhere\`
- 1 duplicate \`cursor\` declaration removed

## Burn-down trail
| PR | Files remaining |
|---|---|
| #526 (initial) | 54 |
| #527 | 51 |
| #528 | 43 |
| #529 | 36 |
| #530 | 28 |
| #531 | 19 |
| #532 | 12 |
| #533 | 7 |
| #534 | 3 |
| #535 | 1 |
| **This PR** | **0** ✅ |

\`.stylelintignore\` now contains only \`dist/\` and \`node_modules/\` entries — no SCSS files grandfathered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)